### PR TITLE
fix(ci): let the prod smoke wait out the rollout it is verifying

### DIFF
--- a/scripts/prod-smoke.sh
+++ b/scripts/prod-smoke.sh
@@ -24,7 +24,9 @@
 #   PROD_URL       base URL (default https://app.lobu.ai)
 #   EXPECT_SHA     if set, require this commit to be an ancestor of the
 #                  deployed revision — i.e. "the rollout actually landed"
-#   ROLLOUT_WAIT   seconds to wait for EXPECT_SHA to appear (default 0 = no wait)
+#   ROLLOUT_WAIT   total seconds to wait for the rollout to land, SHARED by the
+#                  liveness probe (the app sits at zero replicas while migrations
+#                  run) and the EXPECT_SHA gate (default 0 = no wait, one attempt)
 
 set -uo pipefail
 
@@ -57,10 +59,29 @@ echo "================================================================"
 #    /health returns {status, version, revision, build_time, environment};
 #    `revision` is APP_GIT_SHA baked into the image at build time.
 # ---------------------------------------------------------------------------
+# One wait budget for the whole rollout, spent here first and continued by the
+# EXPECT_SHA gate below. Liveness and revision are the same wait: a deploy that
+# is still quiescing has not landed, so each must not spend ROLLOUT_WAIT in full.
+waited=0
+
 note "health"
-health=$(curl -fsS --max-time 15 "${BASE}/health" 2>/dev/null)
+# Retried, because a `workflow_run` smoke fires while the rollout it verifies is
+# still in progress: migrations scale the app to zero, so /health returns
+# nothing for the gap between the old pod terminating and the new one serving.
+# A single attempt failed the entire gate before the caller's wait budget was
+# ever consulted — run 1539 asked for ROLLOUT_WAIT=1200, gave up 0.7s in at
+# 04:12:31, and the replacement pod was ready at 04:13:04.
+# ROLLOUT_WAIT=0 (the default) keeps the previous single-attempt path exactly.
+health=""
+while :; do
+  health=$(curl -fsS --max-time 15 "${BASE}/health" 2>/dev/null)
+  [ -n "$health" ] && break
+  [ "$waited" -ge "$ROLLOUT_WAIT" ] && break
+  sleep 30
+  waited=$((waited + 30))
+done
 if [ -z "$health" ]; then
-  bad "GET /health returned nothing — prod is down or unreachable"
+  bad "GET /health returned nothing after ${waited}s — prod is down or unreachable"
   echo ""
   echo "RESULT: prod smoke FAILED (unreachable)"
   exit 1
@@ -107,7 +128,7 @@ fi
 # ---------------------------------------------------------------------------
 if [ -n "$EXPECT_SHA" ]; then
   note "rollout"
-  waited=0
+  # Continues the budget the liveness probe may already have spent.
   landed=false
   while :; do
     cur=$(curl -fsS --max-time 15 "${BASE}/health" 2>/dev/null \


### PR DESCRIPTION
## Summary
- `ROLLOUT_WAIT` only guarded the `EXPECT_SHA` gate in step 3. The step-1 liveness probe was a single `curl` that hard-exits on an empty response, so a `workflow_run` smoke firing during its own deploy failed before the caller's wait budget was ever consulted.
- Migrations scale the app to zero replicas, so `/health` returns nothing for the gap between the old pod terminating and the new one serving. The gate reported "prod is down or unreachable" while prod was healthy.
- Prod smoke run 1539 asked for `ROLLOUT_WAIT=1200`, gave up **0.7s in** at 04:12:31Z; the replacement pod was serving at 04:13:04Z. The next scheduled run passed. It flakes on every deploy, which trains everyone to ignore it.

Liveness now retries inside the same budget, and step 3 continues that budget instead of resetting it — liveness and revision are one wait, since a deploy that is still quiescing has not landed. `ROLLOUT_WAIT=0` (the default, used by every manual and scheduled run) keeps the single-attempt path exactly.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (build, per-package typecheck, knip, naming, gateway/entity-write gates)
- [ ] Tests run: no suite covers `scripts/prod-smoke.sh`; verified by direct execution instead (below)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: n/a

### RED — original script, budget ignored
```
$ ROLLOUT_WAIT=30 <original>/prod-smoke.sh http://127.0.0.1:1
== health ==
  FAIL — GET /health returned nothing — prod is down or unreachable
RESULT: prod smoke FAILED (unreachable)
elapsed=0s
```

### GREEN — budget spent and reported
```
$ ROLLOUT_WAIT=30 ./scripts/prod-smoke.sh http://127.0.0.1:1
== health ==
  FAIL — GET /health returned nothing after 30s — prod is down or unreachable
RESULT: prod smoke FAILED (unreachable)
elapsed=30s
```

### GREEN — recovery, endpoint down at t=0 and up at t=10
```
$ ROLLOUT_WAIT=60 ./scripts/prod-smoke.sh http://127.0.0.1:18099
== health ==
  ok   — /health status=ok
       version=test revision=deadbeefcafe environment=prod
== readiness ==
  ok   — /health/ready 200 — pod can reach the database
elapsed=30s
```
Recovered at the first retry instead of exiting 1. Fixture served prod-shaped compact JSON — a spaced-JSON mock silently fails the script's `sed` parse and looks like a script bug.

## Notes
Found while investigating why main showed red. The other red on main is `Published-artifact smoke`, which is a **separate and genuine** defect: it installs `@lobu/cli@latest` from the registry, latest is 17.2.0 (published 2026-08-29, nothing since), and it has failed on every run since #3233 began invoking `connector runtime-self-check` from outside the install tree on 2026-08-31. `synthetic-connector-subprocess-execute` was introduced in #1037 on 2026-05-26 and ships inside 17.2.0, so this is not version skew — the published artifact really cannot resolve the SDK from connector-worker's package graph. It clears when a release publishes (#3241).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved production health checks to retry incrementally within the configured rollout wait period.
  - Rollout verification now uses the remaining shared wait time instead of restarting its timeout.
  - Failure messages provide clearer information about how long health checks waited.

- **Documentation**
  - Updated rollout wait configuration guidance to describe the shared time budget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->