### PR TITLE
fix(server): let an external claimant complete the window it claimed

### DIFF
--- a/packages/server/src/__tests__/integration/automations/external-claim-completion.test.ts
+++ b/packages/server/src/__tests__/integration/automations/external-claim-completion.test.ts
@@ -1,21 +1,26 @@
+import type { AutomationClaimNextWindowResult } from '@lobu/core/contracts/tools/manage-automations';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { DbClient } from '../../../db/client';
 import { initWorkspaceProvider } from '../../../workspace';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestEntity, createTestEvent, seedOwnerContext } from '../../setup/test-fixtures';
 import { TestApiClient } from '../../setup/test-mcp-client';
+import type { Env } from '../../../index';
+import type { ToolContext } from '../../../tools/registry';
+import { handleClaimNextWindow } from '../../../tools/admin/manage_automations/claim-next-window';
+import { handleCompleteWindow } from '../../../tools/admin/manage_automations/complete-window';
 
-type ClaimResult = {
-  run_id: number;
-  context: { window_start: string; window_end: string; window_token: string };
-};
+const ENV = { JWT_SECRET: 'test-jwt-secret-for-testing-only' } as Env;
 
 /**
- * An Automation with NO managed agent and NO device worker is the shape an
- * external MCP client drives: `claim_next_window` opens the run, the same
- * client completes it. Every other suite seeds `managed_agent_id`, which makes
- * the run non-manual-open and skips the external claim-ownership fence
- * entirely — so this shape is the only one that exercises it.
+ * `claim_next_window` writes the run's claim owner and `complete_window`
+ * re-derives it to fence the completion, so the two encodings only ever meet on
+ * an Automation with NO managed agent and NO device worker that is claimed and
+ * then completed by the same external caller. The other claim-then-complete
+ * suites seed `managed_agent_id`, which skips the fence; the agentless suites
+ * open their runs with `trigger`, where `complete_window` mints the claim
+ * itself and therefore agrees with whatever it wrote. Only this shape compares
+ * them.
  */
 describe('external MCP claim then completion', () => {
   let sql: DbClient;
@@ -24,6 +29,7 @@ describe('external MCP claim then completion', () => {
   let entityId: number;
   let automationId: number;
   let api: TestApiClient;
+  let ownerCtx: ToolContext;
 
   beforeAll(async () => {
     await initWorkspaceProvider();
@@ -32,6 +38,7 @@ describe('external MCP claim then completion', () => {
   beforeEach(async () => {
     await cleanupTestDatabase();
     const seeded = await seedOwnerContext();
+    ownerCtx = seeded.ctx as ToolContext;
     sql = getTestDb() as unknown as DbClient;
     orgId = seeded.org.id;
     userId = seeded.user.id;
@@ -71,7 +78,7 @@ describe('external MCP claim then completion', () => {
 
     const claimed = (await api.automations.claimNextWindow({
       automation_id: String(automationId),
-    })) as ClaimResult;
+    })) as AutomationClaimNextWindowResult;
 
     const [run] = await sql<{ claimed_by: string | null }>`
       SELECT claimed_by FROM runs WHERE id = ${claimed.run_id}
@@ -99,12 +106,53 @@ describe('external MCP claim then completion', () => {
     expect(new Date(after.last_completed_window_start as string).toISOString()).toBe(
       claimed.context.window_start
     );
+
+    // The completion must leave the claim owner byte-identical to the one the
+    // claim wrote — a re-encoding that merely happened to pass the fence would
+    // still strand the next caller.
+    const [finished] = await sql<{ status: string; claimed_by: string | null }>`
+      SELECT status, claimed_by FROM runs WHERE id = ${claimed.run_id}
+    `;
+    expect(finished).toMatchObject({ status: 'completed', claimed_by: run.claimed_by });
+  });
+
+  it('completes a claim opened under a DIFFERENT MCP session', async () => {
+    // ChatGPT opens a new MCP session per tool call, so the session that claims
+    // a window is never the session that completes it. An owner encoding that
+    // included `mcp_session_id` made the pairing structurally impossible.
+    const claimSession: ToolContext = { ...ownerCtx, mcpSessionId: 'session-claim' };
+    const completeSession: ToolContext = { ...ownerCtx, mcpSessionId: 'session-complete' };
+
+    const claimed = await handleClaimNextWindow(
+      { action: 'claim_next_window', automation_id: String(automationId) } as never,
+      ENV,
+      claimSession
+    );
+
+    const completed = (await handleCompleteWindow(
+      {
+        action: 'complete_window',
+        automation_id: String(automationId),
+        run_id: claimed.run_id,
+        window_token: claimed.context.window_token,
+        extracted_data: { signals: [] },
+      } as never,
+      ENV,
+      completeSession
+    )) as { run_id: number; completed_now: boolean };
+
+    expect(completed).toMatchObject({ run_id: claimed.run_id, completed_now: true });
+
+    const [after] = await sql<{ next_window_start: string | Date }>`
+      SELECT next_window_start FROM automations WHERE id = ${automationId}
+    `;
+    expect(new Date(after.next_window_start).toISOString()).toBe(claimed.context.window_end);
   });
 
   it('completes an empty window so the arrival mark still advances', async () => {
     const claimed = (await api.automations.claimNextWindow({
       automation_id: String(automationId),
-    })) as ClaimResult;
+    })) as AutomationClaimNextWindowResult;
 
     const completed = (await api.automations.completeWindow({
       automation_id: String(automationId),

--- a/packages/server/src/__tests__/integration/automations/external-claim-completion.test.ts
+++ b/packages/server/src/__tests__/integration/automations/external-claim-completion.test.ts
@@ -1,0 +1,123 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { DbClient } from '../../../db/client';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestEntity, createTestEvent, seedOwnerContext } from '../../setup/test-fixtures';
+import { TestApiClient } from '../../setup/test-mcp-client';
+
+type ClaimResult = {
+  run_id: number;
+  context: { window_start: string; window_end: string; window_token: string };
+};
+
+/**
+ * An Automation with NO managed agent and NO device worker is the shape an
+ * external MCP client drives: `claim_next_window` opens the run, the same
+ * client completes it. Every other suite seeds `managed_agent_id`, which makes
+ * the run non-manual-open and skips the external claim-ownership fence
+ * entirely — so this shape is the only one that exercises it.
+ */
+describe('external MCP claim then completion', () => {
+  let sql: DbClient;
+  let orgId: string;
+  let userId: string;
+  let entityId: number;
+  let automationId: number;
+  let api: TestApiClient;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    const seeded = await seedOwnerContext();
+    sql = getTestDb() as unknown as DbClient;
+    orgId = seeded.org.id;
+    userId = seeded.user.id;
+    const entity = await createTestEntity({
+      name: 'External claim subject',
+      organization_id: orgId,
+      created_by: userId,
+    });
+    entityId = entity.id;
+    api = await TestApiClient.for({ organizationId: orgId, userId, memberRole: 'owner' });
+    const created = (await api.automations.create({
+      entity_id: entityId,
+      slug: 'external-claim',
+      name: 'External claim',
+      prompt: 'Extract durable signals from each arrival window.',
+      sources: [
+        {
+          name: 'content',
+          query:
+            "SELECT id, occurred_at, payload_text FROM events WHERE semantic_type = 'content' ORDER BY occurred_at DESC, id DESC",
+        },
+      ],
+      outputs: { signals: { event: 'observation' } },
+      // Manual-only (no triggers), so no executor is required and both
+      // `managed_agent_id` and `device_worker_id` stay null — the shape an
+      // external MCP client claims and completes itself.
+    })) as { automation_id: string };
+    automationId = Number(created.automation_id);
+  });
+
+  it('completes a window the same caller claimed', async () => {
+    await createTestEvent({
+      entity_id: entityId,
+      organization_id: orgId,
+      content: 'Arrival inside the claimed window',
+    });
+
+    const claimed = (await api.automations.claimNextWindow({
+      automation_id: String(automationId),
+    })) as ClaimResult;
+
+    const [run] = await sql<{ claimed_by: string | null }>`
+      SELECT claimed_by FROM runs WHERE id = ${claimed.run_id}
+    `;
+    // claim_next_window records the caller as `external:{...}`.
+    expect(String(run.claimed_by)).toMatch(/^external:/);
+
+    const completed = (await api.automations.completeWindow({
+      automation_id: String(automationId),
+      run_id: claimed.run_id,
+      window_token: claimed.context.window_token,
+      extracted_data: { signals: [] },
+    })) as { run_id: number; completed_now: boolean };
+
+    expect(completed).toMatchObject({ run_id: claimed.run_id, completed_now: true });
+
+    const [after] = await sql<{
+      next_window_start: string | Date;
+      last_completed_window_start: string | Date | null;
+    }>`
+      SELECT next_window_start, last_completed_window_start
+      FROM automations WHERE id = ${automationId}
+    `;
+    expect(new Date(after.next_window_start).toISOString()).toBe(claimed.context.window_end);
+    expect(new Date(after.last_completed_window_start as string).toISOString()).toBe(
+      claimed.context.window_start
+    );
+  });
+
+  it('completes an empty window so the arrival mark still advances', async () => {
+    const claimed = (await api.automations.claimNextWindow({
+      automation_id: String(automationId),
+    })) as ClaimResult;
+
+    const completed = (await api.automations.completeWindow({
+      automation_id: String(automationId),
+      run_id: claimed.run_id,
+      window_token: claimed.context.window_token,
+      extracted_data: { signals: [] },
+    })) as { completed_now: boolean };
+
+    expect(completed.completed_now).toBe(true);
+
+    const [after] = await sql<{ next_window_start: string | Date }>`
+      SELECT next_window_start FROM automations WHERE id = ${automationId}
+    `;
+    expect(new Date(after.next_window_start).toISOString()).toBe(claimed.context.window_end);
+  });
+});

--- a/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
+++ b/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
@@ -2,10 +2,10 @@ import type { AutomationTriggerResult } from '@lobu/core/contracts/tools/manage-
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { Env } from '../../../index';
 import { createAutomationRun } from '../../../runs/queue-service';
+import { encodeExternalAutomationClaimOwner } from '../../../tools/admin/manage_automations/claim-next-window';
 import { handleCompleteWindow } from '../../../tools/admin/manage_automations/complete-window';
 import { handleAutomationMode } from '../../../tools/get_content/automation-mode';
 import type { ToolContext } from '../../../tools/registry';
-import { encodeExternalAutomationClaimOwner } from '../../../tools/admin/manage_automations/claim-next-window';
 import { generateWindowToken, verifyWindowToken } from '../../../utils/jwt';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import {

--- a/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
+++ b/packages/server/src/__tests__/integration/automations/external-manual-run.test.ts
@@ -5,6 +5,7 @@ import { createAutomationRun } from '../../../runs/queue-service';
 import { handleCompleteWindow } from '../../../tools/admin/manage_automations/complete-window';
 import { handleAutomationMode } from '../../../tools/get_content/automation-mode';
 import type { ToolContext } from '../../../tools/registry';
+import { encodeExternalAutomationClaimOwner } from '../../../tools/admin/manage_automations/claim-next-window';
 import { generateWindowToken, verifyWindowToken } from '../../../utils/jwt';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import {
@@ -46,6 +47,14 @@ const TEST_ENV: Env = {
   JWT_SECRET: 'test-jwt-secret-for-testing-only',
   BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only',
 };
+
+/**
+ * The claim owner both `claim_next_window` and `complete_window` encode for a
+ * plain user caller. Built through the production encoder so a change to that
+ * encoding fails here instead of silently fencing real claimants out.
+ */
+const claimOwnerForUser = (userId: string): string =>
+  encodeExternalAutomationClaimOwner({ userId } as ToolContext);
 
 describe('external manual Automation execution', () => {
   beforeEach(async () => {
@@ -286,7 +295,7 @@ describe('external manual Automation execution', () => {
         TEST_ENV,
         identitylessContext
       )
-    ).rejects.toThrow(/requires an authenticated MCP client or user/);
+    ).rejects.toThrow(/complete_window requires an identified caller/);
     const [stillUnclaimed] = await sql<{ status: string; claimed_by: string | null }>`
       SELECT status, claimed_by FROM runs WHERE id = ${triggered.run_id}
     `;
@@ -316,7 +325,9 @@ describe('external manual Automation execution', () => {
     `;
     expect(completed).toMatchObject({
       status: 'completed',
-      claimed_by: `user:${workspace.users.owner.id}`,
+      // complete_window must persist the SAME owner encoding claim_next_window
+      // writes, so a claimed run stays completable by its own claimant.
+      claimed_by: claimOwnerForUser(workspace.users.owner.id),
       model_used: 'chatgpt/test',
     });
     expect(completed.approved_input.granularity).toBeUndefined();
@@ -539,7 +550,7 @@ describe('external manual Automation execution', () => {
     // Retrying a claim already durably owned by this caller remains valid.
     await sql`
       UPDATE runs
-      SET claimed_by = ${`user:${workspace.users.owner.id}`}
+      SET claimed_by = ${claimOwnerForUser(workspace.users.owner.id)}
       WHERE id = ${secondRun.runId}
     `;
     const sameClaimRetry = (await workspace.owner.automations.completeWindow({

--- a/packages/server/src/__tests__/integration/automations/window-claim-recovery.test.ts
+++ b/packages/server/src/__tests__/integration/automations/window-claim-recovery.test.ts
@@ -290,13 +290,28 @@ describe('Automation window claim and recovery', () => {
     expect(active).toHaveLength(0);
   });
 
-  it('fences continuations to the full identified caller and rejects unidentified claimants', async () => {
+  it('fences continuations to the identified caller, across sessions, and rejects unidentified claimants', async () => {
     const first = await handleClaimNextWindow(
       { action: 'claim_next_window', automation_id: String(automationId) },
       ENV,
       { ...ctx, mcpSessionId: 'session-a' }
     );
 
+    // A different MCP SESSION of the same caller continues its own claim: an
+    // MCP session is a transport artifact that rotates per tool call, so
+    // session-scoped ownership would make claim -> complete impossible.
+    const continued = await handleClaimNextWindow(
+      {
+        action: 'claim_next_window',
+        automation_id: String(automationId),
+        run_id: first.run_id,
+      },
+      ENV,
+      { ...ctx, mcpSessionId: 'session-b' }
+    );
+    expect(continued.run_id).toBe(first.run_id);
+
+    // A different OAuth CLIENT is a different caller and still cannot take it.
     await expect(
       handleClaimNextWindow(
         {
@@ -305,7 +320,7 @@ describe('Automation window claim and recovery', () => {
           run_id: first.run_id,
         },
         ENV,
-        { ...ctx, mcpSessionId: 'session-b' }
+        { ...ctx, clientId: 'someone-elses-client', mcpSessionId: 'session-c' }
       )
     ).rejects.toThrow('Automation window continuation does not own an active lease.');
 

--- a/packages/server/src/__tests__/integration/automations/window-lag-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/automations/window-lag-visibility.test.ts
@@ -21,6 +21,7 @@ import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { DbClient } from "../../../db/client";
 import type { Env } from "../../../index";
 import { formatToolResult } from "../../../formatting/markdown-formatter";
+import { encodeExternalAutomationClaimOwner } from "../../../tools/admin/manage_automations/claim-next-window";
 import { manageAutomations } from "../../../tools/admin/manage_automations";
 import { handleAutomationMode } from "../../../tools/get_content/automation-mode";
 import { createAutomationRun } from "../../../runs/queue-service";
@@ -146,7 +147,7 @@ describe("Automation arrival lag is visible and actionable", () => {
 		});
 		await sql`
 			UPDATE runs
-			SET status = 'running', claimed_at = NOW(), claimed_by = ${`user:${userId}`}
+			SET status = 'running', claimed_at = NOW(), claimed_by = ${encodeExternalAutomationClaimOwner(ctx)}
 			WHERE id = ${run.runId}
 		`;
 		const bound = await read({ run_id: run.runId });

--- a/packages/server/src/__tests__/unit/automations/external-claim-owner.test.ts
+++ b/packages/server/src/__tests__/unit/automations/external-claim-owner.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { ToolContext } from "../../../tools/registry";
+import {
+	encodeExternalAutomationClaimOwner,
+	isExternalAutomationClaimOwner,
+} from "../../../tools/admin/manage_automations/claim-next-window";
+
+const ctx = (over: Partial<ToolContext>): ToolContext => over as ToolContext;
+
+describe("external Automation claim owner", () => {
+	it("omits the MCP session, which rotates per tool call", () => {
+		const owner = encodeExternalAutomationClaimOwner(
+			ctx({ userId: "u1", clientId: "c1", mcpSessionId: "session-a" }),
+		);
+		expect(owner).not.toContain("session-a");
+		// Same caller, different transport session -> identical owner, so a claim
+		// stays completable by the caller that opened it.
+		expect(
+			encodeExternalAutomationClaimOwner(
+				ctx({ userId: "u1", clientId: "c1", mcpSessionId: "session-b" }),
+			),
+		).toBe(owner);
+	});
+
+	it("refuses a caller with no identity at all", () => {
+		expect(() =>
+			encodeExternalAutomationClaimOwner(
+				ctx({ userId: null, agentId: null, clientId: null }),
+				"complete_window",
+			),
+		).toThrow(/complete_window requires an identified caller/);
+	});
+
+	it("reads its own output as an external claim", () => {
+		expect(
+			isExternalAutomationClaimOwner(
+				encodeExternalAutomationClaimOwner(ctx({ userId: "u1" })),
+			),
+		).toBe(true);
+	});
+
+	it("still reads a legacy session-bearing row as external", () => {
+		expect(
+			isExternalAutomationClaimOwner(
+				'external:{"user_id":"u1","agent_id":null,"client_id":"c1","mcp_session_id":"s1"}',
+			),
+		).toBe(true);
+	});
+
+	it("reads a legacy row whose ONLY identity was the session as external", () => {
+		// `trigger` routes on this predicate. Returning false here would push a
+		// real external claim into the worker lane.
+		expect(
+			isExternalAutomationClaimOwner(
+				'external:{"user_id":null,"agent_id":null,"client_id":null,"mcp_session_id":"s1"}',
+			),
+		).toBe(true);
+	});
+
+	it("rejects worker claims and malformed owners", () => {
+		expect(isExternalAutomationClaimOwner("gateway-abc")).toBe(false);
+		expect(isExternalAutomationClaimOwner("mac-abc")).toBe(false);
+		expect(isExternalAutomationClaimOwner("external:not-json")).toBe(false);
+		expect(isExternalAutomationClaimOwner('external:{"user_id":"u1"}')).toBe(false);
+		expect(
+			isExternalAutomationClaimOwner(
+				'external:{"user_id":"u1","agent_id":null,"client_id":null,"surprise":"x"}',
+			),
+		).toBe(false);
+		expect(
+			isExternalAutomationClaimOwner(
+				'external:{"user_id":null,"agent_id":null,"client_id":null}',
+			),
+		).toBe(false);
+	});
+});

--- a/packages/server/src/tools/admin/manage_automations/claim-next-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/claim-next-window.ts
@@ -21,6 +21,22 @@ const DEFAULT_LEASE_SECONDS = 900;
 const MIN_LEASE_SECONDS = 30;
 const MAX_LEASE_SECONDS = 3600;
 
+/**
+ * The durable owner of an Automation window claim.
+ *
+ * Deliberately excludes `mcp_session_id`. An MCP session is a transport
+ * artifact, not an identity: ChatGPT opens a NEW session per tool call (75
+ * sessions in 24 minutes, each used exactly once), so a session-scoped owner
+ * makes `claim_next_window` -> `complete_window` structurally impossible — the
+ * completion never matches the claim, the lease expires, and the same window is
+ * re-served forever. Ownership is the caller, and the caller outlives the
+ * session.
+ *
+ * What still fences a completion: the signed `window_token` binds the exact run,
+ * attempt and lease; claims serialize per Automation; and the lease expires. So
+ * the narrowing this drops is only "a different session of the SAME user, agent
+ * and OAuth client", which is the same principal by every other measure.
+ */
 export function encodeExternalAutomationClaimOwner(
   ctx: ToolContext,
   action: 'claim_next_window' | 'complete_window' = 'claim_next_window'
@@ -29,7 +45,6 @@ export function encodeExternalAutomationClaimOwner(
     user_id: ctx.userId ?? null,
     agent_id: ctx.agentId ?? null,
     client_id: ctx.clientId ?? null,
-    mcp_session_id: ctx.mcpSessionId ?? null,
   };
   if (Object.values(identity).every((value) => value == null)) {
     throw new ToolUserError(
@@ -48,14 +63,19 @@ export function isExternalAutomationClaimOwner(value: string): boolean {
       return false;
     }
     const record = identity as Record<string, unknown>;
-    const keys = ['user_id', 'agent_id', 'client_id', 'mcp_session_id'];
+    const keys = ['user_id', 'agent_id', 'client_id'];
+    // Rows claimed before `mcp_session_id` left the identity still carry it.
+    // They can no longer be completed (the owner will not match), but they must
+    // still READ as external so `trigger` routes them to the external lane
+    // instead of mistaking them for a worker claim.
+    const optional = ['mcp_session_id'];
     if (
-      Object.keys(record).length !== keys.length ||
       !keys.every(
         (key) =>
           Object.hasOwn(record, key) &&
           (record[key] == null || typeof record[key] === 'string')
-      )
+      ) ||
+      Object.keys(record).some((key) => !keys.includes(key) && !optional.includes(key))
     ) {
       return false;
     }

--- a/packages/server/src/tools/admin/manage_automations/claim-next-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/claim-next-window.ts
@@ -75,11 +75,15 @@ export function isExternalAutomationClaimOwner(value: string): boolean {
           Object.hasOwn(record, key) &&
           (record[key] == null || typeof record[key] === 'string')
       ) ||
-      Object.keys(record).some((key) => !keys.includes(key) && !optional.includes(key))
+      Object.keys(record).some((key) => !keys.includes(key) && !optional.includes(key)) ||
+      optional.some((key) => Object.hasOwn(record, key) && record[key] != null && typeof record[key] !== 'string')
     ) {
       return false;
     }
-    return keys.some((key) => record[key] != null);
+    // `optional` counts here too: a legacy row whose only non-null field was
+    // `mcp_session_id` is still an external claim, and must read as one so
+    // `trigger` does not mistake it for a worker claim.
+    return [...keys, ...optional].some((key) => record[key] != null);
   } catch {
     return false;
   }

--- a/packages/server/src/tools/admin/manage_automations/claim-next-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/claim-next-window.ts
@@ -21,7 +21,10 @@ const DEFAULT_LEASE_SECONDS = 900;
 const MIN_LEASE_SECONDS = 30;
 const MAX_LEASE_SECONDS = 3600;
 
-export function encodeExternalAutomationClaimOwner(ctx: ToolContext): string {
+export function encodeExternalAutomationClaimOwner(
+  ctx: ToolContext,
+  action: 'claim_next_window' | 'complete_window' = 'claim_next_window'
+): string {
   const identity = {
     user_id: ctx.userId ?? null,
     agent_id: ctx.agentId ?? null,
@@ -30,7 +33,7 @@ export function encodeExternalAutomationClaimOwner(ctx: ToolContext): string {
   };
   if (Object.values(identity).every((value) => value == null)) {
     throw new ToolUserError(
-      'claim_next_window requires an identified caller to own the window lease.',
+      `${action} requires an identified caller to own the window lease.`,
       403
     );
   }

--- a/packages/server/src/tools/admin/manage_automations/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/complete-window.ts
@@ -44,6 +44,7 @@ import { normalizeExtractedData, parseJson, requireAutomationAccess } from './sh
 import { getErrorMessage } from '@lobu/core';
 import { classifyRunOutcome } from "../../../runs/run-outcome";
 import { claimPendingAutomationRun } from '../../../runs/queue-service';
+import { encodeExternalAutomationClaimOwner } from './claim-next-window';
 import { AUTOMATION_EVAL_RUN_TYPE, AUTOMATION_RUN_TYPE } from "../../../runs/run-types.js";
 import {
   advanceAutomationArrivalMark,
@@ -576,18 +577,12 @@ export async function handleCompleteWindow(
   // cannot strand the durable run in running state.
   let externalClaimedBy: string | null = null;
   if (manualOpenRun) {
-    const claimedBy = ctx.clientId
-      ? `mcp:${ctx.clientId}`
-      : ctx.userId
-        ? `user:${ctx.userId}`
-        : null;
-    if (!claimedBy) {
-      throw new ToolUserError(
-        `Automation run ${runId} requires an authenticated MCP client or user to claim it.`,
-        401
-      );
-    }
-    externalClaimedBy = claimedBy;
+    // Must use the SAME encoding `claim_next_window` wrote, or a run this very
+    // caller claimed reads back as owned by someone else and the ownership
+    // fence below rejects every completion with a 409 — the lease then expires,
+    // the run times out, the arrival mark never moves, and the identical window
+    // is served again forever.
+    externalClaimedBy = encodeExternalAutomationClaimOwner(ctx, 'complete_window');
   }
 
   // ============================================


### PR DESCRIPTION
## Summary
- `complete_window` encoded the external claim owner **differently** from `claim_next_window`, so a run could never be completed by its own claimant: the fence at `complete-window.ts:700` compared `external:{…}` against `mcp:<clientId>`/`user:<userId>` and threw **409 "already claimed by another executor."** The lease then expired, the run went `timeout`/`infra_error`, the arrival mark never advanced, and the identical window was re-served forever.
- Both sides now use `encodeExternalAutomationClaimOwner(ctx)`, which is already the canonical encoding — `trigger.ts:139` compares against it and `isExternalAutomationClaimOwner` only ever parses `external:`.
- Adds the missing coverage: an Automation with **no managed agent and no device worker**, which is the only shape that reaches the fence.

## Why no existing test caught it
The fence runs only when `manualOpenRun` is true — `!approved_input.agent_id && !approved_input.device_worker_id` — and `claim_next_window` copies those from the Automation's `managed_agent_id`/`device_worker_id`. Every existing suite seeds `managed_agent_id`, so the branch was dead in tests. It is reachable only as a *manual-only* Automation (no triggers), since `assertAutomationExecutorsResolve` refuses an automated Automation without an executor.

## Prod evidence
Run `1340169` on automation 5 — the payload validated and was still refused:

```
[complete_window] extracted_data validated against template schema successfully
[complete_window] Token valid: 0 content items across 1 page(s), oldest token age: 0s
ToolUserError: Automation run 1340169 is already claimed by another executor.  (409)
```

Automation 5 has `managed_agent_id` NULL and `device_worker_id` NULL; automations 20/98 carry `personal-agent`, which is exactly why only 5 looped.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: targeted suites + full `packages/server` graph
- [x] Bug fix: red→fix→green outputs pasted below

**RED** (before the fix) — `external-claim-completion.test.ts`:
```
ToolUserError: Automation run 2 is already claimed by another executor.
 ❯ src/tools/admin/manage_automations/complete-window.ts:638:17
 Test Files  1 failed (1)
      Tests  2 failed (2)
```

**GREEN** (after the fix):
```
[manage_automations] Completed run 2 for automation 1 (…), linked 0 content items
 ✓ src/__tests__/integration/automations/external-claim-completion.test.ts (2 tests) 579ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Full automations integration suite: `Test Files 51 passed (51) · Tests 426 passed (426)`.

## Notes
No migration needed: nothing reads the retired `mcp:`/`user:` form, and all 12 prod rows carrying it are terminal `completed` — zero in-flight, so nothing can be stranded.

Two fixtures hard-coded the retired encoding (`window-lag-visibility.test.ts`, `external-manual-run.test.ts`); they now build it through the production encoder, so a future change to that encoding fails the tests instead of silently fencing real claimants out. The identityless-caller check keeps its intent (rejected, run left unclaimed); only the message and status change (401 → 403).

---

## Second defect found while verifying: session-scoped ownership
The encoding fix alone did **not** unblock prod. `mcp_session_id` was part of the claim identity, and ChatGPT opens a **new MCP session per tool call** — measured on the live client: **75 sessions in 24 minutes**, each with `last_accessed_at` equal to its claim instant and never touched again. So the completing session is never the claiming session and the fence still 409s.

Ownership is now **user + agent + OAuth client**. Still fencing a completion: the signed `window_token` (bound to run, attempt and lease), per-Automation claim serialization, and lease expiry. The only narrowing dropped is "a different session of the same principal".

`isExternalAutomationClaimOwner` still accepts legacy session-bearing rows so `trigger` keeps routing them to the external lane.

**Mutation proof of the new guard** — putting the session back into the identity:
```
FAIL  external-claim-completion.test.ts > completes a claim opened under a DIFFERENT MCP session
ToolUserError: Automation run 2 is already claimed by another executor.
      Tests  1 failed | 2 passed (3)
```
Restored → `Tests 3 passed (3)`. Automations suite: **51 files / 427 tests passing**.

`window-claim-recovery.test.ts` previously asserted session-scoped fencing; it now asserts the property that matters — a different OAuth client still cannot take over a continuation, and an unidentified caller is still refused.
