### PR TITLE
fix(ci): pipe the attested jobs payload into jq in publish-packages

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -97,9 +97,13 @@ jobs:
           # jobs are completed-success, which an unfinished producer cannot
           # fake, and none of the six is the job doing the dispatching.
 
-          jobs=$(gh api --paginate --slurp "repos/${REPOSITORY}/actions/runs/${IMAGE_RUN_ID}/jobs?filter=all&per_page=100")
-          jq -n --argjson pages "$jobs" --arg required "$REQUIRED_IMAGE_JOBS" \
-            '{pages: $pages, required: ($required | split(" "))}' \
+          # Piped, never --argjson: filter=all returns the jobs of every rerun
+          # attempt, so this payload grows without bound and dies with "jq:
+          # Argument list too long" past ARG_MAX. macOS has no per-argument cap,
+          # so the failure cannot be reproduced locally.
+          gh api --paginate --slurp "repos/${REPOSITORY}/actions/runs/${IMAGE_RUN_ID}/jobs?filter=all&per_page=100" \
+            | jq --arg required "$REQUIRED_IMAGE_JOBS" \
+              '{pages: ., required: ($required | split(" "))}' \
             | node scripts/release-provenance.mjs attest-jobs >/dev/null
 
           ci_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml" --jq '.id' | tr -d '\n')

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -217,19 +217,6 @@ describe("the release is created bound to the attested commit", () => {
     expect(body()).toContain("main advanced after attestation");
   });
 
-  it("pipes paginated API payloads into jq instead of passing them as arguments", () => {
-    // A paginated payload handed to jq via --argjson dies with "jq: Argument
-    // list too long" once it outgrows the runner's per-argument cap (Linux
-    // MAX_ARG_STRLEN is 128KB; the release list was already 808KB at 106
-    // releases). macOS has no equivalent per-arg cap, so this cannot be caught
-    // locally -- it only ever fails in CI, and the release-decision step runs
-    // on every main push, so it blocked all releases.
-    const yml = read("release-please.yml");
-    expect(yml).not.toContain("--argjson pages");
-    const piped = yml.match(/gh api --paginate --slurp [^\n]*\\\n\s*\| jq /g);
-    expect(piped).toHaveLength(3);
-  });
-
   it("lets release-please open the PR and creates the release itself", () => {
     const action = steps("release-please.yml", id).find((step) =>
       step.uses?.includes("release-please-action")
@@ -690,5 +677,35 @@ describe("the attestation policy itself", () => {
         release: { ...stable.release, target_commitish: "b".repeat(40) },
       })
     ).toThrow("does not match peeled tag");
+  });
+});
+
+// A paginated payload handed to jq via --argjson dies with "jq: Argument list
+// too long" once it outgrows the runner's per-argument cap (Linux
+// MAX_ARG_STRLEN is 128KB; the release list was already 808KB at 106
+// releases). macOS has no equivalent per-arg cap, so this only ever fails in
+// CI. It is asserted across every workflow rather than the one file that broke:
+// the first fix missed publish-packages.yml, whose jobs read is 20KB today but
+// grows with each rerun attempt because filter=all returns all of them.
+describe("paginated API payloads are piped into jq, never passed as arguments", () => {
+  const paginated = names.filter((name) =>
+    read(name).includes("gh api --paginate")
+  );
+
+  it("still guards the two workflows known to read paginated APIs", () => {
+    expect(paginated).toEqual(
+      expect.arrayContaining(["publish-packages.yml", "release-please.yml"])
+    );
+  });
+
+  it.each(
+    paginated
+  )("%s pipes every slurped payload straight into jq", (name) => {
+    const yml = read(name);
+    expect(yml).not.toContain("--argjson pages");
+    const slurped = yml.match(/gh api --paginate --slurp /g) ?? [];
+    const piped =
+      yml.match(/gh api --paginate --slurp [^\n]*\\\n\s*\| jq /g) ?? [];
+    expect(piped).toHaveLength(slurped.length);
   });
 });


### PR DESCRIPTION
## What

`#3323` fixed the `jq: Argument list too long` regression in `release-please.yml` but left the identical pattern at `.github/workflows/publish-packages.yml:101`. Its guard test only read `release-please.yml`, so it stayed green (51 pass) with the bug on `main` — the review on #3323 flagged this as a class leftover.

This pipes the last `--paginate --slurp` payload into `jq` and makes the guard class-wide.

## Why it matters

Measured against the real 18.0.0 release build (run `33753295340`):

| | value |
|---|---|
| jobs payload | 20,240 bytes (9 jobs, ~2.2KB each) |
| Linux `MAX_ARG_STRLEN` | 131,072 bytes |
| breaks at | ~58 jobs ≈ **6.5 rerun attempts** |

Not broken today, but `filter=all` returns the jobs of *every rerun attempt*, so the payload grows without bound. The failure mode is the one this workflow exists to prevent: a release whose images already built fails to reach npm. arm64 release builds take 30+ min and have been flaky, so 6.5 reruns is reachable.

## Verification

- Piped and `--argjson` forms both return `{"ok":true,"required":6}` on the real 18.0.0 jobs payload — `attest-jobs` takes `{pages, required}` either way, and `$pages[][]` → `.[][]` is semantically identical.
- Old guard, unchanged, run against `main`'s state: **51 pass** — confirming it was blind to this file.
- Mutation 1 (restore `--argjson pages`): new guard fails. ✅
- Mutation 2 (keep the pipe but slurp into a variable): new guard fails. ✅
- `bun test scripts/__tests__/release-publish-order.test.ts` → 53 pass, 707 expect().
- `make pre-pr` clean.

The workflow itself cannot be executed locally; the equivalence check above against the live API payload is the closest available proof.

## Guard change

Instead of naming one file and counting a hardcoded 3 pipes, it now enumerates every workflow containing `gh api --paginate` and asserts each slurped payload is piped — so the next paginated read is covered on arrival rather than after it breaks a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdV1DpRTcwz8GiFyUwVUZY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of paginated image-job data during release workflows, preventing failures caused by oversized command arguments.
  - Preserved equivalent attestation payload generation while streaming data directly between workflow tools.

- **Tests**
  - Added repository-wide validation to ensure paginated API results are piped safely into JSON processing.
  - Removed a release-specific check in favor of broader workflow coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->