### PR TITLE
fix(server): make the empty-search guidance's promises true

### DIFF
--- a/packages/server/src/__tests__/integration/tools/search-memory-federation.test.ts
+++ b/packages/server/src/__tests__/integration/tools/search-memory-federation.test.ts
@@ -12,6 +12,7 @@ import {
   mergeFederatedSearchResults,
   UnifiedSearchResultSchema,
   search,
+  highestGrantedRole,
 } from '../../../tools/search';
 import type { ToolContext } from '../../../tools/registry';
 import { initWorkspaceProvider } from '../../../workspace';
@@ -276,6 +277,57 @@ describe('search_memory direct OAuth workspace federation', () => {
     expect(suggestion).toContain('client.feeds.readMany');
     expect(suggestion).toContain('query_sql');
     expectValidSearchResult(merged);
+  });
+
+  // The federated tier comes from the SHARD roles, not the outer context: a
+  // bare cross-workspace grant carries no role on `ctx`, so scoring it directly
+  // would floor every federated caller at read, and coercing it to 'owner'
+  // offers admin-only type creation to a plain member. Member in both here.
+  it('does not offer admin-only type creation to a member of every granted workspace', async () => {
+    const targets = [
+      { id: orgA.id, slug: orgA.slug, name: orgA.name, role: 'member', personal: false },
+      { id: orgB.id, slug: orgB.slug, name: orgB.name, role: 'member', personal: false },
+    ];
+    const args = {
+      query: 'zzzz-absent-federated-tier-probe-qqqq',
+      fuzzy: false,
+      include_content: false,
+    };
+    const shard = async (slug: string) =>
+      await search({ ...args, workspace: slug, include_public_catalogs: false }, {} as Env, {
+        ...context(),
+        memberRole: 'member',
+        scopes: ['mcp:write'],
+      } as ToolContext);
+
+    const merged = mergeFederatedSearchResults(
+      args,
+      targets,
+      [
+        { status: 'fulfilled', value: await shard(orgA.slug) },
+        { status: 'fulfilled', value: await shard(orgB.slug) },
+      ],
+      'write'
+    );
+
+    expect(merged.discovery_status).toBe('not_found');
+    const suggestion = merged.suggestion ?? '';
+    expect(suggestion).not.toContain('client.entitySchema.createType(...)');
+    expect(suggestion).toContain('Creating a brand-new entity type needs admin access');
+    // The write-tier half a member CAN reach is still offered.
+    expect(suggestion).toContain('client.entities.create');
+    expectValidSearchResult(merged);
+  });
+
+  // The tier the federated merge is handed comes from this: strongest role
+  // wins, so an admin in ANY granted workspace can still reach createType
+  // somewhere, while a member everywhere cannot.
+  it('scores the federated tier from the strongest role across granted workspaces', () => {
+    const at = (role: string) => ({ id: 1, slug: 's', name: 'n', role, personal: false });
+    expect(highestGrantedRole([at('member'), at('admin')])).toBe('admin');
+    expect(highestGrantedRole([at('admin'), at('owner')])).toBe('owner');
+    expect(highestGrantedRole([at('member'), at('member')])).toBe('member');
+    expect(highestGrantedRole([])).toBeNull();
   });
 
   it('narrows through the grant resolver and makes unknown, ungranted, and revoked identical', async () => {

--- a/packages/server/src/__tests__/integration/tools/search-memory-recall-contract.test.ts
+++ b/packages/server/src/__tests__/integration/tools/search-memory-recall-contract.test.ts
@@ -524,4 +524,29 @@ describe('search_memory > recall contract', () => {
     expect(suggestion).not.toContain('client.entities.create');
     expect(suggestion).not.toContain('client.entitySchema.createType(...)');
   });
+  // An automation reaction has no user identity, so the tier resolver floors it
+  // at read — but `save_content` bypasses its write gate for exactly this
+  // context (`isSystemContext`), so read-only copy would be a lie to a caller
+  // that CAN persist. It gets the write-tier block, minus the admin-only hop.
+  it('does not call an in-process system caller read-only when it can write', async () => {
+    const result = await search(
+      { query: 'zzzz-tier-probe-system' },
+      env,
+      {
+        organizationId: org.id,
+        userId: null,
+        memberRole: null,
+        isAuthenticated: true,
+        tokenType: 'session',
+        scopes: ['*'],
+      } as ToolContext
+    );
+
+    const suggestion = result.suggestion ?? '';
+    expect(suggestion).not.toContain('this caller has read-only access to the workspace');
+    expect(suggestion).toContain('save_memory');
+    expect(suggestion).toContain('client.entities.create');
+    // Still not admin: type creation stays behind the admin gate.
+    expect(suggestion).not.toContain('client.entitySchema.createType(...)');
+  });
 });

--- a/packages/server/src/__tests__/integration/tools/search-memory-recall-contract.test.ts
+++ b/packages/server/src/__tests__/integration/tools/search-memory-recall-contract.test.ts
@@ -147,10 +147,14 @@ describe('search_memory > recall contract', () => {
     });
     exactMemoryId = exactMemory.id;
 
+    // The fixture user is an org OWNER (see addUserToOrganization above), and
+    // the empty-result guidance is tier-aware, so the shared context must carry
+    // the role it actually has.
     ctx = {
       organizationId: org.id,
       userId: user.id,
       tokenType: 'session',
+      memberRole: 'owner',
     } as ToolContext;
   });
 
@@ -452,5 +456,72 @@ describe('search_memory > recall contract', () => {
     expect(suggestion).toContain('`readable-feed/default`');
     expect(suggestion).toContain('feed_id');
     expect(suggestion).toContain('client.feeds.readMany({ reads: [{ feed_id }] })');
+  });
+
+  // ── Tier-aware persist guidance ─────────────────────────────────────────
+  // `entitySchema.createType` is admin-tier, `entities.create` is write, and
+  // `run_sdk`/`save_memory` are write-tier. The guidance must name only what
+  // the caller can reach. The admin and member variants both still name
+  // `entities.create`, which is why the general empty-result case above cannot
+  // tell those two apart.
+  it('offers createType only to an admin-tier caller', async () => {
+    const result = await search(
+      { query: 'zzzz-tier-probe-admin' },
+      env,
+      {
+        organizationId: org.id,
+        userId: user.id,
+        tokenType: 'session',
+        memberRole: 'owner',
+        scopes: ['*'],
+      } as ToolContext
+    );
+
+    const suggestion = result.suggestion ?? '';
+    expect(suggestion).toContain('client.entitySchema.createType(...)');
+    expect(suggestion).not.toContain('needs admin access');
+  });
+
+  it('sends a member to the existing types instead of a call that would deny', async () => {
+    const result = await search(
+      { query: 'zzzz-tier-probe-member' },
+      env,
+      {
+        organizationId: org.id,
+        userId: user.id,
+        tokenType: 'session',
+        memberRole: 'member',
+        scopes: ['*'],
+      } as ToolContext
+    );
+
+    const suggestion = result.suggestion ?? '';
+    expect(suggestion).not.toContain('client.entitySchema.createType(...)');
+    expect(suggestion).toContain('Creating a brand-new entity type needs admin access');
+    // The reachable half is still offered — a member CAN create an entity of a
+    // type that already exists.
+    expect(suggestion).toContain('client.entitySchema.listTypes()');
+    expect(suggestion).toContain('client.entities.create');
+  });
+
+  it('names the boundary instead of write calls for a read-only caller', async () => {
+    const result = await search(
+      { query: 'zzzz-tier-probe-read' },
+      env,
+      {
+        organizationId: org.id,
+        userId: user.id,
+        tokenType: 'session',
+        memberRole: 'member',
+        scopes: ['mcp:read'],
+      } as ToolContext
+    );
+
+    const suggestion = result.suggestion ?? '';
+    // The read steps above the persist block stay — they are all read-tier.
+    expect(suggestion).toContain('Additional steps to read relevant data:');
+    expect(suggestion).toContain('this caller has read-only access to the workspace');
+    expect(suggestion).not.toContain('client.entities.create');
+    expect(suggestion).not.toContain('client.entitySchema.createType(...)');
   });
 });

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -312,7 +312,7 @@ export default async (_ctx, client) => {
 			"Read knowledge events by id (`content_ids`, an array — there is no singular `content_id` arg), or Automation-window context. Pass automation_id with run_id to bind the read to that queued run's persisted version, window, and trigger inputs.",
 		access: "read",
 		signature:
-			"knowledge.read(input: { content_ids?: number[]; automation_id?: number; run_id?: number; ... }): Promise<unknown>",
+			"knowledge.read(input: { content_ids?: number[]; automation_id?: number; run_id?: number; semantic_type?: string | string[]; entity_id?: number; entity_types?: string[]; query?: string; since?: string; until?: string; limit?: number; ... }): Promise<unknown>",
 		example: "await client.knowledge.read({ content_ids: [2321593] });",
 	},
 	"knowledge.delete": {

--- a/packages/server/src/sandbox/namespaces/knowledge.ts
+++ b/packages/server/src/sandbox/namespaces/knowledge.ts
@@ -8,7 +8,7 @@
 
 import type { Env } from "../../index";
 import { deleteContent } from "../../tools/delete_content";
-import { getContent } from "../../tools/get_content";
+import { getContent, type PublicGetContentArgs } from "../../tools/get_content";
 import type { ToolContext } from "../../tools/registry";
 import { saveContent } from "../../tools/save_content";
 import { search } from "../../tools/search";
@@ -61,20 +61,15 @@ export type KnowledgeSaveInput =
 			content?: string;
 	  });
 
-export interface KnowledgeReadInput {
-	/** Fetch specific content events by id. */
-	content_ids?: number[];
-	/** Fetch structured knowledge for an Automation window. */
-	automation_id?: number;
-	/** Bind an Automation read to the queued run's version, window, and trigger inputs. */
-	run_id?: number;
-	since?: string;
-	until?: string;
-	limit?: number;
-	before_occurred_at?: string;
-	before_id?: number;
-	entity_ids?: number[];
-}
+/**
+ * `client.knowledge.read` forwards straight to `getContent`, so its input IS
+ * the tool's public schema. Hand-listing the fields drifted: it had grown to
+ * omit real filters the handler accepts (`semantic_type`, `entity_types`,
+ * `query`, …) while advertising `entity_ids`, which `getContent` never read as
+ * an input — a caller filtering by it silently got unfiltered results. Deriving
+ * the type keeps the two in lockstep.
+ */
+export type KnowledgeReadInput = PublicGetContentArgs;
 
 export type KnowledgeDeleteInput =
 	| number

--- a/packages/server/src/sandbox/namespaces/knowledge.typecheck.ts
+++ b/packages/server/src/sandbox/namespaces/knowledge.typecheck.ts
@@ -1,4 +1,4 @@
-import type { KnowledgeSaveInput } from "./knowledge";
+import type { KnowledgeReadInput, KnowledgeSaveInput } from "./knowledge";
 
 type Assert<T extends true> = T;
 type Accepts<T> = T extends KnowledgeSaveInput ? true : false;
@@ -16,4 +16,30 @@ export type KnowledgeSaveInputContract = [
 	Assert<Accepts<{ semantic_type: "note"; content: string }>>,
 	Assert<Rejects<{ semantic_type: "note" }>>,
 	Assert<Rejects<{ semantic_type: "note"; payload_type: "text" }>>,
+];
+
+/**
+ * @internal Compile-time fixture pinning `knowledge.read` to the tool schema.
+ *
+ * Keyed on `keyof`, not assignability: every field is optional, so a stray
+ * object still structurally extends the type and an `Accepts`/`Rejects` pair
+ * would pass no matter what the interface declared.
+ */
+type HasReadKey<K extends string> = K extends keyof KnowledgeReadInput
+	? true
+	: false;
+
+export type KnowledgeReadInputContract = [
+	// `semantic_type` is the filter the empty-search guidance tells callers to
+	// pass to `client.knowledge.read`; `entity_types` and `query` are schema
+	// filters the hand-listed interface had dropped. All three must stay
+	// declared.
+	Assert<HasReadKey<"semantic_type">>,
+	Assert<HasReadKey<"entity_types">>,
+	Assert<HasReadKey<"query">>,
+	// `getContent` reads `entity_ids` off the ROW, never off the input. Declaring
+	// it told callers they could filter by it while results came back unfiltered.
+	Assert<HasReadKey<"entity_ids"> extends false ? true : false>,
+	// Accepted at the boundary but deliberately never an SDK affordance.
+	Assert<HasReadKey<"mcp_activity_id"> extends false ? true : false>,
 ];

--- a/packages/server/src/tools/get_content.ts
+++ b/packages/server/src/tools/get_content.ts
@@ -16,5 +16,6 @@ export {
   PublicGetContentSchema,
   getIncludeSupersededValidationErrors,
 } from './get_content/schema';
+export type { PublicGetContentArgs } from './get_content/schema';
 export { GetContentResultSchema } from './get_content/types';
 export type { ContentItem } from './get_content/types';

--- a/packages/server/src/tools/get_content/schema.ts
+++ b/packages/server/src/tools/get_content/schema.ts
@@ -256,7 +256,7 @@ export const GetContentSchema = Type.Object({
   ),
 });
 
-const GET_CONTENT_INTERNAL_FIELDS = ['mcp_activity_id'];
+const GET_CONTENT_INTERNAL_FIELDS = ['mcp_activity_id'] as const;
 // The Connected App UI receives this exact pair from an authenticated internal
 // endpoint. It is accepted by the REST/tool boundary but is not an MCP or SDK
 // discovery affordance: external callers have no route that constructs it.
@@ -265,12 +265,23 @@ markAcceptedInternalFields(GetContentSchema, GET_CONTENT_INTERNAL_FIELDS);
 export const PublicGetContentSchema = Type.Object(
   Object.fromEntries(
     Object.entries(GetContentSchema.properties).filter(
-      ([key]) => !GET_CONTENT_INTERNAL_FIELDS.includes(key)
+      ([key]) => !(GET_CONTENT_INTERNAL_FIELDS as readonly string[]).includes(key)
     )
   )
 );
 
 export type GetContentArgs = Static<typeof GetContentSchema>;
+
+/**
+ * The `get_content` input an external caller may actually construct: every
+ * declared filter minus the accepted-but-unadvertised internal fields. SDK
+ * surfaces that forward straight to `getContent` derive their input type from
+ * this so the declared shape cannot drift from the schema the handler enforces.
+ */
+export type PublicGetContentArgs = Omit<
+  GetContentArgs,
+  (typeof GET_CONTENT_INTERNAL_FIELDS)[number]
+>;
 
 export function getIncludeSupersededValidationErrors(args: Partial<GetContentArgs>): string[] {
   const errors: string[] = [];

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -8,7 +8,11 @@
  */
 
 import { type Static, Type } from '@sinclair/typebox';
-import { hasRequiredMcpScope } from '../auth/tool-access';
+import {
+  hasRequiredMcpScope,
+  resolveSdkMaxAccessLevel,
+  type ToolAccessLevel,
+} from '../auth/tool-access';
 import {
   type GrantedMemberWorkspace,
   listLiveGrantedMemberWorkspaces,
@@ -626,7 +630,8 @@ function unavailableWorkspaceCoverage(workspace: GrantedMemberWorkspace): Worksp
 function buildEmptySearchSuggestion(
   query: string | null,
   args: SearchArgs,
-  coverage?: SearchCoverage
+  coverage?: SearchCoverage,
+  callerMax?: ToolAccessLevel
 ): string {
   const isFederated = coverage?.scope === 'all_granted';
   const queryLabel = !isFederated && query ? ` for "${query}"` : '';
@@ -677,6 +682,18 @@ function buildEmptySearchSuggestion(
   );
 
   lines.push('');
+  // Every line below is write-tier: `save_memory` is a member-write action and
+  // `run_sdk` — the only route to `entities.create` — requires write access
+  // too, so a read-tier caller would be denied on both. Name the boundary
+  // instead of handing it two calls that cannot run. An absent tier (the
+  // exported merge helper called without one) keeps the write-tier text.
+  if (callerMax === 'read') {
+    lines.push(
+      '**If this is new knowledge to persist:** this caller has read-only access to the workspace, so `save_memory` and entity creation would be denied. Reconnect with write access, or ask a workspace member to persist it.'
+    );
+    return lines.join('\n');
+  }
+
   lines.push('**If this is new knowledge to persist:**');
   lines.push('- To save facts or notes: call `save_memory` with content and semantic_type.');
   // Only a single-workspace text search names one entity worth pre-filling:
@@ -684,8 +701,14 @@ function buildEmptySearchSuggestion(
   // text at all. Both fall back to a placeholder in the SAME angle-bracket
   // shape as `<entity_type>` below — a bare `...` reads as copyable literal.
   const newEntityName = !isFederated && query ? query : '<entity_name>';
+  // `entitySchema.createType` is admin-tier while `entities.create` is write.
+  // Telling a member to create the type sends them at a call that will deny,
+  // so below admin we name the reachable half and say who can do the rest.
+  const canCreateEntityType = callerMax === 'admin';
   lines.push(
-    `- To create a new entity: its type must exist first (\`client.entitySchema.listTypes()\` to check, \`client.entitySchema.createType(...)\` for a type new to this workspace), then call \`run_sdk\` with \`await client.entities.create({ type: '<entity_type>', name: '${newEntityName}' })\`.`
+    canCreateEntityType
+      ? `- To create a new entity: its type must exist first (\`client.entitySchema.listTypes()\` to check, \`client.entitySchema.createType(...)\` for a type new to this workspace), then call \`run_sdk\` with \`await client.entities.create({ type: '<entity_type>', name: '${newEntityName}' })\`.`
+      : `- To create a new entity: pick a type that already exists (\`client.entitySchema.listTypes()\`), then call \`run_sdk\` with \`await client.entities.create({ type: '<entity_type>', name: '${newEntityName}' })\`. Creating a brand-new entity type needs admin access, so ask a workspace admin if none of the existing types fit.`
   );
 
   return lines.join('\n');
@@ -694,7 +717,8 @@ function buildEmptySearchSuggestion(
 export function mergeFederatedSearchResults(
   args: SearchArgs,
   targets: readonly GrantedMemberWorkspace[],
-  settled: readonly PromiseSettledResult<UnifiedSearchResult>[]
+  settled: readonly PromiseSettledResult<UnifiedSearchResult>[],
+  callerMax?: ToolAccessLevel
 ): UnifiedSearchResult {
   const fulfilled = settled.flatMap((item) => (item.status === 'fulfilled' ? [item.value] : []));
   if (fulfilled.length === 0) {
@@ -819,7 +843,7 @@ export function mergeFederatedSearchResults(
       : status === 'partial'
         ? 'Search returned partial results; one or more granted workspaces was temporarily unavailable.'
         : matches.length === 0 && !hasAnyRecall
-          ? buildEmptySearchSuggestion(args.query ?? null, args, coverage)
+          ? buildEmptySearchSuggestion(args.query ?? null, args, coverage, callerMax)
           : selectedResult?.suggestion,
     ...(entity && selectedResult?.view_url ? { view_url: selectedResult.view_url } : {}),
     metadata: {
@@ -1437,7 +1461,12 @@ async function searchImpl(
       logger.warn({ err: getErrorMessage(item.reason) }, '[search] workspace shard failed');
     }
   }
-  return mergeFederatedSearchResults(args, targets, settled);
+  return mergeFederatedSearchResults(
+    args,
+    targets,
+    settled,
+    resolveSdkMaxAccessLevel(ctx.allowCrossOrg ? 'owner' : ctx.memberRole, ctx.scopes)
+  );
 }
 
 /**
@@ -1733,7 +1762,12 @@ async function searchWorkspaceImpl(
 
   const suggestionText = hasRecallHits
     ? 'No matching entities found, but related memory content was recalled below.'
-    : buildEmptySearchSuggestion(query, args, recall.coverage);
+    : buildEmptySearchSuggestion(
+        query,
+        args,
+        recall.coverage,
+        resolveSdkMaxAccessLevel(ctx.allowCrossOrg ? 'owner' : ctx.memberRole, ctx.scopes)
+      );
 
   const result = withRecall(
     emptyResult({

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -636,9 +636,33 @@ function unavailableWorkspaceCoverage(workspace: GrantedMemberWorkspace): Worksp
  * copy would state a falsehood to a caller that CAN persist. Treat them as
  * write: they get the persist block, without the admin-only type-creation hop.
  */
-function guidanceAccessTier(ctx: ToolContext): ToolAccessLevel {
+function guidanceAccessTier(
+  ctx: ToolContext,
+  memberRole: string | null = ctx.memberRole ?? null
+): ToolAccessLevel {
   if (isInProcessSystemCall(ctx)) return 'write';
-  return resolveSdkMaxAccessLevel(ctx.allowCrossOrg ? 'owner' : ctx.memberRole, ctx.scopes);
+  return resolveSdkMaxAccessLevel(memberRole, ctx.scopes);
+}
+
+/**
+ * Best role the caller actually holds across the workspaces a federated merge
+ * covers. The outer context carries no role on a bare cross-workspace grant, so
+ * scoring it directly would floor every federated caller at read; coercing it to
+ * 'owner' — as this did first — went the other way and offered admin-only type
+ * creation to a caller who is merely a member everywhere. The real roles are on
+ * the shard targets, so use the strongest one: if any workspace makes them an
+ * admin, `entitySchema.createType` is reachable in at least one place.
+ */
+export function highestGrantedRole(
+  targets: readonly GrantedMemberWorkspace[]
+): string | null {
+  let best: string | null = null;
+  for (const target of targets) {
+    if (target.role === 'owner') return 'owner';
+    if (target.role === 'admin') best = 'admin';
+    else if (target.role && best === null) best = target.role;
+  }
+  return best;
 }
 
 function buildEmptySearchSuggestion(
@@ -1475,7 +1499,12 @@ async function searchImpl(
       logger.warn({ err: getErrorMessage(item.reason) }, '[search] workspace shard failed');
     }
   }
-  return mergeFederatedSearchResults(args, targets, settled, guidanceAccessTier(ctx));
+  return mergeFederatedSearchResults(
+    args,
+    targets,
+    settled,
+    guidanceAccessTier(ctx, highestGrantedRole(targets))
+  );
 }
 
 /**

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -627,6 +627,20 @@ function unavailableWorkspaceCoverage(workspace: GrantedMemberWorkspace): Worksp
   };
 }
 
+/**
+ * Access tier the empty-result guidance should speak to.
+ *
+ * In-process system callers (automation reactions) carry no user identity, so
+ * `resolveSdkMaxAccessLevel` floors them at 'read' — but `save_content` and the
+ * entity-write path bypass their gates for exactly those contexts, so read-only
+ * copy would state a falsehood to a caller that CAN persist. Treat them as
+ * write: they get the persist block, without the admin-only type-creation hop.
+ */
+function guidanceAccessTier(ctx: ToolContext): ToolAccessLevel {
+  if (isInProcessSystemCall(ctx)) return 'write';
+  return resolveSdkMaxAccessLevel(ctx.allowCrossOrg ? 'owner' : ctx.memberRole, ctx.scopes);
+}
+
 function buildEmptySearchSuggestion(
   query: string | null,
   args: SearchArgs,
@@ -1461,12 +1475,7 @@ async function searchImpl(
       logger.warn({ err: getErrorMessage(item.reason) }, '[search] workspace shard failed');
     }
   }
-  return mergeFederatedSearchResults(
-    args,
-    targets,
-    settled,
-    resolveSdkMaxAccessLevel(ctx.allowCrossOrg ? 'owner' : ctx.memberRole, ctx.scopes)
-  );
+  return mergeFederatedSearchResults(args, targets, settled, guidanceAccessTier(ctx));
 }
 
 /**
@@ -1762,12 +1771,7 @@ async function searchWorkspaceImpl(
 
   const suggestionText = hasRecallHits
     ? 'No matching entities found, but related memory content was recalled below.'
-    : buildEmptySearchSuggestion(
-        query,
-        args,
-        recall.coverage,
-        resolveSdkMaxAccessLevel(ctx.allowCrossOrg ? 'owner' : ctx.memberRole, ctx.scopes)
-      );
+    : buildEmptySearchSuggestion(query, args, recall.coverage, guidanceAccessTier(ctx));
 
   const result = withRecall(
     emptyResult({


### PR DESCRIPTION
## Summary

Follow-up to #3340. That PR made an empty `search_memory` hand back read-first guidance instead of create coaching — but the guidance advertised two things a caller could not actually rely on. This makes both true.

- **`client.knowledge.read({ semantic_type: 'audit' })` is now a declared input.** #3340's guidance tells agents to call it; it worked only because the namespace forwards `input as never` and the sandbox is transpile-only. `KnowledgeReadInput` was hand-listed and had drifted badly: it omitted ~27 filters `getContent` really accepts (`semantic_type`, `entity_types`, `query`, `min_similarity`, …) **and declared `entity_ids`, which `getContent` only ever reads off the row, never off the input** — so a caller filtering by it silently got unfiltered results with no error. Replaced the hand-list with `PublicGetContentArgs`, derived from `GetContentSchema` minus the accepted-but-unadvertised internal fields, following the `metrics.ts` precedent (`Static<typeof …Schema>`).
- **The persist block no longer names calls the caller cannot make.** `entitySchema.createType` is `access: "admin"` while `entities.create` is `write` — so below admin the guidance pointed at a call that denies. Widening the check further: `save_memory` and `run_sdk` are both in `MEMBER_WRITE_ACTIONS`, so for a **read-tier** caller *every line* of that block was unreachable. Three tiers now each get only what they can reach — admin keeps the two-hop `createType` path, write is sent to the existing types, and read is told the boundary instead of being handed two calls that would be denied.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean (all 5 gates: build, per-package strict typecheck, knip, exposed-surface naming, gateway/entity-write funnel)
- [x] Tests run: targeted suites, all green
  - `search-memory-recall-contract.test.ts` — **14/14** (11 → 14; one new case per access tier)
  - `search-memory-federation.test.ts` — **11/11**
  - `content-read-bounds.test.ts` — **6/6**
  - (the three vitest suites together: **31/31**)
  - `sdk-signature-contract` + `method-metadata` + `sdk-search` + `manifest-enforcement` (bun) — **98 pass / 0 fail**, 890 assertions
- [ ] Bug fix: red→fix→green — n/a, see Notes
- [ ] If bot runtime changed — n/a

## Notes

**Why no red→green.** Neither defect is reachable as a failing runtime assertion. The `semantic_type` gap was type-level only (it already worked at runtime), and the phantom `entity_ids` failed *silently* — that is the bug. Both are pinned by compile-time contracts in `knowledge.typecheck.ts` instead, extending the fixture pattern already there for `KnowledgeSaveInput`. Those asserts are keyed on `keyof`, not assignability: every field is optional, so an `Accepts`/`Rejects` pair would pass regardless of what the type declared. `bun run typecheck` passing IS the evidence that `semantic_type`/`entity_types`/`query` are declared and `entity_ids`/`mcp_activity_id` are not.

**No caller relied on the phantom field.** Removing `entity_ids` from the read input broke no typecheck anywhere in the workspace.

**Also updated** the advertised `knowledge.read` signature in `method-metadata.ts`, which listed three fields and an ellipsis, to name the filters the guidance sends agents at.

**Verified in prod first.** #3340 (`bf4096a7c`) is live; two probes against `buremba` confirmed the empty path renders the read-first guidance and the recall-only path reports `discovery_status: "complete"` with no create coaching.

**Reviewed with Opus, not codex.** codex is out of credits until Sep 7, so `review-fix`/`review` ran same-model rather than cross-harness — a weaker signal than the usual independent verdict. The fixer did catch a real miss of its own (the read-tier hole above), which I verified against `MEMBER_WRITE_ACTIONS` before accepting.

**Follow-up not in scope:** the *other* empty-ish suggestion branch — entity found with zero connections — still uses the older create-biased phrasing (`Use search_sdk to choose a connector and feed…`). Same class as #3340, separate diff.

Two more drift items found and deliberately left out: `KnowledgeSearchInput` is the same hand-listed-drift class fixed here for `read` (it omits `title`, `content_limit`, `metadata_filter`, `workspace`, … from `SearchSchema`) — no guidance string promises those, and widening it changes the public SDK contract, so it wants its own design-locked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QyAFsa9B1WQMVJyB3XV5z1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now provide guidance appropriate to the caller’s access level.
  * Read-only callers are no longer prompted to save memories or create entities.
  * Non-admin callers are directed to existing entity types, while admins can create new types.
  * Knowledge searches now correctly support semantic type, entity type, query, time-range, and pagination filters.

* **Documentation**
  * Updated knowledge search metadata to describe the supported filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->