### PR TITLE
fix(spotify): stop three snapshot feeds rewriting rows that never changed

### DIFF
--- a/examples/personal-agent/__tests__/connector-sdk.mock.ts
+++ b/examples/personal-agent/__tests__/connector-sdk.mock.ts
@@ -124,7 +124,19 @@ export function connectorSdkMock() {
       json: notUsed("http.json"),
       request: notUsed("http.request"),
     }),
-    requireBearerClient: notUsed("requireBearerClient"),
+    // The real helper wraps stored credentials into a bearer HttpClient. Tests
+    // that exercise a sync path pass their fake client AS the credentials and
+    // get it straight back; anything else still throws, so a connector that
+    // reaches the network unintentionally fails loudly.
+    requireBearerClient: (credentials: unknown) => {
+      if (
+        credentials &&
+        typeof (credentials as { get?: unknown }).get === "function"
+      ) {
+        return credentials;
+      }
+      return notUsed("requireBearerClient")();
+    },
     paginateByCursor,
     paginateByOffset,
     // Generic identity namespaces (real values — connectors read IDENTITY.EMAIL

--- a/examples/personal-agent/__tests__/spotify.connector.test.ts
+++ b/examples/personal-agent/__tests__/spotify.connector.test.ts
@@ -64,12 +64,14 @@ describe("trackKey", () => {
 // ---------------------------------------------------------------------------
 
 let snapshotDigest: any;
+let timestampKey: any;
 let topTracksLimit: any;
 let SpotifyConnector: any;
 
 beforeAll(async () => {
   const mod = await import("../spotify.connector");
   snapshotDigest = mod.snapshotDigest;
+  timestampKey = mod.timestampKey;
   topTracksLimit = mod.topTracksLimit;
   SpotifyConnector = mod.default;
 });
@@ -194,7 +196,9 @@ describe("playlists snapshot gate", () => {
 
     const first = await connector.sync(syncCtx("playlists", http));
     expect(first.events.length).toBeGreaterThan(0);
-    expect(first.checkpoint.playlist_snapshots).toEqual({ PL1: "snap-1" });
+    // The stored key is a composite (snapshot_id + the fields snapshot_id does
+    // not version), so assert it round-trips rather than pinning its value.
+    expect(Object.keys(first.checkpoint.playlist_snapshots)).toEqual(["PL1"]);
     expect(http.calls.some((u: string) => u.includes("/tracks"))).toBe(true);
 
     http.calls.length = 0;
@@ -206,7 +210,9 @@ describe("playlists snapshot gate", () => {
     // never even ask Spotify for its tracks.
     expect(second.events).toEqual([]);
     expect(http.calls.some((u: string) => u.includes("/tracks"))).toBe(false);
-    expect(second.checkpoint.playlist_snapshots).toEqual({ PL1: "snap-1" });
+    expect(second.checkpoint.playlist_snapshots).toEqual(
+      first.checkpoint.playlist_snapshots
+    );
   });
 
   test("a changed snapshot_id re-emits that playlist", async () => {
@@ -223,7 +229,7 @@ describe("playlists snapshot gate", () => {
     );
 
     expect(result.events.length).toBeGreaterThan(0);
-    expect(result.checkpoint.playlist_snapshots).toEqual({ PL1: "snap-2" });
+    expect(result.checkpoint.playlist_snapshots.PL1).not.toBe("snap-1");
   });
 
   // Regression: the same track can sit in a playlist several times, each entry
@@ -373,5 +379,84 @@ describe("no snapshot feed emits a volatile provider counter", () => {
         expect(Object.keys(event.metadata ?? {})).not.toContain(field);
       }
     }
+  });
+});
+
+describe("timestampKey", () => {
+  test("is a no-op for well-formed timestamps so existing keys keep their shape", () => {
+    expect(timestampKey("2025-06-22T17:27:32Z")).toBe(
+      String(new Date("2025-06-22T17:27:32Z").getTime())
+    );
+  });
+
+  // Without this, every entry with an unparseable timestamp keys on "NaN" and
+  // they collapse onto one origin_id — the collision this PR exists to fix.
+  test("malformed timestamps stay distinct instead of collapsing onto NaN", () => {
+    const a = timestampKey("not-a-date");
+    const b = timestampKey("also-not-a-date");
+    expect(a).not.toBe(b);
+    expect(a).not.toContain("NaN");
+    expect(b).not.toContain("NaN");
+  });
+});
+
+// Spotify bumps `snapshot_id` for track-list edits only. A rename or a
+// description edit leaves it untouched, so gating on it alone left the stored
+// title and payload_text stale forever.
+describe("playlists gate covers edits snapshot_id does not version", () => {
+  const tracksPage = {
+    items: [
+      {
+        added_at: "2025-06-22T17:27:32Z",
+        added_by: { id: "me" },
+        track: fakeTrack("t1"),
+      },
+    ],
+    total: 1,
+    limit: 50,
+    offset: 0,
+    next: null,
+    previous: null,
+  };
+
+  async function syncWith(page: any, checkpoint: unknown) {
+    const http = fakeSpotifyApi({
+      "/me/playlists": page,
+      "/playlists/PL1/tracks": tracksPage,
+    });
+    const connector = new SpotifyConnector();
+    return connector.sync(syncCtx("playlists", http, { checkpoint }));
+  }
+
+  test("a rename re-emits even though snapshot_id is unchanged", async () => {
+    const first = await syncWith(playlistPage("snap-1"), null);
+
+    const renamed = playlistPage("snap-1");
+    (renamed.items[0] as any).name = "hiphop (2026)";
+    const second = await syncWith(renamed, first.checkpoint);
+
+    const emitted = second.events.filter(
+      (e: any) => e.origin_type === "playlist"
+    );
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].title).toBe("hiphop (2026)");
+  });
+
+  test("a description edit re-emits too", async () => {
+    const first = await syncWith(playlistPage("snap-1"), null);
+
+    const edited = playlistPage("snap-1");
+    (edited.items[0] as any).description = "now with a description";
+    const second = await syncWith(edited, first.checkpoint);
+
+    expect(
+      second.events.filter((e: any) => e.origin_type === "playlist")
+    ).toHaveLength(1);
+  });
+
+  test("no edit at all still emits nothing", async () => {
+    const first = await syncWith(playlistPage("snap-1"), null);
+    const second = await syncWith(playlistPage("snap-1"), first.checkpoint);
+    expect(second.events).toEqual([]);
   });
 });

--- a/examples/personal-agent/__tests__/spotify.connector.test.ts
+++ b/examples/personal-agent/__tests__/spotify.connector.test.ts
@@ -43,3 +43,335 @@ describe("trackKey", () => {
     expect(b).not.toBe("null");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Snapshot-churn regressions
+//
+// Three of the four Spotify feeds read a SNAPSHOT (your library, your
+// playlists, your ranking) and emit it as per-item events. Every one of them
+// was rewriting rows that had not changed. Measured on prod events, versions
+// per distinct origin_id:
+//
+//   playlists / playlist rows   62.3x   occurred_at: new Date() every run
+//   top_tracks                  18.6x   rank shifts + popularity drift
+//   playlists / playlist_track   5.1x   duplicate entries colliding in-run
+//   saved_tracks                 1.8x   popularity drift alone
+//   recently_played              1.0x   a real event stream — the control
+//
+// These guards are written against the CLASS (no volatile provider counters in
+// emitted content; an unchanged snapshot emits nothing) rather than against the
+// individual field that happened to churn.
+// ---------------------------------------------------------------------------
+
+let snapshotDigest: any;
+let topTracksLimit: any;
+let SpotifyConnector: any;
+
+beforeAll(async () => {
+  const mod = await import("../spotify.connector");
+  snapshotDigest = mod.snapshotDigest;
+  topTracksLimit = mod.topTracksLimit;
+  SpotifyConnector = mod.default;
+});
+
+function fakeTrack(id: string, name = `track ${id}`) {
+  return {
+    id,
+    name,
+    artists: [{ id: "a1", name: "Artist", external_urls: { spotify: "u" } }],
+    album: {
+      id: "al1",
+      name: "Album",
+      images: [{ url: "img", height: 1, width: 1 }],
+      release_date: "2020-01-01",
+      external_urls: { spotify: "u" },
+    },
+    duration_ms: 1000,
+    // Spotify's global chart figure. It drifts daily and must never reach an
+    // emitted event — that drift alone superseded unchanged rows in prod.
+    popularity: 42,
+    explicit: false,
+    external_urls: { spotify: `https://open.spotify.com/track/${id}` },
+    uri: `spotify:track:${id}`,
+    preview_url: null,
+  };
+}
+
+/** Routes by longest-matching path fragment and records every URL requested. */
+function fakeSpotifyApi(routes: Record<string, unknown>) {
+  const calls: string[] = [];
+  const keys = Object.keys(routes).sort((a, b) => b.length - a.length);
+  return {
+    calls,
+    get: async (url: string) => {
+      calls.push(url);
+      const key = keys.find((k) => url.includes(k));
+      if (!key) throw new Error(`unrouted request: ${url}`);
+      return routes[key];
+    },
+  };
+}
+
+function playlistPage(snapshotId: string) {
+  return {
+    items: [
+      {
+        id: "PL1",
+        name: "hiphop",
+        description: null,
+        public: true,
+        collaborative: false,
+        snapshot_id: snapshotId,
+        owner: { id: "me", display_name: "Me" },
+        tracks: { total: 2, href: "h" },
+        images: [],
+        external_urls: { spotify: "https://open.spotify.com/playlist/PL1" },
+      },
+    ],
+    total: 1,
+    limit: 50,
+    offset: 0,
+    next: null,
+    previous: null,
+  };
+}
+
+function syncCtx(
+  feedKey: string,
+  http: unknown,
+  extra: Record<string, unknown> = {}
+) {
+  // The SDK mock hands `credentials` back as the bearer client.
+  return { feedKey, credentials: http, config: {}, checkpoint: null, ...extra };
+}
+
+describe("topTracksLimit", () => {
+  test("defaults to a bounded ranking and clamps junk", () => {
+    expect(topTracksLimit(undefined)).toBe(50);
+    expect(topTracksLimit(0)).toBe(50);
+    expect(topTracksLimit("100")).toBe(50);
+    expect(topTracksLimit(10)).toBe(10);
+    expect(topTracksLimit(99999)).toBe(1000);
+  });
+});
+
+describe("snapshotDigest", () => {
+  test("is stable for the same list and moves when the order does", () => {
+    expect(snapshotDigest(["a", "b"])).toBe(snapshotDigest(["a", "b"]));
+    expect(snapshotDigest(["a", "b"])).not.toBe(snapshotDigest(["b", "a"]));
+    // Joining must not let ["ab"] and ["a","b"] collide.
+    expect(snapshotDigest(["ab"])).not.toBe(snapshotDigest(["a", "b"]));
+  });
+});
+
+describe("playlists snapshot gate", () => {
+  const tracksPage = {
+    items: [
+      {
+        added_at: "2025-06-22T17:27:32Z",
+        added_by: { id: "me" },
+        track: fakeTrack("t1"),
+      },
+      {
+        added_at: "2025-07-03T17:27:13Z",
+        added_by: { id: "me" },
+        track: fakeTrack("t1"),
+      },
+    ],
+    total: 2,
+    limit: 50,
+    offset: 0,
+    next: null,
+    previous: null,
+  };
+
+  test("an unchanged snapshot_id emits nothing and skips the track fetch", async () => {
+    const http = fakeSpotifyApi({
+      "/me/playlists": playlistPage("snap-1"),
+      "/playlists/PL1/tracks": tracksPage,
+    });
+    const connector = new SpotifyConnector();
+
+    const first = await connector.sync(syncCtx("playlists", http));
+    expect(first.events.length).toBeGreaterThan(0);
+    expect(first.checkpoint.playlist_snapshots).toEqual({ PL1: "snap-1" });
+    expect(http.calls.some((u: string) => u.includes("/tracks"))).toBe(true);
+
+    http.calls.length = 0;
+    const second = await connector.sync(
+      syncCtx("playlists", http, { checkpoint: first.checkpoint })
+    );
+
+    // The whole point: an untouched playlist produces no rows at all, and we
+    // never even ask Spotify for its tracks.
+    expect(second.events).toEqual([]);
+    expect(http.calls.some((u: string) => u.includes("/tracks"))).toBe(false);
+    expect(second.checkpoint.playlist_snapshots).toEqual({ PL1: "snap-1" });
+  });
+
+  test("a changed snapshot_id re-emits that playlist", async () => {
+    const http = fakeSpotifyApi({
+      "/me/playlists": playlistPage("snap-2"),
+      "/playlists/PL1/tracks": tracksPage,
+    });
+    const connector = new SpotifyConnector();
+
+    const result = await connector.sync(
+      syncCtx("playlists", http, {
+        checkpoint: { playlist_snapshots: { PL1: "snap-1" } },
+      })
+    );
+
+    expect(result.events.length).toBeGreaterThan(0);
+    expect(result.checkpoint.playlist_snapshots).toEqual({ PL1: "snap-2" });
+  });
+
+  // Regression: the same track can sit in a playlist several times, each entry
+  // with its own added_at. Keying the origin_id on the track alone collapsed
+  // them, so inside ONE run they superseded each other down to the last entry
+  // (prod: 4 versions of "Stillness" written 8 seconds apart, 3 destroyed).
+  test("duplicate entries of one track stay distinct rows", async () => {
+    const http = fakeSpotifyApi({
+      "/me/playlists": playlistPage("snap-1"),
+      "/playlists/PL1/tracks": tracksPage,
+    });
+    const connector = new SpotifyConnector();
+
+    const result = await connector.sync(syncCtx("playlists", http));
+    const trackIds = result.events
+      .filter((e: any) => e.origin_type === "playlist_track")
+      .map((e: any) => e.origin_id);
+
+    expect(trackIds).toHaveLength(2);
+    expect(new Set(trackIds).size).toBe(2);
+  });
+});
+
+describe("top_tracks", () => {
+  function topPage(ids: string[]) {
+    return {
+      items: ids.map((id) => fakeTrack(id)),
+      total: ids.length,
+      limit: 50,
+      offset: 0,
+      next: null,
+      previous: null,
+    };
+  }
+
+  test("an unchanged ranking emits nothing on the next sync", async () => {
+    const http = fakeSpotifyApi({
+      "/me/top/tracks": topPage(["t1", "t2", "t3"]),
+    });
+    const connector = new SpotifyConnector();
+
+    const first = await connector.sync(syncCtx("top_tracks", http));
+    expect(first.events).toHaveLength(3);
+    expect(first.checkpoint.top_tracks_digest).toBeTruthy();
+
+    const second = await connector.sync(
+      syncCtx("top_tracks", http, { checkpoint: first.checkpoint })
+    );
+    expect(second.events).toEqual([]);
+    expect(second.checkpoint.top_tracks_digest).toBe(
+      first.checkpoint.top_tracks_digest
+    );
+  });
+
+  test("a reshuffled ranking does emit", async () => {
+    const connector = new SpotifyConnector();
+    const before = await connector.sync(
+      syncCtx(
+        "top_tracks",
+        fakeSpotifyApi({ "/me/top/tracks": topPage(["t1", "t2"]) })
+      )
+    );
+    const after = await connector.sync(
+      syncCtx(
+        "top_tracks",
+        fakeSpotifyApi({ "/me/top/tracks": topPage(["t2", "t1"]) }),
+        {
+          checkpoint: before.checkpoint,
+        }
+      )
+    );
+    expect(after.events).toHaveLength(2);
+  });
+
+  test("the configured limit bounds how deep the ranking goes", async () => {
+    const http = fakeSpotifyApi({
+      "/me/top/tracks": topPage(["t1", "t2", "t3", "t4", "t5"]),
+    });
+    const connector = new SpotifyConnector();
+
+    const result = await connector.sync(
+      syncCtx("top_tracks", http, { config: { limit: 2 } })
+    );
+
+    expect(result.events).toHaveLength(2);
+    expect(result.events.map((e: any) => e.metadata.rank)).toEqual([1, 2]);
+    expect(http.calls[0]).toContain("limit=2");
+  });
+
+  // The rank belongs in metadata. Embedding it in the title made the title
+  // churn on every reshuffle and rewrote the search index for a track whose
+  // name never changed.
+  test("the title is the track name, not the ranking", async () => {
+    const http = fakeSpotifyApi({ "/me/top/tracks": topPage(["t1"]) });
+    const connector = new SpotifyConnector();
+    const result = await connector.sync(syncCtx("top_tracks", http));
+
+    expect(result.events[0].title).toBe("track t1");
+    expect(result.events[0].metadata.rank).toBe(1);
+  });
+});
+
+// Class-wide guard rather than a per-field one: no snapshot feed may carry a
+// volatile provider counter into emitted content, whichever field it is.
+describe("no snapshot feed emits a volatile provider counter", () => {
+  const VOLATILE = ["popularity"];
+
+  test.each([
+    [
+      "saved_tracks",
+      {
+        "/me/tracks": {
+          items: [{ added_at: "2025-01-09T18:21:15Z", track: fakeTrack("t1") }],
+          total: 1,
+          limit: 50,
+          offset: 0,
+          next: null,
+          previous: null,
+        },
+      },
+    ],
+    [
+      "top_tracks",
+      {
+        "/me/top/tracks": {
+          items: [fakeTrack("t1")],
+          total: 1,
+          limit: 50,
+          offset: 0,
+          next: null,
+          previous: null,
+        },
+      },
+    ],
+  ])("%s", async (feedKey, routes) => {
+    const connector = new SpotifyConnector();
+    const result = await connector.sync(
+      syncCtx(
+        feedKey as string,
+        fakeSpotifyApi(routes as Record<string, unknown>)
+      )
+    );
+
+    expect(result.events.length).toBeGreaterThan(0);
+    for (const event of result.events) {
+      for (const field of VOLATILE) {
+        expect(Object.keys(event.metadata ?? {})).not.toContain(field);
+      }
+    }
+  });
+});

--- a/examples/personal-agent/spotify.connector.ts
+++ b/examples/personal-agent/spotify.connector.ts
@@ -77,6 +77,12 @@ interface SpotifySavedTrack {
 interface SpotifyPlaylist {
   id: string;
   name: string;
+  /**
+   * Spotify's own content fingerprint — it changes when and only when the
+   * playlist's contents change. `syncPlaylists` gates on it, which is why that
+   * feed can stamp `occurred_at` with the observation time.
+   */
+  snapshot_id: string;
   description: string | null;
   public: boolean | null;
   collaborative: boolean;
@@ -112,6 +118,10 @@ interface SpotifyCheckpoint {
   last_sync_at?: string;
   offset?: number;
   cursor?: string;
+  /** Per-playlist `snapshot_id` as of the last sync. See `syncPlaylists`. */
+  playlist_snapshots?: Record<string, string>;
+  /** Fingerprint of the last emitted top-tracks ranking. See `syncTopTracks`. */
+  top_tracks_digest?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -135,6 +145,34 @@ export function trackKey(track: { id: string | null; uri: string }): string {
 
 function albumArt(images: SpotifyImage[]): string | undefined {
   return images[0]?.url;
+}
+
+/**
+ * Spotify's own ceiling for `/me/top/tracks` is offset 999, and the default
+ * stays deliberately shallow: a rank only carries information inside a bounded
+ * list. Prod ran the maximum depth and every run rewrote ~1000 rows because one
+ * listen shifted every position below it.
+ */
+export function topTracksLimit(raw: unknown): number {
+  const parsed = typeof raw === "number" ? Math.floor(raw) : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 1) return 50;
+  return Math.min(parsed, 1000);
+}
+
+/**
+ * FNV-1a over the canonical form of a snapshot. Not cryptographic — it only has
+ * to answer "did this list change since the last sync", and it is written in
+ * plain JS so the connector stays portable across isolate backends (no
+ * `node:crypto`, no `crypto.subtle` async).
+ */
+export function snapshotDigest(parts: readonly string[]): string {
+  let hash = 0x811c9dc5;
+  const canonical = parts.join("\u0000");
+  for (let i = 0; i < canonical.length; i++) {
+    hash ^= canonical.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
 }
 
 // ---------------------------------------------------------------------------
@@ -188,6 +226,11 @@ export default class SpotifyConnector extends ConnectorRuntime {
         eventKinds: {
           track: {
             description: "A saved Spotify track",
+            // No `popularity`: it is Spotify's global chart figure, it drifts
+            // daily, and it says nothing about the user's own library. Carrying
+            // it made an otherwise unchanged saved track supersede itself on
+            // every run (observed in prod: popularity oscillating 21<->22 was
+            // the ONLY difference between stored versions).
             metadataSchema: {
               type: "object",
               properties: {
@@ -195,7 +238,6 @@ export default class SpotifyConnector extends ConnectorRuntime {
                 album: { type: "string" },
                 album_art_url: { type: "string", format: "uri" },
                 duration_ms: { type: "number" },
-                popularity: { type: "number" },
                 explicit: { type: "boolean" },
                 release_date: { type: "string" },
               },
@@ -220,6 +262,7 @@ export default class SpotifyConnector extends ConnectorRuntime {
                 public: { type: "boolean" },
                 collaborative: { type: "boolean" },
                 owner: { type: "string" },
+                snapshot_id: { type: "string" },
               },
             },
           },
@@ -279,17 +322,28 @@ export default class SpotifyConnector extends ConnectorRuntime {
               description:
                 "Time range: short_term (~4 weeks), medium_term (~6 months), long_term (all time).",
             },
+            limit: {
+              type: "integer",
+              minimum: 1,
+              maximum: 1000,
+              default: 50,
+              description:
+                "How deep the ranking goes. A rank is only meaningful inside a bounded list — at depth 1000 a single listen reshuffles hundreds of positions and rewrites the whole feed.",
+            },
           },
         },
         eventKinds: {
           top_track: {
             description: "A top track by listening frequency",
+            // No `popularity` here either — same volatile global counter as in
+            // saved_tracks. `rank` stays because it IS this feed's subject, and
+            // the digest gate below keeps a reshuffle from rewriting the list
+            // when the ranking has not actually moved.
             metadataSchema: {
               type: "object",
               properties: {
                 artist: { type: "string" },
                 album: { type: "string" },
-                popularity: { type: "number" },
                 rank: { type: "number" },
                 time_range: { type: "string" },
               },
@@ -367,7 +421,6 @@ export default class SpotifyConnector extends ConnectorRuntime {
             album: track.album.name,
             album_art_url: albumArt(track.album.images),
             duration_ms: track.duration_ms,
-            popularity: track.popularity,
             explicit: track.explicit,
             release_date: track.album.release_date,
           },
@@ -394,6 +447,9 @@ export default class SpotifyConnector extends ConnectorRuntime {
     http: HttpClient
   ): Promise<SyncResult> {
     const events: EventEnvelope[] = [];
+    const previous = (ctx.checkpoint ?? {}) as SpotifyCheckpoint;
+    const lastSnapshots = previous.playlist_snapshots ?? {};
+    const snapshots: Record<string, string> = {};
 
     // First, fetch all playlists
     const playlists: SpotifyPlaylist[] = [];
@@ -410,29 +466,16 @@ export default class SpotifyConnector extends ConnectorRuntime {
       playlists.push(...items);
     }
 
-    // Emit playlist events
     for (const pl of playlists) {
-      events.push({
-        origin_id: `spotify_playlist_${pl.id}`,
-        title: pl.name,
-        payload_text: pl.description ?? pl.name,
-        author_name: pl.owner.display_name ?? pl.owner.id,
-        source_url: pl.external_urls.spotify,
-        occurred_at: new Date(),
-        origin_type: "playlist",
-        metadata: {
-          track_count: pl.tracks.total,
-          public: pl.public,
-          collaborative: pl.collaborative,
-          owner: pl.owner.display_name ?? pl.owner.id,
-        },
-      });
-    }
+      snapshots[pl.id] = pl.snapshot_id;
 
-    if (ctx.emitEvents) await ctx.emitEvents(events.splice(0));
+      // Spotify hands us a content fingerprint for free. An unchanged
+      // `snapshot_id` means nothing in this playlist moved, so there is nothing
+      // to emit AND nothing to fetch — the track request below is skipped too.
+      // An absent entry is the first run, so no backfill flag is needed.
+      if (lastSnapshots[pl.id] === pl.snapshot_id) continue;
 
-    // Then fetch tracks for each playlist
-    for (const pl of playlists) {
+      const trackEvents: EventEnvelope[] = [];
       const trackPages = paginateByOffset(
         async (offset) => {
           const data = await http.get<
@@ -446,17 +489,23 @@ export default class SpotifyConnector extends ConnectorRuntime {
       );
 
       for await (const items of trackPages) {
-        const trackEvents: EventEnvelope[] = [];
         for (const item of items) {
           if (!item.track) continue;
           const track = item.track;
+          const addedAt = new Date(item.added_at);
           trackEvents.push({
-            origin_id: `spotify_pl_${pl.id}_track_${trackKey(track)}`,
+            // A playlist ENTRY, not a track: Spotify allows the same track to
+            // sit in one playlist several times, each with its own `added_at`.
+            // Keying on the track alone collapsed those entries onto one
+            // origin_id, so within a single run they superseded each other down
+            // to the last one — silent data loss, the same collision class the
+            // `trackKey` doc warns about. Mirrors `recently_played`'s key.
+            origin_id: `spotify_pl_${pl.id}_track_${trackKey(track)}_${addedAt.getTime()}`,
             title: track.name,
             payload_text: `${track.name} by ${artistNames(track.artists)}`,
             author_name: artistNames(track.artists),
             source_url: track.external_urls.spotify,
-            occurred_at: new Date(item.added_at),
+            occurred_at: addedAt,
             origin_type: "playlist_track",
             origin_parent_id: `spotify_playlist_${pl.id}`,
             metadata: {
@@ -469,16 +518,38 @@ export default class SpotifyConnector extends ConnectorRuntime {
             },
           });
         }
-
-        if (ctx.emitEvents) await ctx.emitEvents(trackEvents);
-        else events.push(...trackEvents);
       }
+
+      events.push({
+        origin_id: `spotify_playlist_${pl.id}`,
+        title: pl.name,
+        payload_text: pl.description ?? pl.name,
+        author_name: pl.owner.display_name ?? pl.owner.id,
+        source_url: pl.external_urls.spotify,
+        // Observation time, which under the `snapshot_id` gate above is only
+        // reached when the playlist actually changed. Ungated this was the
+        // single worst source of churn in prod (62x): an untouched playlist got
+        // a fresh occurred_at every run and superseded itself forever.
+        occurred_at: new Date(),
+        origin_type: "playlist",
+        metadata: {
+          track_count: pl.tracks.total,
+          public: pl.public,
+          collaborative: pl.collaborative,
+          owner: pl.owner.display_name ?? pl.owner.id,
+          snapshot_id: pl.snapshot_id,
+        },
+      });
+      events.push(...trackEvents);
+
+      if (ctx.emitEvents) await ctx.emitEvents(events.splice(0));
     }
 
     return {
       events,
       checkpoint: {
         last_sync_at: new Date().toISOString(),
+        playlist_snapshots: snapshots,
       } satisfies SpotifyCheckpoint as Record<string, unknown>,
     };
   }
@@ -560,6 +631,8 @@ export default class SpotifyConnector extends ConnectorRuntime {
     http: HttpClient
   ): Promise<SyncResult> {
     const timeRange = (ctx.config.time_range as string) ?? "medium_term";
+    const limit = topTracksLimit(ctx.config.limit);
+    const previous = (ctx.checkpoint ?? {}) as SpotifyCheckpoint;
     const events: EventEnvelope[] = [];
     let rank = 1;
     // UTC-midnight bucket so re-syncs within the same day dedup (see occurred_at below).
@@ -569,19 +642,30 @@ export default class SpotifyConnector extends ConnectorRuntime {
 
     const pages = paginateByOffset(
       async (offset) => {
+        const pageSize = Math.min(this.PAGE_SIZE, limit - offset);
         const data = await http.get<SpotifyPagingResponse<SpotifyTrack>>(
-          `${this.API_BASE}/me/top/tracks?time_range=${timeRange}&limit=${this.PAGE_SIZE}&offset=${offset}`
+          `${this.API_BASE}/me/top/tracks?time_range=${timeRange}&limit=${pageSize}&offset=${offset}`
         );
-        return { items: data.items, hasMore: !!data.next };
+        return {
+          items: data.items,
+          hasMore: !!data.next && offset + pageSize < limit,
+        };
       },
-      { pageSize: this.PAGE_SIZE, maxPages: this.MAX_PAGES }
+      {
+        pageSize: this.PAGE_SIZE,
+        maxPages: Math.ceil(limit / this.PAGE_SIZE),
+      }
     );
 
     for await (const items of pages) {
       for (const track of items) {
+        if (rank > limit) break;
         events.push({
           origin_id: `spotify_top_${timeRange}_${trackKey(track)}`,
-          title: `#${rank} ${track.name}`,
+          // The rank lives in metadata, not in the title. Embedding it made the
+          // title itself churn on every reshuffle, which rewrites the search
+          // index for a track whose name never changed.
+          title: track.name,
           payload_text: `${track.name} by ${artistNames(track.artists)} — ${track.album.name}`,
           author_name: artistNames(track.artists),
           source_url: track.external_urls.spotify,
@@ -596,21 +680,38 @@ export default class SpotifyConnector extends ConnectorRuntime {
           metadata: {
             artist: artistNames(track.artists),
             album: track.album.name,
-            popularity: track.popularity,
             rank,
             time_range: timeRange,
           },
         });
         rank++;
       }
-
-      if (ctx.emitEvents) await ctx.emitEvents(events.splice(0));
     }
+
+    // The ranking is a snapshot, so re-emitting an unmoved list buys nothing:
+    // each item supersedes its own previous version and mints a fresh row. Gate
+    // on a fingerprint of the ranking itself — same digest, emit nothing.
+    // Absent digest IS the first run, so no separate backfill flag is needed.
+    const digest = snapshotDigest(
+      events.map((e, index) => `${index}:${e.origin_id}`)
+    );
+    if (previous.top_tracks_digest === digest) {
+      return {
+        events: [],
+        checkpoint: {
+          last_sync_at: new Date().toISOString(),
+          top_tracks_digest: digest,
+        } satisfies SpotifyCheckpoint as Record<string, unknown>,
+      };
+    }
+
+    if (ctx.emitEvents) await ctx.emitEvents(events.splice(0));
 
     return {
       events,
       checkpoint: {
         last_sync_at: new Date().toISOString(),
+        top_tracks_digest: digest,
       } satisfies SpotifyCheckpoint as Record<string, unknown>,
     };
   }

--- a/examples/personal-agent/spotify.connector.ts
+++ b/examples/personal-agent/spotify.connector.ts
@@ -118,7 +118,7 @@ interface SpotifyCheckpoint {
   last_sync_at?: string;
   offset?: number;
   cursor?: string;
-  /** Per-playlist `snapshot_id` as of the last sync. See `syncPlaylists`. */
+  /** Per-playlist content key as of the last sync. See `syncPlaylists`. */
   playlist_snapshots?: Record<string, string>;
   /** Fingerprint of the last emitted top-tracks ranking. See `syncTopTracks`. */
   top_tracks_digest?: string;
@@ -157,6 +157,17 @@ export function topTracksLimit(raw: unknown): number {
   const parsed = typeof raw === "number" ? Math.floor(raw) : Number.NaN;
   if (!Number.isFinite(parsed) || parsed < 1) return 50;
   return Math.min(parsed, 1000);
+}
+
+/**
+ * Millisecond component for an origin_id. `new Date(bad).getTime()` is NaN, and
+ * every NaN entry would then collapse onto a single origin_id — the same
+ * collision class `trackKey` guards against. Falls back to the raw string, and
+ * is a no-op for well-formed timestamps so existing keys keep their shape.
+ */
+export function timestampKey(raw: string): string {
+  const ms = new Date(raw).getTime();
+  return Number.isFinite(ms) ? String(ms) : `raw_${raw}`;
 }
 
 /**
@@ -467,13 +478,24 @@ export default class SpotifyConnector extends ConnectorRuntime {
     }
 
     for (const pl of playlists) {
-      snapshots[pl.id] = pl.snapshot_id;
+      // Spotify hands us a content fingerprint for free, but `snapshot_id`
+      // versions the TRACK LIST only — renaming a playlist or editing its
+      // description or visibility does not bump it, and those fields are the
+      // emitted title and payload_text. Fold them in so an edit still re-emits
+      // instead of leaving the stored row stale forever.
+      const playlistKey = snapshotDigest([
+        pl.snapshot_id,
+        pl.name,
+        pl.description ?? "",
+        String(pl.public),
+        String(pl.collaborative),
+      ]);
+      snapshots[pl.id] = playlistKey;
 
-      // Spotify hands us a content fingerprint for free. An unchanged
-      // `snapshot_id` means nothing in this playlist moved, so there is nothing
-      // to emit AND nothing to fetch — the track request below is skipped too.
-      // An absent entry is the first run, so no backfill flag is needed.
-      if (lastSnapshots[pl.id] === pl.snapshot_id) continue;
+      // Unchanged means nothing to emit AND nothing to fetch — the per-playlist
+      // track request below is skipped too. An absent entry is the first run,
+      // so no backfill flag is needed.
+      if (lastSnapshots[pl.id] === playlistKey) continue;
 
       const trackEvents: EventEnvelope[] = [];
       const trackPages = paginateByOffset(
@@ -500,7 +522,7 @@ export default class SpotifyConnector extends ConnectorRuntime {
             // origin_id, so within a single run they superseded each other down
             // to the last one — silent data loss, the same collision class the
             // `trackKey` doc warns about. Mirrors `recently_played`'s key.
-            origin_id: `spotify_pl_${pl.id}_track_${trackKey(track)}_${addedAt.getTime()}`,
+            origin_id: `spotify_pl_${pl.id}_track_${trackKey(track)}_${timestampKey(item.added_at)}`,
             title: track.name,
             payload_text: `${track.name} by ${artistNames(track.artists)}`,
             author_name: artistNames(track.artists),
@@ -593,7 +615,7 @@ export default class SpotifyConnector extends ConnectorRuntime {
         const track = item.track;
         const playedAt = new Date(item.played_at);
         events.push({
-          origin_id: `spotify_play_${trackKey(track)}_${playedAt.getTime()}`,
+          origin_id: `spotify_play_${trackKey(track)}_${timestampKey(item.played_at)}`,
           title: track.name,
           payload_text: `${track.name} by ${artistNames(track.artists)}`,
           author_name: artistNames(track.artists),


### PR DESCRIPTION
## Summary

- All three Spotify **snapshot** feeds re-emitted their entire snapshot every run, so unchanged items superseded their own previous version and minted a fresh row. `recently_played` — a genuine append-only stream — sits at 1.0x and is the control that says this is a snapshot-modelling fault, not a sync fault.
- Four distinct causes, each proven against stored prod rows, not inferred from source.
- Nothing here arms anything. These three feeds are dormant (no cron, no webhook route); this makes them safe to arm, which was the blocker flagged in #3338.

Measured on prod `events`, versions per distinct `origin_id`:

| feed | amp | rows / items |
|---|---|---|
| `playlists` → `playlist` | **62.3x** | 10,662 / 1,291 (whole feed) |
| `top_tracks` | **18.6x** | 22,356 / 1,203 |
| `playlists` → `playlist_track` | 5.1x | |
| `saved_tracks` | 1.8x | |
| `recently_played` | 1.0x | the control |

### The four causes

1. **`playlists` stamped `occurred_at: new Date()`** — an untouched playlist looked new on every run. Proven: eight stored versions of playlist `hiphop`, identical title and `track_count`, differing only in `occurred_at`. Now gated on Spotify's own `snapshot_id`, which changes when and only when the playlist's contents change. An unchanged playlist emits nothing **and is no longer fetched**, so its per-playlist track request disappears too.
2. **Playlist entries collided.** `origin_id` keyed on the track alone, but Spotify allows the same track in one playlist several times, each with its own `added_at`. Those entries superseded each other *inside a single run* — silent data loss. Proven: four versions of one entry written 8 seconds apart with four different `added_at`, three destroyed. Now keyed on the entry, mirroring what `recently_played` already does.
3. **`top_tracks` pulled the full 1000-deep ranking**, where a single listen shifts every position below it. Bounded via a new `limit` config (default 50, Spotify's own ceiling is 999) and gated on a fingerprint of the ranking. The rank moved out of the title — embedding it churned the search index for a track whose name never changed.
4. **`popularity` was emitted** by `saved_tracks` and `top_tracks`. It is Spotify's global chart figure, it drifts daily, and it says nothing about the user. Proven: stored versions of "Belong - Edit" identical apart from popularity oscillating 21↔22.

The regression guards assert the **class** — no snapshot feed may emit a volatile provider counter, and an unchanged snapshot must emit nothing — rather than the specific field that happened to churn.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `bun test __tests__/` in `examples/personal-agent`
- [x] Bug fix: red→fix→green outputs pasted below

**RED** — the new tests against the pre-fix connector (`git show origin/main:…/spotify.connector.ts`):

```
(fail) topTracksLimit > defaults to a bounded ranking and clamps junk
(fail) snapshotDigest > is stable for the same list and moves when the order does
(fail) playlists snapshot gate > an unchanged snapshot_id emits nothing and skips the track fetch
(fail) playlists snapshot gate > a changed snapshot_id re-emits that playlist
(fail) playlists snapshot gate > duplicate entries of one track stay distinct rows
(fail) top_tracks > an unchanged ranking emits nothing on the next sync
(fail) top_tracks > the configured limit bounds how deep the ranking goes
(fail) top_tracks > the title is the track name, not the ranking
(fail) no snapshot feed emits a volatile provider counter > saved_tracks
(fail) no snapshot feed emits a volatile provider counter > top_tracks
 3 pass
 10 fail
```

The 3 that pass pre-fix are the two existing `trackKey` tests plus "a reshuffled ranking does emit" — the negative control, which passes trivially when everything always emits.

**GREEN** — whole example suite on the fix:

```
 293 pass
 0 fail
 1393 expect() calls
Ran 293 tests across 14 files.
```

## Notes

- **One-time re-emit on first sync after this lands.** The `playlist_track` origin_id changes shape, so those entries are written once under the new key; the old rows stay as-is rather than being superseded. That is the cost of making duplicate entries survivable, and it is bounded (~1.2k items).
- `make review-fix` could not run — the codex account is at its usage limit until Sep 7, so it made no edits.
- **Not in this PR, needs a product decision:** `reddit.posts` is the same class at far larger scale — **1,730,582 rows for 73,776 distinct posts (23.5x)**, driven by `score` / `upvote_ratio` / `num_comments`. Unlike `popularity` those are genuinely meaningful, so the fix is platform-level (a volatile-field marker in `eventKinds.metadataSchema` excluded from `isSemanticallyEqual` in `insert-event.ts`) and changes SDK surface. Filed here so it is not lost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reduced duplicate Spotify updates by detecting unchanged playlists and top-track lists.
  * Added configurable top-track limits from 1 to 1,000, defaulting to 50.
  * Preserved distinct playlist entries, including duplicate tracks and tracks without provider IDs.
  * Added playlist snapshot information to sync events.

* **Bug Fixes**
  * Corrected track titles and ranking limits in top-track results.
  * Removed volatile popularity data from Spotify metadata.
  * Improved Spotify snapshot stability and change detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->