### PR TITLE
fix(ci): attest release commits reachable from main, not only the tip

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,8 +37,8 @@ jobs:
       sha: ${{ steps.producer.outputs.sha }}
     steps:
       # Deliberately before any checkout: no repository code runs until the
-      # producing run is known to be a completed-success push to the current
-      # main tip.
+      # producing run is known to be a completed-success push to a commit
+      # that is still reachable from main.
       - name: Attest the producing Build Images run
         id: producer
         env:
@@ -70,14 +70,20 @@ jobs:
           [ "$event" = push ] && [ "$branch" = main ] || { echo "::error::Build Images run must be a main push"; exit 1; }
           [ "$status" = completed ] && [ "$conclusion" = success ] || { echo "::error::Build Images run is not completed-success"; exit 1; }
 
+          # Reachability, not tip-ness. A release commit's own image build
+          # routinely finishes after later commits have landed; demanding the
+          # tip threw that run away and left the version unreleased with every
+          # run green. A commit still reachable from main got there through
+          # branch protection, which is the property the checkout below needs.
           current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
-          [ "$current_sha" = "$sha" ] || { echo "::error::main moved while attesting Build Images"; exit 1; }
+          compare_status=$(gh api "repos/${REPOSITORY}/compare/${sha}...${current_sha}" --jq '.status')
+          [ "$compare_status" = ahead ] || [ "$compare_status" = identical ] || { echo "::error::attested SHA ${sha} is not reachable from main (${compare_status})"; exit 1; }
 
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "image_run_id=$image_run_id" >> "$GITHUB_OUTPUT"
 
-      # Pinned to the SHA the step above proved is the current main tip, so the
-      # policy helper cannot come from a ref that moved mid-run.
+      # Pinned to the SHA the step above proved is reachable from main, so the
+      # policy helper cannot come from a ref that never merged.
       - name: Check out the attested commit
         uses: actions/checkout@v7
         with:
@@ -104,8 +110,11 @@ jobs:
           ci_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml" --jq '.id' | tr -d '\n')
           ci_run_id=""
           for _ in $(seq 1 20); do
+            # Re-checked every iteration so the bounded wait still bails out
+            # early: a commit force-pushed off main stops being reachable.
             current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
-            [ "$current_sha" = "$ATTESTED_SHA" ] || { echo "::error::main moved while waiting for exact CI"; exit 1; }
+            compare_status=$(gh api "repos/${REPOSITORY}/compare/${ATTESTED_SHA}...${current_sha}" --jq '.status')
+            [ "$compare_status" = ahead ] || [ "$compare_status" = identical ] || { echo "::error::attested SHA left main while waiting for exact CI (${compare_status})"; exit 1; }
             ci_runs=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${ATTESTED_SHA}&event=push&branch=main&status=completed&per_page=100")
             selection=$(jq -n --argjson body "$ci_runs" --argjson workflow_id "$ci_workflow_id" --arg repo "$REPOSITORY" --arg sha "$ATTESTED_SHA" \
               '{runs: [$body.workflow_runs[] | . + {repo: .repository.full_name}],
@@ -145,15 +154,19 @@ jobs:
           ref: ${{ needs.attest.outputs.sha }}
           fetch-depth: 2
 
-      - name: Recheck current main immediately before release action
+      - name: Recheck the attested commit is still on main before releasing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ATTESTED_SHA: ${{ needs.attest.outputs.sha }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # main advancing after attestation is normal and harmless: the
+          # release below is bound to ATTESTED_SHA, not to whatever the action
+          # considers HEAD. Only an attested commit that left main is a fault.
           current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
-          [ "$current_sha" = "$ATTESTED_SHA" ] || { echo "::error::main advanced after attestation"; exit 1; }
+          compare_status=$(gh api "repos/${REPOSITORY}/compare/${ATTESTED_SHA}...${current_sha}" --jq '.status')
+          [ "$compare_status" = ahead ] || [ "$compare_status" = identical ] || { echo "::error::attested SHA is no longer reachable from main (${compare_status})"; exit 1; }
 
       - name: Run Release Please against main
         uses: googleapis/release-please-action@v5

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -199,8 +199,39 @@ describe("release-please only acts on a green main push", () => {
     for (const name of REQUIRED_IMAGE_JOBS) {
       expect(read("release-please.yml")).toContain(name);
     }
-    // The bounded wait must re-check that main has not moved under it.
-    expect(body).toContain("main moved while waiting for exact CI");
+    // The bounded wait must re-check, every iteration, that the commit it is
+    // waiting on is still on main.
+    expect(body).toContain("attested SHA left main while waiting for exact CI");
+  });
+
+  // A release commit's own image build routinely finishes after later commits
+  // have landed. Requiring the attested SHA to *be* the main tip threw that
+  // run away, so the release never got cut -- silently, with every run green.
+  // Merged is merged: the predicate is reachability from main, spelled the
+  // same way publish-packages.yml already spells it.
+  it("attests any commit reachable from main, not only the current tip", () => {
+    const bodies = {
+      attest: shell("release-please.yml", "attest"),
+      write: shell("release-please.yml", "release-please-write"),
+    };
+    for (const [id, body] of Object.entries(bodies)) {
+      // `compare/<commit>...<main>` is `identical` at the tip and `ahead`
+      // once main has moved on; anything else means the commit left main.
+      expect(body, id).toContain("...${current_sha}");
+      expect(body, id).toContain('[ "$compare_status" = ahead ]');
+      expect(body, id).toContain('[ "$compare_status" = identical ]');
+      // The equality tests that stranded 18.0.0 must not come back. Guard the
+      // shape rather than one error string, so a reworded copy still fails.
+      expect(body, id).not.toMatch(/"\$current_sha" = "\$(sha|ATTESTED_SHA)"/);
+    }
+    // Class guard: both stranding bugs read main's tip into `current_sha` and
+    // put it on the left of an equality. Nothing may do that again. The one
+    // legitimate tip comparison left is the workflow_dispatch ref guard, whose
+    // subject is GITHUB_SHA -- the ref being dispatched, not a commit being
+    // attested -- and which reads `[ "$GITHUB_SHA" = "$current_sha" ]`.
+    for (const [id, body] of Object.entries(bodies)) {
+      expect(body, id).not.toMatch(/"\$current_sha" = /);
+    }
   });
 });
 
@@ -214,7 +245,9 @@ describe("the release is created bound to the attested commit", () => {
       "pull-requests": "write",
     });
     expect(read("release-please.yml")).not.toContain("concurrency:");
-    expect(body()).toContain("main advanced after attestation");
+    // main advancing after attestation is expected, not a fault: the release
+    // is bound to ATTESTED_SHA. Only losing reachability is a fault.
+    expect(body()).toContain("attested SHA is no longer reachable from main");
   });
 
   it("lets release-please open the PR and creates the release itself", () => {


### PR DESCRIPTION
## Summary
- release-please's `attest` job read main's tip and required the attested SHA to **equal** it. A release commit's own image build routinely finishes after later commits land, so the run holding the right SHA threw it away — and every downstream step is release-event triggered, so the version was skipped **with every run reporting success**. 18.0.0 sat unreleased for ~8 hours this way, green throughout.
- #3320 fixed the *bump gate* half (it now asks whether the manifest version has a release yet, instead of diffing against the parent commit). That step is never reached, because `attest` hard-fails first. With both halves in place a stranded version is picked up by the next successful main image build — **no scheduled reconciler needed**.
- Reachability is the correct predicate: a commit still reachable from main got there through branch protection, which is the property the pinned checkout of the policy helper actually needs. Spelled the way `publish-packages.yml:74` already spells it (`compare`, `ahead|identical`).

Three sites, one class — the producer step (`:74`), the bounded CI wait (`:104`), and the pre-release recheck (`:171`). The bounded wait keeps its early bail-out: a force-pushed commit stops being reachable. The `workflow_dispatch` ref guard keeps its equality test — its subject is `GITHUB_SHA`, the ref being dispatched, not a commit being attested.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `bun test scripts/__tests__/release-publish-order.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below

**Red** — regression test against the workflow as it stands on main:
```
(fail) release-please only acts on a green main push > delegates job and run selection to the tested helper
(fail) release-please only acts on a green main push > attests any commit reachable from main, not only the current tip
(fail) the release is created bound to the attested commit > holds the write permissions without a global evicting queue
 51 pass
 3 fail
```

**Green** — with the fix:
```
 54 pass
 0 fail
 717 expect() calls
Ran 54 tests across 1 file. [263.00ms]
```

The predicate itself is verified against the live repo rather than assumed:

| commit | `compare/<sha>...main` | |
|---|---|---|
| current main tip | `identical` | accepted |
| `da6397db8` — the stranded 18.0.0 release commit | `ahead` | **accepted; this is the fix** |
| unmerged PR heads (#3331, #3330, #3326) | `diverged` | rejected |

## Notes
The class guard in the test forbids reading main's tip into `current_sha` and putting it on the left of an equality — the shape both stranding bugs shared — rather than pinning an error string, so a reworded copy still fails.

`make review-fix` could not run: codex's backend returned 404 on both websocket and HTTPS transport (`wss://chatgpt.com/backend-api/codex/responses`). No edits were made by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mCQyxJYCpSBRgjcEhcCwh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release validation to accept builds whose attested commit is still reachable from the main branch, including when newer commits have been added.
  - Updated release checks to consistently detect when an attested build is no longer part of the main branch history.

- **Tests**
  - Expanded automated coverage to verify reachability-based validation across release and attestation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->