### PR TITLE
fix(server): stop an archived Automation anchoring a dead device forever

### DIFF
--- a/packages/server/src/scheduled/__tests__/reap-stale-device-workers.test.ts
+++ b/packages/server/src/scheduled/__tests__/reap-stale-device-workers.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Integration test for the stale device-worker reaper's automation binding.
+ *
+ * An ARCHIVED Automation can never execute again, so it must not count as a
+ * binding that keeps a dead machine alive — otherwise one soft-deleted row
+ * anchors its device permanently and the reaper skips it every night. Because
+ * `automations.device_worker_id` is a NO ACTION FK, ignoring archived rows in
+ * the predicate is not enough on its own: the pin has to be released inside the
+ * delete transaction or the FK rejects the DELETE.
+ *
+ * A LIVE pin must still block, and must not be cleared as a side effect — that
+ * is the difference between reaping a dead machine and silently un-pinning a
+ * runnable Automation.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { getDb } from '../../db/client';
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from '../../gateway/__tests__/helpers/db-setup';
+import { handleDelete } from '../../tools/admin/manage_automations/crud';
+import { reapStaleDeviceWorkers } from '../reap-stale-device-workers';
+
+const ORG_ID = 'device-pin-reaper-org';
+const USER_ID = 'device-pin-reaper-user';
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+});
+
+beforeEach(async () => {
+  await resetTestDatabase();
+  const sql = getDb();
+  await sql`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${ORG_ID}, ${ORG_ID}, ${ORG_ID})
+    ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO "user" (id, name, email)
+    VALUES (${USER_ID}, ${USER_ID}, ${`${USER_ID}@example.test`})
+    ON CONFLICT (id) DO NOTHING
+  `;
+});
+
+/** A device unseen well past the reaper's 30-day threshold. */
+async function seedStaleDevice(workerId: string): Promise<string> {
+  const sql = getDb();
+  const [row] = (await sql`
+    INSERT INTO device_workers (user_id, worker_id, organization_id, platform, last_seen_at)
+    VALUES (${USER_ID}, ${workerId}, ${ORG_ID}, 'macos', now() - interval '40 days')
+    RETURNING id
+  `) as unknown as Array<{ id: string }>;
+  return String(row.id);
+}
+
+async function seedAutomationPinnedTo(
+  deviceWorkerId: string,
+  name: string
+): Promise<number> {
+  const sql = getDb();
+  const [row] = (await sql`
+    WITH next_id AS (SELECT nextval('automations_id_seq')::integer AS id)
+    INSERT INTO automations (
+      id, automation_group_id, organization_id, created_by, name, slug, device_worker_id
+    )
+    SELECT id, id, ${ORG_ID}, ${USER_ID}, ${name}, ${name}, ${deviceWorkerId}
+    FROM next_id
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+  return Number(row.id);
+}
+
+async function archive(automationId: number): Promise<void> {
+  const result = await handleDelete(
+    { action: 'delete', automation_ids: [String(automationId)] } as never,
+    { organizationId: ORG_ID, userId: USER_ID } as never
+  );
+  expect(result.summary.successful).toBe(1);
+}
+
+async function deviceExists(id: string): Promise<boolean> {
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT 1 FROM device_workers WHERE id = ${id}
+  `) as unknown as Array<unknown>;
+  return rows.length > 0;
+}
+
+async function pinOf(automationId: number): Promise<string | null> {
+  const sql = getDb();
+  const [row] = (await sql`
+    SELECT device_worker_id FROM automations WHERE id = ${automationId}
+  `) as unknown as Array<{ device_worker_id: string | null }>;
+  return row?.device_worker_id ?? null;
+}
+
+describe('stale device-worker reaper vs archived automation pins', () => {
+  test('reaps a device whose only pin is an archived Automation', async () => {
+    const deviceId = await seedStaleDevice('worker-archived-pin');
+    const automationId = await seedAutomationPinnedTo(deviceId, 'stale-envelope');
+
+    // Blocked while the Automation is live.
+    const blocked = await reapStaleDeviceWorkers();
+    expect(blocked.reaped).toBe(0);
+    expect(await deviceExists(deviceId)).toBe(true);
+
+    await archive(automationId);
+
+    // Archival is a soft delete: the pin is retained as history, NOT cleared
+    // eagerly. Releasing it is the reaper's job, at the moment it deletes.
+    expect(await pinOf(automationId)).toBe(deviceId);
+
+    const after = await reapStaleDeviceWorkers();
+    expect(after.reaped).toBe(1);
+    expect(await deviceExists(deviceId)).toBe(false);
+    expect(await pinOf(automationId)).toBeNull();
+  });
+
+  test('a live pin still blocks its device and is never cleared', async () => {
+    const deviceId = await seedStaleDevice('worker-live-pin');
+    const automationId = await seedAutomationPinnedTo(deviceId, 'still-active');
+
+    const result = await reapStaleDeviceWorkers();
+
+    expect(result.reaped).toBe(0);
+    expect(await deviceExists(deviceId)).toBe(true);
+    // The release must be scoped to archived rows — a runnable Automation must
+    // not be silently un-pinned by a reaper pass that spared its device.
+    expect(await pinOf(automationId)).toBe(deviceId);
+  });
+
+  test('one live pin protects the device even alongside archived ones', async () => {
+    const deviceId = await seedStaleDevice('worker-mixed-pins');
+    const archivedId = await seedAutomationPinnedTo(deviceId, 'mixed-archived');
+    const liveId = await seedAutomationPinnedTo(deviceId, 'mixed-live');
+    await archive(archivedId);
+
+    const result = await reapStaleDeviceWorkers();
+
+    expect(result.reaped).toBe(0);
+    expect(await deviceExists(deviceId)).toBe(true);
+    expect(await pinOf(liveId)).toBe(deviceId);
+    expect(await pinOf(archivedId)).toBe(deviceId);
+  });
+});

--- a/packages/server/src/scheduled/reap-stale-device-workers.ts
+++ b/packages/server/src/scheduled/reap-stale-device-workers.ts
@@ -11,9 +11,13 @@
  * the Devices page.
  *
  * This reaper deletes device_workers rows that are BOTH stale (unseen far
- * beyond the 7-day freshness window) AND have no bindings — no pinned
- * connections, automations, or auth-profiles — so it never disturbs a device a
- * connection or automation still depends on. The no-binding predicate is re-checked
+ * beyond the 7-day freshness window) AND have no LIVE bindings — no pinned
+ * connections, non-archived automations, or auth-profiles — so it never
+ * disturbs a device a connection or a runnable automation still depends on.
+ * An ARCHIVED automation is not a binding: it can never execute again, so
+ * counting it would let one soft-deleted row anchor a dead machine forever.
+ * Its pin is released in the delete transaction, matching what the explicit
+ * device-delete path already does (`worker-api/device-management.ts`). The no-binding predicate is re-checked
  * inside the DELETE so a binding created between the candidate scan and the
  * delete keeps the row alive. Child PATs bound to the reaped worker_ids are
  * revoked on the way out.
@@ -43,7 +47,8 @@ export async function reapStaleDeviceWorkers(): Promise<{
         WHERE c.device_worker_id = device_workers.id AND c.deleted_at IS NULL
       )
       AND NOT EXISTS (
-        SELECT 1 FROM automations w WHERE w.device_worker_id = device_workers.id
+        SELECT 1 FROM automations w
+        WHERE w.device_worker_id = device_workers.id AND w.status <> 'archived'
       )
       AND NOT EXISTS (
         SELECT 1 FROM auth_profiles ap WHERE ap.device_worker_id = device_workers.id
@@ -77,6 +82,21 @@ export async function reapStaleDeviceWorkers(): Promise<{
   //    (see the note in worker-api/device-reconcile.ts). UUIDs are canonical
   //    lowercase, so text equality matches the uuid form 1:1.
   const deleted = await sql.begin(async (tx) => {
+    // `automations.device_worker_id` is a NO ACTION FK, so a pin held by an
+    // archived Automation would reject the DELETE even though the predicate
+    // above ignores it. Release those pins first — the same order, and the same
+    // reasoning, as the explicit device-delete path in
+    // `worker-api/device-management.ts`: archival is the supported soft-delete,
+    // and an archived row is retained for history but must not keep the
+    // restrictive FK alive. Scoped to the candidates and to `archived`, so a
+    // live pin still blocks its device in the re-check below rather than being
+    // silently cleared here.
+    await tx`
+      UPDATE automations
+      SET device_worker_id = NULL, updated_at = NOW()
+      WHERE device_worker_id::text = ANY(${pgTextArray(ids)}::text[])
+        AND status = 'archived'
+    `;
     const rows = (await tx`
       DELETE FROM device_workers
       WHERE id::text = ANY(${pgTextArray(ids)}::text[])
@@ -86,7 +106,8 @@ export async function reapStaleDeviceWorkers(): Promise<{
           WHERE c.device_worker_id = device_workers.id AND c.deleted_at IS NULL
         )
         AND NOT EXISTS (
-          SELECT 1 FROM automations w WHERE w.device_worker_id = device_workers.id
+          SELECT 1 FROM automations w
+          WHERE w.device_worker_id = device_workers.id AND w.status <> 'archived'
         )
         AND NOT EXISTS (
           SELECT 1 FROM auth_profiles ap WHERE ap.device_worker_id = device_workers.id


### PR DESCRIPTION
## Summary
- An **archived** Automation can never execute again, but the stale device-worker reaper counted its device pin as a live binding. One soft-deleted row kept an abandoned machine unreapable, and the reaper silently skipped it every night.
- Ignore archived Automations in both the candidate scan and the authoritative DELETE re-check, and release their pins inside the delete transaction.
- The predicate alone is not enough: `automations.device_worker_id` is a **NO ACTION** FK, so the DELETE is rejected unless the pin is cleared first.

Found auditing a workspace that had archived 71 one-shot device-dispatch Automations, leaving 70 permanent anchors.

### Why here, and not at archive time
`worker-api/device-management.ts` — the explicit device-delete path — already established this policy, and the comment says it outright:

> Archival is the supported soft-delete for Automations. Archived rows are retained for history, but no longer execute and must not keep the restrictive FK alive after the user explicitly archives them.

It refuses on a live pin, releases archived pins, then deletes. The reaper is the *other* place that deletes a device and simply never got the same treatment. Putting the rule here rather than at archive time:

- keeps the pin as history until a device is genuinely deleted, instead of destroying it early;
- puts it in the one place that deletes devices, instead of obliging all four current archive writers — and every future one — to remember;
- reuses the existing mechanism instead of adding a second one for the same policy.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (build, per-package strict typecheck, knip, naming, gateway-LLM + entity-write funnel gates)
- [x] Tests run: targeted `bun test` (below)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: n/a

### Red (before the fix)
```
$ bun test ./packages/server/src/scheduled/__tests__/reap-stale-device-workers.test.ts
Expected: 1
Received: 0
(fail) reaps a device whose only pin is an archived Automation
```

### Green (after)
```
 3 pass
 0 fail
 15 expect() calls
```

### Mutation-tested — both halves are load-bearing
| reverted | result |
| --- | --- |
| the `status <> 'archived'` predicate | `Expected: 1, Received: 0` — device not reaped |
| the in-transaction pin release | `PostgresError: update or delete on table "device_workers" violates foreign key constraint "automations_device_worker_id_fkey"` |

The other two cases pass in every run, including both mutations: a live pin still blocks its device and is **never** cleared, including when it shares a device with archived pins. That is the difference between reaping a dead machine and silently un-pinning a runnable Automation.

## Notes
No archive writer changes, no trigger redefinition, no backfill migration — an earlier draft of this PR did all three and has been dropped. Existing archived pins are released lazily the first time the reaper considers their device, so no data migration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P5Qqv2A8QoP9KaCJxR9hK
