### PR TITLE
docs(server): correct the STT provider-health routing claim

### DIFF
--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -558,9 +558,14 @@ export async function transcribeOne(
  * Returns true when the ACCOUNT is walled (quota/credit or auth) rather than
  * this one file being unsupported — the caller uses that to stop the batch.
  *
- * Best-effort, mirroring `secret-proxy`'s `recordProviderHealth`: nothing
- * routes on `status` today, so failing to write a display label must never
- * turn into a thrown error on a path that already kept its placeholder.
+ * Best-effort, mirroring `secret-proxy`'s `recordProviderHealth`. Routing DOES
+ * read `status` — `resolveDispatchModel` takes an `isHealthy` predicate built
+ * from it (#3308) — but only as a PREFERENCE that can never shrink the
+ * candidate set: the strongest thing a missed, stale or duplicated write can do
+ * is fail to break a tie toward a healthy sibling the agent already lists. It
+ * can never strand a workspace or fail a turn that would otherwise have run,
+ * so writing a health label must never turn into a thrown error on a path that
+ * already kept its placeholder.
  */
 async function recordTranscriptionProviderHealth(
   organizationId: string,

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -538,8 +538,10 @@ export async function transcribeOne(
     // would stay `error` forever once credits were restored.
     //
     // Best-effort for the same reason the proxy's is: `status` is a display
-    // signal, and failing to clear a label must not fail a transcript that is
-    // already written.
+    // signal plus a routing PREFERENCE (`resolveDispatchModel` prefers a
+    // healthy sibling among the refs an agent already lists), never a gate —
+    // so failing to clear a label can only cost that preference, and must not
+    // fail a transcript that is already written.
     try {
       await clearInferenceProviderError(organizationId, result.providerSlug);
     } catch (err) {


### PR DESCRIPTION
## Summary
- `recordTranscriptionProviderHealth` justified its best-effort write with "nothing routes on `status` today". That was already false when #3310 merged — #3308 (`cb74675a7`) is its own ancestor and builds an `isHealthy` predicate from `inference_providers.status` that `resolveDispatchModel` consumes.
- The conclusion stands (the write must never throw on a path that already kept its placeholder), but the reason was backwards: if routing *does* read `status`, a missed write matters more, not less.
- Replaced with the real justification, which `model-selection.ts:52-58` already states — health is a PREFERENCE that can never shrink the candidate set, so the worst a missed or stale write can do is fail to break a tie toward a healthy sibling the agent already lists.

Caught by two independent sessions reviewing the #3310 blast radius. The stale comment is what led me to frame an already-deployed coupling as a future risk, so it was actively misleading the next reader.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (local gates; comment-only change, no runtime path touched)
- [ ] Tests run — not applicable, no executable change
- [ ] Bug fix red→fix→green — not applicable, documentation defect
- [ ] Bot runtime unchanged

`make review-fix` could not run: the codex pool is at capacity until 2026-09-07 (`ERROR: You've hit your usage limit ... try again at Sep 7th, 2026`). It made no changes; the diff is comment-only.

## Notes
Comment only — `git diff --name-only origin/main...HEAD` is exactly one file and the change is inside a single doc block. Follow-up not in this PR: `recordTranscriptionProviderHealth` only runs on whole-batch failure, so a batch rescued by a later candidate leaves a walled provider `active` — that silently weakens the very signal `resolveDispatchModel` now reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how transcription provider health information influences routing decisions.
  - Documented that missed, outdated, or repeated health updates do not prevent workspaces from being served or interrupt transcription.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->