### PR TITLE
fix(ci): pipe paginated API payloads into jq instead of passing them as args

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -92,9 +92,13 @@ jobs:
           IMAGE_RUN_ID: ${{ steps.producer.outputs.image_run_id }}
         run: |
           set -euo pipefail
-          jobs=$(gh api --paginate --slurp "repos/${REPOSITORY}/actions/runs/${IMAGE_RUN_ID}/jobs?filter=all&per_page=100")
-          jq -n --argjson pages "$jobs" --arg required "$REQUIRED_IMAGE_JOBS" \
-            '{pages: $pages, required: ($required | split(" "))}' \
+          # Piped, never --argjson: a paginated API payload passed as a command
+          # argument dies with "jq: Argument list too long" once it outgrows
+          # ARG_MAX on the runner, and macOS tolerates a payload Linux rejects,
+          # so it cannot be caught locally.
+          gh api --paginate --slurp "repos/${REPOSITORY}/actions/runs/${IMAGE_RUN_ID}/jobs?filter=all&per_page=100" \
+            | jq --arg required "$REQUIRED_IMAGE_JOBS" \
+              '{pages: ., required: ($required | split(" "))}' \
             | node scripts/release-provenance.mjs attest-jobs >/dev/null
 
           ci_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml" --jq '.id' | tr -d '\n')
@@ -185,13 +189,18 @@ jobs:
           set -euo pipefail
           current_version=$(git show "${ATTESTED_SHA}:package.json" \
             | node -pe 'JSON.parse(require("fs").readFileSync(0, "utf8")).version')
-          releases=$(gh api --paginate --slurp "repos/${REPOSITORY}/releases?per_page=100")
           # Drafts are excluded as well as prereleases: the list endpoint returns
           # drafts to a write-scoped token, and a draft lobu-v<version> counted
           # as released would make this step skip creation AND the verify step
           # below, turning a loud "release is a draft" failure into silence.
-          decision=$(jq -n --argjson pages "$releases" --arg current "$current_version" \
-            '{current: $current, versions: [$pages[][] | select((.draft or .prerelease) | not) | .tag_name | select(startswith("lobu-v")) | ltrimstr("lobu-v")]}' \
+          #
+          # Piped straight into jq rather than through --argjson: the release
+          # list grows without bound, and at 106 releases it already exceeded
+          # ARG_MAX on the runner ("jq: Argument list too long"). This step runs
+          # on every main push, so that failure blocked all releases.
+          decision=$(gh api --paginate --slurp "repos/${REPOSITORY}/releases?per_page=100" \
+            | jq --arg current "$current_version" \
+              '{current: $current, versions: [.[][] | select((.draft or .prerelease) | not) | .tag_name | select(startswith("lobu-v")) | ltrimstr("lobu-v")]}' \
             | node scripts/release-provenance.mjs release-needed)
           if [ "$(jq -r '.needed' <<<"$decision")" != true ]; then
             echo "Manifest version ${current_version} is already released; nothing to cut."
@@ -214,9 +223,9 @@ jobs:
           VERSION: ${{ steps.bump.outputs.version }}
         run: |
           set -euo pipefail
-          releases=$(gh api --paginate --slurp "repos/${REPOSITORY}/releases?per_page=100")
-          jq -n --argjson pages "$releases" --arg current "$VERSION" \
-            '{current: $current, versions: [$pages[][] | select((.draft or .prerelease) | not) | .tag_name | select(startswith("lobu-v")) | ltrimstr("lobu-v")]}' \
+          gh api --paginate --slurp "repos/${REPOSITORY}/releases?per_page=100" \
+            | jq --arg current "$VERSION" \
+              '{current: $current, versions: [.[][] | select((.draft or .prerelease) | not) | .tag_name | select(startswith("lobu-v")) | ltrimstr("lobu-v")]}' \
             | node scripts/release-provenance.mjs assert-newer >/dev/null
 
           if gh api "repos/${REPOSITORY}/releases/tags/${TAG}" >/dev/null 2>&1; then

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -217,6 +217,19 @@ describe("the release is created bound to the attested commit", () => {
     expect(body()).toContain("main advanced after attestation");
   });
 
+  it("pipes paginated API payloads into jq instead of passing them as arguments", () => {
+    // A paginated payload handed to jq via --argjson dies with "jq: Argument
+    // list too long" once it outgrows the runner's per-argument cap (Linux
+    // MAX_ARG_STRLEN is 128KB; the release list was already 808KB at 106
+    // releases). macOS has no equivalent per-arg cap, so this cannot be caught
+    // locally -- it only ever fails in CI, and the release-decision step runs
+    // on every main push, so it blocked all releases.
+    const yml = read("release-please.yml");
+    expect(yml).not.toContain("--argjson pages");
+    const piped = yml.match(/gh api --paginate --slurp [^\n]*\\\n\s*\| jq /g);
+    expect(piped).toHaveLength(3);
+  });
+
   it("lets release-please open the PR and creates the release itself", () => {
     const action = steps("release-please.yml", id).find((step) =>
       step.uses?.includes("release-please-action")


### PR DESCRIPTION
## Summary
- **#3320 regressed the release job and this restores it.** `jq -n --argjson pages "$releases"` hands the whole paginated release list to jq as a **command-line argument**. That list is already **808,671 bytes** at 106 releases — 6.2× Linux's 128KB per-argument cap (`MAX_ARG_STRLEN`).
- release-please **#3085** died with `/usr/bin/jq: Argument list too long`. The decision step runs on **every push to main**, so this blocked *all* releases — worse than the stranding #3320 fixed.
- **macOS has no equivalent per-arg cap.** I validated the same jq against the live release list locally, it passed, and it shipped broken. That is why the regression test asserts the *shape* rather than the behaviour.
- Fixed at **all three** payload sites, not only the one that fired: the release decision, the pre-create forward-only guard, and the image-jobs attestation. The third had the identical hazard and only survived because a single run's job list is small, whereas the release list grows without bound.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `bun test scripts/__tests__/release-publish-order.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: n/a — CI-only

### Red — the real instance, from CI
release-please #3085, on `04e4f575f`:

```
/usr/bin/jq: Argument list too long
<anonymous_script>:1
SyntaxError: Unexpected end of JSON input
    at file:///home/runner/work/lobu/lobu/scripts/release-provenance.mjs:280:51
##[error]Process completed with exit code 1.
```

### Red — the class, reproduced locally
The real payload (808KB) sits under macOS's ~1MB total `ARG_MAX`, so it cannot fail here. With a 1.8MB payload the same error appears:

```
synthetic payload bytes: 1846802
OLD  jq -n --argjson pages "$big"  ->  argument list too long: jq
NEW  cat big.json | jq ...         ->  {"n": 600}
```

### Green — piped form against the real 106-release list
```
payload bytes: 808671
current 18.0.0 -> {"needed":false,"version":"18.0.0"}
current 18.1.0 -> {"needed":true,"version":"18.1.0"}
```

### Suite + mutation test
```
bun test scripts/__tests__/release-publish-order.test.ts   51 pass  0 fail
```

| mutation | caught |
|---|---|
| revert the release-decision site to `--argjson pages` | ✅ 1 fail |

## Notes
- The new guard asserts `--argjson pages` appears nowhere and that exactly three sites pipe. A behavioural test cannot catch this class, because the failure depends on the runner's per-argument cap and does not reproduce on the platform the tests run on locally.
- `scripts/release-provenance.mjs` is unchanged; `releaseNeeded` was correct. Only how the payload reaches jq changed.
- Sequencing note for reviewers: releases are blocked until this lands, so it is worth merging ahead of anything else queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdV1DpRTcwz8GiFyUwVUZY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release validation reliability for projects with large or paginated release data.
  - Reduced the risk of continuous integration failures during image attestation, version detection, and release verification.
- **Tests**
  - Added coverage to help ensure release checks continue handling large API responses correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->