### PR TITLE
fix(server): release a device pin only if the reaper deletes that device

### DIFF
--- a/packages/server/src/scheduled/__tests__/reap-stale-device-workers.test.ts
+++ b/packages/server/src/scheduled/__tests__/reap-stale-device-workers.test.ts
@@ -144,4 +144,89 @@ describe('stale device-worker reaper vs archived automation pins', () => {
     expect(await pinOf(liveId)).toBe(deviceId);
     expect(await pinOf(archivedId)).toBe(deviceId);
   });
+
+  /**
+   * A pin is cleared IF AND ONLY IF its device is actually deleted. The
+   * likeliest way for the two to disagree is `last_seen_at` moving between the
+   * candidate scan and the delete: the dark laptop coming back.
+   *
+   * A real concurrent poll cannot be scheduled deterministically from one
+   * connection, so a trigger stands in for it: it fires the moment the reaper
+   * releases a pin and refreshes that device's `last_seen_at`, landing the
+   * "device came back" change inside the reaper's own transaction — the worst
+   * case for statement ordering. The assertion is the invariant, not the
+   * simulation: whatever the reaper decides, released pins and deleted devices
+   * must match.
+   */
+  test('releases a pin only if the device is actually deleted', async () => {
+    const sql = getDb();
+    const deviceId = await seedStaleDevice('worker-revived-midflight');
+    const automationId = await seedAutomationPinnedTo(deviceId, 'revived-envelope');
+    await archive(automationId);
+
+    await sql`
+      CREATE OR REPLACE FUNCTION test_revive_device_on_unpin() RETURNS trigger
+      LANGUAGE plpgsql AS $revive$
+      BEGIN
+        UPDATE device_workers SET last_seen_at = now() WHERE id = OLD.device_worker_id;
+        RETURN NEW;
+      END
+      $revive$
+    `;
+    await sql`
+      CREATE TRIGGER test_revive_device_on_unpin
+      AFTER UPDATE OF device_worker_id ON automations
+      FOR EACH ROW
+      WHEN (OLD.device_worker_id IS NOT NULL AND NEW.device_worker_id IS NULL)
+      EXECUTE FUNCTION test_revive_device_on_unpin()
+    `;
+
+    try {
+      await reapStaleDeviceWorkers();
+    } finally {
+      await sql`DROP TRIGGER IF EXISTS test_revive_device_on_unpin ON automations`;
+      await sql`DROP FUNCTION IF EXISTS test_revive_device_on_unpin()`;
+    }
+
+    const stillThere = await deviceExists(deviceId);
+    const pinReleased = (await pinOf(automationId)) === null;
+
+    // Either both happened or neither did. The failure this guards is
+    // pinReleased === true while stillThere === true: history destroyed for a
+    // device the reaper decided to keep.
+    expect(pinReleased).toBe(!stillThere);
+    // ...and the pairing must not be satisfied by a reaper that does nothing:
+    // this candidate had no live binding, so it is expected to go.
+    expect(stillThere).toBe(false);
+  });
+
+  test('spares a non-candidate device and leaves its archived pin intact', async () => {
+    const sql = getDb();
+    // Reaped: stale, only an archived pin.
+    const doomedId = await seedStaleDevice('worker-pair-doomed');
+    const doomedAutomation = await seedAutomationPinnedTo(doomedId, 'pair-doomed');
+    await archive(doomedAutomation);
+
+    // Spared: identically stale with an archived pin, but a live connection
+    // keeps it bound, so it never becomes a candidate.
+    const sparedId = await seedStaleDevice('worker-pair-spared');
+    const sparedAutomation = await seedAutomationPinnedTo(sparedId, 'pair-spared');
+    await archive(sparedAutomation);
+    await sql`
+      INSERT INTO connections
+        (organization_id, connector_key, slug, created_by, device_worker_id, status)
+      VALUES
+        (${ORG_ID}, 'os.shell', 'pair-spared-shell', ${USER_ID}, ${sparedId}, 'active')
+    `;
+
+    const result = await reapStaleDeviceWorkers();
+
+    expect(result.reaped).toBe(1);
+    expect(await deviceExists(doomedId)).toBe(false);
+    expect(await pinOf(doomedAutomation)).toBeNull();
+
+    // The spared device keeps both its row and its Automation's record of it.
+    expect(await deviceExists(sparedId)).toBe(true);
+    expect(await pinOf(sparedAutomation)).toBe(sparedId);
+  });
 });

--- a/packages/server/src/scheduled/reap-stale-device-workers.ts
+++ b/packages/server/src/scheduled/reap-stale-device-workers.ts
@@ -17,10 +17,10 @@
  * An ARCHIVED automation is not a binding: it can never execute again, so
  * counting it would let one soft-deleted row anchor a dead machine forever.
  * Its pin is released in the delete transaction, matching what the explicit
- * device-delete path already does (`worker-api/device-management.ts`). The no-binding predicate is re-checked
- * inside the DELETE so a binding created between the candidate scan and the
- * delete keeps the row alive. Child PATs bound to the reaped worker_ids are
- * revoked on the way out.
+ * device-delete path already does (`worker-api/device-management.ts`). The
+ * no-binding predicate is re-checked under a row lock inside that transaction,
+ * so a binding created between the candidate scan and the delete keeps the row
+ * alive. Child PATs bound to the reaped worker_ids are revoked on the way out.
  *
  * Single-claimant per tick via the runs-queue (like the other scheduled jobs);
  * pure Postgres, so it's correct under N>1 app replicas.
@@ -36,9 +36,10 @@ export async function reapStaleDeviceWorkers(): Promise<{
   const sql = getDb();
 
   // 1. Candidate scan: stale + no bindings. Read-only; the authoritative
-  //    no-binding check is repeated inside the DELETE below. 30 days is well
-  //    beyond the 7-day freshness window reconcileDeviceCapabilities uses, so a
-  //    temporarily offline device (laptop closed, vacation) is never reaped.
+  //    no-binding check is repeated under lock in the transaction below. 30
+  //    days is well beyond the 7-day freshness window
+  //    reconcileDeviceCapabilities uses, so a temporarily offline device
+  //    (laptop closed, vacation) is never reaped.
   const candidates = (await sql`
     SELECT id, worker_id FROM device_workers
     WHERE last_seen_at < now() - interval '30 days'
@@ -63,13 +64,14 @@ export async function reapStaleDeviceWorkers(): Promise<{
   const ids = candidates.map((c) => c.id);
 
   // 2-3. Authoritative delete + PAT revocation in ONE transaction. Re-check
-  //    every no-binding predicate inside the DELETE so a binding created since
-  //    the scan keeps its row; RETURNING the worker_ids actually deleted scopes
-  //    PAT revocation to exactly the rows we removed. Doing both inside a single
-  //    transaction avoids the inter-statement window where a concurrent poll
-  //    could re-create a just-deleted row (poll upserts device_workers) and then
-  //    have its token revoked afterward — here the row is gone and the PAT is
-  //    revoked at the same commit, so there's no post-delete/pre-revoke gap.
+  //    every no-binding predicate inside the transaction so a binding created
+  //    since the scan keeps its row; RETURNING the worker_ids actually deleted
+  //    scopes PAT revocation to exactly the rows we removed. Doing both inside
+  //    a single transaction avoids the inter-statement window where a
+  //    concurrent poll could re-create a just-deleted row (poll upserts
+  //    device_workers) and then have its token revoked afterward — here the
+  //    row is gone and the PAT is revoked at the same commit, so there's no
+  //    post-delete/pre-revoke gap.
   //
   //    A dangling PAT on a reaped worker_id CAN still poll if a device holding
   //    it comes back online — poll re-creates the device_workers row — so
@@ -82,23 +84,14 @@ export async function reapStaleDeviceWorkers(): Promise<{
   //    (see the note in worker-api/device-reconcile.ts). UUIDs are canonical
   //    lowercase, so text equality matches the uuid form 1:1.
   const deleted = await sql.begin(async (tx) => {
-    // `automations.device_worker_id` is a NO ACTION FK, so a pin held by an
-    // archived Automation would reject the DELETE even though the predicate
-    // above ignores it. Release those pins first — the same order, and the same
-    // reasoning, as the explicit device-delete path in
-    // `worker-api/device-management.ts`: archival is the supported soft-delete,
-    // and an archived row is retained for history but must not keep the
-    // restrictive FK alive. Scoped to the candidates and to `archived`, so a
-    // live pin still blocks its device in the re-check below rather than being
-    // silently cleared here.
-    await tx`
-      UPDATE automations
-      SET device_worker_id = NULL, updated_at = NOW()
-      WHERE device_worker_id::text = ANY(${pgTextArray(ids)}::text[])
-        AND status = 'archived'
-    `;
-    const rows = (await tx`
-      DELETE FROM device_workers
+    // Pick the doomed set FIRST, re-checking every predicate and taking a row
+    // lock, so the decision to delete is made once and nothing downstream can
+    // disagree with it. `FOR UPDATE` makes a concurrent poll (which upserts
+    // device_workers) block until this commits rather than refreshing
+    // last_seen_at underneath us; under READ COMMITTED the lock wait re-checks
+    // the predicate, so a device that genuinely came back is dropped here.
+    const doomed = (await tx`
+      SELECT id FROM device_workers
       WHERE id::text = ANY(${pgTextArray(ids)}::text[])
         AND last_seen_at < now() - interval '30 days'
         AND NOT EXISTS (
@@ -112,6 +105,39 @@ export async function reapStaleDeviceWorkers(): Promise<{
         AND NOT EXISTS (
           SELECT 1 FROM auth_profiles ap WHERE ap.device_worker_id = device_workers.id
         )
+      FOR UPDATE
+    `) as unknown as Array<{ id: string }>;
+
+    if (doomed.length === 0) return [];
+    const doomedIds = doomed.map((d) => d.id);
+
+    // `automations.device_worker_id` is a NO ACTION FK, so a pin held by an
+    // archived Automation would reject the DELETE even though the predicate
+    // above ignores it. Release those pins — the same order, and the same
+    // reasoning, as the explicit device-delete path in
+    // `worker-api/device-management.ts`: archival is the supported soft-delete,
+    // and an archived row is retained for history but must not keep the
+    // restrictive FK alive.
+    //
+    // Scoped to `doomed`, NOT to every candidate: a pin must be released if and
+    // only if its device is actually deleted. Releasing across all candidates
+    // and letting a second predicate re-check refuse some of them strips history
+    // from rows whose device then survives — the reaper's own 30-day window
+    // exists to spare a laptop that was merely closed, and that laptop must keep
+    // its Automations' pins.
+    await tx`
+      UPDATE automations
+      SET device_worker_id = NULL, updated_at = NOW()
+      WHERE device_worker_id::text = ANY(${pgTextArray(doomedIds)}::text[])
+        AND status = 'archived'
+    `;
+
+    // Addressed by id: `doomed` is the authoritative set, already predicate-
+    // checked and locked above, so re-stating the predicates here would only
+    // invite the two lists to drift apart.
+    const rows = (await tx`
+      DELETE FROM device_workers
+      WHERE id::text = ANY(${pgTextArray(doomedIds)}::text[])
       RETURNING worker_id
     `) as unknown as Array<{ worker_id: string }>;
 


### PR DESCRIPTION
## Summary
Follow-up to #3322, which introduced this while fixing a different bug.

- #3322 released archived Automations' device pins for **every candidate**, then re-checked four predicates in the `DELETE` and could refuse some of them — leaving a device alive whose Automations had already lost the record of where they ran, and committing anyway.
- The likeliest refusal is `last_seen_at`: a device dark 30+ days polls between the candidate scan and the transaction, so the `DELETE` correctly spares it. That is precisely the case the 30-day window exists to protect — the file's own comment says *"a temporarily offline device (laptop closed, vacation) is never reaped"* — and it is the case that silently lost its history.
- Select the doomed set first, re-checking every predicate under `FOR UPDATE`, then scope **both** the pin release and the `DELETE` to that set.

A pin is now released **if and only if** its device is deleted. The predicate list is also stated once instead of twice, so the scan and the delete can no longer drift apart.

Severity is low — it loses `device_worker_id` on already-archived rows, no live path reads it, and prod has never had a reapable device, so this has never fired.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `bun test ./packages/server/src/scheduled/__tests__/reap-stale-device-workers.test.ts`
- [x] Bug fix: red→green below
- [ ] If bot runtime changed: n/a

### Red (against merged `origin/main`)
```
Expected: false
Received: true
(fail) releases a pin only if the device is actually deleted
 4 pass
 1 fail
```
`pinReleased` was `true` while the device was still present.

### Green
```
 5 pass
 0 fail
 25 expect() calls
```

### How the race is staged
A real concurrent poll can't be scheduled deterministically from one connection, so a trigger stands in: it fires the moment the reaper releases a pin and refreshes that device's `last_seen_at`, landing the "device came back" change inside the reaper's own transaction — the worst case for statement ordering. **The assertion is the invariant, not the simulation:** whatever the reaper decides, released pins and deleted devices must match. A second test pairs a reaped device against a spared one (held by a live connection) and asserts the spared device keeps both its row and its Automation's pin.

## Notes — coverage limit, stated plainly
Scoping the release to `doomed` rather than to all candidates **survives every test in this suite**. `ids` can only exceed `doomed` under genuine cross-connection concurrency, which a single-connection suite cannot stage. That scoping is correct and defensive, not test-proven, and I'd rather say so than imply the suite covers it.

The `FOR UPDATE` comment asserts that a READ COMMITTED lock wait re-evaluates the `last_seen_at` qual against the updated row. That is documented EvalPlanQual behaviour, but only the single-connection simulation was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P5Qqv2A8QoP9KaCJxR9hK
