### PR TITLE
fix(feeds): name the feed that has no way to be dispatched

### DIFF
--- a/packages/server/src/__tests__/integration/device-reconcile-feed-rearm.test.ts
+++ b/packages/server/src/__tests__/integration/device-reconcile-feed-rearm.test.ts
@@ -1,0 +1,204 @@
+/**
+ * reconcileDeviceCapabilities — the slow wire path must not invent a trigger
+ * for a feed that has no cron.
+ *
+ * `CheckDueFeeds` selects on `next_run_at <= now`, and after #2021 a feed with
+ * no `schedule` is manual: `run-lifecycle` deliberately leaves `next_run_at`
+ * NULL when such a run completes. Auto-wire's re-arm then stamped NOW() over
+ * that NULL every time the wire path ran — which the `ready` fast path skips
+ * until the manifest hash changes, so the feed resynced once per extension
+ * version and looked healthy in between (every run `completed`, so no failure
+ * signal, no backoff, no auto-pause).
+ *
+ * Measured on prod 2026-09-03: chrome `tab_events` and `watch_observations`
+ * had 9 sync runs since 2026-08-04 while their cron'd siblings (`visits`,
+ * `bookmarks`, `downloads`) had 5,449 / 5,530 / 5,445.
+ *
+ * A feed that DOES carry a cron keeps the re-arm: there NULL means auto-paused
+ * or cleared, and resuming its cadence is the documented self-heal.
+ */
+
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { reconcileDeviceCapabilities } from '../../worker-api/device-reconcile';
+import {
+  deviceManifestHash,
+  type DeviceConnectorManifest,
+} from '../../worker-api/device-manifests';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { createTestOrganization, createTestUser } from '../setup/test-fixtures';
+
+const sql = getTestDb();
+
+const CONNECTOR = 'test.device_feed_rearm';
+const CAPABILITY = 'test_device_feed_rearm';
+const FEED_KEY = 'items';
+
+const FEEDS_SCHEMA = {
+  [FEED_KEY]: { key: FEED_KEY, name: 'Items', operations: ['sync'] },
+};
+
+function manifestFor(version: string) {
+  return {
+    key: CONNECTOR,
+    version,
+    name: 'Test Device Feed Rearm',
+    required_capability: CAPABILITY,
+    runtime: { platforms: ['macos'] },
+    auth_schema: {},
+    actions_schema: {},
+    options_schema: {},
+    feeds_schema: FEEDS_SCHEMA,
+  };
+}
+
+async function seedDefinition(orgId: string, version: string) {
+  await sql`
+    INSERT INTO connector_definitions (
+      organization_id, key, name, version, status, required_capability,
+      runtime, feeds_schema, auth_schema, actions_schema, options_schema
+    ) VALUES (
+      ${orgId}, ${CONNECTOR}, 'Test Device Feed Rearm', ${version}, 'active', ${CAPABILITY},
+      ${sql.json({ platforms: ['macos'] })}, ${sql.json(FEEDS_SCHEMA)}, ${sql.json({})},
+      ${sql.json({})}, ${sql.json({})}
+    )
+    ON CONFLICT DO NOTHING
+  `;
+  await sql`
+    INSERT INTO connector_versions (organization_id, connector_key, version)
+    VALUES (${orgId}, ${CONNECTOR}, ${version})
+    ON CONFLICT DO NOTHING
+  `;
+}
+
+/** Publish `version` as the device's advertised manifest, as an app upgrade would. */
+async function advertise(workerDbId: string, version: string) {
+  const manifest = manifestFor(version);
+  const manifests = {
+    [CONNECTOR]: {
+      manifest,
+      manifest_hash: deviceManifestHash(manifest as unknown as DeviceConnectorManifest),
+      received_at: new Date().toISOString(),
+    },
+  };
+  await sql`
+    UPDATE device_workers
+    SET connector_manifests = ${sql.json(manifests)}, last_seen_at = NOW()
+    WHERE id = ${workerDbId}::uuid
+  `;
+}
+
+async function seedWorker(userId: string, orgId: string, version: string): Promise<string> {
+  const manifest = manifestFor(version);
+  const manifests = {
+    [CONNECTOR]: {
+      manifest,
+      manifest_hash: deviceManifestHash(manifest as unknown as DeviceConnectorManifest),
+      received_at: new Date().toISOString(),
+    },
+  };
+  const [row] = (await sql`
+    INSERT INTO device_workers (
+      user_id, worker_id, platform, capabilities, label, organization_id,
+      last_seen_at, connector_manifests
+    ) VALUES (
+      ${userId}, ${`mac-${Math.random().toString(36).slice(2, 10)}`}, 'macos',
+      ${sql.json([CAPABILITY])}, 'Mac mini', ${orgId}, NOW(), ${sql.json(manifests)}
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: string }>;
+  return String(row.id);
+}
+
+async function feedRow(orgId: string): Promise<{
+  id: number;
+  schedule: string | null;
+  next_run_at: Date | null;
+}> {
+  const [row] = (await sql`
+    SELECT f.id, f.schedule, f.next_run_at
+    FROM feeds f
+    JOIN connections c ON c.id = f.connection_id
+    WHERE c.connector_key = ${CONNECTOR}
+      AND c.organization_id = ${orgId}
+      AND f.feed_key = ${FEED_KEY}
+      AND f.deleted_at IS NULL
+  `) as unknown as Array<{ id: number; schedule: string | null; next_run_at: Date | null }>;
+  return row;
+}
+
+/** The state `run-lifecycle` leaves after a manual feed's run completes. */
+async function completeRunLeaving(feedId: number, schedule: string | null) {
+  await sql`
+    UPDATE feeds
+    SET schedule = ${schedule}, next_run_at = NULL, last_sync_at = NOW(),
+        last_sync_status = 'success'
+    WHERE id = ${feedId}
+  `;
+}
+
+async function setUpOrg(): Promise<{ orgId: string; userId: string }> {
+  const user = await createTestUser();
+  const org = await createTestOrganization();
+  await sql`
+    UPDATE "organization"
+    SET metadata = ${JSON.stringify({ personal_org_for_user_id: user.id })}
+    WHERE id = ${org.id}
+  `;
+  return { orgId: org.id, userId: user.id };
+}
+
+describe('device reconcile feed re-arm', () => {
+  let orgId: string;
+  let userId: string;
+  let workerDbId: string;
+
+  beforeEach(async () => {
+    ({ orgId, userId } = await setUpOrg());
+    await seedDefinition(orgId, '1.0.0');
+    workerDbId = await seedWorker(userId, orgId, '1.0.0');
+  });
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('arms a syncable feed once when it first wires the connector', async () => {
+    await reconcileDeviceCapabilities(userId);
+    const feed = await feedRow(orgId);
+    expect(feed).toBeDefined();
+    // The one-shot backfill: without it a newly connected device shows nothing.
+    expect(feed.next_run_at).not.toBeNull();
+  });
+
+  it('does not re-arm a cron-less feed when the manifest changes', async () => {
+    await reconcileDeviceCapabilities(userId);
+    const created = await feedRow(orgId);
+    await completeRunLeaving(created.id, null);
+
+    // An extension upgrade: new version -> `definitionMatchesSource` fails ->
+    // the wire path runs again instead of the pin-only fast path.
+    await seedDefinition(orgId, '2.0.0');
+    await advertise(workerDbId, '2.0.0');
+    await reconcileDeviceCapabilities(userId);
+
+    const after = await feedRow(orgId);
+    expect(after.schedule).toBeNull();
+    // The regression: this used to be stamped NOW(), giving the feed exactly
+    // one more sync and hiding a permanently dormant row behind a success.
+    expect(after.next_run_at).toBeNull();
+  });
+
+  it('still re-arms a feed that carries a cron', async () => {
+    await reconcileDeviceCapabilities(userId);
+    const created = await feedRow(orgId);
+    await completeRunLeaving(created.id, '*/5 * * * *');
+
+    await seedDefinition(orgId, '2.0.0');
+    await advertise(workerDbId, '2.0.0');
+    await reconcileDeviceCapabilities(userId);
+
+    const after = await feedRow(orgId);
+    expect(after.schedule).toBe('*/5 * * * *');
+    expect(after.next_run_at).not.toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -278,8 +278,9 @@ describe("list_feeds health filter and true total", () => {
 	});
 
 	it("only a dispatchable webhook route counts as a dispatch path", async () => {
-		// buildWebhookRoutes (app-webhooks.ts) routes a delivery only when
-		// `webhook.events` is an array holding at least one non-empty string.
+		// loadGithubWebhookRoutes (gateway/routes/public/app-webhooks.ts) routes
+		// a delivery only when `webhook.events` is an array holding at least one
+		// non-empty string.
 		// Anything looser declares nothing the router will ever dispatch, so it
 		// must NOT suppress `no_trigger` — otherwise a malformed declaration
 		// hides the feed this classification exists to surface. Note `null`:

--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -59,7 +59,18 @@ describe("list_feeds health filter and true total", () => {
 					"scheduled-overdue",
 					"scheduled-active",
 					"no-schedule-old",
-				].map((feedKey) => [feedKey, {}]),
+				].map((feedKey) => [
+					feedKey,
+					// Everything here except `no-schedule-old` models an unattended
+					// EVENT-DRIVEN feed: no cron, but a webhook route that re-arms
+					// next_run_at (the github `issue_comments` shape). That keeps this
+					// suite's axis sync history + lifecycle, and keeps execution_mode
+					// `no_schedule`, without the rows tripping `attention='no_trigger'`
+					// — which is what `no-schedule-old` is here to cover.
+					feedKey === "no-schedule-old"
+						? {}
+						: { webhook: { events: ["item"] } },
+				]),
 			),
 		});
 
@@ -233,7 +244,9 @@ describe("list_feeds health filter and true total", () => {
 		const byKey = new Map(
 			res.feeds.map((f) => [f.feed_key, f as Record<string, unknown>]),
 		);
-		// h3 (never synced) carries no cron → no_schedule, never_run.
+		// h3 (never synced) carries no cron but IS webhook-driven → no_schedule,
+		// never_run. `no_trigger` must not fire for it: a webhook delivery can
+		// still make it due.
 		const h3 = byKey.get("h3");
 		expect(h3?.execution_mode).toBe("no_schedule");
 		expect(h3?.attention).toBe("never_run");
@@ -342,10 +355,17 @@ describe("list_feeds health filter and true total", () => {
 		const byKey = new Map(listed.feeds.map((feed) => [feed.feed_key, feed]));
 		expect(byKey.get("scheduled-overdue")?.attention).toBe("overdue");
 		expect(byKey.get("scheduled-active")?.attention).toBe("healthy");
-		expect(byKey.get("no-schedule-old")?.attention).toBe("healthy");
+		// 30 days since its last (successful) sync, no cron, no webhook — the
+		// exact shape that read as healthy while being unreachable.
+		expect(byKey.get("no-schedule-old")?.attention).toBe("no_trigger");
 		expect(byKey.get("pinned-read-only")?.operations).toEqual(["read"]);
 		expect(byKey.get("pinned-read-only")?.attention).toBe("healthy");
 
+		// `health` is a SYNC-health filter and deliberately narrower than
+		// `attention`: it mirrors only the paused / failing / overdue portions of
+		// deriveFeedHealthSemantics. `no_trigger` is not a sync failure — the feed
+		// is unconfigured, not broken — so like needs_auth and device_offline it
+		// is not excluded here, and `no-schedule-old` stays in this set.
 		const healthy = await runList({
 			connection_id: conn.id,
 			health: "healthy",

--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -277,6 +277,62 @@ describe("list_feeds health filter and true total", () => {
 		}
 	});
 
+	it("only a dispatchable webhook route counts as a dispatch path", async () => {
+		// buildWebhookRoutes (app-webhooks.ts) routes a delivery only when
+		// `webhook.events` is an array holding at least one non-empty string.
+		// Anything looser declares nothing the router will ever dispatch, so it
+		// must NOT suppress `no_trigger` — otherwise a malformed declaration
+		// hides the feed this classification exists to surface. Note `null`:
+		// jsonb null is not SQL NULL, so a bare IS NOT NULL check passes it.
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "webhook-shapes",
+			createDefaultFeed: false,
+		});
+		const sql = getTestDb();
+		const shapes: Array<[string, unknown, string]> = [
+			["wh-real", { events: ["item"] }, "healthy"],
+			["wh-empty-object", {}, "no_trigger"],
+			["wh-mode-only", { mode: "store" }, "no_trigger"],
+			["wh-empty-events", { events: [] }, "no_trigger"],
+			["wh-blank-event", { events: [""] }, "no_trigger"],
+			["wh-non-string-event", { events: [7] }, "no_trigger"],
+			["wh-json-null", null, "no_trigger"],
+		];
+		await createTestConnectorDefinition({
+			key: "webhook-shapes",
+			name: "Webhook Shapes",
+			organization_id: orgId,
+			feeds_schema: Object.fromEntries(
+				shapes.map(([feedKey, webhook]) => [
+					feedKey,
+					{ operations: ["sync"], webhook },
+				]),
+			),
+		});
+		for (const [feedKey] of shapes) {
+			await sql`
+				INSERT INTO feeds (
+					organization_id, connection_id, feed_key, status, schedule,
+					last_sync_status, last_sync_at, consecutive_failures, entity_ids,
+					created_at, updated_at
+				) VALUES (
+					${orgId}, ${conn.id}, ${feedKey}, 'active', NULL,
+					'success', current_timestamp - interval '30 days', 0,
+					ARRAY[]::bigint[], NOW(), NOW()
+				)
+			`;
+		}
+
+		const listed = await runList({ connection_id: conn.id, limit: 20 });
+		const byKey = new Map(listed.feeds.map((feed) => [feed.feed_key, feed]));
+		for (const [feedKey, , expected] of shapes) {
+			expect(`${feedKey}=${byKey.get(feedKey)?.attention}`).toBe(
+				`${feedKey}=${expected}`,
+			);
+		}
+	});
+
 	it("keeps health filters aligned for overdue, active-run, and manual feeds", async () => {
 		const conn = await createTestConnection({
 			organization_id: orgId,

--- a/packages/server/src/__tests__/unit/feed-health-semantics.test.ts
+++ b/packages/server/src/__tests__/unit/feed-health-semantics.test.ts
@@ -84,9 +84,19 @@ describe("feed attention", () => {
     expect(syncFeed({ status: "active", consecutive_failures: 1 }).attention).toBe(
       "last_attempt_failed",
     );
-    expect(syncFeed({ status: "active", last_sync_at: null }).attention).toBe("never_run");
+    // Both carry a dispatch path so they isolate sync HISTORY: without one the
+    // row would classify on the dispatch gap instead, which the no_trigger
+    // tests below cover separately.
     expect(
-      syncFeed({ status: "active", last_sync_status: "success", last_sync_at: null }).attention,
+      syncFeed({ status: "active", schedule: "0 * * * *", last_sync_at: null }).attention,
+    ).toBe("never_run");
+    expect(
+      syncFeed({
+        status: "active",
+        webhook_driven: true,
+        last_sync_status: "success",
+        last_sync_at: null,
+      }).attention,
     ).toBe("healthy");
   });
 
@@ -104,16 +114,88 @@ describe("feed attention", () => {
         now,
       ).attention,
     ).toBe("overdue");
+    // A webhook-driven feed legitimately carries no cron: the delivery re-arms
+    // next_run_at, so `overdue` (which is measured against the cron) must not
+    // fire for it however old the last sync is.
     expect(
       syncFeed(
         {
           schedule: null,
+          webhook_driven: true,
           status: "active",
           last_sync_status: "success",
           last_sync_at: "2026-01-01T00:00:00Z",
         },
         now,
       ).attention,
+    ).toBe("healthy");
+  });
+
+  test("a sync feed with no cron and no webhook has no dispatch path", () => {
+    const now = Date.parse("2026-09-03T12:00:00Z");
+    // The exact shape of the 78 feeds left dormant by #2021: active, syncable,
+    // last run succeeded, zero failures — and unreachable, because
+    // CheckDueFeeds selects on `next_run_at <= now` and nothing re-arms it.
+    expect(
+      syncFeed(
+        {
+          schedule: null,
+          webhook_driven: false,
+          status: "active",
+          last_sync_status: "success",
+          last_sync_at: "2026-07-18T00:00:00Z",
+          consecutive_failures: 0,
+        },
+        now,
+      ).attention,
+    ).toBe("no_trigger");
+  });
+
+  test("no_trigger yields to states the operator must act on first", () => {
+    const base = {
+      schedule: null,
+      webhook_driven: false,
+      status: "active",
+      last_sync_at: "2026-07-18T00:00:00Z",
+    } as const;
+    expect(syncFeed({ ...base, connection_status: "revoked" }).attention).toBe("needs_auth");
+    expect(syncFeed({ ...base, status: "paused" }).attention).toBe("paused");
+    expect(syncFeed({ ...base, last_sync_status: "failed" }).attention).toBe(
+      "last_attempt_failed",
+    );
+  });
+
+  test("no_trigger explains a feed that has never run", () => {
+    // Precedence matters: `never_run` states the symptom, `no_trigger` states
+    // the cause, and only the cause tells the operator what to do about it.
+    expect(
+      syncFeed({
+        schedule: null,
+        webhook_driven: false,
+        status: "active",
+        last_sync_at: null,
+        last_sync_status: null,
+      }).attention,
+    ).toBe("no_trigger");
+  });
+
+  test("a streaming or read-only feed is never no_trigger", () => {
+    // Neither runs a sync lifecycle, so "no cron" carries no meaning for them.
+    expect(
+      deriveFeedHealthSemantics({
+        operations: [],
+        store: "channel_messages",
+        status: "active",
+        schedule: null,
+      }).attention,
+    ).toBe("healthy");
+    expect(
+      deriveFeedHealthSemantics({
+        operations: ["read"],
+        store: "events",
+        status: "active",
+        schedule: null,
+      }).attention,
     ).toBe("healthy");
   });
 

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -70,12 +70,23 @@
  * this scan on `execution_mode === 'scheduled'` drops its coverage from 43
  * connections to 14 and silences the exact shape it exists for (connection 412,
  * 10 of 11 feeds failing) — so `schedule` is deliberately not read here.
- * Nothing stored today distinguishes an unattended event-driven feed from a
- * human-triggered one; until something does, `schedule` cannot be this scan's
- * predicate. (`deriveFeedHealthSemantics` used to publish an `incidentEligible`
- * flag built on that same inference. Nothing consumed it and it disagreed with
- * this scan, so it was deleted — the paging decision lives here, in the one
- * place that acts on it.)
+ * `schedule` alone therefore cannot be this scan's predicate, and still is not.
+ * (`deriveFeedHealthSemantics` used to publish an `incidentEligible` flag built
+ * on that same inference. Nothing consumed it and it disagreed with this scan,
+ * so it was deleted — the paging decision lives here, in the one place that
+ * acts on it.)
+ *
+ * What HAS changed since that measurement is the signal, not the reasoning.
+ * `feeds_schema[key].webhook` positively identifies the event-driven half, so
+ * `attention='no_trigger'` can name a feed with no dispatch path at all
+ * without inferring intent from a missing cron — see the semantics module's
+ * header. Such a feed is excluded from `expected` below.
+ *
+ * Two of the 2026-08-12 examples are worth re-reading in that light: github
+ * `issue_comments` is genuinely webhook-driven and stays healthy, but linkedin
+ * `home_feed`'s "~hourly" was measured the day after `lobu apply` cleared its
+ * cron (audit ledger, 2026-08-11, 23 feeds that day). It was a feed draining,
+ * not a feed running unattended.
  */
 
 import { type DbClient, getDb, tsTimeOrNull } from '../db/client';
@@ -270,6 +281,9 @@ interface FeedHealthRow {
   device_stale: boolean | null;
   feed_id: string | null;
   operations: Array<'sync' | 'read'> | null;
+  /** Connector declares a webhook route for this feed key — the dispatch path
+   *  that re-arms `next_run_at` without a cron. */
+  webhook_driven: boolean | null;
   store: 'events' | 'channel_messages' | null;
   feed_status: string | null;
   schedule: string | null;
@@ -320,6 +334,7 @@ async function loadConnectionHealthRows(
       ) AS device_stale,
       f.id AS feed_id,
       cd.feed_operations AS operations,
+      cd.feed_webhook_driven AS webhook_driven,
       CASE WHEN f.config ->> 'store' = 'channel_messages' THEN 'channel_messages' ELSE 'events' END AS store,
       f.status AS feed_status,
       f.schedule,
@@ -364,6 +379,8 @@ async function loadConnectionHealthRows(
       SELECT
         COALESCE(definition.feeds_schema -> f.feed_key -> 'operations', '[]'::jsonb)
           AS feed_operations,
+        (definition.feeds_schema -> f.feed_key -> 'webhook') IS NOT NULL
+          AS feed_webhook_driven,
         EXISTS (
           SELECT 1
           FROM jsonb_each(COALESCE(definition.feeds_schema, '{}'::jsonb)) AS declared(feed_key, config)
@@ -430,6 +447,7 @@ function classifyFeed(row: FeedHealthRow, cfg: ConnectorHealthConfig): Classifie
     store: row.store,
     status: row.feed_status,
     schedule: row.schedule,
+    webhook_driven: row.webhook_driven,
     last_sync_status: row.last_sync_status,
     last_sync_at: row.last_sync_at,
     consecutive_failures: cf,
@@ -439,6 +457,14 @@ function classifyFeed(row: FeedHealthRow, cfg: ConnectorHealthConfig): Classifie
 
   const operatorPausedClean = row.feed_status === 'paused' && cf === 0;
   const syncable = row.operations?.includes('sync') === true;
+  // `no_trigger` is deliberately NOT excluded here, though the argument for
+  // excluding it is easy to make (the feed cannot sync, so counting it lets
+  // Rule C report a working connector as stale). Whether a dispatch-less feed
+  // is worth paging about is a paging decision, and this file's header records
+  // that such decisions are made here against prod measurements of what
+  // actually fires — which this change does not have. The feed-level
+  // `attention` is what surfaces the state to an operator; changing who gets
+  // paged is a separate, evidence-backed change.
   const expected =
     syncable && semantics.attention !== 'needs_auth' && !operatorPausedClean;
 

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -80,7 +80,8 @@
  * `feeds_schema[key].webhook` positively identifies the event-driven half, so
  * `attention='no_trigger'` can name a feed with no dispatch path at all
  * without inferring intent from a missing cron — see the semantics module's
- * header. Such a feed is excluded from `expected` below.
+ * header. It is deliberately NOT excluded from `expected` below; see the note
+ * at `classifyFeed` for why that stays a separate, evidence-backed decision.
  *
  * Two of the 2026-08-12 examples are worth re-reading in that light: github
  * `issue_comments` is genuinely webhook-driven and stays healthy, but linkedin
@@ -379,8 +380,23 @@ async function loadConnectionHealthRows(
       SELECT
         COALESCE(definition.feeds_schema -> f.feed_key -> 'operations', '[]'::jsonb)
           AS feed_operations,
-        (definition.feeds_schema -> f.feed_key -> 'webhook') IS NOT NULL
-          AS feed_webhook_driven,
+        -- Match what the router actually dispatches on. buildWebhookRoutes
+        -- (app-webhooks.ts) skips a feed unless webhook.events is an ARRAY
+        -- holding at least one non-empty string, so an empty object, a
+        -- mode-only object, an empty events array and a JSON-null webhook are
+        -- all undispatchable. A bare IS NOT NULL on the webhook key would call
+        -- every one of them webhook-driven and hide exactly the feed this
+        -- classification exists to surface (jsonb null is not SQL NULL).
+        jsonb_typeof(definition.feeds_schema -> f.feed_key -> 'webhook' -> 'events')
+            = 'array'
+          AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(
+              definition.feeds_schema -> f.feed_key -> 'webhook' -> 'events'
+            ) AS declared_event
+            WHERE jsonb_typeof(declared_event) = 'string'
+              AND declared_event #>> '{}' <> ''
+          ) AS feed_webhook_driven,
         EXISTS (
           SELECT 1
           FROM jsonb_each(COALESCE(definition.feeds_schema, '{}'::jsonb)) AS declared(feed_key, config)

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -82,12 +82,6 @@
  * without inferring intent from a missing cron — see the semantics module's
  * header. It is deliberately NOT excluded from `expected` below; see the note
  * at `classifyFeed` for why that stays a separate, evidence-backed decision.
- *
- * Two of the 2026-08-12 examples are worth re-reading in that light: github
- * `issue_comments` is genuinely webhook-driven and stays healthy, but linkedin
- * `home_feed`'s "~hourly" was measured the day after `lobu apply` cleared its
- * cron (audit ledger, 2026-08-11, 23 feeds that day). It was a feed draining,
- * not a feed running unattended.
  */
 
 import { type DbClient, getDb, tsTimeOrNull } from '../db/client';

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -94,7 +94,7 @@ import { type DbClient, getDb, tsTimeOrNull } from '../db/client';
 import { notifyBrowserAuthExpired } from '../notifications/triggers';
 import logger from '../utils/logger';
 import { aclConnectionIdSql, isAclErrorMessage } from '../authz/acl-observability';
-import { deriveFeedHealthSemantics } from './feed-health-semantics';
+import { deriveFeedHealthSemantics, feedWebhookDrivenSql } from './feed-health-semantics';
 
 /**
  * Does this feed error look like an expired/invalid site session (the user must
@@ -380,23 +380,9 @@ async function loadConnectionHealthRows(
       SELECT
         COALESCE(definition.feeds_schema -> f.feed_key -> 'operations', '[]'::jsonb)
           AS feed_operations,
-        -- Match what the router actually dispatches on. buildWebhookRoutes
-        -- (app-webhooks.ts) skips a feed unless webhook.events is an ARRAY
-        -- holding at least one non-empty string, so an empty object, a
-        -- mode-only object, an empty events array and a JSON-null webhook are
-        -- all undispatchable. A bare IS NOT NULL on the webhook key would call
-        -- every one of them webhook-driven and hide exactly the feed this
-        -- classification exists to surface (jsonb null is not SQL NULL).
-        jsonb_typeof(definition.feeds_schema -> f.feed_key -> 'webhook' -> 'events')
-            = 'array'
-          AND EXISTS (
-            SELECT 1
-            FROM jsonb_array_elements(
-              definition.feeds_schema -> f.feed_key -> 'webhook' -> 'events'
-            ) AS declared_event
-            WHERE jsonb_typeof(declared_event) = 'string'
-              AND declared_event #>> '{}' <> ''
-          ) AS feed_webhook_driven,
+        -- Shared with list_feeds; see feedWebhookDrivenSql for why a bare
+        -- IS NOT NULL on the webhook key is not equivalent.
+        ${sql.unsafe(feedWebhookDrivenSql('definition', 'f'))} AS feed_webhook_driven,
         EXISTS (
           SELECT 1
           FROM jsonb_each(COALESCE(definition.feeds_schema, '{}'::jsonb)) AS declared(feed_key, config)

--- a/packages/server/src/connectors/feed-health-semantics.ts
+++ b/packages/server/src/connectors/feed-health-semantics.ts
@@ -27,6 +27,15 @@
  *     driven unattended through other dispatch paths (github `issue_comments` =
  *     4551 sync runs in 14 days with `schedule` and `next_run_at` both NULL).
  *     Do not reintroduce the intent reading under a new name.
+ *
+ *     `attention='no_trigger'` is NOT that reading returning. The 2026-08-12
+ *     note named its own precondition — "a stored signal that distinguishes an
+ *     unattended event-driven feed from a human-triggered one" — and that
+ *     signal now exists: `feeds_schema[key].webhook`, the declaration the
+ *     app-webhook router dispatches on. So the classification below is not
+ *     "no cron, therefore manual"; it enumerates the three things that can
+ *     re-arm `next_run_at` and fires only when a syncable feed has none of
+ *     them. github's no-cron feeds declare a webhook and stay `healthy`.
  * - `attention` — what a human/UI should be told about the feed right now,
  *   ordered so the most actionable state wins:
  *   - `needs_auth` — the connection/auth profile is not usable (pending_auth,
@@ -41,6 +50,13 @@
  *     including backoff episodes).
  *   - `overdue` — a scheduled feed has had no active run for more than an hour
  *     past `next_run_at`.
+ *   - `no_trigger` — a syncable feed with no way to be dispatched: no cron, no
+ *     webhook route, not a channel. `CheckDueFeeds` selects on
+ *     `next_run_at <= now`, and the only writers of that column are the cron
+ *     (stamped at run completion), an app-webhook delivery, and device
+ *     auto-wire. With none of them the row can never become due again, so it
+ *     runs only if a human triggers it by hand. Ranked above `never_run`
+ *     because that one states the symptom while this states the cause.
  *   - `never_run` — never synced.
  *   - `healthy` — everything else.
  *
@@ -66,6 +82,7 @@ type FeedAttentionState =
   | "setup_required"
   | "last_attempt_failed"
   | "overdue"
+  | "no_trigger"
   | "never_run"
   | "device_offline"
   | "misconfigured";
@@ -88,6 +105,14 @@ interface FeedHealthSemanticsInput {
   consecutive_failures?: number | null;
   /** `feeds.next_run_at` — only meaningful when schedule is present. */
   next_run_at?: Date | string | null;
+  /**
+   * The connector declares `feeds_schema[feed_key].webhook` for this feed, so
+   * an inbound app-webhook delivery re-arms `next_run_at` (see
+   * `gateway/routes/public/app-webhooks.ts`). This is the stored signal that
+   * separates an unattended event-driven feed from one with no dispatch path
+   * at all; without it, "no cron" is not classifiable (see the header).
+   */
+  webhook_driven?: boolean | null;
   /** Number of pending/claimed/running sync runs selected by list_feeds. */
   active_runs?: number | null;
   /** `connections.status` — 'active' | 'paused' | 'error' | 'revoked' |
@@ -179,6 +204,23 @@ function scheduledExecutionOverdue(
   return Number.isFinite(nextRun) && nextRun < now - FEED_OVERDUE_MARGIN_MS;
 }
 
+/**
+ * A syncable feed with nothing that can re-arm `next_run_at`. Enumerates the
+ * dispatch paths rather than inferring intent from the absence of a cron:
+ * cron (`feeds.schedule`), app-webhook delivery (`webhook_driven`), or a
+ * channel/read-only feed that runs no sync lifecycle at all (both handled
+ * before this is reached). Device auto-wire also stamps `next_run_at` once at
+ * creation, which is why such a feed can show one successful sync and still be
+ * unreachable forever after.
+ */
+function hasNoDispatchPath(input: FeedHealthSemanticsInput): boolean {
+  return (
+    input.operations?.includes('sync') === true &&
+    !isScheduled(input) &&
+    input.webhook_driven !== true
+  );
+}
+
 /** The feed is paused, by operator or auto-pause. */
 function isPaused(input: FeedHealthSemanticsInput): boolean {
   return input.status === "paused" || input.connection_status === "paused";
@@ -247,6 +289,8 @@ export function deriveFeedHealthSemantics(
     attention = "last_attempt_failed";
   } else if (scheduledExecutionOverdue(input, now)) {
     attention = "overdue";
+  } else if (hasNoDispatchPath(input)) {
+    attention = "no_trigger";
   } else if (
     input.last_sync_at == null &&
     input.last_sync_status !== "success"

--- a/packages/server/src/connectors/feed-health-semantics.ts
+++ b/packages/server/src/connectors/feed-health-semantics.ts
@@ -33,9 +33,9 @@
  *     unattended event-driven feed from a human-triggered one" — and that
  *     signal now exists: `feeds_schema[key].webhook`, the declaration the
  *     app-webhook router dispatches on. So the classification below is not
- *     "no cron, therefore manual"; it enumerates the three things that can
- *     re-arm `next_run_at` and fires only when a syncable feed has none of
- *     them. github's no-cron feeds declare a webhook and stay `healthy`.
+ *     "no cron, therefore manual"; it enumerates what can REPEATEDLY re-arm
+ *     `next_run_at` and fires only when a syncable feed has neither. github's
+ *     no-cron feeds declare a webhook and stay `healthy`.
  * - `attention` — what a human/UI should be told about the feed right now,
  *   ordered so the most actionable state wins:
  *   - `needs_auth` — the connection/auth profile is not usable (pending_auth,
@@ -52,11 +52,18 @@
  *     past `next_run_at`.
  *   - `no_trigger` — a syncable feed with no way to be dispatched: no cron, no
  *     webhook route, not a channel. `CheckDueFeeds` selects on
- *     `next_run_at <= now`, and the only writers of that column are the cron
- *     (stamped at run completion), an app-webhook delivery, and device
- *     auto-wire. With none of them the row can never become due again, so it
- *     runs only if a human triggers it by hand. Ranked above `never_run`
- *     because that one states the symptom while this states the cause.
+ *     `next_run_at <= now`. Two writers of that column are REPEATING and can
+ *     sustain a cadence: the cron (re-stamped at every run completion) and an
+ *     app-webhook delivery. The rest are one-shot episodic re-arms tied to a
+ *     lifecycle moment — device auto-wire's first stamp, auth-completion and
+ *     browser-reauth resume (`run-lifecycle`), connect (`connect/routes`), and
+ *     auth-profile activation (`manage_auth_profiles`). Each fires once and
+ *     `run-lifecycle` nulls the column again when that run completes, because
+ *     there is no cron to compute the next one from. So a feed with neither
+ *     repeating writer cannot hold a cadence however many episodic re-arms it
+ *     sees, and runs only when something triggers it by hand. Ranked above
+ *     `never_run` because that one states the symptom while this states the
+ *     cause.
  *   - `never_run` — never synced.
  *   - `healthy` — everything else.
  *
@@ -106,11 +113,18 @@ interface FeedHealthSemanticsInput {
   /** `feeds.next_run_at` — only meaningful when schedule is present. */
   next_run_at?: Date | string | null;
   /**
-   * The connector declares `feeds_schema[feed_key].webhook` for this feed, so
-   * an inbound app-webhook delivery re-arms `next_run_at` (see
-   * `gateway/routes/public/app-webhooks.ts`). This is the stored signal that
-   * separates an unattended event-driven feed from one with no dispatch path
-   * at all; without it, "no cron" is not classifiable (see the header).
+   * The connector declares a DISPATCHABLE webhook route for this feed, so an
+   * inbound delivery re-arms `next_run_at`. Callers must mirror what
+   * `buildWebhookRoutes` (`gateway/routes/public/app-webhooks.ts`) actually
+   * routes on — `webhook.events` being an array with at least one non-empty
+   * string — not merely that a `webhook` key is present: `{}`,
+   * `{mode:'store'}`, `{events: []}` and a JSON-null all declare nothing the
+   * router will dispatch, and treating them as event-driven would hide exactly
+   * the feed this classification exists to surface.
+   *
+   * This is the stored signal that separates an unattended event-driven feed
+   * from one with no dispatch path at all; without it, "no cron" is not
+   * classifiable (see the header).
    */
   webhook_driven?: boolean | null;
   /** Number of pending/claimed/running sync runs selected by list_feeds. */

--- a/packages/server/src/connectors/feed-health-semantics.ts
+++ b/packages/server/src/connectors/feed-health-semantics.ts
@@ -80,6 +80,39 @@
  * unattended event-driven feed from a human-triggered one.
  */
 
+/**
+ * SQL for the `webhook_driven` input below — the single definition of what
+ * counts as a dispatchable webhook route.
+ *
+ * It mirrors `buildWebhookRoutes` (`app-webhooks.ts`), which skips a feed
+ * unless `webhook.events` is an ARRAY holding at least one non-empty string.
+ * A bare `IS NOT NULL` on the `webhook` key is NOT equivalent: jsonb null is
+ * not SQL NULL, so `{}`, `{mode:'store'}`, `{events: []}`, `{events: ['']}`
+ * and a JSON-null webhook would all read as event-driven and hide exactly the
+ * feed `no_trigger` exists to surface.
+ *
+ * Exported as one fragment because two readers must agree — `list_feeds`
+ * (`tools/admin/manage_feeds.ts`) and the health scan
+ * (`connectors/connector-health.ts`). Hand-copied jsonb predicates drift, and
+ * drift here means the two surfaces silently disagree about one feed.
+ *
+ * `jsonb_typeof(...) = 'array'` short-circuits the EXISTS, so a scalar or
+ * object `events` cannot reach `jsonb_array_elements` and error.
+ */
+export function feedWebhookDrivenSql(
+  definitionAlias: string,
+  feedAlias: string
+): string {
+  const events = `${definitionAlias}.feeds_schema -> ${feedAlias}.feed_key -> 'webhook' -> 'events'`;
+  return `jsonb_typeof(${events}) = 'array'
+          AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(${events}) AS declared_event
+            WHERE jsonb_typeof(declared_event) = 'string'
+              AND declared_event #>> '{}' <> ''
+          )`;
+}
+
 type FeedExecutionMode = "source_only" | "streaming" | "scheduled" | "no_schedule";
 
 type FeedAttentionState =

--- a/packages/server/src/connectors/feed-health-semantics.ts
+++ b/packages/server/src/connectors/feed-health-semantics.ts
@@ -84,8 +84,9 @@
  * SQL for the `webhook_driven` input below — the single definition of what
  * counts as a dispatchable webhook route.
  *
- * It mirrors `buildWebhookRoutes` (`app-webhooks.ts`), which skips a feed
- * unless `webhook.events` is an ARRAY holding at least one non-empty string.
+ * It mirrors `loadGithubWebhookRoutes`
+ * (`gateway/routes/public/app-webhooks.ts`), which skips a feed unless
+ * `webhook.events` is an ARRAY holding at least one non-empty string.
  * A bare `IS NOT NULL` on the `webhook` key is NOT equivalent: jsonb null is
  * not SQL NULL, so `{}`, `{mode:'store'}`, `{events: []}`, `{events: ['']}`
  * and a JSON-null webhook would all read as event-driven and hide exactly the
@@ -103,7 +104,9 @@ export function feedWebhookDrivenSql(
   definitionAlias: string,
   feedAlias: string
 ): string {
-  const events = `${definitionAlias}.feeds_schema -> ${feedAlias}.feed_key -> 'webhook' -> 'events'`;
+  const events =
+    `${definitionAlias}.feeds_schema -> ${feedAlias}.feed_key` +
+    ` -> 'webhook' -> 'events'`;
   return `jsonb_typeof(${events}) = 'array'
           AND EXISTS (
             SELECT 1
@@ -148,7 +151,7 @@ interface FeedHealthSemanticsInput {
   /**
    * The connector declares a DISPATCHABLE webhook route for this feed, so an
    * inbound delivery re-arms `next_run_at`. Callers must mirror what
-   * `buildWebhookRoutes` (`gateway/routes/public/app-webhooks.ts`) actually
+   * `loadGithubWebhookRoutes` (`gateway/routes/public/app-webhooks.ts`) actually
    * routes on — `webhook.events` being an array with at least one non-empty
    * string — not merely that a `webhook` key is present: `{}`,
    * `{mode:'store'}`, `{events: []}` and a JSON-null all declare nothing the

--- a/packages/server/src/connectors/feed-health-semantics.ts
+++ b/packages/server/src/connectors/feed-health-semantics.ts
@@ -153,17 +153,11 @@ interface FeedHealthSemanticsInput {
   next_run_at?: Date | string | null;
   /**
    * The connector declares a DISPATCHABLE webhook route for this feed, so an
-   * inbound delivery re-arms `next_run_at`. Callers must mirror what
-   * `loadGithubWebhookRoutes` (`gateway/routes/public/app-webhooks.ts`) actually
-   * routes on — `webhook.events` being an array with at least one non-empty
-   * string — not merely that a `webhook` key is present: `{}`,
-   * `{mode:'store'}`, `{events: []}` and a JSON-null all declare nothing the
-   * router will dispatch, and treating them as event-driven would hide exactly
-   * the feed this classification exists to surface.
-   *
-   * This is the stored signal that separates an unattended event-driven feed
-   * from one with no dispatch path at all; without it, "no cron" is not
-   * classifiable (see the header).
+   * inbound delivery re-arms `next_run_at`. This is the stored signal that
+   * separates an unattended event-driven feed from one with no dispatch path
+   * at all; without it, "no cron" is not classifiable (see the header).
+   * Compute it with `feedWebhookDrivenSql` above — "dispatchable" is narrower
+   * than "a webhook key exists", and that fragment is the definition.
    */
   webhook_driven?: boolean | null;
   /** Number of pending/claimed/running sync runs selected by list_feeds. */

--- a/packages/server/src/connectors/feed-health-semantics.ts
+++ b/packages/server/src/connectors/feed-health-semantics.ts
@@ -97,8 +97,12 @@
  * (`connectors/connector-health.ts`). Hand-copied jsonb predicates drift, and
  * drift here means the two surfaces silently disagree about one feed.
  *
- * `jsonb_typeof(...) = 'array'` short-circuits the EXISTS, so a scalar or
- * object `events` cannot reach `jsonb_array_elements` and error.
+ * The type guard is a CASE, not `AND`, deliberately. Postgres does not promise
+ * that `AND` short-circuits left-to-right ("Expression Evaluation Rules" — use
+ * CASE when order matters), and if the planner evaluated the EXISTS first a
+ * scalar or object `events` would reach `jsonb_array_elements` and raise
+ * "cannot extract elements from a scalar", 500ing a user-facing read path.
+ * CASE makes the guard ordering part of the semantics rather than a bet.
  */
 export function feedWebhookDrivenSql(
   definitionAlias: string,
@@ -107,13 +111,12 @@ export function feedWebhookDrivenSql(
   const events =
     `${definitionAlias}.feeds_schema -> ${feedAlias}.feed_key` +
     ` -> 'webhook' -> 'events'`;
-  return `jsonb_typeof(${events}) = 'array'
-          AND EXISTS (
+  return `CASE WHEN jsonb_typeof(${events}) = 'array' THEN EXISTS (
             SELECT 1
             FROM jsonb_array_elements(${events}) AS declared_event
             WHERE jsonb_typeof(declared_event) = 'string'
               AND declared_event #>> '{}' <> ''
-          )`;
+          ) ELSE false END`;
 }
 
 type FeedExecutionMode = "source_only" | "streaming" | "scheduled" | "no_schedule";

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -322,51 +322,32 @@ async function handleListFeeds(
   // true count there.
   const pageQuery = sql`
     SELECT ${sql.unsafe(publicFeedColumnList('f'))}, c.connector_key,
-           COALESCE((
-             SELECT definition.feeds_schema -> f.feed_key -> 'operations'
-             FROM connector_definitions definition
-             WHERE definition.key = c.connector_key
-               AND definition.organization_id = f.organization_id
-               -- Same definition selection as readSourceFeed, so the reported
-               -- capabilities are the ones a read/sync would actually run.
-               AND (
-                 (f.pinned_version IS NULL AND definition.status = 'active')
-                 OR (
-                   f.pinned_version IS NOT NULL
-                   AND (definition.version = f.pinned_version OR definition.status = 'active')
-                 )
-               )
-             ORDER BY (definition.version = f.pinned_version) DESC,
-                      (definition.status = 'active') DESC,
-                      definition.updated_at DESC, definition.id DESC
-             LIMIT 1
-           ), '[]'::jsonb) AS operations,
-           -- Same definition selection as the operations subquery above: the
-           -- webhook declaration must come from the version a sync would
-           -- actually run, or a pinned feed is classified against a newer
-           -- contract than the one that would execute.
-           COALESCE((
-             -- Shared with connector-health's lateral so the two surfaces
-             -- cannot disagree about one feed; see feedWebhookDrivenSql.
-             SELECT ${sql.unsafe(feedWebhookDrivenSql('definition', 'f'))}
-             FROM connector_definitions definition
-             WHERE definition.key = c.connector_key
-               AND definition.organization_id = f.organization_id
-               AND (
-                 (f.pinned_version IS NULL AND definition.status = 'active')
-                 OR (
-                   f.pinned_version IS NOT NULL
-                   AND (definition.version = f.pinned_version OR definition.status = 'active')
-                 )
-               )
-             ORDER BY (definition.version = f.pinned_version) DESC,
-                      (definition.status = 'active') DESC,
-                      definition.updated_at DESC, definition.id DESC
-             LIMIT 1
-           ), false) AS webhook_driven,
+           COALESCE(selected_definition.operations, '[]'::jsonb) AS operations,
+           COALESCE(selected_definition.webhook_driven, false) AS webhook_driven,
            COUNT(*) OVER()::int AS filtered_total
     FROM feeds f
     JOIN connections c ON c.id = f.connection_id
+    -- One definition per feed, projected twice. Same selection as
+    -- readSourceFeed, so the reported capabilities and the webhook
+    -- declaration both come from the version a read/sync would actually run.
+    LEFT JOIN LATERAL (
+      SELECT definition.feeds_schema -> f.feed_key -> 'operations' AS operations,
+             ${sql.unsafe(feedWebhookDrivenSql('definition', 'f'))} AS webhook_driven
+      FROM connector_definitions definition
+      WHERE definition.key = c.connector_key
+        AND definition.organization_id = f.organization_id
+        AND (
+          (f.pinned_version IS NULL AND definition.status = 'active')
+          OR (
+            f.pinned_version IS NOT NULL
+            AND (definition.version = f.pinned_version OR definition.status = 'active')
+          )
+        )
+      ORDER BY (definition.version = f.pinned_version) DESC,
+               (definition.status = 'active') DESC,
+               definition.updated_at DESC, definition.id DESC
+      LIMIT 1
+    ) selected_definition ON true
     WHERE ${where}
     ORDER BY f.created_at DESC LIMIT ${limit} OFFSET ${offset}
   `;

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -346,7 +346,21 @@ async function handleListFeeds(
            -- actually run, or a pinned feed is classified against a newer
            -- contract than the one that would execute.
            COALESCE((
-             SELECT (definition.feeds_schema -> f.feed_key -> 'webhook') IS NOT NULL
+             -- Same predicate as connector-health's lateral, and for the same
+             -- reason: only a non-empty array of non-empty string events is
+             -- something buildWebhookRoutes will dispatch. The two must agree,
+             -- or list_feeds and the health scan disagree about one feed.
+             SELECT jsonb_typeof(
+                      definition.feeds_schema -> f.feed_key -> 'webhook' -> 'events'
+                    ) = 'array'
+                    AND EXISTS (
+                      SELECT 1
+                      FROM jsonb_array_elements(
+                        definition.feeds_schema -> f.feed_key -> 'webhook' -> 'events'
+                      ) AS declared_event
+                      WHERE jsonb_typeof(declared_event) = 'string'
+                        AND declared_event #>> '{}' <> ''
+                    )
              FROM connector_definitions definition
              WHERE definition.key = c.connector_key
                AND definition.organization_id = f.organization_id

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -341,6 +341,27 @@ async function handleListFeeds(
                       definition.updated_at DESC, definition.id DESC
              LIMIT 1
            ), '[]'::jsonb) AS operations,
+           -- Same definition selection as the operations subquery above: the
+           -- webhook declaration must come from the version a sync would
+           -- actually run, or a pinned feed is classified against a newer
+           -- contract than the one that would execute.
+           COALESCE((
+             SELECT (definition.feeds_schema -> f.feed_key -> 'webhook') IS NOT NULL
+             FROM connector_definitions definition
+             WHERE definition.key = c.connector_key
+               AND definition.organization_id = f.organization_id
+               AND (
+                 (f.pinned_version IS NULL AND definition.status = 'active')
+                 OR (
+                   f.pinned_version IS NOT NULL
+                   AND (definition.version = f.pinned_version OR definition.status = 'active')
+                 )
+               )
+             ORDER BY (definition.version = f.pinned_version) DESC,
+                      (definition.status = 'active') DESC,
+                      definition.updated_at DESC, definition.id DESC
+             LIMIT 1
+           ), false) AS webhook_driven,
            COUNT(*) OVER()::int AS filtered_total
     FROM feeds f
     JOIN connections c ON c.id = f.connection_id
@@ -489,6 +510,7 @@ async function handleListFeeds(
           : 'events',
       status: feed.status as string | null,
       schedule: feed.schedule as string | null,
+      webhook_driven: feed.webhook_driven as boolean | null,
       last_sync_status: feed.last_sync_status as string | null,
       last_sync_at: feed.last_sync_at as Date | string | null,
       consecutive_failures: feed.consecutive_failures as number | null,
@@ -505,6 +527,9 @@ async function handleListFeeds(
       connector_version: _connectorVersion,
       connector_manifest_backed: _connectorManifestBacked,
       connector_manifest_hash: _connectorManifestHash,
+      // Derivation input, not public surface — it is already expressed in the
+      // `attention` value the caller reads.
+      webhook_driven: _webhookDriven,
       ...publicFeed
     } = feed;
     return {

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -40,7 +40,7 @@ import {
 import { compileConnectionRowVisibility } from '../../authz/connection-visibility';
 import { authzScopeFromToolContext } from '../../authz/scope';
 import { reconcileAtlassianMcpJiraSite } from '../../connect/atlassian-mcp-site';
-import { deriveFeedHealthSemantics } from '../../connectors/feed-health-semantics';
+import { deriveFeedHealthSemantics, feedWebhookDrivenSql } from '../../connectors/feed-health-semantics';
 import { getDb, pgBigintArray } from '../../db/client';
 import type { Env } from '../../index';
 import {
@@ -346,21 +346,9 @@ async function handleListFeeds(
            -- actually run, or a pinned feed is classified against a newer
            -- contract than the one that would execute.
            COALESCE((
-             -- Same predicate as connector-health's lateral, and for the same
-             -- reason: only a non-empty array of non-empty string events is
-             -- something buildWebhookRoutes will dispatch. The two must agree,
-             -- or list_feeds and the health scan disagree about one feed.
-             SELECT jsonb_typeof(
-                      definition.feeds_schema -> f.feed_key -> 'webhook' -> 'events'
-                    ) = 'array'
-                    AND EXISTS (
-                      SELECT 1
-                      FROM jsonb_array_elements(
-                        definition.feeds_schema -> f.feed_key -> 'webhook' -> 'events'
-                      ) AS declared_event
-                      WHERE jsonb_typeof(declared_event) = 'string'
-                        AND declared_event #>> '{}' <> ''
-                    )
+             -- Shared with connector-health's lateral so the two surfaces
+             -- cannot disagree about one feed; see feedWebhookDrivenSql.
+             SELECT ${sql.unsafe(feedWebhookDrivenSql('definition', 'f'))}
              FROM connector_definitions definition
              WHERE definition.key = c.connector_key
                AND definition.organization_id = f.organization_id

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -675,7 +675,22 @@ async function ensureDeviceConnectorWired(
           await tx`
             UPDATE feeds
             SET status = 'active',
-                next_run_at = ${canSync ? tx`COALESCE(next_run_at, NOW())` : tx`NULL::timestamptz`},
+                next_run_at = ${
+                  canSync
+                    ? // Re-arm only a feed that HAS a cron, where NULL means
+                      // "auto-paused / cleared" and NOW() resumes its cadence.
+                      // A feed with no cron is manual by #2021, and stamping
+                      // NOW() here invented a trigger nobody chose: this branch
+                      // runs on the slow wire path, which the `ready` fast path
+                      // skips until the manifest hash changes, so the feed
+                      // synced exactly once per extension version. Prod: chrome
+                      // `tab_events` and `watch_observations` = 9 runs since
+                      // 2026-08-04 while their scheduled siblings ran 5,449 —
+                      // every one `completed`, so no failure signal ever fired.
+                      tx`CASE WHEN schedule IS NULL THEN next_run_at
+                              ELSE COALESCE(next_run_at, NOW()) END`
+                    : tx`NULL::timestamptz`
+                },
                 updated_at = current_timestamp
             WHERE id = ${existingFeed[0].id}
           `;
@@ -687,6 +702,12 @@ async function ensureDeviceConnectorWired(
             typeof declaredName === 'string' && declaredName.trim().length > 0
               ? declaredName.trim()
               : metadata.name;
+          // The initial stamp STAYS, unlike the re-arm above: one backfill on
+          // first wire is what makes a newly connected device show anything at
+          // all, and it is a one-shot, not a cadence. What it must not do is
+          // masquerade as a working feed afterwards — that is now visible as
+          // `attention='no_trigger'` rather than hidden behind a lone
+          // successful sync (see `connectors/feed-health-semantics.ts`).
           await tx`
             INSERT INTO feeds (
               organization_id, connection_id, feed_key, display_name, status,


### PR DESCRIPTION
## Summary

- **#2021 made a cron-less feed manual-only and nothing ever said which feeds that left unreachable.** They keep reporting `healthy`: `status='active'`, `last_sync_status='success'`, `consecutive_failures=0`, and no dispatch path at all. `deriveFeedHealthSemantics` now names that state `no_trigger`.
- **Device auto-wire stops re-arming `next_run_at` on a cron-less feed** — the stamp gave it exactly one sync per extension version, which is what made a permanently dormant feed look intermittent rather than broken.

### How a feed becomes due

`CheckDueFeeds` selects on `f.next_run_at <= current_timestamp` and exactly three things write that column:

| writer | where |
|---|---|
| cron in `feeds.schedule` | `run-lifecycle.ts` at run completion |
| app-webhook delivery | `app-webhooks.ts:580` `SET next_run_at = now()` |
| device auto-wire | `device-reconcile.ts` `COALESCE(next_run_at, NOW())` |

With none of them the row can never become due again.

### Prod, 2026-09-03

78 active sync-capable feeds across 7 orgs have no cron and no webhook:

| connector | feeds | days stale |
|---|---|---|
| google_play `reviews` | 5 | 168 |
| reddit `posts`/`comments` | 8 | 47 |
| spotify ×3 | 3 | 46 |
| website `pages` | 39 | 30 |
| chrome ×3 | 7 | 12 |

The within-connector control is the proof — same connector, same org, the cron is the only variable:

| connector | with cron | without cron |
|---|---|---|
| spotify | 1 feed, 2 days | 3 feeds, 46 days |
| website | 2 feeds, 2 days | 39 feeds, 30 days |
| google.calendar | 2 feeds, 0 days | 1 feed, never synced |

Two causes, both downstream of #2021: its migration nulled the `0 */6 * * *` default (the 2026-07-18 cliff on spotify and reddit), and `lobu apply` clears the cron whenever a config file omits `schedule` — the audit ledger shows 23 such changes on 2026-08-11 and 18 more on 2026-08-12, all `cli`.

### Why this is not the inference the module forbids

`feed-health-semantics.ts` says not to read intent from a missing cron, and names its own precondition: *"a stored signal that distinguishes an unattended event-driven feed from a human-triggered one."* That signal is `feeds_schema[key].webhook`, the declaration the app-webhook router dispatches on. `no_trigger` enumerates the three dispatch paths and fires only when a syncable feed has none — github's cron-less feeds declare a webhook and stay `healthy`.

Worth re-reading one of that note's examples in this light: linkedin `home_feed`'s "~hourly" was measured 2026-08-12, the day after `lobu apply` cleared its cron. It was a feed draining, not running unattended. The github example stands.

### Deliberately unchanged

`connector-health`'s `expected` predicate still counts these feeds. Whether a dispatch-less feed is worth paging about is a paging decision, and that file's header records those as made against prod measurements of what actually fires — which this change does not have. Excluding them is defensible and is a follow-up with its own evidence.

Also left alone: `app-install.ts:606` still writes `AUTO_FEED_SCHEDULE = "0 */6 * * *"`, the literal #2021's migration deleted. It predates #2021 (added 2026-06-22) so it is a missed site, but those github feeds are webhook-driven and removing their backstop poll is a separate risk decision.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: targeted `bun test` + `bun run test -- run <path>`
- [x] Bug fix: red→fix→green outputs pasted below

**Red** — `device-reconcile-feed-rearm.test.ts` with the re-arm restored:
```
 × does not re-arm a cron-less feed when the manifest changes 14ms
   → expected 2026-09-03T20:12:14.827Z to be null
 ✓ still re-arms a feed that carries a cron 9ms
 Tests  1 failed | 2 passed (3)
```

**Red** — `feed-health-semantics.test.ts` before the classifier:
```
 (fail) a sync feed with no cron and no webhook has no dispatch path
   Expected: "no_trigger"   Received: "healthy"
 (fail) no_trigger explains a feed that has never run
   Expected: "no_trigger"   Received: "never_run"
 11 pass, 2 fail
```

**Green** — after both fixes:
```
 ✓ device-reconcile-feed-rearm.test.ts (3 tests) 2600ms
 feed-health-semantics.test.ts: 13 pass, 0 fail
 connector-health-alert + reauth-notify + manage-feeds-delete-isolation: 26 passed
 device-reconcile-config-seed + slug-race + feeds-manual-schedule: 10 passed
 owletto connector-scope-lists.test.ts: 7 passed
```

## Notes

`make review-fix` could not run — codex is at its usage limit until Sep 7 and exited without making any edits.

The 78 existing dormant feeds are untouched by this PR; it stops new ones being minted silently and makes the existing ones visible so they can be triaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQwZr5tmJxRYLDpT4y1xy5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Feed health indicators now distinguish feeds without a schedule or dispatch mechanism as **No trigger**.
  * Webhook-driven feeds are correctly recognized as active, including feeds without cron schedules.
  * Health status priorities now correctly surface authentication issues, pauses, and failed sync attempts.
  * Reconnecting devices no longer reactivates scheduled runs for manually triggered feeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->