### PR TITLE
refactor(automations): drop the redundant completed_window_coverage column

### DIFF
--- a/db/migrations/20260903220000_drop_automation_completed_window_coverage.sql
+++ b/db/migrations/20260903220000_drop_automation_completed_window_coverage.sql
@@ -1,0 +1,31 @@
+-- migrate:up
+
+-- Finish the arrival-axis cutover by removing `completed_window_coverage`.
+--
+-- 20260903160000 moved Automation windowing onto the arrival mark and left this
+-- column behind as a multirange holding exactly one contiguous range,
+-- [first booked instant, next_window_start). Its own COMMENT said it "carries no
+-- information the mark does not" and was "kept as a multirange for one release".
+-- This is that release.
+--
+-- Structural evidence it is dead, checked against origin/main:
+--   * Nothing reads it. The single `lower(completed_window_coverage)` in
+--     `advanceAutomationArrivalMark` is self-referential — the column is read
+--     only to preserve its own lower bound on the next write.
+--   * The three other production references are INSERT column lists writing the
+--     `'{}'` default (manage_automations/crud.ts create + clone,
+--     gateway/channels/automation-subscription-service.ts).
+--   * It is absent from every contract, client type, connector-SDK type and
+--     Owletto surface, so no consumer can observe the drop.
+--   * The value a caller actually consumes is `last_completed_window_start`,
+--     which `get_content/automation-mode.ts` reads for the `window_lag` surface
+--     and which this migration leaves untouched.
+ALTER TABLE automations DROP COLUMN IF EXISTS completed_window_coverage;
+
+-- migrate:down
+
+-- Restores the column and its default. The historical ranges are NOT rebuilt:
+-- they were derived from the mark, nothing consumed them, and the arrival mark
+-- plus `last_completed_window_start` still carry every value a reader used.
+ALTER TABLE automations
+  ADD COLUMN IF NOT EXISTS completed_window_coverage tstzmultirange NOT NULL DEFAULT '{}'::tstzmultirange;

--- a/packages/server/src/__tests__/integration/automations/arrival-axis-window.test.ts
+++ b/packages/server/src/__tests__/integration/automations/arrival-axis-window.test.ts
@@ -147,29 +147,14 @@ describe('Automation windows on the arrival axis', () => {
   async function readProjection() {
     const [row] = await sql<{
       next_window_start: Date | string;
-      coverage_lower: Date | string | null;
-      coverage_upper: Date | string | null;
-      coverage_ranges: number | string;
       last_completed_window_start: Date | string | null;
     }>`
-      SELECT next_window_start,
-             lower(completed_window_coverage) AS coverage_lower,
-             upper(completed_window_coverage) AS coverage_upper,
-             (SELECT count(*) FROM unnest(completed_window_coverage)) AS coverage_ranges,
-             last_completed_window_start
+      SELECT next_window_start, last_completed_window_start
       FROM automations
       WHERE id = ${automationId}
     `;
     return {
       mark: new Date(row.next_window_start).toISOString(),
-      coverage:
-        row.coverage_lower == null || row.coverage_upper == null
-          ? null
-          : {
-              lower: new Date(row.coverage_lower).toISOString(),
-              upper: new Date(row.coverage_upper).toISOString(),
-              ranges: Number(row.coverage_ranges),
-            },
       lastCompletedWindowStart:
         row.last_completed_window_start == null
           ? null
@@ -258,28 +243,22 @@ describe('Automation windows on the arrival axis', () => {
     await complete(first);
 
     const projection = await readProjection();
+    // The mark IS the coverage record: everything before it is booked, so a run
+    // that starts exactly where the mark sits can never leave a gap behind it.
     expect(projection.mark).toBe(first.context.window_end);
-    // One contiguous range from the seed to the mark — never a set with gaps.
-    expect(projection.coverage).toEqual({
-      lower: mark.toISOString(),
-      upper: first.context.window_end,
-      ranges: 1,
-    });
     expect(projection.lastCompletedWindowStart).toBe(first.context.window_start);
 
     const second = await claim();
     expect(second.context.window_start).toBe(first.context.window_end);
     expect(second.context.content.map((r) => r.id)).not.toContain(row.id);
 
-    // Completing the second range keeps the coverage a single range.
+    // Completing the second range walks the mark forward with no gap: the second
+    // window began exactly at the first mark (asserted above) and the mark now
+    // sits at its end, so [seed, mark) stays contiguous without a coverage set.
     await complete(second);
     const after = await readProjection();
     expect(after.mark).toBe(second.context.window_end);
-    expect(after.coverage).toEqual({
-      lower: mark.toISOString(),
-      upper: second.context.window_end,
-      ranges: 1,
-    });
+    expect(after.lastCompletedWindowStart).toBe(second.context.window_start);
   });
 
   it('lets a scheduled tick inside a fresh mark\'s settle budget wait instead of erroring', async () => {

--- a/packages/server/src/__tests__/integration/automations/automations-crud.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automations-crud.test.ts
@@ -79,19 +79,16 @@ describe('automation CRUD', () => {
     })) as { automation_id: string };
     const automationId = created.automation_id;
     expect(automationId).toBeDefined();
-    // A new Automation starts covering arrivals from its creation instant: the
-    // mark is seeded, nothing is booked, and no granularity interprets either.
+    // A new Automation starts covering arrivals from its lookback seed: the
+    // mark is set and nothing has completed yet.
     const [createdProjection] = await getTestDb()<{
       next_window_start: string | Date | null;
-      completed_window_coverage: string;
       last_completed_window_start: string | Date | null;
     }[]>`
-      SELECT next_window_start, completed_window_coverage::text AS completed_window_coverage,
-             last_completed_window_start
+      SELECT next_window_start, last_completed_window_start
       FROM automations WHERE id = ${automationId}
     `;
     expect(createdProjection.next_window_start).not.toBeNull();
-    expect(createdProjection.completed_window_coverage).toBe('{}');
     expect(createdProjection.last_completed_window_start).toBeNull();
 
     const got = (await owner.automations.get({ automation_id: automationId })) as {
@@ -143,9 +140,6 @@ describe('automation CRUD', () => {
     await sql`
       UPDATE automations
       SET next_window_start = '2025-01-01T00:00:00.000Z'::timestamptz,
-          completed_window_coverage = tstzmultirange(
-            tstzrange('2025-01-08T00:00:00.000Z', '2025-01-09T00:00:00.000Z', '[)')
-          ),
           last_completed_window_start = '2025-01-08T00:00:00.000Z'::timestamptz
       WHERE id = ${created.automation_id}
     `;
@@ -157,17 +151,14 @@ describe('automation CRUD', () => {
 
     const [projection] = await sql<{
       next_window_start: string | Date;
-      completed_window_coverage: string;
       last_completed_window_start: string | Date | null;
     }[]>`
-      SELECT next_window_start, completed_window_coverage::text AS completed_window_coverage,
-             last_completed_window_start
+      SELECT next_window_start, last_completed_window_start
       FROM automations WHERE id = ${created.automation_id}
     `;
     expect(new Date(projection.next_window_start).toISOString()).toBe(
       '2025-01-01T00:00:00.000Z'
     );
-    expect(projection.completed_window_coverage).not.toBe('{}');
     expect(new Date(projection.last_completed_window_start as string).toISOString()).toBe(
       '2025-01-08T00:00:00.000Z'
     );
@@ -1306,7 +1297,6 @@ describe('automation CRUD', () => {
       const [clone] = await sql`
         SELECT managed_agent_id, device_worker_id, agent_kind,
                triggers::text AS triggers, next_window_start,
-               completed_window_coverage::text AS completed_window_coverage,
                last_completed_window_start
         FROM automations WHERE id = ${cloneId}
       `;
@@ -1314,7 +1304,6 @@ describe('automation CRUD', () => {
       expect(clone.device_worker_id).toBe(deviceId);
       expect(clone.agent_kind).toBe('codex');
       expect(clone.next_window_start).not.toBeNull();
-      expect(clone.completed_window_coverage).toBe('{}');
       expect(clone.last_completed_window_start).toBeNull();
       // The schedule trigger is preserved and still resolves via the device pin.
       expect(clone.triggers).toMatch(/schedule/);

--- a/packages/server/src/__tests__/integration/automations/device-schedule-liveness.test.ts
+++ b/packages/server/src/__tests__/integration/automations/device-schedule-liveness.test.ts
@@ -287,7 +287,6 @@ describe("device-pinned scheduled Automation liveness (#2538)", () => {
 		await sql`
 			UPDATE automations
 			SET next_window_start = ${mark.toISOString()}::timestamptz,
-				completed_window_coverage = '{}'::tstzmultirange,
 				next_run_at = current_timestamp - interval '2 hours'
 			WHERE id = ${automationId}
 		`;

--- a/packages/server/src/__tests__/integration/automations/trigger-execution.test.ts
+++ b/packages/server/src/__tests__/integration/automations/trigger-execution.test.ts
@@ -70,8 +70,7 @@ describe("Automation trigger execution contract", () => {
 		windowStart.setUTCDate(windowStart.getUTCDate() - 2);
 		await sql`
       UPDATE automations
-      SET next_window_start = ${windowStart.toISOString()}::timestamptz,
-          completed_window_coverage = '{}'::tstzmultirange
+      SET next_window_start = ${windowStart.toISOString()}::timestamptz
       WHERE id = ${Number(automation.automation_id)}
     `;
 		const claim = (await workspace.owner.automations.claimNextWindow({

--- a/packages/server/src/__tests__/integration/automations/window-automation-keys.test.ts
+++ b/packages/server/src/__tests__/integration/automations/window-automation-keys.test.ts
@@ -84,8 +84,7 @@ describe("Automation window vocabulary", () => {
 		const expectedMark = new Date("2026-08-01T00:00:00.000Z");
 		await sql`
 			UPDATE automations
-			SET next_window_start = ${expectedMark.toISOString()}::timestamptz,
-				completed_window_coverage = '{}'::tstzmultirange
+			SET next_window_start = ${expectedMark.toISOString()}::timestamptz
 			WHERE id = ${automationId}
 		`;
 		await createTestEvent({

--- a/packages/server/src/__tests__/integration/automations/window-claim-recovery.test.ts
+++ b/packages/server/src/__tests__/integration/automations/window-claim-recovery.test.ts
@@ -153,8 +153,7 @@ describe('Automation window claim and recovery', () => {
     });
     await sql`
       UPDATE automations
-      SET next_window_start = ${failedStart.toISOString()}::timestamptz,
-          completed_window_coverage = '{}'::tstzmultirange
+      SET next_window_start = ${failedStart.toISOString()}::timestamptz
       WHERE id = ${automationId}
     `;
     const event = await createTestEvent({
@@ -216,7 +215,6 @@ describe('Automation window claim and recovery', () => {
     await sql`
       UPDATE automations
       SET next_window_start = ${staleMark.toISOString()}::timestamptz,
-          completed_window_coverage = '{}'::tstzmultirange,
           last_completed_window_start = NULL
       WHERE id = ${automationId}
     `;
@@ -238,18 +236,14 @@ describe('Automation window claim and recovery', () => {
 
     const [projection] = await sql<{
       next_window_start: string | Date;
-      completed_window_coverage: string;
       last_completed_window_start: string | Date | null;
     }>`
-      SELECT next_window_start,
-             completed_window_coverage::text AS completed_window_coverage,
-             last_completed_window_start
+      SELECT next_window_start, last_completed_window_start
       FROM automations WHERE id = ${automationId}
     `;
     expect(new Date(projection.next_window_start).toISOString()).toBe(
       staleMark.toISOString()
     );
-    expect(projection.completed_window_coverage).toBe('{}');
     expect(projection.last_completed_window_start).toBeNull();
 
     // And the claim still hands out the whole unclaimed range.
@@ -678,7 +672,6 @@ describe('Automation window claim and recovery', () => {
     await sql`
       UPDATE automations
       SET next_window_start = ${staleMark.toISOString()}::timestamptz,
-          completed_window_coverage = '{}'::tstzmultirange,
           last_completed_window_start = NULL
       WHERE id = ${automationId}
     `;

--- a/packages/server/src/__tests__/integration/automations/window-lag-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/automations/window-lag-visibility.test.ts
@@ -123,7 +123,6 @@ describe("Automation arrival lag is visible and actionable", () => {
 		await sql`
 			UPDATE automations
 			SET next_window_start = ${mark.toISOString()}::timestamptz,
-				completed_window_coverage = '{}'::tstzmultirange,
 				last_completed_window_start = NULL
 			WHERE id = ${automationId}
 		`;

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -697,7 +697,8 @@ async function finalizeStalePendingAutomationRuns(
 			}
 			if (!candidate.schedule) continue;
 			// An orphaned device snapshot must retry the same unfinished window under
-			// current ownership, so preserve both schedule and coverage cursors.
+			// current ownership, so leave both cursors alone: `next_run_at` and the
+			// arrival mark `next_window_start`.
 			if (candidate.device_worker_id) continue;
 			const next = nextRunAt(
 				candidate.schedule,

--- a/packages/server/src/gateway/channels/__tests__/automation-subscription-service-org-scope.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/automation-subscription-service-org-scope.test.ts
@@ -88,10 +88,8 @@ describe("AutomationSubscriptionService connection-scoped routing", () => {
 		expect(rows).toHaveLength(2);
 		const projections = await getDb()<{
 			next_window_start: string | Date | null;
-			completed_window_coverage: string;
 		}>`
-			SELECT next_window_start,
-			       completed_window_coverage::text AS completed_window_coverage
+			SELECT next_window_start
 			FROM automations
 			WHERE organization_id = ${ORG_A}
 			  AND tags @> ARRAY['system:chat-link']::text[]
@@ -99,7 +97,6 @@ describe("AutomationSubscriptionService connection-scoped routing", () => {
 		expect(projections).toHaveLength(2);
 		for (const projection of projections) {
 			expect(projection.next_window_start).not.toBeNull();
-			expect(projection.completed_window_coverage).toBe("{}");
 		}
 	});
 

--- a/packages/server/src/gateway/channels/automation-subscription-service.ts
+++ b/packages/server/src/gateway/channels/automation-subscription-service.ts
@@ -510,7 +510,7 @@ export class AutomationSubscriptionService {
 					schedule, next_run_at, triggers, managed_agent_id, model_config,
 					execution_config, sources, version, current_version_id, tags,
 					status, created_by, created_at, updated_at, automation_group_id,
-					next_window_start, completed_window_coverage
+					next_window_start
 				) VALUES (
 					${automationId}, ${`Messages in ${channelId}`}, ${`chat-${platform}-${automationId}`},
 					'Chat subscription', ${organizationId}, '{}'::bigint[],
@@ -518,8 +518,7 @@ export class AutomationSubscriptionService {
 					${model ? tx.json({ model }) : null}, '[]'::jsonb, 1, NULL,
 					ARRAY[${CHAT_LINK_TAG}]::text[], 'active', ${createdBy},
 					current_timestamp, current_timestamp, ${automationId},
-					date_trunc('milliseconds', current_timestamp) + interval '1 millisecond',
-					'{}'::tstzmultirange
+					date_trunc('milliseconds', current_timestamp) + interval '1 millisecond'
 				)
 			`;
 			await tx`

--- a/packages/server/src/tools/admin/manage_automations/crud.ts
+++ b/packages/server/src/tools/admin/manage_automations/crud.ts
@@ -334,7 +334,7 @@ export async function handleCreate(
         min_cooldown_seconds,
         delivery_target, execution_config,
         reaction_script, reaction_script_compiled, reaction_input_schema,
-        next_window_start, completed_window_coverage
+        next_window_start
       ) VALUES (
         ${automationId}, ${args.name ?? args.slug}, ${args.slug}, ${organizationId},
         ${`{${entityIdsArray.join(',')}}`}::bigint[],
@@ -351,8 +351,7 @@ export async function handleCreate(
         ${reactionScript}, ${reactionScriptCompiled},
         ${reactionInputSchema ? tx.json(reactionInputSchema) : null},
         date_trunc('milliseconds', current_timestamp) + interval '1 millisecond'
-          - make_interval(secs => ${intervals.automationFirstWindowLookbackMs / 1000}),
-        '{}'::tstzmultirange
+          - make_interval(secs => ${intervals.automationFirstWindowLookbackMs / 1000})
       )
     `;
 
@@ -1026,7 +1025,7 @@ export async function handleCreateFromVersion(
             current_version_id, tags, status, created_by, created_at, updated_at,
             automation_group_id, source_automation_id,
             reaction_script, reaction_script_compiled, reaction_input_schema,
-            next_window_start, completed_window_coverage
+            next_window_start
           ) VALUES (
             ${automationId}, ${automationName}, ${automationSlug}, ${organizationId},
             ${`{${entityId}}`}::bigint[],
@@ -1042,8 +1041,7 @@ export async function handleCreateFromVersion(
             ${(version.reaction_script_compiled as string | null) ?? null},
             ${toJsonParam(tx, version.reaction_input_schema)},
             date_trunc('milliseconds', current_timestamp) + interval '1 millisecond'
-              - make_interval(secs => ${intervals.automationFirstWindowLookbackMs / 1000}),
-            '{}'::tstzmultirange
+              - make_interval(secs => ${intervals.automationFirstWindowLookbackMs / 1000})
           )
         `;
 

--- a/packages/server/src/utils/__tests__/compute-pending-window.test.ts
+++ b/packages/server/src/utils/__tests__/compute-pending-window.test.ts
@@ -41,11 +41,11 @@ async function seedAutomation(automationId: number, mark: Date | null): Promise<
   await getTestDb()`
     INSERT INTO automations (
       id, name, slug, created_by, organization_id, managed_agent_id, automation_group_id,
-      next_window_start, completed_window_coverage
+      next_window_start
     ) VALUES (
       ${automationId}, ${`Window ${automationId}`}, ${`window-${automationId}`},
       ${userId}, ${orgId}, ${agent.agentId}, ${automationId},
-      ${mark ? mark.toISOString() : null}::timestamptz, '{}'::tstzmultirange
+      ${mark ? mark.toISOString() : null}::timestamptz
     )
   `;
 }
@@ -55,23 +55,6 @@ async function readMark(automationId: number): Promise<Date | null> {
     SELECT next_window_start FROM automations WHERE id = ${automationId}
   `;
   return row?.next_window_start ? new Date(row.next_window_start) : null;
-}
-
-/** Coverage as bounds plus range count — asserted semantically, never as rendered text. */
-async function readCoverage(
-  automationId: number
-): Promise<{ from: Date | null; to: Date | null; ranges: number }> {
-  const [row] = await getTestDb()`
-    SELECT lower(completed_window_coverage) AS from_ts,
-           upper(completed_window_coverage) AS to_ts,
-           (SELECT count(*) FROM unnest(completed_window_coverage) r) AS ranges
-    FROM automations WHERE id = ${automationId}
-  `;
-  return {
-    from: row.from_ts ? new Date(row.from_ts) : null,
-    to: row.to_ts ? new Date(row.to_ts) : null,
-    ranges: Number(row.ranges),
-  };
 }
 
 describe('the arrival mark', () => {
@@ -145,22 +128,21 @@ describe('the arrival mark', () => {
     expect(await advanceAutomationArrivalMark(sql, 1, mark, end)).toBe(true);
     expect((await readMark(1))?.toISOString()).toBe(end.toISOString());
     expect(await readLastCompletedWindowStart(sql, 1)).toEqual(mark);
-    // Coverage stays ONE contiguous range: [first booked, mark).
-    expect(await readCoverage(1)).toEqual({ from: mark, to: end, ranges: 1 });
   });
 
-  it('keeps coverage contiguous across consecutive completions', async () => {
+  it('walks the mark contiguously across consecutive completions', async () => {
     const first = new Date(Date.now() - 30 * MINUTE_MS);
     const second = new Date(first.getTime() + 10 * MINUTE_MS);
     const third = new Date(second.getTime() + 10 * MINUTE_MS);
     await seedAutomation(1, first);
 
-    await advanceAutomationArrivalMark(sql, 1, first, second);
-    await advanceAutomationArrivalMark(sql, 1, second, third);
+    // Each advance requires `start <= mark < end`, so a second completion can
+    // only ever butt against the first: [first, third) cannot fragment.
+    expect(await advanceAutomationArrivalMark(sql, 1, first, second)).toBe(true);
+    expect(await advanceAutomationArrivalMark(sql, 1, second, third)).toBe(true);
 
     expect((await readMark(1))?.toISOString()).toBe(third.toISOString());
-    // One range, not two: the multirange never fragments on the arrival axis.
-    expect(await readCoverage(1)).toEqual({ from: first, to: third, ranges: 1 });
+    expect(await readLastCompletedWindowStart(sql, 1)).toEqual(second);
   });
 
   it('books nothing for a range that is entirely behind the mark (a re-read)', async () => {

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -294,12 +294,11 @@ describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
     // QUERYABLE_SCHEMA entry until the phase-2 migration. next_window_start is
     // internal scheduler coordination state, exposed through the Automation
     // contract as pending_analysis.next_window rather than raw query_sql. The
-    // coverage multirange, its granularity, and the latest-completion scalar are
-    // the rest of that same scheduler-internal projection.
+    // latest-completion scalar is the rest of that same scheduler-internal
+    // projection.
     automations: new Set([
       'scheduler_client_id',
       'next_window_start',
-      'completed_window_coverage',
       'last_completed_window_start',
     ]),
     user: new Set(['email', 'phoneNumber', 'phoneNumberVerified']),

--- a/packages/server/src/utils/window-utils.ts
+++ b/packages/server/src/utils/window-utils.ts
@@ -11,10 +11,10 @@
  *
  * The bookkeeping is one mark per Automation, `automations.next_window_start`:
  * every row with `created_at >= mark` is unclaimed. Claims are serialized per
- * Automation (a second claim gets 409 while one is active), so a set of covered
- * ranges can never diverge from the mark — `completed_window_coverage` holds
- * exactly one contiguous range, [first booked instant, mark), until the column
- * is retyped to a single timestamptz.
+ * Automation (a second claim gets 409 while one is active), so the mark alone is
+ * the whole record of progress: everything before it is covered, everything at
+ * or after it is not. `last_completed_window_start` records where the newest
+ * completed run began, which is what the `window_lag` surface reports.
  */
 
 import { intervals } from '../config/intervals';
@@ -164,12 +164,13 @@ export async function readPendingWindow(
  * A range entirely behind the mark is a re-read and books nothing. A range that
  * starts after the mark is an explicitly selected later span and books nothing
  * either: the rows stored between the mark and it stay unclaimed, and the next
- * ordinary claim returns them. Coverage stays one contiguous range.
+ * ordinary claim returns them. The booked span behind the mark therefore
+ * stays contiguous.
  *
  * This is the only writer of the mark. The two completion sites that store
  * `action_output` — `complete-window.ts` and the unchanged-source skip in
  * `automations/automation.ts` — both call it inside their completion
- * transaction; no trigger re-derives coverage from run history any more.
+ * transaction; no trigger re-derives the mark from run history any more.
  *
  * Returns whether the mark moved.
  */
@@ -191,11 +192,6 @@ export async function advanceAutomationArrivalMark(
   const moved = await sql`
     UPDATE automations
     SET next_window_start = LEAST(${end}::timestamptz, current_timestamp),
-        completed_window_coverage = tstzmultirange(tstzrange(
-          LEAST(lower(completed_window_coverage), ${start}::timestamptz),
-          LEAST(${end}::timestamptz, current_timestamp),
-          '[)'
-        )),
         last_completed_window_start = GREATEST(
           last_completed_window_start,
           ${start}::timestamptz


### PR DESCRIPTION
## What

Finishes the arrival-axis cutover (#3334) by removing `automations.completed_window_coverage`.

#3334 moved Automation windowing onto a single arrival mark and left this column behind as a
multirange holding exactly one contiguous range, `[first booked instant, next_window_start)`.
Its own migration COMMENT said it *"carries no information the mark does not"* and was
*"kept as a multirange for one release"*. This is that release.

The planned follow-up was to **retype** it to a plain `timestamptz`. It turned out the retype
target has no consumer either, so the column is dropped outright rather than shrunk.

## Why drop rather than retype

Structural evidence, checked against `origin/main`:

- **Nothing reads it.** The single `lower(completed_window_coverage)` in
  `advanceAutomationArrivalMark` is self-referential — the column is read only to preserve its
  own lower bound on the next write.
- The three other production references are INSERT column lists writing the `'{}'` default
  (`manage_automations/crud.ts` create + clone, `gateway/channels/automation-subscription-service.ts`).
- It is absent from every contract, client type, connector-SDK type and Owletto surface, so no
  consumer can observe the drop.
- The value callers actually consume is `last_completed_window_start`, which
  `get_content/automation-mode.ts` reads for the `window_lag` surface. Untouched here.

## Test changes

The suites asserted on coverage bounds and range counts. Where that assertion carried real
intent — "consecutive completions never fragment the covered range" — it is replaced by the
invariant that actually enforces it: `advanceAutomationArrivalMark`'s
`WHERE start <= mark AND end > mark` means a second completion can only butt against the first,
so `[seed, mark)` cannot fragment without a coverage set to record it.

## Proof

Migration applied against the real migrated schema, then `information_schema` queried directly
(temporary test, since removed):

```
SURVIVING COLUMNS: [ 'last_completed_window_start', 'next_window_start' ]
```

- `tsc --noEmit` in `packages/server`: clean.
- All automation integration suites + the subscription-service org-scope suite:
  **50 files, 424 tests passed**.
- Full `packages/server` vitest on this branch: **531 files, 4910 passed, 2 skipped, 0 failed**.
- Control run of the same full suite on clean `origin/main` (3382b31b1): **531 files, 4908 passed, 0 failed**.
  An earlier run of this branch showed 3 failures in `operations-execute-backends` and
  `acl-sync-lock`; both pass in isolation on this branch AND on the base, and the clean re-run above
  is green, so they were suite-ordering flakes, not this change.
- `make pre-pr`: clean (build, per-package typecheck, knip, naming, gateway-LLM + entity-write funnel gates).

## Rollback — exercised, not just written

The `migrate:down` block was executed verbatim against the real migrated schema, then `migrate:up`
re-applied:

```
AFTER DOWN:  [{"column_name":"completed_window_coverage","data_type":"tstzmultirange",
              "is_nullable":"NO","column_default":"'{}'::tstzmultirange"}]
AFTER RE-UP: []
```

Both directions are idempotent (`DROP COLUMN IF EXISTS` / `ADD COLUMN IF NOT EXISTS`), the drop
needs no `CASCADE` (no view or trigger depends on the column), and no `events` row is touched.

`migrate:down` restores the column and its default. Historical ranges are not rebuilt — they were
derived from the mark, nothing consumed them, and the mark plus `last_completed_window_start`
still carry every value a reader used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified automation progress tracking to use the arrival mark as the single contiguous completion marker.
  * Removed the separate completed-window coverage tracking from automation state.
  * Automation completion now advances the progress marker and records the latest completed window for lag reporting.

* **Tests**
  * Updated automation, scheduling, recovery, and execution coverage to validate arrival-mark behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->