### PR TITLE
docs(automations): tell external claimers they must complete every window

### DIFF
--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -119,6 +119,15 @@ await client.automations.completeWindow({
 });
 ```
 
+**Every claim must end in a `completeWindow` call, including a window that held
+nothing worth acting on.** The arrival mark advances only inside the completion
+transaction, so a claim that is simply abandoned lets the lease expire, marks the
+run `timeout`, leaves the mark where it was, and serves the same arrivals again on
+the next claim — indefinitely. Submit the completion with whatever the extraction
+contract allows for an empty result rather than dropping the lease; nothing is
+lost by completing an empty window, because the mark only ever moves forward over
+arrivals the run was actually shown.
+
 The database serializes claims per Automation. The signed tokens bind the exact
 window, run attempt, lease, source IDs, and page chain. A stale attempt cannot
 complete after a newer claim, while retrying an already committed completion is

--- a/packages/core/src/contracts/tools/manage-automations.ts
+++ b/packages/core/src/contracts/tools/manage-automations.ts
@@ -504,11 +504,12 @@ export const ManageAutomationsSchema = Type.Object(
           description: "Create a new versioned Automation config.",
         }),
         Type.Literal("complete_window", {
-          description: "Submit an Automation window result.",
+          description:
+            "Submit an Automation window result and advance the Automation arrival mark. Required after every claim_next_window, including when the window held nothing actionable: the mark moves only inside this call, so an unfinished claim lets the lease expire, times the run out, and serves the same content again on the next claim.",
         }),
         Type.Literal("claim_next_window", {
           description:
-            "Atomically claim the oldest completed Automation period and return bounded source context plus a fenced window token.",
+            "Atomically claim the Automation unclaimed arrival window and return bounded source context plus a fenced window token. The window is [arrival mark, now - settle) over events.created_at, not a calendar period. The caller MUST finish the claim with complete_window, even for an empty or non-actionable window.",
         }),
         Type.Literal("trigger", {
           description:

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -633,12 +633,12 @@ export default async (_ctx, client) => {
 	},
 	"automations.completeWindow": {
 		summary:
-			"Submit LLM-extracted data for an Automation window. Requires a signed window_token.",
+			"Submit LLM-extracted data for an Automation window and advance the Automation arrival mark. Requires a signed window_token. Required after every claimNextWindow, including when the window held nothing actionable: the mark moves only inside this call, so an unfinished claim lets the lease expire, times the run out, and serves the same content again on the next claim.",
 		access: "write",
 	},
 	"automations.claimNextWindow": {
 		summary:
-			"Atomically lease the oldest completed Automation period and return bounded source context plus a fenced window_token. Pass run_id and context.page.next_cursor to continue a multi-page claim.",
+			"Atomically claim the Automation unclaimed arrival window and return bounded source context plus a fenced window_token. The window is [arrival mark, now - settle) over events.created_at, not a calendar period. The caller MUST finish the claim with completeWindow, even for an empty or non-actionable window. Pass run_id and context.page.next_cursor to continue a multi-page claim.",
 		access: "write",
 		signature:
 			"automations.claimNextWindow(input: { automation_id: string; lease_seconds?: number; limit?: number; run_id?: number; before_occurred_at?: string; before_id?: number }): Promise<AutomationClaimNextWindowResult>",


### PR DESCRIPTION
## What

Tells external Automation claimers that `complete_window` is mandatory — including for a window that
held nothing actionable — and retires the last bit of calendar vocabulary from the claim contract.

Description text and docs prose only. No behaviour change.

## Why — a live e2e found this

Driving the paired browser, I asked ChatGPT (via its Lobu connector) to find and process the automation
behind an hourly scheduled task. It did almost everything right:

- found the automation unaided — *"I found Hourly Task Collaborator (automation 5)"*
- claimed the arrival window with correct bounds: run `1339712`, `window_start` = `2026-09-03T20:55:11.994Z`
  (the arrival mark), `window_end` = `2026-09-03T22:48:39.960Z` — exactly `[mark, claim − 60s settle)`
- read the content and judged it: *"One new Warp marketing email was analyzed as non-actionable"*

Then it stopped without completing. The lease expired, run `1339712` went `timeout` / `infra_error`, and
`automations.next_window_start` stayed at the seed with `last_completed_window_start` still NULL.

That mark behaviour is **correct** — `advanceAutomationArrivalMark` only fires inside a completion
transaction, so a timed-out run books nothing and opens no coverage hole. But the same arrivals are
re-served on every subsequent claim, forever, until something completes the window. ChatGPT then
re-claimed (`1339755`, 30s lease) and looped.

Nothing in the product told it otherwise:

| surface | before |
|---|---|
| `complete_window` | "Submit an Automation window result." |
| `claim_next_window` | "Atomically claim **the oldest completed Automation period**…" (retired calendar vocabulary) |
| `docs/AUTOMATIONS.md` | showed the claim/complete loop, never stated the obligation |

Only `trigger` described the flow, in passing.

## Client regen

`[client-regen-not-needed]`. openapi-ts drops `Type.Literal` descriptions. Verified against the committed
generated client rather than assumed: none of the sibling action descriptions from this same union
("Archive one or more Automations", "Attach/remove a TypeScript reaction script", "List an Automation…",
"Create or reuse an immediate Automation run") appear in `packages/client/src/generated/types.gen.ts`, and
the `action` union there renders as bare string literals with no per-member doc comments.

## Proof

- `make pre-pr` clean — build, per-package typecheck, knip, exposed-surface naming, gateway-LLM and
  entity-write funnel gates.
- Pre-commit hook clean: biome 612 files, `tsc --noEmit`.
- Contrast evidence that the axis itself is healthy in prod — automation 81 (`*/30 * * * *`) walks
  contiguously with zero gaps, each `window_start` equal to the previous `window_end`:
  `[20:59:17.034, 21:29:06.900)` → `[21:29:06.900, 21:59:20.737)` → `[21:59:20.737, 22:29:00.959)`,
  each end ~60s behind its run start (the settle horizon).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that every claimed automation window must be completed, including windows with no results.
  - Documented that abandoned claims expire and the same arrivals may be served again until completion.
  - Updated guidance on how automation windows are defined and when the arrival position advances.
  - Added clearer lifecycle descriptions for claiming and completing automation windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->