### PR TITLE
test(gateway): poll for terminal run status instead of racing the write

### DIFF
--- a/packages/server/src/gateway/__tests__/runs-queue-integration.test.ts
+++ b/packages/server/src/gateway/__tests__/runs-queue-integration.test.ts
@@ -326,10 +326,28 @@ describe("RunsQueue — worker re-registration", () => {
 
     // Both rows reached a terminal state rather than being stranded as
     // `claimed` by a worker that got swapped out from under them.
-    const leftover = await sql<{ count: string }>`
-      SELECT count(*)::text AS count FROM runs
-      WHERE queue_name = 'test-reconnect' AND status <> 'completed'
-    `;
+    //
+    // Polled rather than read once: `order` is pushed from inside the handler,
+    // and runs-queue.ts awaits `markCompleted` only *after* `worker.handler`
+    // resolves, so seeing turn 2 in `order` guarantees nothing about its row.
+    // Reading immediately raced that second round-trip and failed CI with
+    // `Expected "0" Received "1"`. The deadline still fails a genuine strand --
+    // it removes the race, not the assertion.
+    let leftover: { count: string; statuses: string | null }[] = [];
+    const settleBy = Date.now() + 10_000;
+    while (Date.now() < settleBy) {
+      leftover = await sql<{ count: string; statuses: string | null }>`
+        SELECT count(*)::text AS count,
+               string_agg(DISTINCT status, ',') AS statuses
+        FROM runs
+        WHERE queue_name = 'test-reconnect' AND status <> 'completed'
+      `;
+      if (leftover[0]?.count === "0") break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    // Asserted on the statuses first so a strand reports what it was stuck as
+    // ("claimed") instead of an opaque count mismatch.
+    expect(leftover[0]?.statuses ?? "none").toBe("none");
     expect(leftover[0]?.count).toBe("0");
   });
 });


### PR DESCRIPTION
## What

`runs-queue-integration.test.ts` failed CI on #3320 with `Expected "0" Received "1"` and went green on rerun. It's a real race **in the test**, not flake in the queue.

## Why

`runs-queue.ts:682`:

```ts
await worker.handler(job);
await this.markCompleted(claimed.runId);
```

The test's handler pushes to `order` and returns, so the existing poll unblocks on `order.length === 2` while `markCompleted` is still a separate awaited round-trip away. Reading `runs` at that instant can legitimately observe the row as `claimed`.

The `order` wait was already polled to a 10s deadline; the leftover-rows check right after it was a single immediate read. This gives it the same deadline.

## The assertion is not weakened

Mutation-tested by forcing the rows to miss the terminal predicate (simulating a strand):

```
350 | expect(leftover[0]?.statuses ?? "none").toBe("none");
Expected: "none"
Received: "completed"
(fail) a reconnect mid-job still runs jobs one at a time and loses none [10396.99ms]
```

It fails after the **full** deadline, and now names the status the row was stuck as instead of reporting an opaque count mismatch — strictly better diagnostics than `Expected "0" Received "1"`.

## Verification

- `bun test --timeout 30000 packages/server/src/gateway/__tests__/runs-queue-integration.test.ts` → **10 pass, 0 fail**
- Mutation → fails as above; restored → 10 pass again
- `make pre-pr` clean

(The `--timeout 30000` flag is required — this suite is bun:test and excluded from the vitest config; bun's 5s default trips the DB-setup hook.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdV1DpRTcwz8GiFyUwVUZY