### PR TITLE
fix(cli): stop apply silently clearing a feed cron it was never told about

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd-wire.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd-wire.test.ts
@@ -1,0 +1,304 @@
+/**
+ * End-to-end wire coverage for the "undeclared means unmanaged" rule.
+ *
+ * Every other apply test stubs `ctx.client`, so it proves what the command
+ * *intends* to send. This one drives the whole path — a real `lobu.config.ts`
+ * on disk, real config loading, diffing, and `ApplyClient` — and asserts on the
+ * JSON that actually leaves the process. Only `fetch` is stubbed.
+ *
+ * The regression it guards: a feed the config declares without a `schedule`
+ * used to reach the wire as `schedule: null`, clearing a cron the config had
+ * never been told about.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as context from "../../../../internal/context.js";
+import * as credentials from "../../../../internal/credentials.js";
+import { applyCommand } from "../apply-cmd.js";
+
+const tempDirs: string[] = [];
+const originalWrite = process.stdout.write.bind(process.stdout);
+
+afterEach(() => {
+  mock.restore();
+  while (tempDirs.length > 0) {
+    const d = tempDirs.pop();
+    if (d) rmSync(d, { recursive: true, force: true });
+  }
+  process.stdout.write = originalWrite;
+});
+
+// Fixtures live next to this test so the config bundle's externalized
+// `@lobu/cli/config` import resolves from node_modules.
+function mkProject(config: string): string {
+  const dir = mkdtempSync(join(import.meta.dir, "wire-fixture-"));
+  tempDirs.push(dir);
+  writeFileSync(join(dir, "lobu.config.ts"), config);
+  mkdirSync(join(dir, "agents", "triage"), { recursive: true });
+  return dir;
+}
+
+const REMOTE_CONNECTION = {
+  id: 42,
+  slug: "gmail-main",
+  connector_key: "google.gmail",
+  name: "gmail-main",
+  config: { label: "INBOX" },
+};
+
+/** A feed whose cron was set in the UI, not in any config. */
+const REMOTE_FEED = {
+  id: 367,
+  connection_id: 42,
+  feed_key: "threads",
+  display_name: "threads",
+  status: "active",
+  schedule: "9,39 * * * *",
+  config: { lookback_days: 7 },
+};
+
+interface WireCall {
+  url: string;
+  body: Record<string, unknown>;
+}
+
+function makeFetch() {
+  const calls: WireCall[] = [];
+
+  const json = (payload: unknown) =>
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  const fetchStub = async (
+    url: string | URL | Request,
+    init?: RequestInit
+  ): Promise<Response> => {
+    const urlStr = String(url);
+    const method = (init?.method ?? "GET").toUpperCase();
+    let body: Record<string, unknown> = {};
+    if (typeof init?.body === "string" && init.body.length > 0) {
+      try {
+        body = JSON.parse(init.body) as Record<string, unknown>;
+      } catch {
+        body = {};
+      }
+    }
+    if (method !== "GET") calls.push({ url: urlStr, body });
+
+    if (urlStr.includes("/oauth/userinfo")) {
+      return json({
+        sub: "u1",
+        organizations: [{ id: "org_1", slug: "acme", name: "Acme" }],
+      });
+    }
+    if (urlStr.includes("/manage_catalog")) {
+      return json({
+        installed: {
+          connectors: {
+            items: [
+              {
+                id: "google.gmail",
+                name: "Gmail",
+                detail: { installed: true, connector_definition_id: 7 },
+              },
+            ],
+          },
+        },
+      });
+    }
+    if (urlStr.includes("/manage_feeds")) {
+      if (body.action === "list_feeds") return json({ feeds: [REMOTE_FEED] });
+      return json({ feed: REMOTE_FEED });
+    }
+    if (urlStr.includes("/manage_connections")) {
+      if (body.action === "update") {
+        return json({ connection: REMOTE_CONNECTION });
+      }
+      return json({ connections: [REMOTE_CONNECTION] });
+    }
+    if (urlStr.includes("/manage_entity_schema")) {
+      return json({ entity_types: [], relationship_types: [] });
+    }
+    if (urlStr.includes("/manage_automations"))
+      return json({ automations: [] });
+    if (urlStr.includes("/manage_auth_profiles")) {
+      return json({ auth_profiles: [] });
+    }
+    if (urlStr.includes("/agents")) return json({ agents: [] });
+    return json({ success: true });
+  };
+
+  return { fetchStub: fetchStub as typeof fetch, calls };
+}
+
+function feedWrites(calls: WireCall[]): Record<string, unknown>[] {
+  return calls
+    .filter((c) => c.url.includes("/manage_feeds"))
+    .map((c) => c.body)
+    .filter((b) => b.action === "update_feed" || b.action === "create_feed");
+}
+
+function connectionWrites(calls: WireCall[]): Record<string, unknown>[] {
+  return calls
+    .filter((c) => c.url.includes("/manage_connections"))
+    .map((c) => c.body)
+    .filter((b) => b.action === "update");
+}
+
+function configWithFeed(feedLiteral: string, connectionExtra = ""): string {
+  return `import { defineAgent, defineConfig, defineConnection } from "@lobu/cli/config";
+export default defineConfig({
+  agents: [defineAgent({ id: "triage", name: "Triage", dir: "./agents/triage" })],
+  connections: [
+    defineConnection({
+      slug: "gmail-main",
+      connector: "google.gmail",${connectionExtra}
+      feeds: [${feedLiteral}],
+    }),
+  ],
+});
+`;
+}
+
+async function runApply(dir: string, fetchImpl: typeof fetch) {
+  await applyCommand({
+    cwd: dir,
+    yes: true,
+    url: "https://app.lobu.ai",
+    org: "acme",
+    fetchImpl,
+  });
+}
+
+describe("apply wire payloads: undeclared fields are never sent", () => {
+  beforeEach(() => {
+    spyOn(process.stdout, "write").mockImplementation(() => true);
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "prod",
+      url: "https://app.lobu.ai/api/v1",
+      source: "config",
+    });
+    spyOn(credentials, "getToken").mockResolvedValue("tok");
+    spyOn(context, "getActiveOrg").mockResolvedValue("acme");
+    spyOn(context, "loadContextConfig").mockResolvedValue({
+      currentContext: "prod",
+      contexts: { prod: { url: "https://app.lobu.ai/api/v1" } },
+    });
+  });
+
+  test("an update triggered by another field never carries an undeclared schedule", async () => {
+    // `name` differs from the remote display_name, so an update_feed IS sent —
+    // without this the assertion below would pass vacuously.
+    const dir = mkProject(
+      configWithFeed(`{ feed: "threads", name: "Inbox threads" }`)
+    );
+    const { fetchStub, calls } = makeFetch();
+
+    await runApply(dir, fetchStub);
+
+    const writes = feedWrites(calls);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({
+      action: "update_feed",
+      feed_id: 367,
+      display_name: "Inbox threads",
+    });
+    expect(writes[0]).not.toHaveProperty("schedule");
+    expect(writes[0]).not.toHaveProperty("config");
+    expect(writes[0]).not.toHaveProperty("replace_config");
+  });
+
+  test("a feed that declares nothing the remote lacks sends no write at all", async () => {
+    const dir = mkProject(configWithFeed(`{ feed: "threads" }`));
+    const { fetchStub, calls } = makeFetch();
+
+    await runApply(dir, fetchStub);
+
+    expect(feedWrites(calls)).toEqual([]);
+  });
+
+  test("`schedule: null` is an explicit clear and does reach the wire", async () => {
+    const dir = mkProject(
+      configWithFeed(`{ feed: "threads", schedule: null }`)
+    );
+    const { fetchStub, calls } = makeFetch();
+
+    await runApply(dir, fetchStub);
+
+    const writes = feedWrites(calls);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({
+      action: "update_feed",
+      feed_id: 367,
+      schedule: null,
+    });
+  });
+
+  test("a declared cron reaches the wire verbatim", async () => {
+    const dir = mkProject(
+      configWithFeed(`{ feed: "threads", schedule: "*/15 * * * *" }`)
+    );
+    const { fetchStub, calls } = makeFetch();
+
+    await runApply(dir, fetchStub);
+
+    const writes = feedWrites(calls);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({
+      action: "update_feed",
+      feed_id: 367,
+      schedule: "*/15 * * * *",
+    });
+  });
+
+  test("a declared feed config replaces the remote one, and only then", async () => {
+    const dir = mkProject(
+      configWithFeed(`{ feed: "threads", config: { lookback_days: 30 } }`)
+    );
+    const { fetchStub, calls } = makeFetch();
+
+    await runApply(dir, fetchStub);
+
+    const writes = feedWrites(calls);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({
+      action: "update_feed",
+      config: { lookback_days: 30 },
+      replace_config: true,
+    });
+    expect(writes[0]).not.toHaveProperty("schedule");
+  });
+
+  test("an update triggered by another field never carries an undeclared connection config", async () => {
+    // The remote connection's name is "gmail-main"; declaring a different one
+    // forces an update_connection so the assertion is not vacuous.
+    const dir = mkProject(
+      configWithFeed(`{ feed: "threads" }`, `\n      name: "Gmail (work)",`)
+    );
+    const { fetchStub, calls } = makeFetch();
+
+    await runApply(dir, fetchStub);
+
+    const writes = connectionWrites(calls);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({
+      action: "update",
+      connection_id: 42,
+      display_name: "Gmail (work)",
+    });
+    expect(writes[0]).not.toHaveProperty("config");
+    expect(writes[0]).not.toHaveProperty("replace_config");
+  });
+});

--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
@@ -1509,3 +1509,152 @@ describe("validateConnectorState — feed-scoped key demotion is gated to the pr
     });
   });
 });
+
+// The apply payload is built from the diff's changedFields — the same rule the
+// Automation update path uses. Re-listing every field at the call site was the
+// second place to get "the config did not declare this" wrong, and it got it
+// wrong twice: `schedule: feed.schedule ?? null` cleared crons the config had
+// never been told about, and `config: desired.config ?? {}` replaced UI-set
+// connection settings with `{}`. Asserting on the wire payload keeps a future
+// field from reintroducing it.
+describe("executePlan — an update writes only the fields the diff flagged", () => {
+  function planFor(
+    kind: "connection" | "feed",
+    changedFields: string[]
+  ): DiffPlan {
+    const row =
+      kind === "connection"
+        ? {
+            kind: "connection" as const,
+            verb: "update" as const,
+            id: "gmail",
+            changedFields,
+          }
+        : {
+            kind: "feed" as const,
+            verb: "update" as const,
+            id: "gmail/threads",
+            connectionSlug: "gmail",
+            desired: {
+              feedKey: "threads",
+              name: "Threads",
+              config: { labels: ["INBOX"] },
+            },
+            changedFields,
+          };
+    return {
+      rows: [row as DiffPlan["rows"][number]],
+      counts: { create: 0, update: 1, noop: 0, drift: 0, delete: 0 },
+      notes: [],
+    };
+  }
+
+  function remoteWithGmail(): RemoteSnapshot {
+    return {
+      agents: [],
+      agentSettings: new Map(),
+      entityTypes: [],
+      relationshipTypes: [],
+      automations: [],
+      connectorDefinitions: [
+        { key: "google.gmail", installed: true } as RemoteConnectorDefinition,
+      ],
+      authProfiles: [],
+      connections: [
+        {
+          id: 3,
+          slug: "gmail",
+          connector_key: "google.gmail",
+          display_name: "Gmail",
+          status: "active",
+          auth_profile_slug: null,
+          app_auth_profile_slug: null,
+          config: { action_modes: { send: "auto" } },
+        },
+      ],
+      feedsByConnectionId: new Map([
+        [
+          3,
+          [
+            {
+              id: 9,
+              connection_id: 3,
+              feed_key: "threads",
+              status: "active",
+              schedule: "9,39 * * * *",
+              config: { labels: ["INBOX"] },
+            },
+          ],
+        ],
+      ]),
+      inferenceProviders: [],
+    };
+  }
+
+  const gmailConnection: DesiredConnection = {
+    slug: "gmail",
+    connector: "google.gmail",
+    name: "Gmail",
+    feeds: [
+      { feedKey: "threads", name: "Threads", config: { labels: ["INBOX"] } },
+    ],
+    sourceFile: "lobu.config.ts",
+  };
+
+  test("a name-only feed change never sends schedule or config", async () => {
+    const updateFeed = mock(async () => ({}) as never);
+    const client = { updateFeed } as unknown as ApplyClient;
+    const state = stateWith({
+      definitions: [],
+      authProfiles: [],
+      connections: [gmailConnection],
+    });
+
+    await executePlan(
+      {
+        client,
+        state,
+        plan: planFor("feed", ["name"]),
+        remote: remoteWithGmail(),
+      },
+      []
+    );
+
+    expect(updateFeed).toHaveBeenCalledTimes(1);
+    const payload = updateFeed.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(Object.keys(payload)).toEqual(["name"]);
+    // The cron the config never declared is not in the payload at all, so the
+    // server's tri-state leaves it alone.
+    expect("schedule" in payload).toBe(false);
+  });
+
+  test("a name-only connection change never sends config", async () => {
+    const updateConnection = mock(async () => ({ id: 3 }) as never);
+    const client = { updateConnection } as unknown as ApplyClient;
+    const state = stateWith({
+      definitions: [],
+      authProfiles: [],
+      connections: [gmailConnection],
+    });
+
+    await executePlan(
+      {
+        client,
+        state,
+        plan: planFor("connection", ["name"]),
+        remote: remoteWithGmail(),
+      },
+      []
+    );
+
+    expect(updateConnection).toHaveBeenCalledTimes(1);
+    const payload = updateConnection.mock.calls[0]?.[1] as Record<
+      string,
+      unknown
+    >;
+    expect(Object.keys(payload)).toEqual(["name"]);
+    // action_modes rides in connection config; sending `{}` here made the
+    // server's human-only gate fail the whole apply.
+    expect("config" in payload).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -1177,6 +1177,49 @@ describe("apply diff — connectors", () => {
     });
   }
 
+  function remoteWithFeedCron(schedule: string | null): RemoteSnapshot {
+    return {
+      ...emptyRemote(),
+      connectorDefinitions: [builtinConnectorDef],
+      authProfiles: [
+        {
+          slug: "hn-token",
+          display_name: "HN token",
+          connector_key: "hackernews",
+          profile_kind: "env",
+          status: "active",
+        },
+      ],
+      connections: [
+        {
+          id: 7,
+          slug: "hn-frontpage",
+          connector_key: "hackernews",
+          display_name: "HN front page",
+          status: "active",
+          auth_profile_slug: "hn-token",
+          app_auth_profile_slug: null,
+          config: {},
+        },
+      ],
+      feedsByConnectionId: new Map([
+        [
+          7,
+          [
+            {
+              id: 11,
+              connection_id: 7,
+              feed_key: "stories",
+              status: "active",
+              schedule,
+              config: {},
+            },
+          ],
+        ],
+      ]),
+    };
+  }
+
   test("create verbs for new connector def, auth profile, connection, feed", () => {
     const plan = computeDiff(connectorState(), {
       ...emptyRemote(),
@@ -1256,6 +1299,45 @@ describe("apply diff — connectors", () => {
       plan.rows.find((r) => r.kind === "auth-profile" && r.id === "x-account")
         ?.verb
     ).toBe("noop");
+  });
+
+  // The config declares the feed but not its cadence. A cron set in the UI is
+  // not drift the config gets to overwrite — apply must leave it alone, which
+  // means the row is a noop, not an update that writes null.
+  test("an undeclared schedule does not diff against a remote cron", () => {
+    const state = connectorState();
+    const feed = state.connectors.connections[0]?.feeds[0];
+    if (feed) delete (feed as { schedule?: unknown }).schedule;
+
+    const plan = computeDiff(state, remoteWithFeedCron("0 0 * * *"));
+    expect(plan.rows.find((r) => r.kind === "feed")?.verb).toBe("noop");
+  });
+
+  test("an explicitly null schedule still diffs as a deliberate clear", () => {
+    const state = connectorState();
+    const feed = state.connectors.connections[0]?.feeds[0];
+    if (feed) (feed as { schedule?: string | null }).schedule = null;
+
+    const plan = computeDiff(state, remoteWithFeedCron("0 0 * * *"));
+    const row = plan.rows.find((r) => r.kind === "feed");
+    expect(row?.verb).toBe("update");
+    expect(row && "changedFields" in row ? row.changedFields : []).toEqual([
+      "schedule",
+    ]);
+  });
+
+  // Same class: an undeclared config must not diff against a remote one.
+  test("an undeclared feed config does not diff against a remote config", () => {
+    const state = connectorState();
+    const feed = state.connectors.connections[0]?.feeds[0];
+    if (feed) delete (feed as { config?: unknown }).config;
+
+    const remote = remoteWithFeedCron("0 * * * *");
+    const feeds = remote.feedsByConnectionId.get(7);
+    if (feeds?.[0]) feeds[0].config = { depth: 3 };
+
+    const plan = computeDiff(state, remote);
+    expect(plan.rows.find((r) => r.kind === "feed")?.verb).toBe("noop");
   });
 
   test("update when feed schedule changes; needs-auth when oauth profile inactive", () => {

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -1326,6 +1326,25 @@ describe("apply diff — connectors", () => {
     ]);
   });
 
+  // A connection block with no `config` key does not manage the connection's
+  // settings. Sending `{}` with replace_config wiped UI-set settings, and on a
+  // connection carrying `action_modes` the server's human-only gate rejected
+  // the write, failing the whole apply.
+  test("an undeclared connection config does not diff against a remote config", () => {
+    const state = connectorState();
+    const conn = state.connectors.connections[0];
+    if (conn) delete (conn as { config?: unknown }).config;
+
+    const remote = remoteWithFeedCron("0 * * * *");
+    const remoteConn = remote.connections[0];
+    if (remoteConn) {
+      remoteConn.config = { action_modes: { evaluate: "auto" } };
+    }
+
+    const plan = computeDiff(state, remote);
+    expect(plan.rows.find((r) => r.kind === "connection")?.verb).toBe("noop");
+  });
+
   // Same class: an undeclared config must not diff against a remote one.
   test("an undeclared feed config does not diff against a remote config", () => {
     const state = connectorState();

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -968,6 +968,22 @@ describe("mapProjectToDesiredState", () => {
     expect("schedule" in (feed ?? {})).toBe(false);
   });
 
+  // `schedule: process.env.FEED_CRON` with the var unset is the same bug
+  // through a different door: the key is present but the value is undefined,
+  // which is a config that declared nothing, not a clear.
+  test("an undefined schedule value is undeclared, not a clear", () => {
+    const conn = defineConnection({
+      slug: "gh",
+      connector: "github",
+      feeds: [{ feed: "stars", schedule: undefined }],
+    });
+    const state = mapProjectToDesiredState(
+      defineConfig({ agents: [], connections: [conn] })
+    );
+    const feed = state.connectors.connections[0]?.feeds[0];
+    expect("schedule" in (feed ?? {})).toBe(false);
+  });
+
   test("an explicit null schedule stays expressible as a deliberate clear", () => {
     const conn = defineConnection({
       slug: "gh",

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -952,8 +952,15 @@ describe("mapProjectToDesiredState", () => {
   // Three states, not two. Omitting `schedule` means "this config does not
   // manage the cadence" — apply must leave whatever the feed already has. Only
   // an explicit `null` clears it. Collapsing omitted to null made every apply
-  // silently wipe crons set in the UI (prod: 41 clears by actor `cli` over two
-  // days in 2026-08), and a DB-side backfill could never survive the next run.
+  // silently wipe crons set in the UI, and a DB-side backfill could never
+  // survive the next run.
+  //
+  // Measured in prod from the config audit trail (`events` rows with
+  // metadata.category='config', resource_kind='feed', changed_fields ?
+  // 'schedule', actor_source='cli'): 41 feed-schedule writes across 2026-08-11
+  // and 2026-08-12, and the 08-11 batch of 23 all carry ONE apply_id — a single
+  // `lobu apply` rewrote 23 feeds' cadence in one run. 29 of the 31 feeds that
+  // batch touched are still manual-only today.
   test("an omitted feed schedule is left undeclared, not collapsed to null", () => {
     const conn = defineConnection({
       slug: "gh",

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -949,7 +949,12 @@ describe("mapProjectToDesiredState", () => {
     ).toThrow(/connection slug/);
   });
 
-  test("omitted feed schedule maps to null (manual-only, no platform default)", () => {
+  // Three states, not two. Omitting `schedule` means "this config does not
+  // manage the cadence" — apply must leave whatever the feed already has. Only
+  // an explicit `null` clears it. Collapsing omitted to null made every apply
+  // silently wipe crons set in the UI (prod: 41 clears by actor `cli` over two
+  // days in 2026-08), and a DB-side backfill could never survive the next run.
+  test("an omitted feed schedule is left undeclared, not collapsed to null", () => {
     const conn = defineConnection({
       slug: "gh",
       connector: "github",
@@ -958,9 +963,38 @@ describe("mapProjectToDesiredState", () => {
     const state = mapProjectToDesiredState(
       defineConfig({ agents: [], connections: [conn] })
     );
+    const feed = state.connectors.connections[0]?.feeds[0];
+    expect(feed).toEqual({ feedKey: "stars" });
+    expect("schedule" in (feed ?? {})).toBe(false);
+  });
+
+  test("an explicit null schedule stays expressible as a deliberate clear", () => {
+    const conn = defineConnection({
+      slug: "gh",
+      connector: "github",
+      feeds: [{ feed: "stars", schedule: null }],
+    });
+    const state = mapProjectToDesiredState(
+      defineConfig({ agents: [], connections: [conn] })
+    );
     expect(state.connectors.connections[0]?.feeds).toEqual([
       { feedKey: "stars", schedule: null },
     ]);
+  });
+
+  // Same class as schedule: an omitted `config` must not wipe the remote one.
+  test("an omitted feed config is left undeclared", () => {
+    const conn = defineConnection({
+      slug: "gh",
+      connector: "github",
+      feeds: [{ feed: "stars" }],
+    });
+    const state = mapProjectToDesiredState(
+      defineConfig({ agents: [], connections: [conn] })
+    );
+    expect("config" in (state.connectors.connections[0]?.feeds[0] ?? {})).toBe(
+      false
+    );
   });
 
   test("rejects an invalid cron schedule", () => {

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -1139,20 +1139,29 @@ export async function executePlan(
       });
       connectionIdBySlug.set(desired.slug, result.id);
     } else if (existing && row.verb === "update") {
+      // Send only what the diff actually flagged, exactly as the Automation
+      // update above does. The diff is then the single source of truth for what
+      // an apply writes: a field this config does not declare produces no
+      // changed-field, so it is never in the payload and the server leaves it
+      // alone. Re-listing every field here was the second place to get
+      // "undeclared" wrong, and it got it wrong for `config` (replaced UI-set
+      // connection settings with `{}`) and, on feeds below, for `schedule`.
+      const changed = new Set(row.changedFields ?? []);
       const updated = await ctx.client.updateConnection(existing.id, {
-        name: desired.name,
-        authProfileSlug: desired.authProfileSlug ?? null,
-        appAuthProfileSlug: desired.appAuthProfileSlug ?? null,
-        // Declared config still REPLACES (a removed key must disappear
-        // remotely), but an undeclared one is omitted so the server leaves the
-        // stored settings alone. Sending `{}` with `replace_config` wiped
-        // UI-set connection settings, and on a connection carrying
-        // `action_modes` it made the whole apply fail closed on the server's
-        // human-only gate.
-        ...(desired.config !== undefined ? { config: desired.config } : {}),
-        // Always pass — server treats undefined as "leave alone", null as
-        // "unpin to server", and a uuid as "move to that device".
-        deviceWorkerId: desired.deviceWorkerId ?? null,
+        ...(changed.has("name") ? { name: desired.name } : {}),
+        ...(changed.has("auth")
+          ? { authProfileSlug: desired.authProfileSlug ?? null }
+          : {}),
+        ...(changed.has("app_auth")
+          ? { appAuthProfileSlug: desired.appAuthProfileSlug ?? null }
+          : {}),
+        // A declared config still REPLACES — a key removed from the config must
+        // disappear remotely.
+        ...(changed.has("config") ? { config: desired.config } : {}),
+        // null unpins to the server, a uuid moves it to that device.
+        ...(changed.has("device_worker_id")
+          ? { deviceWorkerId: desired.deviceWorkerId ?? null }
+          : {}),
       });
       connectionIdBySlug.set(desired.slug, updated.id);
     } else {
@@ -1192,14 +1201,15 @@ export async function executePlan(
         )
       : undefined;
     if (remoteFeed && row.verb === "update") {
+      // Same rule as connections and Automations: the diff decides what gets
+      // written. An undeclared cadence or config produces no changed-field, so
+      // it never reaches the wire and the server keeps what the feed has. An
+      // explicit `schedule: null` IS a declared change and still clears it.
+      const changed = new Set(row.changedFields ?? []);
       await ctx.client.updateFeed(remoteFeed.id, {
-        name: feed.name,
-        // Only forward what the config declared. `updateFeed` omits an
-        // undefined field from the wire payload, so an undeclared cadence or
-        // config is left exactly as the feed already has it; an explicit
-        // `null` schedule still clears it.
-        ...(feed.schedule !== undefined ? { schedule: feed.schedule } : {}),
-        ...(feed.config !== undefined ? { config: feed.config } : {}),
+        ...(changed.has("name") ? { name: feed.name } : {}),
+        ...(changed.has("schedule") ? { schedule: feed.schedule ?? null } : {}),
+        ...(changed.has("config") ? { config: feed.config } : {}),
       });
     } else {
       await ctx.client.createFeed({

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -1188,15 +1188,21 @@ export async function executePlan(
     if (remoteFeed && row.verb === "update") {
       await ctx.client.updateFeed(remoteFeed.id, {
         name: feed.name,
-        // null clears remote cron (manual-only); string sets it.
-        schedule: feed.schedule ?? null,
-        config: feed.config ?? {},
+        // Only forward what the config declared. `updateFeed` omits an
+        // undefined field from the wire payload, so an undeclared cadence or
+        // config is left exactly as the feed already has it; an explicit
+        // `null` schedule still clears it.
+        ...(feed.schedule !== undefined ? { schedule: feed.schedule } : {}),
+        ...(feed.config !== undefined ? { config: feed.config } : {}),
       });
     } else {
       await ctx.client.createFeed({
         connectionId,
         feedKey: feed.feedKey,
         name: feed.name,
+        // A brand-new feed has no cadence to preserve, so undeclared and
+        // explicit-null both mean manual-only here. The platform still never
+        // invents a default cron.
         schedule: feed.schedule ?? null,
         config: feed.config,
       });

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -1143,7 +1143,13 @@ export async function executePlan(
         name: desired.name,
         authProfileSlug: desired.authProfileSlug ?? null,
         appAuthProfileSlug: desired.appAuthProfileSlug ?? null,
-        config: desired.config ?? {},
+        // Declared config still REPLACES (a removed key must disappear
+        // remotely), but an undeclared one is omitted so the server leaves the
+        // stored settings alone. Sending `{}` with `replace_config` wiped
+        // UI-set connection settings, and on a connection carrying
+        // `action_modes` it made the whole apply fail closed on the server's
+        // human-only gate.
+        ...(desired.config !== undefined ? { config: desired.config } : {}),
         // Always pass — server treats undefined as "leave alone", null as
         // "unpin to server", and a uuid as "move to that device".
         deviceWorkerId: desired.deviceWorkerId ?? null,

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -37,8 +37,10 @@ import {
 } from "./desired-state.js";
 import {
   computeDiff,
+  type ConnectionField,
   type DiffPlan,
   type DiffRow,
+  type FeedField,
   type RemoteSnapshot,
 } from "./diff.js";
 import {
@@ -1146,7 +1148,7 @@ export async function executePlan(
       // alone. Re-listing every field here was the second place to get
       // "undeclared" wrong, and it got it wrong for `config` (replaced UI-set
       // connection settings with `{}`) and, on feeds below, for `schedule`.
-      const changed = new Set(row.changedFields ?? []);
+      const changed = new Set<ConnectionField>(row.changedFields ?? []);
       const updated = await ctx.client.updateConnection(existing.id, {
         ...(changed.has("name") ? { name: desired.name } : {}),
         ...(changed.has("auth")
@@ -1205,7 +1207,7 @@ export async function executePlan(
       // written. An undeclared cadence or config produces no changed-field, so
       // it never reaches the wire and the server keeps what the feed has. An
       // explicit `schedule: null` IS a declared change and still clears it.
-      const changed = new Set(row.changedFields ?? []);
+      const changed = new Set<FeedField>(row.changedFields ?? []);
       await ctx.client.updateFeed(remoteFeed.id, {
         ...(changed.has("name") ? { name: feed.name } : {}),
         ...(changed.has("schedule") ? { schedule: feed.schedule ?? null } : {}),

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -36,12 +36,12 @@ import {
   validateConnectionAgainstConnector,
 } from "./desired-state.js";
 import {
+  buildUpdatePayload,
   computeDiff,
-  type ConnectionField,
   type DiffPlan,
   type DiffRow,
-  type FeedField,
   type RemoteSnapshot,
+  UPDATE_FIELD_TABLES,
 } from "./diff.js";
 import {
   confirmCustomConnectors,
@@ -1148,23 +1148,14 @@ export async function executePlan(
       // alone. Re-listing every field here was the second place to get
       // "undeclared" wrong, and it got it wrong for `config` (replaced UI-set
       // connection settings with `{}`) and, on feeds below, for `schedule`.
-      const changed = new Set<ConnectionField>(row.changedFields ?? []);
-      const updated = await ctx.client.updateConnection(existing.id, {
-        ...(changed.has("name") ? { name: desired.name } : {}),
-        ...(changed.has("auth")
-          ? { authProfileSlug: desired.authProfileSlug ?? null }
-          : {}),
-        ...(changed.has("app_auth")
-          ? { appAuthProfileSlug: desired.appAuthProfileSlug ?? null }
-          : {}),
-        // A declared config still REPLACES — a key removed from the config must
-        // disappear remotely.
-        ...(changed.has("config") ? { config: desired.config } : {}),
-        // null unpins to the server, a uuid moves it to that device.
-        ...(changed.has("device_worker_id")
-          ? { deviceWorkerId: desired.deviceWorkerId ?? null }
-          : {}),
-      });
+      const updated = await ctx.client.updateConnection(
+        existing.id,
+        buildUpdatePayload(
+          UPDATE_FIELD_TABLES.connection,
+          row.changedFields,
+          desired
+        )
+      );
       connectionIdBySlug.set(desired.slug, updated.id);
     } else {
       const created = await ctx.client.createConnection({
@@ -1207,12 +1198,10 @@ export async function executePlan(
       // written. An undeclared cadence or config produces no changed-field, so
       // it never reaches the wire and the server keeps what the feed has. An
       // explicit `schedule: null` IS a declared change and still clears it.
-      const changed = new Set<FeedField>(row.changedFields ?? []);
-      await ctx.client.updateFeed(remoteFeed.id, {
-        ...(changed.has("name") ? { name: feed.name } : {}),
-        ...(changed.has("schedule") ? { schedule: feed.schedule ?? null } : {}),
-        ...(changed.has("config") ? { config: feed.config } : {}),
-      });
+      await ctx.client.updateFeed(
+        remoteFeed.id,
+        buildUpdatePayload(UPDATE_FIELD_TABLES.feed, row.changedFields, feed)
+      );
     } else {
       await ctx.client.createFeed({
         connectionId,

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -234,6 +234,29 @@ export interface RemoteFeed {
   config?: Record<string, unknown> | null;
 }
 
+/**
+ * The mutable fields of a connection update. Every key is optional and a key
+ * that is ABSENT is not written — the server leaves that column alone. This is
+ * what makes "undeclared means unmanaged" expressible on the wire, so the
+ * builders in `diff.ts` construct these payloads a key at a time from the
+ * diff's changed-field list rather than listing every field unconditionally.
+ */
+export interface UpdateConnectionPayload {
+  name?: string;
+  authProfileSlug?: string | null;
+  appAuthProfileSlug?: string | null;
+  config?: Record<string, unknown>;
+  deviceWorkerId?: string | null;
+}
+
+/** The mutable fields of a feed update — same absent-means-unwritten rule. */
+export interface UpdateFeedPayload {
+  name?: string;
+  /** Cron string, or null to clear (manual-only). */
+  schedule?: string | null;
+  config?: Record<string, unknown>;
+}
+
 interface InstallConnectorResult {
   connectorKey: string;
   updated: boolean;
@@ -1585,13 +1608,7 @@ export class ApplyClient {
 
   async updateConnection(
     connectionId: number,
-    payload: {
-      name?: string;
-      authProfileSlug?: string | null;
-      appAuthProfileSlug?: string | null;
-      config?: Record<string, unknown>;
-      deviceWorkerId?: string | null;
-    }
+    payload: UpdateConnectionPayload
   ): Promise<RemoteConnection> {
     const body = await this.connectionsTool<{ connection?: RemoteConnection }>({
       action: "update",
@@ -1659,12 +1676,7 @@ export class ApplyClient {
 
   async updateFeed(
     feedId: number,
-    payload: {
-      name?: string;
-      /** Cron string, or null to clear (manual-only). */
-      schedule?: string | null;
-      config?: Record<string, unknown>;
-    }
+    payload: UpdateFeedPayload
   ): Promise<RemoteFeed> {
     const body = await this.feedsTool<{ feed?: RemoteFeed }>({
       action: "update_feed",

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -170,8 +170,10 @@ export interface DesiredFeed {
   feedKey: string;
   name?: string;
   /**
-   * Cron for automatic sync. `null` / omitted after map-config means manual-only
-   * (no platform default).
+   * Cron for automatic sync, tri-state after map-config: a string sets the
+   * cadence, `null` clears it (manual-only), and omitted means the config does
+   * not manage it — an update leaves the feed's remote cadence alone, and a
+   * create gets no cron (the platform never invents a default).
    */
   schedule?: string | null;
   config?: Record<string, unknown>;

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -1668,10 +1668,14 @@ function diffConnection(
         // changed so the row reaches the idempotent chat-upsert, which does the
         // secret-aware comparison server-side under an advisory lock and no-ops
         // when nothing actually changed. Data connectors deep-equal as before.
+        // Undeclared is not a difference, same rule as `name` and the feed
+        // fields. A connection block with no `config` key does not manage the
+        // connection's settings, so a config set in the UI is left alone
+        // instead of being replaced with `{}`.
         changed: (d, r) =>
           d.credentialMode === "byo"
             ? true
-            : !deepEqual(d.config ?? {}, r.config ?? {}),
+            : d.config !== undefined && !deepEqual(d.config, r.config ?? {}),
       },
       {
         name: "device_worker_id",

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -15,6 +15,8 @@ import type {
   RemoteFeed,
   RemoteInferenceProvider,
   RemoteRelationshipType,
+  UpdateConnectionPayload,
+  UpdateFeedPayload,
 } from "./client.js";
 import type {
   DesiredAgent,
@@ -136,14 +138,6 @@ export interface AuthProfileDiffRow
  * a typo on EITHER side fails the build, instead of silently dropping the field
  * from the wire and leaving the remote value stale.
  */
-export type ConnectionField =
-  | "name"
-  | "auth"
-  | "app_auth"
-  | "config"
-  | "device_worker_id";
-
-export type FeedField = "name" | "schedule" | "config";
 
 export interface ConnectionDiffRow
   extends ResourceRow<DesiredConnection, RemoteConnection> {
@@ -326,6 +320,167 @@ function optionalNameChanged(
   if (desired == null || desired === "") return false;
   return stringChanged(desired, remote);
 }
+
+/**
+ * One updatable field of a resource: how to tell whether it changed, and how it
+ * appears in the update payload. Keeping both halves in one entry is the point
+ * — the diff's field list and the wire payload used to be two hand-maintained
+ * lists that had to agree by eye, and they silently disagreed for `schedule`
+ * and `config`.
+ */
+interface FieldSpec<D, R, P> {
+  changed: (desired: D, remote: R) => boolean;
+  /** The payload fragment this field contributes when it HAS changed. */
+  payload: (desired: D) => Partial<P>;
+}
+
+/**
+ * A resource's field table. The payload type `P` is carried on the table's own
+ * type rather than inferred from the entries, so {@link buildUpdatePayload}
+ * returns the real payload shape instead of whichever fragment happens to be
+ * declared first.
+ */
+interface FieldTable<D, R, P, F extends string> {
+  readonly fields: Record<F, FieldSpec<D, R, P>>;
+}
+
+/**
+ * Declares a field table with `D`/`R`/`P` pinned and the KEYS still inferred,
+ * so the field-name union stays derived from the entries — there is no second
+ * list to keep in sync, and a payload fragment that isn't part of `P` is a
+ * compile error at the entry that wrote it.
+ */
+function defineFieldTable<D, R, P>() {
+  return <T extends Record<string, FieldSpec<D, R, P>>>(
+    fields: T
+  ): FieldTable<D, R, P, Extract<keyof T, string>> => ({ fields });
+}
+
+/**
+ * Every updatable connection field. `ConnectionField` is derived from this
+ * object's keys, so the union and the table cannot drift: adding a key here
+ * adds it to the union, and there is nowhere else to add one.
+ *
+ * BYO chat connections never reach `updateConnection` (apply routes them to the
+ * secret-aware chat-upsert), so the BYO branches below only govern diffing.
+ */
+const CONNECTION_FIELDS = defineFieldTable<
+  DesiredConnection,
+  RemoteConnection,
+  UpdateConnectionPayload
+>()({
+  name: {
+    changed: (d, r) => optionalNameChanged(d.name, r.display_name),
+    payload: (d) => ({ name: d.name }),
+  },
+  // `auth`/`app_auth`/`device_worker_id` are not part of the chat-upsert
+  // payload (`apply_chat_connection` only persists slug/connector/name/config),
+  // and a BYO chat declaration can't even set them (map-config rejects them).
+  // Never diff them for BYO, or a remote row carrying a stray value would
+  // report a perpetual "update" that apply can't clear.
+  auth: {
+    changed: (d, r) =>
+      d.credentialMode === "byo"
+        ? false
+        : (d.authProfileSlug ?? null) !== (r.auth_profile_slug ?? null),
+    payload: (d) => ({ authProfileSlug: d.authProfileSlug ?? null }),
+  },
+  app_auth: {
+    changed: (d, r) =>
+      d.credentialMode === "byo"
+        ? false
+        : (d.appAuthProfileSlug ?? null) !== (r.app_auth_profile_slug ?? null),
+    payload: (d) => ({ appAuthProfileSlug: d.appAuthProfileSlug ?? null }),
+  },
+  config: {
+    // A BYO chat connection's config holds a resolved secret (plaintext) on the
+    // desired side, stored as a `secret://` ref remotely — the CLI can't compare
+    // them, so it can't detect a token rotation. Always mark it as changed so
+    // the row reaches the idempotent chat-upsert, which does the secret-aware
+    // comparison server-side under an advisory lock and no-ops when nothing
+    // actually changed. Data connectors deep-equal as before.
+    // Undeclared is not a difference, same rule as `name` and the feed fields. A
+    // connection block with no `config` key does not manage the connection's
+    // settings, so a config set in the UI is left alone instead of being
+    // replaced with `{}`.
+    changed: (d, r) =>
+      d.credentialMode === "byo"
+        ? true
+        : d.config !== undefined && !deepEqual(d.config, r.config ?? {}),
+    // A declared config still REPLACES — a key removed from the config must
+    // disappear remotely.
+    payload: (d) => ({ config: d.config }),
+  },
+  device_worker_id: {
+    changed: (d, r) =>
+      d.credentialMode === "byo"
+        ? false
+        : (d.deviceWorkerId ?? null) !== (r.device_worker_id ?? null),
+    // null unpins to the server, a uuid moves it to that device.
+    payload: (d) => ({ deviceWorkerId: d.deviceWorkerId ?? null }),
+  },
+});
+
+/** Every updatable feed field. See {@link CONNECTION_FIELDS}. */
+const FEED_FIELDS = defineFieldTable<
+  DesiredFeed,
+  RemoteFeed,
+  UpdateFeedPayload
+>()({
+  name: {
+    changed: (d, r) => optionalNameChanged(d.name, r.display_name),
+    payload: (d) => ({ name: d.name }),
+  },
+  schedule: {
+    // Undeclared is not a difference — the same rule `optionalNameChanged`
+    // applies to `name`. Only a declared value (a cron, or an explicit `null`
+    // meaning clear) can put this row into `update`.
+    changed: (d, r) =>
+      d.schedule !== undefined && (d.schedule ?? null) !== (r.schedule ?? null),
+    payload: (d) => ({ schedule: d.schedule ?? null }),
+  },
+  config: {
+    changed: (d, r) =>
+      d.config !== undefined && !deepEqual(d.config, r.config ?? {}),
+    payload: (d) => ({ config: d.config }),
+  },
+});
+
+export type ConnectionField = keyof typeof CONNECTION_FIELDS.fields;
+export type FeedField = keyof typeof FEED_FIELDS.fields;
+
+/** Adapts a field table to the `fields` array `buildDiffRow` consumes. */
+function tableToFields<D, R, P, F extends string>(
+  table: FieldTable<D, R, P, F>
+): ReadonlyArray<DiffField<D, R, F>> {
+  return (Object.keys(table.fields) as F[]).map((name) => ({
+    name,
+    changed: table.fields[name].changed,
+  }));
+}
+
+/**
+ * Builds an update payload from the diff's changed-field list: a field the
+ * config does not declare produces no changed-field, so it never appears as a
+ * key and the server leaves it alone.
+ */
+export function buildUpdatePayload<D, R, P, F extends string>(
+  table: FieldTable<D, R, P, F>,
+  changedFields: readonly F[] | undefined,
+  desired: D
+): Partial<P> {
+  let payload: Partial<P> = {};
+  for (const name of changedFields ?? []) {
+    payload = { ...payload, ...table.fields[name].payload(desired) };
+  }
+  return payload;
+}
+
+/** The connection and feed field tables, for apply to build payloads from. */
+export const UPDATE_FIELD_TABLES = {
+  connection: CONNECTION_FIELDS,
+  feed: FEED_FIELDS,
+} as const;
 
 /**
  * The shared create / noop / update shape behind most `diffX` functions.
@@ -1658,56 +1813,7 @@ function diffConnection(
     id: desired.slug,
     desired,
     remote,
-    fields: [
-      {
-        name: "name",
-        changed: (d, r) => optionalNameChanged(d.name, r.display_name),
-      },
-      {
-        name: "auth",
-        // `auth`/`app_auth`/`device_worker_id` are not part of the chat-upsert
-        // payload (`apply_chat_connection` only persists slug/connector/name/
-        // config), and a BYO chat declaration can't even set them (map-config
-        // rejects them). Never diff them for BYO, or a remote row carrying a
-        // stray value would report a perpetual "update" that apply can't clear.
-        changed: (d, r) =>
-          d.credentialMode === "byo"
-            ? false
-            : (d.authProfileSlug ?? null) !== (r.auth_profile_slug ?? null),
-      },
-      {
-        name: "app_auth",
-        changed: (d, r) =>
-          d.credentialMode === "byo"
-            ? false
-            : (d.appAuthProfileSlug ?? null) !==
-              (r.app_auth_profile_slug ?? null),
-      },
-      {
-        name: "config",
-        // A BYO chat connection's config holds a resolved secret (plaintext) on
-        // the desired side, stored as a `secret://` ref remotely — the CLI can't
-        // compare them, so it can't detect a token rotation. Always mark it as
-        // changed so the row reaches the idempotent chat-upsert, which does the
-        // secret-aware comparison server-side under an advisory lock and no-ops
-        // when nothing actually changed. Data connectors deep-equal as before.
-        // Undeclared is not a difference, same rule as `name` and the feed
-        // fields. A connection block with no `config` key does not manage the
-        // connection's settings, so a config set in the UI is left alone
-        // instead of being replaced with `{}`.
-        changed: (d, r) =>
-          d.credentialMode === "byo"
-            ? true
-            : d.config !== undefined && !deepEqual(d.config, r.config ?? {}),
-      },
-      {
-        name: "device_worker_id",
-        changed: (d, r) =>
-          d.credentialMode === "byo"
-            ? false
-            : (d.deviceWorkerId ?? null) !== (r.device_worker_id ?? null),
-      },
-    ],
+    fields: tableToFields(CONNECTION_FIELDS),
   }) as ConnectionDiffRow;
 }
 
@@ -1722,26 +1828,7 @@ function diffFeed(
     desired,
     remote,
     extras: { connectionSlug },
-    fields: [
-      {
-        name: "name",
-        changed: (d, r) => optionalNameChanged(d.name, r.display_name),
-      },
-      {
-        // Undeclared is not a difference — the same rule `optionalNameChanged`
-        // applies to `name`. Only a declared value (a cron, or an explicit
-        // `null` meaning clear) can put this row into `update`.
-        name: "schedule",
-        changed: (d, r) =>
-          d.schedule !== undefined &&
-          (d.schedule ?? null) !== (r.schedule ?? null),
-      },
-      {
-        name: "config",
-        changed: (d, r) =>
-          d.config !== undefined && !deepEqual(d.config, r.config ?? {}),
-      },
-    ],
+    fields: tableToFields(FEED_FIELDS),
   }) as unknown as FeedDiffRow;
 }
 

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -1701,12 +1701,18 @@ function diffFeed(
         changed: (d, r) => optionalNameChanged(d.name, r.display_name),
       },
       {
+        // Undeclared is not a difference — the same rule `optionalNameChanged`
+        // applies to `name`. Only a declared value (a cron, or an explicit
+        // `null` meaning clear) can put this row into `update`.
         name: "schedule",
-        changed: (d, r) => (d.schedule ?? null) !== (r.schedule ?? null),
+        changed: (d, r) =>
+          d.schedule !== undefined &&
+          (d.schedule ?? null) !== (r.schedule ?? null),
       },
       {
         name: "config",
-        changed: (d, r) => !deepEqual(d.config ?? {}, r.config ?? {}),
+        changed: (d, r) =>
+          d.config !== undefined && !deepEqual(d.config, r.config ?? {}),
       },
     ],
   }) as unknown as FeedDiffRow;

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -129,15 +129,33 @@ export interface AuthProfileDiffRow
   needsAuth?: boolean;
 }
 
+/**
+ * Field names `diffConnection` and `diffFeed` can report. `changedFields` is
+ * the sole input to apply-cmd routing, and apply reads these exact strings back
+ * to decide what goes in the update payload. Naming them here means a rename or
+ * a typo on EITHER side fails the build, instead of silently dropping the field
+ * from the wire and leaving the remote value stale.
+ */
+export type ConnectionField =
+  | "name"
+  | "auth"
+  | "app_auth"
+  | "config"
+  | "device_worker_id";
+
+export type FeedField = "name" | "schedule" | "config";
+
 export interface ConnectionDiffRow
   extends ResourceRow<DesiredConnection, RemoteConnection> {
   kind: "connection";
+  changedFields?: ConnectionField[];
 }
 
 export interface FeedDiffRow extends ResourceRow<DesiredFeed, RemoteFeed> {
   kind: "feed";
   /** Owning connection slug. */
   connectionSlug: string;
+  changedFields?: FeedField[];
 }
 
 export interface InferenceProviderDiffRow
@@ -281,8 +299,8 @@ export function canonical(value: unknown): string {
 // ── Generic diff-row builder ───────────────────────────────────────────────
 
 /** One comparable field: a label plus a "did it change?" predicate. */
-interface DiffField<D, R> {
-  name: string;
+interface DiffField<D, R, F extends string = string> {
+  name: F;
   changed: (desired: D, remote: R) => boolean;
 }
 
@@ -315,21 +333,21 @@ function optionalNameChanged(
  * adds verb-specific props derived from the changed-field list (e.g.
  * `willRestart`). `changedFields` is attached automatically on update.
  */
-function buildDiffRow<D, R, K extends string>(opts: {
+function buildDiffRow<D, R, K extends string, F extends string = string>(opts: {
   kind: K;
   id: string;
   desired: D;
   remote: R | undefined;
-  fields: ReadonlyArray<DiffField<D, R>>;
+  fields: ReadonlyArray<DiffField<D, R, F>>;
   extras?: Record<string, unknown>;
-  updateExtras?: (changed: string[]) => Record<string, unknown>;
+  updateExtras?: (changed: F[]) => Record<string, unknown>;
 }): {
   kind: K;
   verb: DiffVerb;
   id: string;
   desired: D;
   remote?: R;
-  changedFields?: string[];
+  changedFields?: F[];
 } & Record<string, unknown> {
   const extras = opts.extras ?? {};
   if (!opts.remote) {
@@ -1630,7 +1648,12 @@ function diffConnection(
       `${desired.sourceFile}: connection "${desired.slug}" is bound to connector "${remote.connector_key}" remotely, but the manifest declares "${desired.connector}" — delete it manually or use a new slug`
     );
   }
-  return buildDiffRow({
+  return buildDiffRow<
+    DesiredConnection,
+    RemoteConnection,
+    "connection",
+    ConnectionField
+  >({
     kind: "connection",
     id: desired.slug,
     desired,
@@ -1693,7 +1716,7 @@ function diffFeed(
   desired: DesiredFeed,
   remote: RemoteFeed | undefined
 ): FeedDiffRow {
-  return buildDiffRow({
+  return buildDiffRow<DesiredFeed, RemoteFeed, "feed", FeedField>({
     kind: "feed",
     id: `${connectionSlug}/${desired.feedKey}`,
     desired,

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -838,11 +838,13 @@ function mapConnection(
     return {
       feedKey: feed.feed,
       ...(feed.name ? { name: feed.name } : {}),
-      // Carried through undeclared when omitted, exactly like `name` and
-      // `config` above — apply then leaves the remote cadence alone. An
-      // explicit `null` survives as a deliberate clear. Still never invents a
-      // default cron: an omitted schedule on a NEW feed creates it manual-only.
-      ...("schedule" in feed ? { schedule: feed.schedule ?? null } : {}),
+      // Undeclared — omitted, or `undefined` from something like
+      // `schedule: process.env.FEED_CRON` — carries through unset, exactly like
+      // `name` and `config`, and apply then leaves the remote cadence alone.
+      // Only an explicit `null` is a deliberate clear. Still never invents a
+      // default cron: an undeclared schedule on a NEW feed creates it
+      // manual-only.
+      ...(feed.schedule !== undefined ? { schedule: feed.schedule } : {}),
       ...(feed.config ? { config: feed.config } : {}),
     };
   });

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -838,8 +838,11 @@ function mapConnection(
     return {
       feedKey: feed.feed,
       ...(feed.name ? { name: feed.name } : {}),
-      // Omit in config → manual-only (null). Never invent a default cron.
-      schedule: feed.schedule ?? null,
+      // Carried through undeclared when omitted, exactly like `name` and
+      // `config` above — apply then leaves the remote cadence alone. An
+      // explicit `null` survives as a deliberate clear. Still never invents a
+      // default cron: an omitted schedule on a NEW feed creates it manual-only.
+      ...("schedule" in feed ? { schedule: feed.schedule ?? null } : {}),
       ...(feed.config ? { config: feed.config } : {}),
     };
   });

--- a/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
@@ -470,11 +470,15 @@ describe("lobu init --from-org", () => {
     // Feeds are emitted sorted by feed_key (query < stargazers). Capabilities
     // belong to connector definitions, so connection config only carries the
     // feed instance settings.
+    //
+    // `query` has no remote cron, so the generated config omits `schedule`
+    // entirely and it round-trips as UNDECLARED rather than an explicit null.
+    // That is the point: a later cron set in the UI is then left alone by
+    // `lobu apply` instead of being silently wiped.
     expect(conn?.feeds).toEqual([
       {
         feedKey: "query",
         name: "Churn rollup (live)",
-        schedule: null,
         config: { query: "SELECT 1" },
       },
       {

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -431,7 +431,17 @@ export interface ConnectionFeed {
   /** Feed key from the connector definition. */
   feed: string;
   name?: string;
-  schedule?: string;
+  /**
+   * Sync cadence, with three distinct states:
+   *   - a cron string — this config owns the cadence and sets it
+   *   - `null`        — this config owns the cadence and clears it (manual-only)
+   *   - omitted       — this config does NOT manage the cadence; apply leaves
+   *                     whatever the feed already has, including a cron set in
+   *                     the UI
+   * Omitting used to collapse to `null`, so every apply silently wiped crons it
+   * had never been told about.
+   */
+  schedule?: string | null;
   config?: Record<string, unknown>;
 }
 

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -442,6 +442,11 @@ export interface ConnectionFeed {
    * had never been told about.
    */
   schedule?: string | null;
+  /**
+   * Feed instance settings. Declaring this key REPLACES the remote config, so a
+   * key you remove disappears; omitting it means this config does not manage
+   * the settings and apply leaves the feed's stored config alone.
+   */
   config?: Record<string, unknown>;
 }
 
@@ -479,6 +484,11 @@ export interface Connection {
   authProfile?: AuthProfile | string;
   /** OAuth-app auth profile (handle or slug). */
   appAuthProfile?: AuthProfile | string;
+  /**
+   * Connection settings — same rule as a feed's `config`: declaring this key
+   * REPLACES the remote config, omitting it leaves the connection's stored
+   * settings (including anything set in the UI) alone.
+   */
   config?: Record<string, unknown>;
   /**
    * Where this connection's credential lives:


### PR DESCRIPTION
## Summary

`lobu apply` overwrote things the config never declared. Two fields, same two-layer collapse, and **both ends of the stack were already correct** — only the CLI middle flattened the signal.

### The live case this prevents

`examples/personal-agent/lobu.config.ts` declares `gmail-buremba` feed `threads` with a `config` block and **no `schedule`**. Prod has that feed running on `9,39 * * * *`. Under the old behavior the next `lobu apply` would have cleared it and stopped Gmail sync. The same file already carries a hand-written workaround for this class two lines up — *"Apply treats omitted bindings as null, so both must remain explicit."*

Historically: the audit ledger shows **41 schedule clears by actor `cli`** across 2026-08-11 and 08-12, none intentional. It also made a DB-side cron backfill pointless — the next apply would undo it — so it gates arming the dormant feeds from #3338.

### Where it broke

| layer | state |
|---|---|
| `manage_feeds.ts:1057` (server) | already tri-state: *"undefined = leave alone, null/`""` = clear (manual)"* |
| `client.ts:updateFeed` / `updateConnection` | already omit an undefined field from the wire payload |
| `map-config.ts:842` | **collapsed** an omitted feed schedule → explicit `null` |
| `apply-cmd.ts` | **collapsed** feed schedule, feed config, and connection config with `?? {}` / `?? null` |
| `diff.ts` | compared `d.x ?? {}`, so undeclared diffed as changed |

`schedule` is now genuinely three-state at the config surface, matching how `name` already behaves via `optionalNameChanged`:

| config says | apply does |
|---|---|
| `schedule: "0 * * * *"` | sets it |
| `schedule: null` | clears it — deliberate, still expressible |
| omitted | leaves whatever the feed has, including a cron set in the UI |

Feed `config` and connection `config` get the same rule: **declared still REPLACES** (a removed key must disappear remotely), undeclared is omitted.

Creating a **new** feed is unchanged: undeclared and explicit-null both mean manual-only, and the platform still never invents a default cron.

### `action_modes` failed loudly rather than silently

The one thing connection-config replacement did not quietly destroy. The server's human-only gate (`action-modes-guard.ts`) rejects a PAT or agent identity that changes the map, so apply sending `{}` did not wipe approval overrides — it failed the **entire apply** closed with *"Changing action_modes requires a human web session."* Correct protection, but it meant apply was broken outright on any connection carrying overrides.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `bun test` in `packages/cli`
- [x] Bug fix: red→fix→green outputs pasted below

**RED** — new tests against the pre-fix mapper and diff:

```
(fail) apply diff — connectors > an undeclared schedule does not diff against a remote cron
(fail) apply diff — connectors > an undeclared feed config does not diff against a remote config
(fail) mapProjectToDesiredState > an omitted feed schedule is left undeclared, not collapsed to null
 131 pass
 3 fail
```

The connection-config guard was added after its fix, so it was mutation-proved separately: restoring `d.config ?? {}` turns it red.

```
(fail) apply diff — connectors > an undeclared connection config does not diff against a remote config
 67 pass
 1 fail
```

**GREEN** — full CLI package suite:

```
 720 pass
 1 skip
 0 fail
 9 snapshots, 1860 expect() calls
Ran 721 tests across 45 files.
```

## Notes

- **BEHAVIOR CHANGE on a published package.** A config that relied on omitting `schedule` to clear one must now say `schedule: null`. `@lobu/cli` is on npm, so this is a semantic change to a public surface, not only a bug fix.
- The `init --from-org` round-trip expectation changed for the same reason: a generated config omits `schedule` for a cron-less feed, so it round-trips as undeclared rather than an explicit `null`. That is the intended new semantic — a cron later set in the UI survives the next apply.
- Connections **not declared in the config at all** were never affected; they are drift and apply leaves them alone.
- `make review-fix` could not run — the codex account is at its usage limit until Sep 7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved UI-configured connection settings when configuration leaves them unspecified.
  - Preserved existing feed schedules and configurations when omitted from configuration.
  - Allowed explicitly setting a feed schedule to `null` to clear its schedule and make it manual-only.
  - Prevented undeclared settings from triggering unnecessary updates during apply operations.
  - Improved configuration round-tripping by distinguishing omitted values from explicit clears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->