### PR TITLE
feat(connector-worker): run the worker image under Node so the isolate lane can load

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -173,9 +173,19 @@ jobs:
           cache-to: type=gha,mode=max,scope=worker
 
       - name: Worker image self-check (docker run --network=none)
+        # The image runs under Node so the connector isolate lane (isolated-vm,
+        # a V8 addon Bun cannot load) works in prod. A green self-check alone
+        # does not prove that addon's native build, so assert the lane too: an
+        # unavailable lane means the builder's node-gyp toolchain or the
+        # optionalDependency install regressed inside the image.
         run: |
+          set -o pipefail
           docker run --rm --network=none lobu-worker:parity-smoke \
-            bun src/bin.ts self-check --json
+            node dist/bin.js self-check --json | tee worker-self-check.json
+          jq -e '.isolate_lane.available == true' worker-self-check.json >/dev/null || {
+            echo "::error::worker image cannot load isolated-vm: $(jq -c .isolate_lane worker-self-check.json)"
+            exit 1
+          }
 
   build-app:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1880,9 +1880,19 @@ jobs:
       # The real prod runtime contract: run the built image's self-check with NO
       # network, so a green result can't depend on reaching anything external.
       - name: Worker image self-check (docker run --network=none)
+        # The image runs under Node so the connector isolate lane (isolated-vm,
+        # a V8 addon Bun cannot load) works in prod. A green self-check alone
+        # does not prove that addon's native build, so assert the lane too: an
+        # unavailable lane means the builder's node-gyp toolchain or the
+        # optionalDependency install regressed inside the image.
         run: |
+          set -o pipefail
           docker run --rm --network=none lobu-worker:parity-smoke \
-            bun src/bin.ts self-check --json
+            node dist/bin.js self-check --json | tee worker-self-check.json
+          jq -e '.isolate_lane.available == true' worker-self-check.json >/dev/null || {
+            echo "::error::worker image cannot load isolated-vm: $(jq -c .isolate_lane worker-self-check.json)"
+            exit 1
+          }
 
       # Host (CLI) leg: same self-check function, exercised from the built CLI
       # runtime. This PR touches the gated paths, so this leg dogfoods the gate.

--- a/charts/lobu/Chart.yaml
+++ b/charts/lobu/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lobu
 description: Lobu Platform - Never forget anything. User content analysis with AI.
 type: application
-version: 17.2.1
+version: 17.2.2
 appVersion: 17.2.0
 keywords:
   - lobu

--- a/charts/lobu/templates/worker-deployment.yaml
+++ b/charts/lobu/templates/worker-deployment.yaml
@@ -137,7 +137,7 @@ spec:
           {{- end }}
           # The worker daemon is a poll loop with no HTTP server, so there's no
           # endpoint to httpGet. Liveness is an exec probe that confirms the
-          # daemon process (PID 1, `bun src/bin.ts daemon` per docker/worker)
+          # daemon process (PID 1, `node dist/bin.js daemon` per docker/worker)
           # is still its own command line — if the loop crashes hard the
           # container exits and PID 1 is gone, so kubelet restarts it. Reuses
           # the chart's healthCheck.livenessProbe timing.

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -4,7 +4,10 @@
 # Self-hosted worker for Lobu connectors and embedding generation.
 
 # Keep container builds on the same Bun version as the workflow lanes instead
-# of resolving a different `latest` release when a layer must be rebuilt.
+# of resolving a different `latest` release when a layer must be rebuilt. Bun
+# is a build tool here (workspace install + tsc); the runtime stage is Node
+# only, because the connector isolate lane's `isolated-vm` is a V8 native
+# addon Bun cannot dlopen.
 ARG BUN_VERSION=1.3.5
 
 FROM node:22-bookworm AS builder
@@ -57,32 +60,32 @@ COPY packages/connectors/ packages/connectors/
 COPY packages/embeddings/ packages/embeddings/
 COPY packages/connector-worker/ packages/connector-worker/
 
-# Build workspace dists required by runtime source imports.
+# Build workspace dists required by runtime imports.
 # connector-sdk imports @lobu/core; connector-worker/src/embeddings.ts imports
-# @lobu/embeddings, whose package exports point at dist/.
+# @lobu/embeddings, whose package exports point at dist/. connector-worker
+# itself builds last: the runtime runs its dist under Node (`bin.js` plus the
+# fork()ed `executor/child-runner.js`), never TypeScript source.
 RUN cd packages/core && bunx tsc \
     && cd ../connector-sdk && bunx tsc \
-    && cd ../embeddings && bunx tsc
+    && cd ../embeddings && bunx tsc \
+    && cd ../connector-worker && bunx tsc
 
 # ===========================================
 # Runtime
 # ===========================================
 FROM node:22-bookworm-slim AS runtime
-ARG BUN_VERSION
 
 WORKDIR /app
 
+# No Bun in this stage: everything runs under the image's Node. curl stays for
+# the chart's wait-for-app initContainer, which runs this image.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl unzip \
+      ca-certificates curl \
       libimage-exiftool-perl \
       libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
       libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libpango-1.0-0 \
       libcairo2 libasound2 libxshmfence1 libxfixes3 libglib2.0-0 fonts-liberation \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash -s -- "bun-v${BUN_VERSION}" \
-    && chmod +x /usr/local/bin/bun
-
-ENV PATH="/usr/local/bin:${PATH}"
+    && rm -rf /var/lib/apt/lists/*
 
 # Non-root user. Pinned UID and numeric final USER so the kubelet can
 # verify runAsNonRoot — a named USER fails CreateContainerConfigError
@@ -129,4 +132,9 @@ ENV TRANSFORMERS_CACHE=/app/.cache/transformers
 
 WORKDIR /app/packages/connector-worker
 
-CMD ["bun", "src/bin.ts", "daemon"]
+# Node, not Bun: the isolate lane loads the isolated-vm addon (built by
+# node-gyp in the builder when no prebuild matches), which Bun cannot dlopen.
+# CI runs `node dist/bin.js self-check --json` in this image and asserts
+# `isolate_lane.available`. The chart's liveness probe greps "daemon" from
+# PID 1's cmdline, so keep that argument.
+CMD ["node", "dist/bin.js", "daemon"]

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -73,6 +73,10 @@ The Dockerfile lives at `docker/app/Dockerfile`. Three notable details:
 2. **Built artifact**, not a workspace install at runtime. The image bundles `dist/server.bundle.mjs` produced by esbuild — fast cold-start, no `bun install` at boot.
 3. **No SPA bundled in the public image by default.** The admin SPA sources live in a private submodule (`packages/owletto`); the public image stubs them out so external contributors can build the backend without owletto access. To run the SPA, build from a checkout that has the submodule initialized, or use Lobu Cloud.
 
+## Fleet worker image
+
+Lobu Cloud's Helm chart (`charts/lobu`) runs connector workers as a separate Deployment built from `docker/worker/Dockerfile`; the self-hosting image above does not need it. Its runtime stage is Node only: the builder compiles `packages/connector-worker` with `tsc`, and the container's `CMD` is `node dist/bin.js daemon`. The worker runs under Node rather than Bun because the connector isolate lane loads `isolated-vm`, a V8 native addon Bun cannot `dlopen`. CI runs `node dist/bin.js self-check --json` inside the built image with `--network=none` and asserts `isolate_lane.available`, so a broken native build fails the image job instead of surfacing as failed isolate runs in prod.
+
 ## Bumping versions
 
 Main-branch builds publish timestamp tags but no longer move `:latest`. Publishing a stable [GitHub Release](https://github.com/lobu-ai/lobu/releases) named `lobu-vX.Y.Z` publishes image tag `:X.Y.Z` and moves `:latest`; prereleases publish only their version tag. For reproducible deploys, pin a published version. Releases from before versioned image publishing was enabled are not backfilled automatically.

--- a/packages/connector-worker/integration-tests/subprocess-source-mode.test.ts
+++ b/packages/connector-worker/integration-tests/subprocess-source-mode.test.ts
@@ -4,13 +4,13 @@
  * The diagnostic suite in subprocess.test.ts imports from `../dist/`, which
  * means SubprocessExecutor's internal `__dirname` resolves to the dist/
  * folder where `child-runner.js` exists. That path takes the .js branch and
- * does NOT exercise the .ts fallback that runs in production worker pods.
+ * does NOT exercise the .ts fallback a source-mode Bun worker takes.
  *
- * Production workers run `bun src/bin.ts daemon` — the SubprocessExecutor
- * loaded from src/ has only `child-runner.ts` next to it, so the executor
- * falls through to the second branch and (before this fix) added
- * `--import tsx` to execArgv, which crashed Bun children with
- * `Cannot find module './cjs/index.cjs' from ''`.
+ * A SubprocessExecutor loaded from src/ under Bun (as this bun:test suite
+ * does; the worker image runs `node dist/bin.js daemon` from dist/) has only
+ * `child-runner.ts` next to it, so the executor falls through to the second
+ * branch and (before this fix) added `--import tsx` to execArgv, which
+ * crashed Bun children with `Cannot find module './cjs/index.cjs' from ''`.
  *
  * This file imports SubprocessExecutor from `../src/executor/subprocess.ts`
  * so the test runner reproduces the source-mode environment. Bun runs .ts

--- a/packages/connector-worker/src/__tests__/self-check-isolate-lane.test.ts
+++ b/packages/connector-worker/src/__tests__/self-check-isolate-lane.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  printSelfCheckResult,
+  probeIsolateLane,
+  runConnectorRuntimeSelfCheck,
+  type SelfCheckResult,
+} from '../self-check/index.js';
+
+// One tiny connector so the full self-check exercises discovery + compile
+// without walking every bundled connector. No native deps: the isolate section
+// is what this suite pins, not the subprocess lane's dependency graph.
+const MINIMAL_CONNECTOR = `
+import { ConnectorRuntime } from '@lobu/connector-sdk';
+
+export default class SelfCheckTestConnector extends ConnectorRuntime {
+  definition = {
+    key: 'self_check_test',
+    name: 'Self-Check Test',
+    description: 'Fixture connector for the self-check isolate_lane test.',
+    version: '0.0.0',
+    authSchema: { methods: [{ type: 'none' }] },
+    feeds: {},
+  };
+}
+`;
+
+function captureStderr(fn: () => void): string {
+  const chunks: string[] = [];
+  const original = process.stderr.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    chunks.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    fn();
+  } finally {
+    process.stderr.write = original;
+  }
+  return chunks.join('');
+}
+
+const BASE_RESULT: Omit<SelfCheckResult, 'isolate_lane'> = {
+  ok: true,
+  surface: 'worker',
+  connectorSourceDir: null,
+  connectorCount: 0,
+  checks: [],
+};
+
+describe('self-check isolate_lane', () => {
+  it('probeIsolateLane reports the lane unavailable under Bun and names the runtime', async () => {
+    // bun:test always runs on Bun, which cannot dlopen the isolated-vm addon.
+    expect(typeof process.versions.bun).toBe('string');
+    const lane = await probeIsolateLane();
+    expect(lane.available).toBe(false);
+    expect(lane.reason).toMatch(/Bun/);
+    expect(lane.node_version).toBe(process.versions.node);
+    // Bun selects no build, so there is no package version to report.
+    expect(lane.isolated_vm_version).toBeNull();
+  });
+
+  it(
+    'runConnectorRuntimeSelfCheck carries the section without letting it decide ok',
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lobu-self-check-isolate-test-'));
+      try {
+        await writeFile(join(dir, 'self-check-test.ts'), MINIMAL_CONNECTOR, 'utf-8');
+        const result = await runConnectorRuntimeSelfCheck({
+          surface: 'worker',
+          connectorSourceCandidates: [dir],
+        });
+        expect(result.isolate_lane).toEqual({
+          available: false,
+          reason: expect.stringMatching(/Bun/),
+          isolated_vm_version: null,
+          node_version: process.versions.node,
+        });
+        // The lane is informational: no check entry carries it, and `ok` is
+        // still exactly the AND of the recorded checks.
+        expect(result.checks.some((c) => /isolate/i.test(c.name))).toBe(false);
+        expect(result.ok).toBe(result.checks.every((c) => c.ok));
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+    60_000
+  );
+
+  it('printSelfCheckResult prints one isolate-lane line for either state', () => {
+    const available = captureStderr(() =>
+      printSelfCheckResult({
+        ...BASE_RESULT,
+        isolate_lane: {
+          available: true,
+          reason: null,
+          isolated_vm_version: '6.1.2',
+          node_version: '22.0.0',
+        },
+      })
+    );
+    expect(available).toContain('isolate lane: available (isolated-vm 6.1.2, Node 22.0.0)');
+
+    const unavailable = captureStderr(() =>
+      printSelfCheckResult({
+        ...BASE_RESULT,
+        isolate_lane: {
+          available: false,
+          reason: 'no build for this line',
+          isolated_vm_version: null,
+          node_version: '25.0.0',
+        },
+      })
+    );
+    expect(unavailable).toContain('isolate lane: unavailable on Node 25.0.0 — no build for this line');
+  });
+});

--- a/packages/connector-worker/src/isolate/load.ts
+++ b/packages/connector-worker/src/isolate/load.ts
@@ -52,6 +52,16 @@ export function isolatedVmUnavailableReason(): string | null {
 const IVM_MODULE = 'isolated-vm';
 const IVM_NEXT_MODULE = 'isolated-vm-next';
 
+/**
+ * The optionalDependency that carries this Node line's isolated-vm build, or
+ * `null` when the runtime has none (`isolatedVmUnavailableReason()` says why).
+ * Shared by the loader and the self-check so both name the same package.
+ */
+export function isolatedVmSpecifier(): string | null {
+  if (isolatedVmUnavailableReason() !== null) return null;
+  return nodeMajor() >= 26 ? IVM_NEXT_MODULE : IVM_MODULE;
+}
+
 let cached: Promise<IsolatedVm | null> | null = null;
 
 /**
@@ -65,8 +75,8 @@ export function loadIsolatedVm(): Promise<IsolatedVm | null> {
 }
 
 async function loadIsolatedVmUncached(): Promise<IsolatedVm | null> {
-  if (isolatedVmUnavailableReason() !== null) return null;
-  const major = nodeMajor();
+  const specifier = isolatedVmSpecifier();
+  if (!specifier) return null;
   try {
     // Dynamic on purpose: the two builds are optionalDependencies gated by
     // Node major, and a static import of a native addon absent on this host
@@ -74,8 +84,6 @@ async function loadIsolatedVmUncached(): Promise<IsolatedVm | null> {
     // load instead of failing closed for the isolate lane alone. The
     // specifier is a variable so the worker typechecks with neither package
     // installed; `unwrapIsolatedVm` narrows to the structural `IsolatedVm`.
-    const specifier = major >= 26 ? IVM_NEXT_MODULE : major >= 22 && major < 25 ? IVM_MODULE : null;
-    if (!specifier) return null;
     return unwrapIsolatedVm(await import(specifier));
   } catch {
     return null;

--- a/packages/connector-worker/src/self-check/index.ts
+++ b/packages/connector-worker/src/self-check/index.ts
@@ -2,10 +2,17 @@
  * Connector runtime parity self-check.
  *
  * One shared function run from BOTH entrypoints — the worker Docker image
- * (`bun src/bin.ts self-check`) and the built CLI (`lobu connector
+ * (`node dist/bin.js self-check`) and the built CLI (`lobu connector
  * runtime-self-check`) — so both assert the identical compile + default
  * `SubprocessExecutor` path. The only per-surface difference is the connector
  * source discovery roots (monorepo vs worker image vs npm-installed CLI).
+ *
+ * The result also reports the isolate lane (`isolate_lane`): whether this
+ * runtime can load `isolated-vm`, the V8 addon behind `lane: 'isolate'` runs.
+ * That section never flips `ok` — the subprocess lane is the parity invariant
+ * and a Bun or Node 25 host legitimately lacks the addon — but the worker
+ * image smoke asserts `isolate_lane.available` separately, because the image
+ * exists to run the isolate lane and its native build is otherwise unproven.
  *
  * Why it exists: the worker image once shipped to prod missing `COPY
  * packages/core`, so `@lobu/connector-sdk`'s transitive `@lobu/core` import
@@ -16,7 +23,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { extname, join, resolve } from "node:path";
@@ -32,10 +39,15 @@ import {
 	stageConnectorRuntimeDependencies,
 } from "../executor/runtime-dependency-loader.js";
 import { executeCompiledConnector } from "../executor/runtime.js";
+import {
+	isolatedVmSpecifier,
+	isolatedVmUnavailableReason,
+	loadIsolatedVm,
+} from "../isolate/load.js";
 
 /**
  * Synthetic no-op connector, inline so the check is self-contained and ships
- * identically in the worker image (`src/`) and the published CLI (`dist/`). It
+ * identically in the worker image and the published CLI (both from `dist/`). It
  * is not a real bundled connector (the catalog never scans it) and touches no
  * network/DB/filesystem, so it passes under `--network=none`.
  */
@@ -82,6 +94,20 @@ export interface SelfCheckEntry {
 	detail: string;
 }
 
+/**
+ * Whether this runtime can host `lane: 'isolate'` runs. Snake_case on purpose:
+ * the image smokes read it with `jq '.isolate_lane.available'`.
+ */
+export interface SelfCheckIsolateLane {
+	/** `isolated-vm` loaded; `selectExecutor` can build an `IsolateExecutor`. */
+	available: boolean;
+	/** Why not, when unavailable; `null` when available. */
+	reason: string | null;
+	/** Installed version of the build this Node line uses; `null` if absent. */
+	isolated_vm_version: string | null;
+	node_version: string;
+}
+
 export interface SelfCheckResult {
 	ok: boolean;
 	/** Which entrypoint ran the check — for log/parity-debugging only. */
@@ -89,6 +115,8 @@ export interface SelfCheckResult {
 	connectorSourceDir: string | null;
 	connectorCount: number;
 	checks: SelfCheckEntry[];
+	/** Informational: does not participate in `ok` (see module doc). */
+	isolate_lane: SelfCheckIsolateLane;
 }
 
 export interface SelfCheckOptions {
@@ -293,6 +321,37 @@ async function runSyntheticConnector(
 }
 
 /**
+ * Probe the isolate lane the way `selectExecutor` does — through the memoized
+ * `loadIsolatedVm()` — and read the installed addon's version from the
+ * package this Node line resolves. The version read is best-effort metadata:
+ * `available` is the assertion.
+ */
+export async function probeIsolateLane(): Promise<SelfCheckIsolateLane> {
+	const node_version = process.versions.node;
+	const specifier = isolatedVmSpecifier();
+	let isolated_vm_version: string | null = null;
+	if (specifier) {
+		try {
+			const pkgPath = createRequire(import.meta.url).resolve(
+				`${specifier}/package.json`,
+			);
+			const pkg = JSON.parse(await readFile(pkgPath, "utf-8")) as {
+				version?: unknown;
+			};
+			if (typeof pkg.version === "string") isolated_vm_version = pkg.version;
+		} catch {
+			// Not installed (optionalDependency skipped) — reported via `reason`.
+		}
+	}
+	const available = (await loadIsolatedVm()) !== null;
+	const reason = available
+		? null
+		: (isolatedVmUnavailableReason() ??
+			`${specifier} did not load on Node ${node_version}: the optionalDependency is missing or its native build failed`);
+	return { available, reason, isolated_vm_version, node_version };
+}
+
+/**
  * Fast boot gate for a worker that is about to advertise connector
  * capabilities. It compiles and executes the synthetic connector through the
  * real subprocess path, so a runtime that cannot load the SDK fails before its
@@ -435,6 +494,7 @@ export async function runConnectorRuntimeSelfCheck(
 		connectorSourceDir,
 		connectorCount: discovered.length,
 		checks,
+		isolate_lane: await probeIsolateLane(),
 	};
 }
 
@@ -451,5 +511,11 @@ export function printSelfCheckResult(result: SelfCheckResult): void {
 	for (const c of result.checks) {
 		lines.push(`  ${c.ok ? "✓" : "✗"} ${c.name}: ${c.detail}`);
 	}
+	const lane = result.isolate_lane;
+	lines.push(
+		lane.available
+			? `  isolate lane: available (isolated-vm ${lane.isolated_vm_version ?? "unknown"}, Node ${lane.node_version})`
+			: `  isolate lane: unavailable on Node ${lane.node_version} — ${lane.reason}`,
+	);
 	process.stderr.write(`${lines.join("\n")}\n`);
 }

--- a/scripts/lib/gate-runner.sh
+++ b/scripts/lib/gate-runner.sh
@@ -318,8 +318,18 @@ gate_optional_smoke_filter() {
 
 gate_connector_parity_smoke() {
   gate_require_docker || return 77
-  docker build -f docker/worker/Dockerfile -t lobu-worker:parity-smoke .
-  docker run --rm --network=none lobu-worker:parity-smoke bun src/bin.ts self-check --json
+  docker build -f docker/worker/Dockerfile -t lobu-worker:parity-smoke . || return 1
+  local self_check rc=0
+  self_check=$(docker run --rm --network=none lobu-worker:parity-smoke node dist/bin.js self-check --json) || rc=$?
+  printf '%s\n' "$self_check"
+  [ "$rc" -eq 0 ] || return 1
+  # Mirrors ci.yml / build-images.yml: the image runs under Node so the isolate
+  # lane's isolated-vm addon loads; a green self-check alone does not prove the
+  # native build, so assert the lane explicitly.
+  if ! printf '%s' "$self_check" | jq -e '.isolate_lane.available == true' >/dev/null; then
+    echo "   ✗ worker image cannot load isolated-vm: $(printf '%s' "$self_check" | jq -c .isolate_lane)"
+    return 1
+  fi
   node packages/cli/bin/lobu.js connector runtime-self-check --json || return 1
 }
 


### PR DESCRIPTION
## Summary
- The connector isolate lane (#3303) loads `isolated-vm`, a V8 native addon Bun cannot dlopen, so the worker image's `CMD ["bun", "src/bin.ts", "daemon"]` meant no prod worker could ever run an `isolate` job. The image now builds `packages/connector-worker`'s dist in the builder (`bunx tsc`, after core/connector-sdk/embeddings) and runs `node dist/bin.js daemon`; Bun is gone from the runtime stage (it was only there to run `src/bin.ts`; `unzip` existed only for its installer; `curl` stays for the chart's `wait-for-app` initContainer, which runs this image).
- The self-check now reports an `isolate_lane` section (`available`, `reason`, `isolated_vm_version`, `node_version`) via the same `loadIsolatedVm()` / `isolatedVmUnavailableReason()` the executor selector uses. It never flips `ok` (a Bun or Node 25 host legitimately lacks the addon, and the CLI surface runs on arbitrary hosts), but the three worker-image smokes (`build-images.yml`, `ci.yml`, `scripts/lib/gate-runner.sh`) now run `node dist/bin.js self-check --json` and assert `.isolate_lane.available == true` with jq — the proof that the image's isolated-vm native build works under Node 22.
- `load.ts` exposes `isolatedVmSpecifier()` (the optionalDependency chosen for this Node line) so the loader and the self-check name the same package instead of duplicating the Node-major gate.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean (local fallback — Docker is not available on this machine, so the image job on CI is the gate)
- [x] `cd packages/connector-worker && bun run build` (tsc) — green
- [x] `bun test src/__tests__/self-check-isolate-lane.test.ts src/__tests__/isolate-load.test.ts` — 4 pass / 0 fail
- [x] `bun test packages/connector-worker --timeout 30000` — 311 pass / 2 fail. The 2 (`daemon-builtin os.shell > uses a minimal child environment…`, `native bridge handshake > does not emit a run before hello…`) fail identically on the untouched files in isolation, import none of the modules this PR changes, and are green on main CI at the base commit; on this Mac the os.shell child visibly inherits the login shell's environment, so they are local-environment failures.
- [x] `cd packages/server && bun run test -- run src/__tests__/integration/sandbox/isolate-executor.test.ts src/__tests__/integration/sandbox/connector-isolate-lane.test.ts` — 2 files, 30 pass / 0 fail
- [x] `node dist/bin.js self-check --json` on local Node 26.7.0 → `ok: true`, 23 connectors, `isolate_lane: { available: true, reason: null, isolated_vm_version: "7.0.0", node_version: "26.7.0" }`
- [x] `bun src/bin.ts self-check` → `PASS`, `isolate lane: unavailable … cannot load under Bun` (the section does not fail the parity check)
- [ ] Docker image self-check under Node 22 — not runnable locally (no Docker). Proof is the `connector-parity-smoke` job in this PR's CI run (and the same-named job in `build-images.yml` on main), which now fails unless the built image reports `isolate_lane.available == true`.

## Notes
- Why Node: `isolated-vm` is ABI-bound per Node major and dlopen'd into V8; Bun's runtime has no compatible V8 symbols. The app image made the same move for the gateway's isolate runner; this mirrors it for the fleet worker. The dist route also removes the source-mode `.ts` + Bun fork special-case from the prod path: the child is `node dist/executor/child-runner.js`.
- The `isolate_lane` assertion is deliberately separate from `ok`: `ok` stays the subprocess-lane parity invariant shared with `lobu connector runtime-self-check`; the worker image alone is required to have the addon.
- The Helm liveness probe (`grep -qa daemon /proc/1/cmdline`) still matches; only its comment changed. No manifest changes.
- `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=fable make review-fix` ran once on the settled diff: it found the branch mechanically sound and fixed two stale comments (both accepted; a third stale line in the same header fixed alongside). It independently reran the Node/Bun self-checks and the touched suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Worker self-check results now report whether the isolated connector lane is available, including version and diagnostic details.
  - Containerized workers now run from compiled output using Node.js, enabling native isolate support.

- **Bug Fixes**
  - Image validation now fails when the isolated connector lane is unavailable.

- **Documentation**
  - Added guidance for the fleet worker image, its Node.js runtime, and isolation requirements.

- **Chores**
  - Updated the Helm chart version to 17.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->