### PR TITLE
feat(server): make empty search results explain themselves honestly

### DIFF
--- a/packages/server/src/__tests__/integration/tools/search-memory-federation.test.ts
+++ b/packages/server/src/__tests__/integration/tools/search-memory-federation.test.ts
@@ -237,6 +237,47 @@ describe('search_memory direct OAuth workspace federation', () => {
     expectValidSearchResult(partialHit);
   });
 
+  // The federated arm of the empty-result guidance. `partialEmpty` above covers
+  // the degraded case, which deliberately says "partial results" instead — this
+  // is the HEALTHY all-granted miss, the one branch of the read guidance that
+  // had no test.
+  it('gives federated misses the read guidance without naming a single workspace query', async () => {
+    const targets = [
+      { id: orgA.id, slug: orgA.slug, name: orgA.name, role: 'owner', personal: false },
+      { id: orgB.id, slug: orgB.slug, name: orgB.name, role: 'admin', personal: false },
+    ];
+    // Nonsense token AND fuzzy off. `definitely absent synthetic entity` is NOT
+    // empty here — trigram admits "Other Alpha Entity" — which the partial case
+    // above never notices because status='partial' short-circuits its
+    // suggestion before the match check.
+    const args = {
+      query: 'zzzz-absent-federated-needle-qqqq',
+      fuzzy: false,
+      include_content: false,
+    };
+    const shard = async (slug: string) =>
+      await search({ ...args, workspace: slug, include_public_catalogs: false }, {} as Env, context());
+
+    const merged = mergeFederatedSearchResults(args, targets, [
+      { status: 'fulfilled', value: await shard(orgA.slug) },
+      { status: 'fulfilled', value: await shard(orgB.slug) },
+    ]);
+
+    expect(merged.coverage).toMatchObject({ scope: 'all_granted', status: 'complete' });
+    expect(merged.discovery_status).toBe('not_found');
+    const suggestion = merged.suggestion ?? '';
+    // Scope-accurate: a federated miss spans workspaces, so it must NOT echo
+    // the query as if one workspace had been searched, and must not pre-fill
+    // that query as an entity name to create.
+    expect(suggestion).toContain('in the currently accessible workspaces granted to this connection');
+    expect(suggestion).not.toContain(`for "${args.query}"`);
+    expect(suggestion).toContain("name: '<entity_name>'");
+    // …while still carrying the same read-first steps as a local miss.
+    expect(suggestion).toContain('client.feeds.readMany');
+    expect(suggestion).toContain('query_sql');
+    expectValidSearchResult(merged);
+  });
+
   it('narrows through the grant resolver and makes unknown, ungranted, and revoked identical', async () => {
     const narrowed = await search(
       {

--- a/packages/server/src/__tests__/integration/tools/search-memory-recall-contract.test.ts
+++ b/packages/server/src/__tests__/integration/tools/search-memory-recall-contract.test.ts
@@ -412,19 +412,22 @@ describe('search_memory > recall contract', () => {
     expect(result.suggestion).not.toContain('entities.create');
   });
 
-  // Runs LAST: it gives the org its first read-capable source feed, which
-  // changes `coverage` for every search after it. The step-1 wording above is
-  // the no-feeds variant precisely because the fixture connector declares no
-  // feeds_schema, so its `default` feed is not read-capable.
+  // Its own org, so a read-capable feed cannot leak into `coverage` for the
+  // cases above and test order stays irrelevant. The step-1 wording asserted
+  // earlier is the no-feeds variant because THIS suite's main fixture
+  // connector declares no feeds_schema, not because this case runs last.
   it('names the discovered source feeds and their feed_id when the org has read-capable feeds', async () => {
+    const feedOrg = await createTestOrganization({ name: 'Recall Feed Coverage Org' });
+    const feedUser = await createTestUser({ email: 'recall-feed-coverage@example.com' });
+    await addUserToOrganization(feedUser.id, feedOrg.id, 'owner');
     await createTestConnectorDefinition({
       key: 'readable-feed-connector',
       name: 'Readable Feed',
-      organization_id: org.id,
+      organization_id: feedOrg.id,
       feeds_schema: { default: { operations: ['read', 'sync'] } },
     });
     await createTestConnection({
-      organization_id: org.id,
+      organization_id: feedOrg.id,
       connector_key: 'readable-feed-connector',
       slug: 'readable-feed',
     });
@@ -432,7 +435,11 @@ describe('search_memory > recall contract', () => {
     const result = await search(
       { query: 'zzzz-no-such-thing-with-feeds-present' },
       env,
-      ctx
+      {
+        organizationId: feedOrg.id,
+        userId: feedUser.id,
+        tokenType: 'session',
+      } as ToolContext
     );
 
     const discovered = result.coverage?.source_feeds ?? [];

--- a/packages/server/src/__tests__/integration/tools/search-memory-recall-contract.test.ts
+++ b/packages/server/src/__tests__/integration/tools/search-memory-recall-contract.test.ts
@@ -411,4 +411,39 @@ describe('search_memory > recall contract', () => {
     expect(result.suggestion).toContain('related memory content was recalled below');
     expect(result.suggestion).not.toContain('entities.create');
   });
+
+  // Runs LAST: it gives the org its first read-capable source feed, which
+  // changes `coverage` for every search after it. The step-1 wording above is
+  // the no-feeds variant precisely because the fixture connector declares no
+  // feeds_schema, so its `default` feed is not read-capable.
+  it('names the discovered source feeds and their feed_id when the org has read-capable feeds', async () => {
+    await createTestConnectorDefinition({
+      key: 'readable-feed-connector',
+      name: 'Readable Feed',
+      organization_id: org.id,
+      feeds_schema: { default: { operations: ['read', 'sync'] } },
+    });
+    await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'readable-feed-connector',
+      slug: 'readable-feed',
+    });
+
+    const result = await search(
+      { query: 'zzzz-no-such-thing-with-feeds-present' },
+      env,
+      ctx
+    );
+
+    const discovered = result.coverage?.source_feeds ?? [];
+    expect(discovered.map((feed) => feed.connection_slug)).toContain('readable-feed');
+
+    const suggestion = result.suggestion ?? '';
+    // The feeds-present branch must name the handle `feeds.readMany` actually
+    // keys on, not just the human-readable slug/key pair.
+    expect(suggestion).toContain('Check unqueried source feeds');
+    expect(suggestion).toContain('`readable-feed/default`');
+    expect(suggestion).toContain('feed_id');
+    expect(suggestion).toContain('client.feeds.readMany({ reads: [{ feed_id }] })');
+  });
 });

--- a/packages/server/src/__tests__/integration/tools/search-memory-recall-contract.test.ts
+++ b/packages/server/src/__tests__/integration/tools/search-memory-recall-contract.test.ts
@@ -359,4 +359,56 @@ describe('search_memory > recall contract', () => {
     // …while still listing the genuinely public ones.
     expect(err).toContain('min_similarity');
   });
+
+  // ── Actionable read guidance on empty results ───────────────────────────
+  it('provides actionable read steps in suggestion when search finds no results', async () => {
+    const result = await search(
+      {
+        query: 'nonexistent-query-for-empty-guidance',
+        entity_type: 'ticket',
+        include_content: true,
+      },
+      env,
+      ctx
+    );
+
+    expect(result.discovery_status).toBe('not_found');
+    expect(result.matches).toEqual([]);
+    expect(result.content ?? []).toEqual([]);
+
+    const suggestion = result.suggestion ?? '';
+    expect(suggestion).toContain('No matches found for "nonexistent-query-for-empty-guidance"');
+    expect(suggestion).toContain('Additional steps to read relevant data:');
+    expect(suggestion).toContain('client.feeds.readMany');
+    expect(suggestion).toContain('query_sql');
+    expect(suggestion).toContain('audit');
+    expect(suggestion).toContain("remove entity_type='ticket'");
+    expect(suggestion).toContain('min_similarity');
+    expect(suggestion).toContain('save_memory');
+    expect(suggestion).toContain('client.entities.create');
+  });
+
+  it('reports memory content recalled without entity-create coaching when recall matches', async () => {
+    await createTestEvent({
+      organization_id: org.id,
+      title: 'Infrastructure migration notes',
+      content: 'Discussion on database migration and deployment infrastructure roadmap',
+    });
+
+    const result = await search(
+      {
+        query: 'deployment infrastructure roadmap',
+        fuzzy: false,
+        include_content: true,
+      },
+      env,
+      ctx
+    );
+
+    expect(result.discovery_status).toBe('complete');
+    expect(result.matches).toEqual([]);
+    expect(result.content?.length).toBeGreaterThan(0);
+    expect(result.suggestion).toContain('related memory content was recalled below');
+    expect(result.suggestion).not.toContain('entities.create');
+  });
 });

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -533,4 +533,33 @@ describe("sdkSearch", () => {
 		expect(result.match_count).toBe(1);
 		expect(result.results[0]).toContain("authProfiles.get");
 	});
+	// A miss that filtered NOTHING must not be explained as an access problem —
+	// that sends the caller after elevation when the fix is rephrasing. The
+	// `client.` prefix keeps this on the SDK-only path so connector discovery
+	// (which needs a live env) stays out of this unit test.
+	it("blames wording, not access tier, when nothing was hidden", async () => {
+		const result = await sdkSearch(
+			{ query: "client.zzznosuchmethod" },
+			stubEnv,
+			adminCtx,
+		);
+
+		expect(result.match_count).toBe(0);
+		expect(result.notes).toContain("No method or runtime-helper name matches");
+		expect(result.notes).not.toContain("No matches at your access tier");
+		// An admin in mode='full' has nothing left to widen to.
+		expect(result.notes).not.toContain("mode='full'");
+	});
+
+	it("points a read-mode miss at mode='full', never back at mode='read'", async () => {
+		const result = await sdkSearch(
+			{ query: "client.zzznosuchmethod", mode: "read" },
+			stubEnv,
+			readCtx,
+		);
+
+		expect(result.match_count).toBe(0);
+		expect(result.notes).toContain("pass mode='full'");
+		expect(result.notes).not.toContain("mode='read' for query_sdk");
+	});
 });

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -204,6 +204,21 @@ function hiddenMethodNote(
 	return `${path} is not available at your access tier (access: ${formatSdkRequiredTier(meta.access)}). ${guidance.instruction ?? ""}`.trim();
 }
 
+/**
+ * Zero-match note for a query nothing matched BY NAME. Access is deliberately
+ * not asserted as the cause: both call sites are reached only after every
+ * hidden-method explanation (`hiddenMethodNote`, `hiddenNamespaceNote`) came
+ * back empty, so the likely cause is wording, not tier. Widening means
+ * mode='full' — mode='read' NARROWS the catalog, so it is no help on a miss.
+ */
+function noNameMatchNote(mode: SdkDiscoveryMode): string {
+	const readHint =
+		mode === "read"
+			? " Only query_sdk-safe methods were searched; pass mode='full' for write and admin methods."
+			: "";
+	return `No method or runtime-helper name matches that wording. Try a namespace (${NAMESPACES.join(", ")}) or a verb (create, list, search).${readHint} A method above your access tier is also not listed.`;
+}
+
 function renderListLine(path: string, meta: MethodMetadata): string {
 	return `${path} — ${meta.summary}`;
 }
@@ -417,7 +432,7 @@ async function sdkMethodSearch(
 			results: [],
 			notes:
 				hidden.join(" ") ||
-				`No matches at your access tier. Try a namespace (${NAMESPACES.join(", ")}), mode='read' for query_sdk, or a verb (create, list, search).`,
+				noNameMatchNote(mode),
 		};
 	}
 
@@ -543,7 +558,7 @@ async function sdkMethodSearch(
 			notes:
 				hiddenNamespaceNote ??
 				existsButHidden ??
-				`No matches at your access tier. Try a namespace (${NAMESPACES.join(", ")}), mode='read' for query_sdk, or a verb (create, list, search).`,
+				noNameMatchNote(mode),
 		};
 	}
 

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -647,18 +647,18 @@ function buildEmptySearchSuggestion(
       .join(', ');
     const moreSuffix = sourceFeeds.length > 3 ? ` and ${sourceFeeds.length - 3} more` : '';
     lines.push(
-      `1. **Check unqueried source feeds:** Connected feeds are not queried automatically. Inspect \`coverage.source_feeds\` (${feedSamples}${moreSuffix}) and use \`query_sdk\` with \`client.feeds.readMany({ reads: [...] })\` to read external source data directly.`
+      `1. **Check unqueried source feeds:** Connected feeds are not queried automatically. Inspect \`coverage.source_feeds\` (${feedSamples}${moreSuffix}) and pass each entry's \`feed_id\` to \`client.feeds.readMany({ reads: [{ feed_id }] })\` via \`query_sdk\` to read external source data directly.`
     );
   } else {
     lines.push(
-      '1. **Check connected source feeds:** Connected feeds are not queried automatically. Discover available feeds with `search_sdk` or `client.feeds.list` and read them with `client.feeds.readMany` via `query_sdk`.'
+      '1. **Check connected source feeds:** Connected feeds are not queried automatically. List them with `client.feeds.list()` and read them with `client.feeds.readMany({ reads: [...] })` via `query_sdk`.'
     );
   }
 
-  // The literal comes from the shared constant so the SQL we hand the agent
-  // cannot drift from the value audit events are actually written with.
+  // The literals come from the shared constant so the SQL and the filter we
+  // hand the agent cannot drift from the value audit events are written with.
   lines.push(
-    `2. **Check activity and audit records:** tool invocations and other operational events are stored in \`events\` without embeddings, so semantic recall never reaches them. Read them explicitly with \`query_sql\` (e.g. \`SELECT id, title, semantic_type, occurred_at FROM events WHERE semantic_type = '${AUDIT_SEMANTIC_TYPE}' ORDER BY occurred_at DESC LIMIT 50\`) or with \`client.knowledge.read\` through \`query_sdk\`.`
+    `2. **Check activity and audit records:** tool invocations and other operational events are written to \`events\` with no body text and no embedding, so semantic recall cannot rank them and only their titles are searchable. Read them explicitly with \`query_sql\` (e.g. \`SELECT id, title, semantic_type, occurred_at FROM events WHERE semantic_type = '${AUDIT_SEMANTIC_TYPE}' ORDER BY occurred_at DESC LIMIT 50\`) or with \`client.knowledge.read({ semantic_type: '${AUDIT_SEMANTIC_TYPE}' })\` through \`query_sdk\`.`
   );
 
   const filterRelaxations: string[] = [];
@@ -666,24 +666,26 @@ function buildEmptySearchSuggestion(
     filterRelaxations.push(`remove entity_type='${args.entity_type}'`);
   }
   if (args.workspace) {
-    filterRelaxations.push(`omit workspace='${args.workspace}' to search all granted workspaces`);
+    filterRelaxations.push(
+      `omit workspace='${args.workspace}' to search every workspace this connection can reach`
+    );
   }
   filterRelaxations.push('lower min_similarity (default 0.3)');
   filterRelaxations.push('try alternate keywords or synonyms');
-  lines.push(`3. **Broaden the search:** retry after you ${filterRelaxations.join('; ')}.`);
+  lines.push(
+    `3. **Broaden the search:** retry with one of these relaxations: ${filterRelaxations.join('; ')}.`
+  );
 
   lines.push('');
   lines.push('**If this is new knowledge to persist:**');
   lines.push('- To save facts or notes: call `save_memory` with content and semantic_type.');
-  if (!isFederated && query) {
-    lines.push(
-      `- To create a new entity: call \`run_sdk\` with \`await client.entities.create({ type: '<entity_type>', name: '${query}' })\`.`
-    );
-  } else {
-    lines.push(
-      "- To create a new entity: call `run_sdk` with `await client.entities.create({ type: '<entity_type>', name: '...' })`."
-    );
-  }
+  // Only a single-workspace text search names one entity worth pre-filling:
+  // federated results span workspaces, and an embedding-only call has no query
+  // text at all. Both fall back to a placeholder.
+  const newEntityName = !isFederated && query ? query : '...';
+  lines.push(
+    `- To create a new entity: its type must exist first (\`client.entitySchema.listTypes()\` to check, \`client.entitySchema.createType(...)\` for a type new to this workspace), then call \`run_sdk\` with \`await client.entities.create({ type: '<entity_type>', name: '${newEntityName}' })\`.`
+  );
 
   return lines.join('\n');
 }

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -15,6 +15,7 @@ import {
   resolveGrantedWorkspaceTarget,
 } from '../auth/oauth/workspace-grants';
 import { isInProcessSystemCall } from './access-control';
+import { AUDIT_SEMANTIC_TYPE } from './constants';
 import { evaluateEntityMutation, resolveActingPrincipal } from '../authz/entity-policy';
 import { type AuthzScope, authzScopeFromToolContext } from '../authz/scope';
 import { compileConnectionRowVisibility } from '../authz/connection-visibility';
@@ -622,6 +623,71 @@ function unavailableWorkspaceCoverage(workspace: GrantedMemberWorkspace): Worksp
   };
 }
 
+function buildEmptySearchSuggestion(
+  query: string | null,
+  args: SearchArgs,
+  coverage?: SearchCoverage
+): string {
+  const isFederated = coverage?.scope === 'all_granted';
+  const queryLabel = !isFederated && query ? ` for "${query}"` : '';
+  const scopeLabel = isFederated
+    ? 'in the currently accessible workspaces granted to this connection'
+    : 'in saved workspace memory';
+
+  const lines: string[] = [`No matches found${queryLabel} ${scopeLabel}.`];
+
+  lines.push('');
+  lines.push('**Additional steps to read relevant data:**');
+
+  const sourceFeeds = coverage?.source_feeds ?? [];
+  if (sourceFeeds.length > 0) {
+    const feedSamples = sourceFeeds
+      .slice(0, 3)
+      .map((f) => `\`${f.connection_slug}/${f.feed_key}\``)
+      .join(', ');
+    const moreSuffix = sourceFeeds.length > 3 ? ` and ${sourceFeeds.length - 3} more` : '';
+    lines.push(
+      `1. **Check unqueried source feeds:** Connected feeds are not queried automatically. Inspect \`coverage.source_feeds\` (${feedSamples}${moreSuffix}) and use \`query_sdk\` with \`client.feeds.readMany({ reads: [...] })\` to read external source data directly.`
+    );
+  } else {
+    lines.push(
+      '1. **Check connected source feeds:** Connected feeds are not queried automatically. Discover available feeds with `search_sdk` or `client.feeds.list` and read them with `client.feeds.readMany` via `query_sdk`.'
+    );
+  }
+
+  // The literal comes from the shared constant so the SQL we hand the agent
+  // cannot drift from the value audit events are actually written with.
+  lines.push(
+    `2. **Check activity and audit records:** tool invocations and other operational events are stored in \`events\` without embeddings, so semantic recall never reaches them. Read them explicitly with \`query_sql\` (e.g. \`SELECT id, title, semantic_type, occurred_at FROM events WHERE semantic_type = '${AUDIT_SEMANTIC_TYPE}' ORDER BY occurred_at DESC LIMIT 50\`) or with \`client.knowledge.read\` through \`query_sdk\`.`
+  );
+
+  const filterRelaxations: string[] = [];
+  if (args.entity_type) {
+    filterRelaxations.push(`remove entity_type='${args.entity_type}'`);
+  }
+  if (args.workspace) {
+    filterRelaxations.push(`omit workspace='${args.workspace}' to search all granted workspaces`);
+  }
+  filterRelaxations.push('lower min_similarity (default 0.3)');
+  filterRelaxations.push('try alternate keywords or synonyms');
+  lines.push(`3. **Broaden the search:** retry after you ${filterRelaxations.join('; ')}.`);
+
+  lines.push('');
+  lines.push('**If this is new knowledge to persist:**');
+  lines.push('- To save facts or notes: call `save_memory` with content and semantic_type.');
+  if (!isFederated && query) {
+    lines.push(
+      `- To create a new entity: call \`run_sdk\` with \`await client.entities.create({ type: '<entity_type>', name: '${query}' })\`.`
+    );
+  } else {
+    lines.push(
+      "- To create a new entity: call `run_sdk` with `await client.entities.create({ type: '<entity_type>', name: '...' })`."
+    );
+  }
+
+  return lines.join('\n');
+}
+
 export function mergeFederatedSearchResults(
   args: SearchArgs,
   targets: readonly GrantedMemberWorkspace[],
@@ -750,7 +816,7 @@ export function mergeFederatedSearchResults(
       : status === 'partial'
         ? 'Search returned partial results; one or more granted workspaces was temporarily unavailable.'
         : matches.length === 0 && !hasAnyRecall
-          ? 'No matches found in the currently accessible workspaces granted to this connection.'
+          ? buildEmptySearchSuggestion(args.query ?? null, args, coverage)
           : selectedResult?.suggestion,
     ...(entity && selectedResult?.view_url ? { view_url: selectedResult.view_url } : {}),
     metadata: {
@@ -1650,21 +1716,26 @@ async function searchWorkspaceImpl(
   }
 
   // ========================================
-  // NOT FOUND
+  // NOT FOUND (or recall-only hit)
   // ========================================
-  logger.info(`[search] No matches found for "${query}" in existing database`);
+  const hasRecallHits =
+    (recall.content != null && recall.content.length > 0) ||
+    (recall.conversation_messages != null && recall.conversation_messages.length > 0);
 
-  const suggestionText =
-    `No matches found for "${query}" in existing database.\n\n` +
-    '**Next steps:** call `run_sdk` with a TS script over `client`:\n' +
-    `1. Create the entity: \`await client.entities.create({ type: '<entity_type>', name: '${query}' })\` (optionally pass parent_id for hierarchy)\n` +
-    "2. Create a connection: `await client.connections.create({ connector_key: '<connector>', ... })`, then scope it with `await client.feeds.create({ ... })`\n" +
-    '3. Wait for ingestion to start automatically, then discover Automations with `client.automations.list(...)` and inspect results with `client.knowledge.read(...)` / `client.automations.get(...)`.\n\n' +
-    '**Alternative:** If you know this entity should exist, verify the spelling or try a different search term.';
+  if (hasRecallHits) {
+    logger.info(`[search] Recalled memory hits for "${query}" with no entity match`);
+  } else {
+    logger.info(`[search] No matches found for "${query}" in existing database`);
+  }
+
+  const suggestionText = hasRecallHits
+    ? 'No matching entities found, but related memory content was recalled below.'
+    : buildEmptySearchSuggestion(query, args, recall.coverage);
 
   const result = withRecall(
     emptyResult({
       ...(title ? { title } : {}),
+      discovery_status: hasRecallHits ? 'complete' : 'not_found',
       suggestion: suggestionText,
     }),
     recall

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -681,8 +681,9 @@ function buildEmptySearchSuggestion(
   lines.push('- To save facts or notes: call `save_memory` with content and semantic_type.');
   // Only a single-workspace text search names one entity worth pre-filling:
   // federated results span workspaces, and an embedding-only call has no query
-  // text at all. Both fall back to a placeholder.
-  const newEntityName = !isFederated && query ? query : '...';
+  // text at all. Both fall back to a placeholder in the SAME angle-bracket
+  // shape as `<entity_type>` below — a bare `...` reads as copyable literal.
+  const newEntityName = !isFederated && query ? query : '<entity_name>';
   lines.push(
     `- To create a new entity: its type must exist first (\`client.entitySchema.listTypes()\` to check, \`client.entitySchema.createType(...)\` for a type new to this workspace), then call \`run_sdk\` with \`await client.entities.create({ type: '<entity_type>', name: '${newEntityName}' })\`.`
   );


### PR DESCRIPTION
## Summary
- An empty `search_memory` result coached the agent to **create** (entity → connection → wait for ingestion). Local semantic recall is only one place the answer can live, so agents either concluded "no data about X exists" or created a duplicate for something already sitting in a connected feed or the audit trail.
- The empty-result `suggestion` now leads with the reads still available — unqueried `coverage.source_feeds` (with the `client.feeds.readMany` call), activity/audit rows in `events` (no embeddings, so semantic recall never reaches them; the `query_sql` example uses the shared `AUDIT_SEMANTIC_TYPE` constant so it cannot drift), and broadening the filters actually set on this call — before it offers `save_memory` / `client.entities.create`.
- `search_sdk` had the same defect: both zero-match sites returned "No matches at your access tier", but each is reached only after every hidden-method explanation came back empty — nothing was filtered by access, so the note sent the agent after an elevation it did not need instead of a rephrase. The two duplicated literals collapse into one `noNameMatchNote(mode)`. Same string also advised `mode='read'` on an empty result, but `read` *narrows* the catalog; widening is `mode='full'`.
- Recall-only hits stop reporting `not_found`: matched content or channel conversation with no entity match now returns `discovery_status: 'complete'`, matching what `mergeFederatedSearchResults` already did for the same case. Both paths build the suggestion from one helper.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (local fallback; full graph runs on CI here)
- [x] Tests run: targeted Vitest — `search-memory-recall-contract`, `search-memory-federation`, `markdown-formatter`, `source-feed-surfaces`, `all-tools-e2e`, `bare-oauth-federated-search-e2e`, `search-content-{embedding-only,org-scope,visibility}`, `workspace-audit-public-visibility`, `search-channel-recall`, `lobu-guidance-sync`; bun:test — `result-title`, `search-entity-limit`, `sandbox/sdk-search` (60/60, was 58 — the 4 logged `DATABASE_URL` warnings are pre-existing, confirmed by running `origin/main`'s copy of the suite against the patched source)
- [x] Bug fix: red→fix→green outputs pasted below

### red — new assertions against `origin/main`'s `search.ts`

```
× search_memory > recall contract > provides actionable read steps in suggestion when search finds no results
  → expected 'No matches found for "nonexistent-que…' to contain 'Additional steps to read relevant dat…'
× search_memory > recall contract > reports memory content recalled without entity-create coaching when recall matches
  → expected 'not_found' to be 'complete' // Object.is equality

 Test Files  1 failed (1)
      Tests  2 failed | 8 passed (10)
```

### green — same suite with the fix

```
 ✓ src/__tests__/integration/tools/search-memory-recall-contract.test.ts (10 tests) 488ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

### green — surrounding suites

```
 ✓ src/__tests__/integration/tools/search-memory-recall-contract.test.ts (10 tests)
 ✓ src/__tests__/integration/tools/search-memory-federation.test.ts (10 tests)
 ✓ src/formatting/__tests__/markdown-formatter.test.ts (19 tests)
 ✓ src/__tests__/integration/connectors/source-feed-surfaces.test.ts (6 tests)
 Test Files  4 passed (4)
      Tests  45 passed (45)

 ✓ src/__tests__/integration/events/workspace-audit-public-visibility.test.ts (17 tests)
 ✓ src/__tests__/integration/tools/all-tools-e2e.test.ts (29 tests)
 ✓ src/__tests__/integration/mcp/bare-oauth-federated-search-e2e.test.ts (1 test)
 ✓ src/tools/__tests__/search-channel-recall.test.ts (4 tests)
 ✓ src/__tests__/integration/events/search-content-org-scope.test.ts (6 tests)
 ✓ src/__tests__/integration/events/search-content-visibility.test.ts (3 tests)
 ✓ src/__tests__/integration/events/search-content-embedding-only.test.ts (3 tests)
 ✓ src/utils/__tests__/lobu-guidance-sync.test.ts (2 tests)
 Test Files  8 passed (8)
      Tests  65 passed (65)
```

## Notes
- No schema change: `discovery_status: 'complete'` and every referenced SDK method (`client.feeds.list`, `client.feeds.readMany`, `client.knowledge.read`) already exist; only the value chosen for the recall-only case and the `suggestion` text change.
- **`pi-review` on this PR is not an independent verdict.** The gate's default reviewer for a Claude Code harness is codex (`review_select_reviewer`), and codex quota is exhausted until Sep 7, so the status was produced by `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus` — the same model that wrote the branch. Recorded here rather than left to look cross-harness. Verdict: bug_free 90, simplicity 82, slop 12, 0 bugs, 0 blockers, risk low; its three non-blocking suggestions were all applied.
- The `search_sdk` hunk landed after the review pass and did not get its own `review-fix` round, by request. `make review` had not yet run on this branch, so the required gate still covers the whole diff in one round.
- `make review-fix`'s codex backend could not run — its codex backend reported `You've hit your usage limit … try again at Sep 7th, 2026`. The diff got a manual pass instead (that pass is what replaced the hand-typed `'audit'` literal with `AUDIT_SEMANTIC_TYPE` and un-exported the helper so full `knip` stays clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QyAFsa9B1WQMVJyB3XV5z1
