### PR TITLE
feat(connectors): add a Google Drive connector with a resumable bootstrap

### DIFF
--- a/packages/cli/src/templates/AGENTS.md.tmpl
+++ b/packages/cli/src/templates/AGENTS.md.tmpl
@@ -215,7 +215,7 @@ const gh = defineConnection({
 
 **Bundled connector keys** — use the exact key; several are dotted (Gmail is
 `google.gmail`, not `gmail` or `google_gmail`): `github`, `slack`, `linear`, `jira`, `google.gmail`,
-`google.calendar`, `microsoft.outlook`, `discord`, `teams`, `telegram`, `webhook`,
+`google.calendar`, `google.drive`, `microsoft.outlook`, `discord`, `teams`, `telegram`, `webhook`,
 `whatsapp`, `gchat`, `rss`, `postgres`, `os.shell`,
 `hackernews`, `market.quotes`, `reddit`, `x`, `youtube`, `producthunt`.
 

--- a/packages/connectors/src/__tests__/google_drive.test.ts
+++ b/packages/connectors/src/__tests__/google_drive.test.ts
@@ -599,7 +599,7 @@ describe('GoogleDriveConnector query construction', () => {
 
     const listUrl = drive.urls.find((u) => u.includes('/files?'))!;
     const q = new URL(listUrl).searchParams.get('q');
-    expect(q).toBe("trashed = false and (mimeType = 'application/pdf')");
+    expect(q).toBe("mimeType != 'application/vnd.google-apps.folder' and trashed = false and (mimeType = 'application/pdf')");
   });
 
   test('include_trashed drops the trashed filter', async () => {
@@ -614,8 +614,11 @@ describe('GoogleDriveConnector query construction', () => {
       checkpoint: {},
     });
 
+    // The folder exclusion is unconditional, so the query never empties out.
     const listUrl = drive.urls.find((u) => u.includes('/files?'))!;
-    expect(new URL(listUrl).searchParams.get('q')).toBeNull();
+    expect(new URL(listUrl).searchParams.get('q')).toBe(
+      "mimeType != 'application/vnd.google-apps.folder'"
+    );
   });
 
   test('folder_id scopes the query to that parent', async () => {
@@ -632,7 +635,7 @@ describe('GoogleDriveConnector query construction', () => {
 
     const listUrl = drive.urls.find((u) => u.includes('/files?'))!;
     expect(new URL(listUrl).searchParams.get('q')).toBe(
-      "trashed = false and 'FOLDER1' in parents"
+      "mimeType != 'application/vnd.google-apps.folder' and trashed = false and 'FOLDER1' in parents"
     );
   });
 });
@@ -896,6 +899,156 @@ describe('GoogleDriveConnector export ceiling', () => {
     // it is how a caller learns how much it did not get. Pinned so the two
     // never quietly collapse into the same number.
     expect(result.output.byte_count).toBe(EXPORT_CEILING + 1);
+  });
+});
+
+describe('GoogleDriveConnector time budget', () => {
+  const manyFiles = (prefix: string, n: number) =>
+    Array.from({ length: n }, (_, i) => driveFile(`${prefix}${i}`));
+
+  /**
+   * Jumps the clock past the budget once the first page has been consumed:
+   * 0 when the deadline is computed, then far past it at the first boundary.
+   * Patched on the instance rather than subclassed — the connector module is
+   * mocked, so a module-scope `extends` runs before the mock is installed.
+   */
+  const withExhaustedClock = (connector: GoogleDriveConnector) => {
+    let calls = 0;
+    (connector as unknown as { now: () => number }).now = () =>
+      calls++ === 0 ? 0 : 60 * 60 * 1000;
+    return connector;
+  };
+
+  test('a bootstrap that runs out of time PARKS a checkpoint instead of being killed', async () => {
+    const connector = withExhaustedClock(new GoogleDriveConnector());
+    const drive = fakeDrive([
+      startToken('TOK-1'),
+      filesList([
+        { files: manyFiles('a', 3), nextPageToken: 'PAGE-2' },
+        { files: manyFiles('b', 3) },
+      ]),
+    ]);
+    connector.client = () => drive.client;
+
+    // The cap is far away: only the clock can stop this run.
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { max_results: 2000, include_content: false },
+      checkpoint: {},
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.events).toHaveLength(3);
+    // The whole point: a run killed by the host persists nothing and repeats
+    // itself forever. Stopping ourselves leaves a resumable position.
+    expect(result.checkpoint.list_page_token).toBe('PAGE-2');
+    expect(result.checkpoint.pending_page_token).toBe('TOK-1');
+    expect(result.checkpoint.page_token).toBeUndefined();
+    expect(result.metadata?.bootstrap_complete).toBe(false);
+  });
+
+  test('an incremental run that runs out of time hands back its cursor', async () => {
+    const connector = withExhaustedClock(new GoogleDriveConnector());
+    const drive = fakeDrive([
+      changesList([
+        { changes: [{ fileId: 'x', time: '2026-01-01T00:00:00Z', file: { id: 'x', name: 'X', mimeType: 'text/plain' } }], nextPageToken: 'C2' },
+        { changes: [], newStartPageToken: 'DONE' },
+      ]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { max_results: 2000, include_content: false },
+      checkpoint: { page_token: 'C1', last_sync_at: '2026-01-01T00:00:00.000Z' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    // Discarding the cursor would silently demote the next run to a full
+    // re-list and restart the whole bootstrap.
+    expect(result.checkpoint.page_token).toBe('C2');
+    expect(result.metadata?.changes_pending).toBe(true);
+  });
+});
+
+describe('GoogleDriveConnector query escaping', () => {
+  test('a folder_id ending in a backslash cannot escape its own quote', async () => {
+    // Escaping only `'` leaves the trailing backslash to escape the closing
+    // quote, letting the rest of the value run on as query syntax.
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([startToken('T'), filesList([{ files: [] }])]);
+    connector.client = () => drive.client;
+
+    await connector.sync({
+      feedKey: 'files',
+      config: { folder_id: "EVIL\\", include_content: false },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    const q = new URL(drive.urls.find((u) => u.includes('/files?'))!).searchParams.get('q')!;
+    expect(q).toContain("'EVIL\\\\' in parents");
+    // The literal closes where it should: an even number of backslashes runs
+    // up to the quote, so the quote is a delimiter and not escaped content.
+    expect(q.endsWith("in parents")).toBe(true);
+  });
+
+  test("a folder_id containing a quote stays inside its literal", async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([startToken('T'), filesList([{ files: [] }])]);
+    connector.client = () => drive.client;
+
+    await connector.sync({
+      feedKey: 'files',
+      config: { folder_id: "a' or '1'='1", include_content: false },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    const q = new URL(drive.urls.find((u) => u.includes('/files?'))!).searchParams.get('q')!;
+    expect(q).toContain("'a\\' or \\'1\\'=\\'1' in parents");
+  });
+});
+
+describe('GoogleDriveConnector folder exclusion', () => {
+  test('a folder arriving through changes.list is dropped, not stored', async () => {
+    // `changes.list` takes no query, so the bootstrap's folder filter has to be
+    // re-applied here or folders leak back in one edit at a time.
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([
+        {
+          changes: [
+            {
+              fileId: 'FOLD',
+              time: '2026-01-01T00:00:00Z',
+              file: {
+                id: 'FOLD',
+                name: 'Some Folder',
+                mimeType: 'application/vnd.google-apps.folder',
+              },
+            },
+            {
+              fileId: 'DOC',
+              time: '2026-01-01T00:00:00Z',
+              file: { id: 'DOC', name: 'Real Doc', mimeType: 'text/plain' },
+            },
+          ],
+          newStartPageToken: 'TOK-2',
+        },
+      ]),
+      contentBody('hello'),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: false },
+      checkpoint: { page_token: 'TOK-1' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.events.map((e) => e.origin_id)).toEqual(['DOC']);
   });
 });
 

--- a/packages/connectors/src/__tests__/google_drive.test.ts
+++ b/packages/connectors/src/__tests__/google_drive.test.ts
@@ -1,0 +1,1285 @@
+import { beforeAll, describe, expect, mock, test } from 'bun:test';
+// Both sync loops run through the cursor paginator; the shared mock provides a
+// faithful generator rather than a throwing stub, so these tests exercise the
+// real paging semantics.
+import { connectorSdkMock } from './connector-sdk.mock';
+
+mock.module('@lobu/connector-sdk', () => connectorSdkMock());
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
+let GoogleDriveConnector: any;
+
+beforeAll(async () => {
+  const mod = await import('../google_drive');
+  GoogleDriveConnector = mod.default;
+});
+
+const DOC_MIME = 'application/vnd.google-apps.document';
+const SHEET_MIME = 'application/vnd.google-apps.spreadsheet';
+const FOLDER_MIME = 'application/vnd.google-apps.folder';
+
+interface RouteResponse {
+  status?: number;
+  body?: unknown;
+  /** Raw body for media/export routes, which the connector reads via text(). */
+  text?: string;
+}
+
+type Route = (url: URL) => RouteResponse | undefined;
+
+/**
+ * Fake Drive HTTP client that dispatches on the request URL, so a test can
+ * assert BOTH the response handling and the order in which endpoints were hit.
+ */
+function fakeDrive(routes: Route[]) {
+  const urls: string[] = [];
+  return {
+    urls,
+    /** Endpoint labels in call order — the invariant most tests assert on. */
+    get trace(): string[] {
+      return urls.map((raw) => {
+        const u = new URL(raw);
+        if (u.pathname.endsWith('/changes/startPageToken')) return 'startPageToken';
+        if (u.pathname.endsWith('/changes')) return 'changes';
+        if (u.pathname.endsWith('/export')) return 'export';
+        if (u.pathname.endsWith('/files')) return 'files.list';
+        if (u.searchParams.get('alt') === 'media') return 'media';
+        return 'files.get';
+      });
+    },
+    client: {
+      raw: async (raw: string) => {
+        urls.push(raw);
+        const url = new URL(raw);
+        for (const route of routes) {
+          const hit = route(url);
+          if (hit) {
+            const status = hit.status ?? 200;
+            return {
+              ok: status >= 200 && status < 300,
+              status,
+              json: async () => hit.body ?? {},
+              text: async () => hit.text ?? JSON.stringify(hit.body ?? {}),
+            } as unknown as Response;
+          }
+        }
+        throw new Error(`unrouted Drive request: ${raw}`);
+      },
+    },
+  };
+}
+
+function driveFile(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    name: `${id}.txt`,
+    mimeType: 'text/plain',
+    webViewLink: `https://drive.google.com/file/${id}`,
+    size: '12',
+    createdTime: '2026-01-01T10:00:00Z',
+    modifiedTime: '2026-01-02T10:00:00Z',
+    owners: [{ emailAddress: 'owner@example.com', displayName: 'Owner' }],
+    ...overrides,
+  };
+}
+
+const startToken = (token: string): Route => (url) =>
+  url.pathname.endsWith('/changes/startPageToken')
+    ? { body: { startPageToken: token } }
+    : undefined;
+
+const filesList = (pages: Array<{ files?: unknown[]; nextPageToken?: string }>): Route => {
+  let i = 0;
+  return (url) =>
+    url.pathname.endsWith('/files') ? { body: pages[i++] ?? { files: [] } } : undefined;
+};
+
+const changesList = (
+  pages: Array<{ status?: number; changes?: unknown[]; nextPageToken?: string; newStartPageToken?: string }>
+): Route => {
+  let i = 0;
+  return (url) => {
+    if (!url.pathname.endsWith('/changes')) return undefined;
+    const page = pages[i++] ?? { changes: [] };
+    return { status: page.status, body: page };
+  };
+};
+
+/** Serves every content route (export + alt=media) with one body. */
+const contentBody = (text: string, status = 200): Route => (url) =>
+  url.pathname.endsWith('/export') || url.searchParams.get('alt') === 'media'
+    ? { status, text }
+    : undefined;
+
+const fileGet = (file: Record<string, unknown>): Route => (url) =>
+  url.pathname.includes('/files/') &&
+  !url.pathname.endsWith('/export') &&
+  url.searchParams.get('alt') !== 'media'
+    ? { body: file }
+    : undefined;
+
+// ---------------------------------------------------------------------------
+
+describe('GoogleDriveConnector authorization and operation policy', () => {
+  test('requests read-only Drive consent and exposes only read actions', () => {
+    const definition = new GoogleDriveConnector().definition;
+    const oauth = definition.authSchema.methods[0];
+
+    expect(definition.key).toBe('google.drive');
+    expect(oauth.provider).toBe('google');
+    expect(oauth.requiredScopes).toEqual([
+      'https://www.googleapis.com/auth/drive.readonly',
+    ]);
+    // Sensitive Drive scopes must never ride on the login consent — that is the
+    // regression PR #1145 fixed for the whole google provider.
+    expect(oauth.loginScopes).toEqual(['openid', 'email', 'profile']);
+
+    for (const actionKey of Object.keys(definition.actions)) {
+      expect(definition.actions[actionKey]).toMatchObject({
+        kind: 'read',
+        requiresApproval: false,
+      });
+    }
+  });
+});
+
+describe('GoogleDriveConnector full sync', () => {
+  test('takes the start page token BEFORE listing files', async () => {
+    // The load-bearing ordering invariant: Drive's change log is a moving
+    // cursor, so a token minted after the traversal would skip every file
+    // written while it ran.
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('TOKEN_1'),
+      filesList([{ files: [driveFile('a')] }]),
+      contentBody('hello'),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: false },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    expect(drive.trace[0]).toBe('startPageToken');
+    expect(drive.trace[1]).toBe('files.list');
+    expect(result.checkpoint.page_token).toBe('TOKEN_1');
+    expect(result.events).toHaveLength(1);
+  });
+
+  test('pages files.list until the page token is exhausted', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('T'),
+      filesList([
+        { files: [driveFile('a')], nextPageToken: 'p2' },
+        { files: [driveFile('b')] },
+      ]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: false },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    expect(result.events).toHaveLength(2);
+    expect(drive.trace.filter((t) => t === 'files.list')).toHaveLength(2);
+  });
+
+  test('stops at the first page boundary at or past max_results', async () => {
+    // The cap bounds the RUN, not the page. A page is consumed whole because
+    // Drive's list cursor cannot resume inside one, so overshooting is the
+    // safe direction: the alternative drops the remainder permanently.
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('T'),
+      filesList([
+        { files: [driveFile('a'), driveFile('b'), driveFile('c')], nextPageToken: 'P2' },
+        { files: [driveFile('d')] },
+      ]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: false, max_results: 2 },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    expect(result.events).toHaveLength(3);
+    expect(result.checkpoint.list_page_token).toBe('P2');
+    expect(result.checkpoint.page_token).toBeUndefined();
+  });
+});
+
+describe('GoogleDriveConnector incremental sync', () => {
+  test('advances the checkpoint to newStartPageToken from the LAST page', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([
+        { changes: [{ fileId: 'a', file: driveFile('a') }], nextPageToken: 'c2' },
+        { changes: [{ fileId: 'b', file: driveFile('b') }], newStartPageToken: 'TOKEN_2' },
+      ]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: false },
+      credentials: { accessToken: 'tok' },
+      checkpoint: { page_token: 'TOKEN_1' },
+    });
+
+    expect(result.events).toHaveLength(2);
+    expect(result.checkpoint.page_token).toBe('TOKEN_2');
+    // Never re-listed: the incremental path succeeded.
+    expect(drive.trace).not.toContain('files.list');
+  });
+
+  test('a removed change becomes a tombstone on the same origin_id', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([
+        {
+          changes: [{ fileId: 'gone', removed: true, time: '2026-02-01T00:00:00Z' }],
+          newStartPageToken: 'T2',
+        },
+      ]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: {},
+      credentials: { accessToken: 'tok' },
+      checkpoint: { page_token: 'T1' },
+    });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toMatchObject({
+      origin_id: 'gone',
+      metadata: { change_type: 'removed' },
+    });
+  });
+
+  test('a trashed file is tombstoned unless the feed opts into trash', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([
+        {
+          changes: [{ fileId: 'x', file: driveFile('x', { trashed: true }) }],
+          newStartPageToken: 'T2',
+        },
+      ]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: false },
+      credentials: { accessToken: 'tok' },
+      checkpoint: { page_token: 'T1' },
+    });
+
+    expect(result.events[0].metadata).toMatchObject({ change_type: 'trashed' });
+  });
+});
+
+describe('GoogleDriveConnector page-token recovery', () => {
+  test('a 404 page token falls through to exactly ONE full re-list', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([{ status: 404 }]),
+      startToken('FRESH'),
+      filesList([{ files: [driveFile('a')] }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: false },
+      credentials: { accessToken: 'tok' },
+      checkpoint: { page_token: 'DEAD' },
+    });
+
+    expect(result.checkpoint.page_token).toBe('FRESH');
+    expect(result.events).toHaveLength(1);
+    // Exactly one changes attempt, then recovery — never a resync loop.
+    expect(drive.trace.filter((t) => t === 'changes')).toHaveLength(1);
+    expect(drive.trace.filter((t) => t === 'files.list')).toHaveLength(1);
+  });
+
+  test('a 403 is a scope failure and must NOT trigger a re-list', async () => {
+    // The distinction that keeps a missing-scope install from becoming an
+    // unbounded full-resync loop against Drive.
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([changesList([{ status: 403 }])]);
+    connector.client = () => drive.client;
+
+    await expect(
+      connector.sync({
+        feedKey: 'files',
+        config: {},
+        credentials: { accessToken: 'tok' },
+        checkpoint: { page_token: 'T1' },
+      })
+    ).rejects.toThrow(/changes.list error \(403\)/);
+
+    expect(drive.trace).not.toContain('files.list');
+  });
+
+  test('a 401 is a credential failure and must NOT trigger a re-list', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([changesList([{ status: 401 }])]);
+    connector.client = () => drive.client;
+
+    await expect(
+      connector.sync({
+        feedKey: 'files',
+        config: {},
+        credentials: { accessToken: 'tok' },
+        checkpoint: { page_token: 'T1' },
+      })
+    ).rejects.toThrow(/changes.list error \(401\)/);
+
+    expect(drive.trace).not.toContain('files.list');
+  });
+});
+
+describe('GoogleDriveConnector content routing', () => {
+  test('a Google Doc is EXPORTED, never downloaded as bytes', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      fileGet(driveFile('doc', { mimeType: DOC_MIME, size: undefined })),
+      contentBody('line one\nline two'),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.execute({
+      actionKey: 'get_file_content',
+      input: { file_id: 'doc' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(drive.trace).toContain('export');
+    expect(drive.trace).not.toContain('media');
+    expect(result.output.exported_as).toBe('text/plain');
+    expect(result.output.line_count).toBe(2);
+  });
+
+  test('a Sheet exports as CSV', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      fileGet(driveFile('sheet', { mimeType: SHEET_MIME, size: undefined })),
+      contentBody('a,b\n1,2'),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.execute({
+      actionKey: 'get_file_content',
+      input: { file_id: 'sheet' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.output.exported_as).toBe('text/csv');
+    const exportUrl = drive.urls.find((u) => u.includes('/export'))!;
+    expect(new URL(exportUrl).searchParams.get('mimeType')).toBe('text/csv');
+  });
+
+  test('a plain text file is downloaded with alt=media, not exported', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      fileGet(driveFile('txt')),
+      contentBody('alpha\nbeta\ngamma'),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.execute({
+      actionKey: 'get_file_content',
+      input: { file_id: 'txt' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(drive.trace).toContain('media');
+    expect(drive.trace).not.toContain('export');
+    expect(result.output.line_count).toBe(3);
+    expect(result.output.exported_as).toBeUndefined();
+  });
+
+  test('a folder has no text export and is refused with a specific reason', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      fileGet(driveFile('folder', { mimeType: FOLDER_MIME, size: undefined })),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.execute({
+      actionKey: 'get_file_content',
+      input: { file_id: 'folder' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/no text export/);
+  });
+
+  test('a binary file is refused rather than decoded into mojibake', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      fileGet(driveFile('pdf', { mimeType: 'application/pdf', name: 'a.pdf' })),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.execute({
+      actionKey: 'get_file_content',
+      input: { file_id: 'pdf' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/binary/);
+    // Critically: it never spent a request fetching bytes it cannot use.
+    expect(drive.trace).not.toContain('media');
+  });
+
+  test('truncation never splits a multi-byte character', async () => {
+    // A byte-slice that lands mid-sequence would decode to U+FFFD and store a
+    // manufactured garbage character. Found against a real 377KB Google Doc.
+    const connector = new GoogleDriveConnector();
+    // 10 ASCII + 10 two-byte chars; cutting at 11 bytes splits the first "é".
+    const drive = fakeDrive([
+      fileGet(driveFile('multi')),
+      contentBody('a'.repeat(10) + 'é'.repeat(10)),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.execute({
+      actionKey: 'get_file_content',
+      input: { file_id: 'multi', max_bytes: 11 },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.output.truncated).toBe(true);
+    expect(result.output.content).not.toContain('\uFFFD');
+    expect(result.output.content).toBe('a'.repeat(10));
+  });
+
+  test('a legitimate replacement character in the source survives truncation', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([fileGet(driveFile('repl')), contentBody('ab\uFFFDcd')]);
+    connector.client = () => drive.client;
+
+    const result = await connector.execute({
+      actionKey: 'get_file_content',
+      // 'ab' (2) + U+FFFD (3 bytes) = 5 bytes, a clean boundary.
+      input: { file_id: 'repl', max_bytes: 5 },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.output.content).toBe('ab\uFFFD');
+  });
+
+  test('content is truncated at max_bytes and reports it', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([fileGet(driveFile('big')), contentBody('abcdefghij')]);
+    connector.client = () => drive.client;
+
+    const result = await connector.execute({
+      actionKey: 'get_file_content',
+      input: { file_id: 'big', max_bytes: 4 },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.output.content).toBe('abcd');
+    expect(result.output.truncated).toBe(true);
+    expect(result.output.byte_count).toBe(10);
+  });
+});
+
+describe('GoogleDriveConnector sync content inlining', () => {
+  test('inlines text content into payload_text when enabled', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('T'),
+      filesList([{ files: [driveFile('a')] }]),
+      contentBody('one\ntwo'),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: true },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    expect(result.events[0].payload_text).toBe('one\ntwo');
+    expect(result.events[0].metadata.content_included).toBe(true);
+  });
+
+  test('a failed content fetch degrades to metadata rather than failing the sync', async () => {
+    // One unreadable file must never take down a whole Drive sync.
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('T'),
+      filesList([{ files: [driveFile('a')] }]),
+      contentBody('nope', 500),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: true },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].metadata.content_included).toBe(false);
+  });
+
+  test('include_content: false skips content requests entirely', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('T'),
+      filesList([{ files: [driveFile('a'), driveFile('b')] }]),
+    ]);
+    connector.client = () => drive.client;
+
+    await connector.sync({
+      feedKey: 'files',
+      config: { include_content: false },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    expect(drive.trace).not.toContain('media');
+    expect(drive.trace).not.toContain('export');
+  });
+
+  test('a large text file syncs as metadata only, below the embedding cap', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('T'),
+      filesList([{ files: [driveFile('huge', { size: String(5 * 1024 * 1024) })] }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: true },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    expect(result.events[0].metadata.content_included).toBe(false);
+    expect(drive.trace).not.toContain('media');
+  });
+});
+
+describe('GoogleDriveConnector query construction', () => {
+  test('excludes trashed files by default and merges a user query with AND', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([startToken('T'), filesList([{ files: [] }])]);
+    connector.client = () => drive.client;
+
+    await connector.sync({
+      feedKey: 'files',
+      config: { query: "mimeType = 'application/pdf'", include_content: false },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    const listUrl = drive.urls.find((u) => u.includes('/files?'))!;
+    const q = new URL(listUrl).searchParams.get('q');
+    expect(q).toBe("trashed = false and (mimeType = 'application/pdf')");
+  });
+
+  test('include_trashed drops the trashed filter', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([startToken('T'), filesList([{ files: [] }])]);
+    connector.client = () => drive.client;
+
+    await connector.sync({
+      feedKey: 'files',
+      config: { include_trashed: true, include_content: false },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    const listUrl = drive.urls.find((u) => u.includes('/files?'))!;
+    expect(new URL(listUrl).searchParams.get('q')).toBeNull();
+  });
+
+  test('folder_id scopes the query to that parent', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([startToken('T'), filesList([{ files: [] }])]);
+    connector.client = () => drive.client;
+
+    await connector.sync({
+      feedKey: 'files',
+      config: { folder_id: 'FOLDER1', include_content: false },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    const listUrl = drive.urls.find((u) => u.includes('/files?'))!;
+    expect(new URL(listUrl).searchParams.get('q')).toBe(
+      "trashed = false and 'FOLDER1' in parents"
+    );
+  });
+});
+
+describe('GoogleDriveConnector live read', () => {
+  test('returns typed rows sorted by Drive and paginates by cursor', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      filesList([{ files: [driveFile('a')], nextPageToken: 'next' }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.read({
+      feedKey: 'files',
+      config: {},
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({
+      id: 'a',
+      name: 'a.txt',
+      mime_type: 'text/plain',
+      owner: 'Owner',
+    });
+    expect(result.hasMore).toBe(true);
+    expect(result.nextCursor).toBe('next');
+    // A live read must never persist or advance the change cursor.
+    expect(drive.trace).not.toContain('startPageToken');
+  });
+});
+
+describe('GoogleDriveConnector view-churn guard', () => {
+  const HOUR = 3600 * 1000;
+  const iso = (ms: number) => new Date(ms).toISOString();
+
+  test('a view-only change does NOT re-fetch content', async () => {
+    // Verified against the live API: opening a Doc bumps viewedByMeTime and
+    // version but leaves modifiedTime alone, so the file reappears in
+    // changes.list with content we already have.
+    const now = Date.now();
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([
+        {
+          changes: [
+            { fileId: 'viewed', file: driveFile('viewed', { modifiedTime: iso(now - 48 * HOUR) }) },
+          ],
+          newStartPageToken: 'T2',
+        },
+      ]),
+      contentBody('should not be fetched'),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: true },
+      credentials: { accessToken: 'tok' },
+      checkpoint: { page_token: 'T1', last_sync_at: iso(now - HOUR) },
+    });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].metadata.content_included).toBe(false);
+    expect(drive.trace).not.toContain('media');
+    expect(drive.trace).not.toContain('export');
+  });
+
+  test('a genuine edit after the last sync DOES re-fetch content', async () => {
+    const now = Date.now();
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([
+        {
+          changes: [
+            { fileId: 'edited', file: driveFile('edited', { modifiedTime: iso(now) }) },
+          ],
+          newStartPageToken: 'T2',
+        },
+      ]),
+      contentBody('fresh content'),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: true },
+      credentials: { accessToken: 'tok' },
+      checkpoint: { page_token: 'T1', last_sync_at: iso(now - HOUR) },
+    });
+
+    expect(result.events[0].metadata.content_included).toBe(true);
+    expect(result.events[0].payload_text).toBe('fresh content');
+  });
+
+  test('clock skew inside the grace window still re-fetches', async () => {
+    // modifiedTime one minute before last_sync_at is inside the 5-minute grace,
+    // so it must NOT be treated as stale — skew must never lose an edit.
+    const now = Date.now();
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([
+        {
+          changes: [
+            { fileId: 'skew', file: driveFile('skew', { modifiedTime: iso(now - 60 * 1000) }) },
+          ],
+          newStartPageToken: 'T2',
+        },
+      ]),
+      contentBody('edge content'),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: true },
+      credentials: { accessToken: 'tok' },
+      checkpoint: { page_token: 'T1', last_sync_at: iso(now) },
+    });
+
+    expect(result.events[0].metadata.content_included).toBe(true);
+  });
+
+  test('a full sync has no last_sync_at and always fetches', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('T'),
+      filesList([{ files: [driveFile('old', { modifiedTime: '2020-01-01T00:00:00Z' })] }]),
+      contentBody('bootstrap content'),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: true },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    expect(result.events[0].metadata.content_included).toBe(true);
+  });
+});
+
+describe('GoogleDriveConnector get_file metadata action', () => {
+  test('returns the typed row and never touches content', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      fileGet(
+        driveFile('meta', {
+          name: 'quarterly.pdf',
+          mimeType: 'application/pdf',
+          size: '2048',
+          trashed: false,
+          lastModifyingUser: { emailAddress: 'editor@example.com', displayName: 'Editor' },
+        })
+      ),
+      // Content routes are wired but must stay unused — a metadata read that
+      // silently downloads bytes would bill the caller for the whole file.
+      contentBody('SHOULD NOT BE READ'),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.execute({
+      actionKey: 'get_file',
+      input: { file_id: 'meta' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(drive.trace).toContain('files.get');
+    expect(drive.trace).not.toContain('export');
+    expect(drive.trace).not.toContain('media');
+    expect(result.output).toEqual({
+      id: 'meta',
+      name: 'quarterly.pdf',
+      mime_type: 'application/pdf',
+      size_bytes: 2048,
+      owner: 'Owner',
+      last_modified_by: 'Editor',
+      created_at: '2026-01-01T10:00:00Z',
+      modified_at: '2026-01-02T10:00:00Z',
+      trashed: false,
+      url: 'https://drive.google.com/file/meta',
+    });
+  });
+
+  test('a missing file_id is rejected before any request', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([fileGet(driveFile('meta'))]);
+    connector.client = () => drive.client;
+
+    const result = await connector.execute({
+      actionKey: 'get_file',
+      input: {},
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('file_id is required.');
+    expect(drive.trace).toHaveLength(0);
+  });
+
+  test('an unknown file id reports the id rather than a bare failure', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([(url) =>
+      url.pathname.includes('/files/') ? { status: 404, body: {} } : undefined,
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.execute({
+      actionKey: 'get_file',
+      input: { file_id: 'ghost' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('ghost');
+  });
+
+  test('an unknown action key is refused', async () => {
+    const connector = new GoogleDriveConnector();
+    connector.client = () => fakeDrive([]).client;
+
+    const result = await connector.execute({
+      actionKey: 'delete_file',
+      input: { file_id: 'x' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('delete_file');
+  });
+});
+
+describe('GoogleDriveConnector export ceiling', () => {
+  test('max_bytes above the export ceiling is clamped, not honoured', async () => {
+    const EXPORT_CEILING = 10 * 1024 * 1024;
+    const connector = new GoogleDriveConnector();
+    // One byte past the ceiling: a caller asking for 50MB must still stop at 10.
+    const oversized = 'a'.repeat(EXPORT_CEILING + 1);
+    const drive = fakeDrive([
+      fileGet(driveFile('huge', { mimeType: DOC_MIME, size: undefined })),
+      contentBody(oversized),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.execute({
+      actionKey: 'get_file_content',
+      input: { file_id: 'huge', max_bytes: 50 * 1024 * 1024 },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output.truncated).toBe(true);
+    // The CONTENT is what the ceiling governs: a caller asking for 50MB still
+    // cannot pull more than 10MB into the turn.
+    expect(
+      new TextEncoder().encode(result.output.content as string).byteLength
+    ).toBeLessThanOrEqual(EXPORT_CEILING);
+    // `byte_count` is deliberately the SOURCE size, not the returned size —
+    // it is how a caller learns how much it did not get. Pinned so the two
+    // never quietly collapse into the same number.
+    expect(result.output.byte_count).toBe(EXPORT_CEILING + 1);
+  });
+});
+
+describe('GoogleDriveConnector bootstrap page-boundary', () => {
+  const manyFiles = (prefix: string, n: number) =>
+    Array.from({ length: n }, (_, i) => driveFile(`${prefix}${i}`));
+
+  test('every file is collected across a resumed bootstrap', async () => {
+    // Page 1 holds 5 files and the cap is 3: stopping mid-page and then
+    // resuming at PAGE-2 would silently drop a3 and a4 forever, because the
+    // change feed only ever reports what changes AFTER the bootstrap.
+    const connector = new GoogleDriveConnector();
+    const pages = [
+      { files: manyFiles('a', 5), nextPageToken: 'PAGE-2' },
+      { files: manyFiles('b', 2) },
+    ];
+
+    const seen = new Set<string>();
+    let checkpoint: Record<string, unknown> = {};
+    for (let run = 0; run < 5; run++) {
+      let i = pages.findIndex((_, idx) =>
+        checkpoint.list_page_token === undefined ? idx === 0 : idx === 1
+      );
+      const drive = fakeDrive([
+        startToken('TOK-1'),
+        (url) => (url.pathname.endsWith('/files') ? { body: pages[i++] ?? { files: [] } } : undefined),
+      ]);
+      connector.client = () => drive.client;
+
+      const result = await connector.sync({
+        feedKey: 'files',
+        config: { max_results: 3, include_content: false },
+        checkpoint,
+        credentials: { accessToken: 'tok' },
+      });
+      for (const e of result.events) seen.add(e.origin_id);
+      checkpoint = result.checkpoint;
+      if (result.metadata?.bootstrap_complete === true) break;
+    }
+
+    expect([...seen].sort()).toEqual(['a0', 'a1', 'a2', 'a3', 'a4', 'b0', 'b1']);
+  });
+});
+
+describe('GoogleDriveConnector resumable bootstrap', () => {
+  const manyFiles = (prefix: string, n: number) =>
+    Array.from({ length: n }, (_, i) => driveFile(`${prefix}${i}`));
+
+  test('a Drive larger than max_results does NOT go incremental', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('TOK-1'),
+      filesList([{ files: manyFiles('a', 3), nextPageToken: 'PAGE-2' }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { max_results: 3, include_content: false },
+      checkpoint: {},
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.events).toHaveLength(3);
+    // The change token must stay parked: promoting it here would strand every
+    // file the traversal never reached, permanently.
+    expect(result.checkpoint.page_token).toBeUndefined();
+    expect(result.checkpoint.pending_page_token).toBe('TOK-1');
+    expect(result.checkpoint.list_page_token).toBe('PAGE-2');
+    expect(result.metadata?.bootstrap_complete).toBe(false);
+  });
+
+  test('the next run resumes the listing instead of re-minting a token', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('TOK-FRESH'),
+      filesList([{ files: manyFiles('b', 2) }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { max_results: 10, include_content: false },
+      checkpoint: { pending_page_token: 'TOK-1', list_page_token: 'PAGE-2' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    // Resuming must NOT call startPageToken — a fresh token would open a gap
+    // covering everything changed since the bootstrap began.
+    expect(drive.trace).not.toContain('startPageToken');
+    expect(drive.urls.some((u) => u.includes('pageToken=PAGE-2'))).toBe(true);
+    // Listing exhausted, so the parked token is promoted and incremental opens.
+    expect(result.checkpoint.page_token).toBe('TOK-1');
+    expect(result.checkpoint.list_page_token).toBeUndefined();
+    expect(result.metadata?.bootstrap_complete).toBe(true);
+  });
+
+  test('a bootstrap that exactly exhausts the listing completes immediately', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('TOK-1'),
+      filesList([{ files: manyFiles('c', 3) }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { max_results: 3, include_content: false },
+      checkpoint: {},
+      credentials: { accessToken: 'tok' },
+    });
+
+    // Hitting the cap on the LAST page is not an unfinished bootstrap.
+    expect(result.checkpoint.page_token).toBe('TOK-1');
+    expect(result.checkpoint.list_page_token).toBeUndefined();
+    expect(result.metadata?.bootstrap_complete).toBe(true);
+  });
+
+  test('an unfinished bootstrap outranks a stale page_token', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      filesList([{ files: manyFiles('d', 2) }]),
+      changesList([{ changes: [], newStartPageToken: 'SHOULD-NOT-BE-USED' }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { max_results: 10, include_content: false },
+      checkpoint: {
+        page_token: 'OLD',
+        pending_page_token: 'TOK-1',
+        list_page_token: 'PAGE-2',
+      },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(drive.trace).not.toContain('changes');
+    expect(result.checkpoint.page_token).toBe('TOK-1');
+  });
+});
+
+describe('GoogleDriveConnector bounded incremental sync', () => {
+  const changeFor = (id: string) => ({
+    fileId: id,
+    time: '2026-02-01T10:00:00Z',
+    file: driveFile(id),
+  });
+  const manyChanges = (prefix: string, n: number) =>
+    Array.from({ length: n }, (_, i) => changeFor(`${prefix}${i}`));
+
+  test('a change burst larger than max_results parks the cursor, never re-lists', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([
+        { changes: manyChanges('x', 4), nextPageToken: 'CHANGES-P2' },
+        { changes: manyChanges('y', 4), newStartPageToken: 'FINAL' },
+      ]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { max_results: 3, include_content: false },
+      checkpoint: { page_token: 'START', last_sync_at: '2026-01-01T00:00:00Z' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    // The cursor, not a dropped token: the next run resumes the change stream.
+    expect(result.checkpoint.page_token).toBe('CHANGES-P2');
+    // Falling back to files.list here would restart the entire bootstrap.
+    expect(drive.trace).not.toContain('files.list');
+    expect(drive.trace).not.toContain('startPageToken');
+  });
+
+  test('a partial run does NOT advance last_sync_at', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([{ changes: manyChanges('z', 4), nextPageToken: 'CHANGES-P2' }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { max_results: 3, include_content: false },
+      checkpoint: { page_token: 'START', last_sync_at: '2026-01-01T00:00:00Z' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    // Advancing the stamp would make the view-churn guard treat the unread
+    // backlog as already-stored and silently skip its content next run.
+    expect(result.checkpoint.last_sync_at).toBe('2026-01-01T00:00:00Z');
+    expect(result.metadata?.changes_pending).toBe(true);
+  });
+
+  test('a drained change stream advances the stamp and clears the pending flag', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([{ changes: manyChanges('w', 2), newStartPageToken: 'FINAL' }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { max_results: 100, include_content: false },
+      checkpoint: { page_token: 'START', last_sync_at: '2026-01-01T00:00:00Z' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.checkpoint.page_token).toBe('FINAL');
+    expect(result.checkpoint.last_sync_at).not.toBe('2026-01-01T00:00:00Z');
+    expect(result.metadata?.changes_pending).toBeUndefined();
+  });
+
+  test('the parked cursor is a real resume point, not a restart', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([{ changes: manyChanges('v', 1), newStartPageToken: 'FINAL' }]),
+    ]);
+    connector.client = () => drive.client;
+
+    await connector.sync({
+      feedKey: 'files',
+      config: { max_results: 100, include_content: false },
+      checkpoint: { page_token: 'CHANGES-P2', last_sync_at: '2026-01-01T00:00:00Z' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(drive.urls.some((u) => u.includes('pageToken=CHANGES-P2'))).toBe(true);
+  });
+});
+
+describe('GoogleDriveConnector content failure visibility', () => {
+  test('a failed export is recorded, not silently indistinguishable from no-text', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('TOK'),
+      filesList([{ files: [driveFile('doc', { mimeType: DOC_MIME, size: undefined })] }]),
+      contentBody('upstream exploded', 500),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: {},
+      checkpoint: {},
+      credentials: { accessToken: 'tok' },
+    });
+
+    const meta = result.events[0].metadata;
+    expect(meta.content_included).toBe(false);
+    // A file that never changes again is never revisited, so without this the
+    // miss is permanent AND invisible.
+    expect(meta.content_error).toContain('500');
+  });
+
+  test('a file with no text by design carries no content_error', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('TOK'),
+      filesList([{ files: [driveFile('img', { mimeType: 'image/jpeg' })] }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: {},
+      checkpoint: {},
+      credentials: { accessToken: 'tok' },
+    });
+
+    const meta = result.events[0].metadata;
+    expect(meta.content_included).toBe(false);
+    expect(meta.content_error).toBeUndefined();
+  });
+});
+
+describe('GoogleDriveConnector bootstrap window', () => {
+  const manyFiles = (prefix: string, n: number) =>
+    Array.from({ length: n }, (_, i) => driveFile(`${prefix}${i}`));
+
+  test('every bootstrap slice carries the SAME start timestamp', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('TOK-1'),
+      filesList([{ files: manyFiles('a', 5), nextPageToken: 'PAGE-2' }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const pinned = '2026-01-01T00:00:00.000Z';
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { max_results: 3, include_content: false },
+      checkpoint: {
+        pending_page_token: 'TOK-1',
+        list_page_token: 'PAGE-EARLIER',
+        last_sync_at: pinned,
+      },
+      credentials: { accessToken: 'tok' },
+    });
+
+    // Advancing this per-slice would push the stamp past edits made while the
+    // bootstrap ran, and the view-churn guard would skip their content.
+    expect(result.checkpoint.last_sync_at).toBe(pinned);
+  });
+
+  test('a completed bootstrap keeps the start stamp, not the finish time', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([filesList([{ files: manyFiles('b', 2) }])]);
+    connector.client = () => drive.client;
+
+    const pinned = '2026-01-01T00:00:00.000Z';
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { max_results: 10, include_content: false },
+      checkpoint: {
+        pending_page_token: 'TOK-1',
+        list_page_token: 'PAGE-2',
+        last_sync_at: pinned,
+      },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.checkpoint.page_token).toBe('TOK-1');
+    // An edit made DURING the bootstrap is newer than this stamp, so the first
+    // incremental run re-fetches its content instead of trusting stale text.
+    expect(result.checkpoint.last_sync_at).toBe(pinned);
+  });
+});
+
+describe('GoogleDriveConnector incomplete search', () => {
+  test('an incomplete allDrives search is recorded, not passed off as complete', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('TOK'),
+      filesList([{ files: [driveFile('a')], incompleteSearch: true }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: false },
+      checkpoint: {},
+      credentials: { accessToken: 'tok' },
+    });
+
+    // Without this a partial traversal is indistinguishable from a complete
+    // one, and files it never reached look like files that do not exist.
+    expect(result.metadata?.search_incomplete).toBe(true);
+  });
+
+  test('a complete search carries no incomplete flag', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('TOK'),
+      filesList([{ files: [driveFile('a')] }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { include_content: false },
+      checkpoint: {},
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.metadata?.search_incomplete).toBeUndefined();
+    expect(result.metadata?.bootstrap_complete).toBe(true);
+  });
+
+  test('the sync traversal actually asks Drive for the flag', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([startToken('TOK'), filesList([{ files: [] }])]);
+    connector.client = () => drive.client;
+
+    await connector.sync({
+      feedKey: 'files',
+      config: { include_content: false },
+      checkpoint: {},
+      credentials: { accessToken: 'tok' },
+    });
+
+    // Requesting it is load-bearing: Drive omits the field unless asked, so
+    // without this the flag above could never fire.
+    expect(drive.urls.some((u) => u.includes('incompleteSearch'))).toBe(true);
+  });
+});

--- a/packages/connectors/src/__tests__/google_drive.test.ts
+++ b/packages/connectors/src/__tests__/google_drive.test.ts
@@ -1219,6 +1219,122 @@ describe('GoogleDriveConnector resumable bootstrap', () => {
   });
 });
 
+describe('GoogleDriveConnector feed scope on the incremental axis', () => {
+  // `changes.list` takes no `q`, so every filter the bootstrap applies at the
+  // listing has to be re-applied here or the feed silently widens to the whole
+  // Drive the moment the bootstrap completes.
+
+  test('a folder-scoped feed ignores changes outside that folder', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([
+        {
+          changes: [
+            {
+              fileId: 'outside',
+              time: '2026-02-01T10:00:00Z',
+              file: driveFile('outside', { parents: ['SOME_OTHER_FOLDER'] }),
+            },
+          ],
+          newStartPageToken: 'FINAL',
+        },
+      ]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { folder_id: 'FOLDER1', include_content: false },
+      checkpoint: { page_token: 'T1', last_sync_at: '2026-01-01T00:00:00Z' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.events).toHaveLength(0);
+  });
+
+  test('a folder-scoped feed still collects changes inside that folder', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([
+        {
+          changes: [
+            {
+              fileId: 'inside',
+              time: '2026-02-01T10:00:00Z',
+              file: driveFile('inside', { parents: ['FOLDER1'] }),
+            },
+          ],
+          newStartPageToken: 'FINAL',
+        },
+      ]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { folder_id: 'FOLDER1', include_content: false },
+      checkpoint: { page_token: 'T1', last_sync_at: '2026-01-01T00:00:00Z' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]!.origin_id).toBe('inside');
+  });
+
+  test('an out-of-scope file is dropped WITHOUT a tombstone', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      changesList([
+        {
+          changes: [
+            {
+              fileId: 'moved',
+              time: '2026-02-01T10:00:00Z',
+              file: driveFile('moved', { parents: ['ELSEWHERE'] }),
+            },
+          ],
+          newStartPageToken: 'FINAL',
+        },
+      ]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { folder_id: 'FOLDER1', include_content: false },
+      checkpoint: { page_token: 'T1', last_sync_at: '2026-01-01T00:00:00Z' },
+      credentials: { accessToken: 'tok' },
+    });
+
+    // No row at all, not even a tombstone: a file that moved OUT of the folder
+    // is indistinguishable from one that was never in it, so tombstoning would
+    // write a row for every changed file in the Drive and leak the existence of
+    // out-of-scope files into the corpus the scope exists to bound.
+    expect(result.events).toHaveLength(0);
+  });
+
+  test('a custom query feed never promotes to the change stream', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('TOK-1'),
+      filesList([{ files: [driveFile('q0')] }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { query: "mimeType = 'application/pdf'", include_content: false },
+      checkpoint: {},
+      credentials: { accessToken: 'tok' },
+    });
+
+    // A Drive `q` cannot be re-evaluated against a changes.list record, so the
+    // only way to keep honouring it is to keep listing. Promoting here would
+    // widen the feed to every changed file in the Drive.
+    expect(result.checkpoint.page_token).toBeUndefined();
+  });
+});
+
 describe('GoogleDriveConnector bounded incremental sync', () => {
   const changeFor = (id: string) => ({
     fileId: id,

--- a/packages/connectors/src/__tests__/google_drive.test.ts
+++ b/packages/connectors/src/__tests__/google_drive.test.ts
@@ -912,10 +912,10 @@ describe('GoogleDriveConnector time budget', () => {
    * Patched on the instance rather than subclassed — the connector module is
    * mocked, so a module-scope `extends` runs before the mock is installed.
    */
-  const withExhaustedClock = (connector: GoogleDriveConnector) => {
+  // biome-ignore lint/suspicious/noExplicitAny: the class is imported after the mock
+  const withExhaustedClock = (connector: any) => {
     let calls = 0;
-    (connector as unknown as { now: () => number }).now = () =>
-      calls++ === 0 ? 0 : 60 * 60 * 1000;
+    connector.now = () => (calls++ === 0 ? 0 : 60 * 60 * 1000);
     return connector;
   };
 
@@ -1260,6 +1260,30 @@ describe('GoogleDriveConnector bounded incremental sync', () => {
 
     expect(result.checkpoint.page_token).toBe('FINAL');
     expect(result.checkpoint.last_sync_at).not.toBe('2026-01-01T00:00:00Z');
+    expect(result.metadata?.changes_pending).toBeUndefined();
+  });
+
+  test('a completed bootstrap keeps its stamp WITHOUT claiming changes are pending', async () => {
+    const connector = new GoogleDriveConnector();
+    const drive = fakeDrive([
+      startToken('TOK-1'),
+      filesList([{ files: [driveFile('u0')] }]),
+    ]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { max_results: 100, include_content: false },
+      checkpoint: {},
+      credentials: { accessToken: 'tok' },
+    });
+
+    // A bootstrap pins `last_sync_at` to the moment it began so the view-churn
+    // guard cannot skip edits made while it ran. That is a stamp decision, not
+    // a backlog: nothing is left unread, so the pending flag must stay off or
+    // an operator reads a finished feed as perpetually behind.
+    expect(result.checkpoint.page_token).toBe('TOK-1');
+    expect(result.metadata?.bootstrap_complete).toBe(true);
     expect(result.metadata?.changes_pending).toBeUndefined();
   });
 

--- a/packages/connectors/src/__tests__/google_drive.test.ts
+++ b/packages/connectors/src/__tests__/google_drive.test.ts
@@ -1121,6 +1121,34 @@ describe('GoogleDriveConnector resumable bootstrap', () => {
     expect(result.metadata?.bootstrap_complete).toBe(false);
   });
 
+  test('a listing stopped by MAX_PAGES parks the token instead of completing', async () => {
+    const connector = new GoogleDriveConnector();
+    // Endless listing: every page yields one file and another cursor, so the
+    // traversal is bounded by the paginator's MAX_PAGES rather than by
+    // max_results or the clock. That is still an unfinished bootstrap — the
+    // only proof of exhaustion is Drive withholding a nextPageToken.
+    let page = 0;
+    const endlessFiles: Route = (url) =>
+      url.pathname.endsWith('/files')
+        ? { body: { files: [driveFile(`f${page}`)], nextPageToken: `P${++page}` } }
+        : undefined;
+    const drive = fakeDrive([startToken('TOK-1'), endlessFiles]);
+    connector.client = () => drive.client;
+
+    const result = await connector.sync({
+      feedKey: 'files',
+      config: { max_results: 2000, include_content: false },
+      checkpoint: {},
+      credentials: { accessToken: 'tok' },
+    });
+
+    expect(result.events).toHaveLength(200);
+    expect(result.checkpoint.page_token).toBeUndefined();
+    expect(result.checkpoint.pending_page_token).toBe('TOK-1');
+    expect(result.checkpoint.list_page_token).toBe('P200');
+    expect(result.metadata?.bootstrap_complete).toBe(false);
+  });
+
   test('the next run resumes the listing instead of re-minting a token', async () => {
     const connector = new GoogleDriveConnector();
     const drive = fakeDrive([

--- a/packages/connectors/src/google_drive.ts
+++ b/packages/connectors/src/google_drive.ts
@@ -278,20 +278,26 @@ function personLabel(
  */
 const FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
 
+/** Where the host kills a feed run, discarding its checkpoint with it. */
+const HOST_RUN_TIMEOUT_MS = 10 * 60 * 1000;
+
 /**
  * Wall-clock budget for one sync run, tested at page boundaries.
  *
- * The host kills a feed run at 600s, and a killed run persists NO checkpoint.
- * So a traversal that overruns does not merely stall: it throws away the work
- * it just did, and the next run repeats it and overruns again — a bootstrap
- * that can never finish. Measured on a real Drive at ~0.86s per exported file,
- * so a few hundred content-bearing files is already the whole budget; the item
- * cap alone cannot bound a run because it cannot see how expensive an item is.
+ * A killed run persists NO checkpoint, so a traversal that overruns does not
+ * merely stall: it throws away the work it just did, the next run repeats it
+ * and overruns again — a bootstrap that can never finish. The item cap cannot
+ * prevent that, because it cannot see what an item costs. Measured per item on
+ * one real Drive: 0.61-0.86s when a content export is involved, 0.01-0.03s for
+ * metadata only. A 30x spread means the same cap is either wasteful or fatal.
  *
- * Set well under the host limit to leave room for the page still in flight
- * plus persisting everything collected so far.
+ * The budget cannot stop a page already in flight, so the true worst case is
+ * budget + one page. At the slowest rate observed and a 100-item content page
+ * that is 240s + 86s = 326s, ~54% of the host limit, leaving the rest as
+ * headroom for the client's 429/5xx backoff — which is unbounded in principle
+ * and is why this keeps a wide margin rather than creeping toward the limit.
  */
-const SYNC_TIME_BUDGET_MS = 4 * 60 * 1000;
+const SYNC_TIME_BUDGET_MS = HOST_RUN_TIMEOUT_MS * 0.4;
 
 /**
  * Escapes a value for a single-quoted Drive query literal.

--- a/packages/connectors/src/google_drive.ts
+++ b/packages/connectors/src/google_drive.ts
@@ -265,11 +265,51 @@ function personLabel(
  * is still returned by an unqualified query and would otherwise resurface on
  * every full sync as if it were live.
  */
+/**
+ * Drive models a folder as a file with a reserved MIME type, so an unfiltered
+ * `files.list` returns the directory tree interleaved with the documents. A
+ * folder carries no content and no `size`, so every one of them lands as a
+ * name-only event: on a real Drive that measured 8,258 of 9,200 rows — 90%
+ * noise that costs an embedding each, dilutes search, and stretches the
+ * bootstrap over ten times as many runs as the documents alone need.
+ *
+ * Excluded at the QUERY, not after the fetch, so the pages Drive returns are
+ * documents and the per-run cap counts things worth storing.
+ */
+const FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
+
+/**
+ * Wall-clock budget for one sync run, tested at page boundaries.
+ *
+ * The host kills a feed run at 600s, and a killed run persists NO checkpoint.
+ * So a traversal that overruns does not merely stall: it throws away the work
+ * it just did, and the next run repeats it and overruns again — a bootstrap
+ * that can never finish. Measured on a real Drive at ~0.86s per exported file,
+ * so a few hundred content-bearing files is already the whole budget; the item
+ * cap alone cannot bound a run because it cannot see how expensive an item is.
+ *
+ * Set well under the host limit to leave room for the page still in flight
+ * plus persisting everything collected so far.
+ */
+const SYNC_TIME_BUDGET_MS = 4 * 60 * 1000;
+
+/**
+ * Escapes a value for a single-quoted Drive query literal.
+ *
+ * Backslashes go FIRST: escaping quotes first would then double-escape the
+ * backslashes it just introduced. Escaping only quotes — as this did — leaves
+ * a value ending in a backslash able to escape its own closing quote and run
+ * on into query syntax (`js/incomplete-sanitization`).
+ */
+function escapeQueryLiteral(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
 function buildListQuery(config: DriveConfig): string | undefined {
-  const clauses: string[] = [];
+  const clauses: string[] = [`mimeType != '${FOLDER_MIME_TYPE}'`];
   if (!config.include_trashed) clauses.push('trashed = false');
   if (typeof config.folder_id === 'string' && config.folder_id.trim()) {
-    clauses.push(`'${config.folder_id.trim().replace(/'/g, "\\'")}' in parents`);
+    clauses.push(`'${escapeQueryLiteral(config.folder_id.trim())}' in parents`);
   }
   const raw = typeof config.query === 'string' ? config.query.trim() : '';
   if (raw) clauses.push(`(${raw})`);
@@ -554,13 +594,14 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
         const cursor = pageToken ?? seededCursor;
         seededCursor = undefined;
         const params = new URLSearchParams({
-          // Sized to the cap so the two coincide. Drive's list cursor
-          // addresses PAGES, not offsets: stopping mid-page and resuming at
-          // the next cursor drops the rest of that page permanently, because
-          // the change feed only ever replays what changes after the
-          // bootstrap. Above 1000 the cap becomes a soft floor instead —
-          // overshooting by part of a page is safe, skipping one is not.
-          pageSize: String(Math.min(1000, Math.max(1, maxResults))),
+          // Drive's list cursor addresses PAGES, not offsets: stopping
+          // mid-page and resuming at the next cursor drops the rest of that
+          // page permanently, because the change feed only ever replays what
+          // changes after the bootstrap. So the page is the unit for BOTH the
+          // item cap and the time budget, and its size tracks what an item
+          // costs — a content-fetching run does real work per file and must
+          // re-check the clock often; a metadata-only run does not.
+          pageSize: String(Math.min(includeContent ? 100 : 1000, Math.max(1, maxResults))),
           fields: `files(${FILE_FIELDS}),nextPageToken,incompleteSearch`,
           orderBy: 'modifiedTime desc',
           supportsAllDrives: 'true',
@@ -588,6 +629,7 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
       { maxPages: MAX_PAGES }
     );
 
+    const deadline = this.now() + SYNC_TIME_BUDGET_MS;
     let capped = false;
     for await (const items of pages) {
       for (const file of items) {
@@ -595,7 +637,8 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
       }
       // Tested only BETWEEN pages: a page is consumed whole or not at all, so
       // `nextListPageToken` always addresses the first file we have not read.
-      if (events.length >= maxResults) {
+      // Stopping on the clock parks a checkpoint; being killed on it does not.
+      if (events.length >= maxResults || this.now() >= deadline) {
         capped = true;
         break;
       }
@@ -659,8 +702,11 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
         const params = new URLSearchParams({
           pageToken: cursor ?? pageToken,
           // Aligned to the cap so a bounded run does not overshoot by most of
-          // a 1000-change page; floored so a tiny cap cannot thrash the API.
-          pageSize: String(Math.min(1000, Math.max(100, maxResults))),
+          // a 1000-change page, and capped tighter when each change carries a
+          // content fetch so the time budget is re-checked often enough.
+          pageSize: String(
+            Math.min(includeContent ? 100 : 1000, Math.max(includeContent ? 1 : 100, maxResults))
+          ),
           fields: `changes(fileId,removed,time,file(${FILE_FIELDS})),nextPageToken,newStartPageToken`,
           supportsAllDrives: 'true',
           includeItemsFromAllDrives: 'true',
@@ -690,6 +736,7 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
     // Bounded at PAGE boundaries, never mid-page: `resumeCursor` addresses the
     // start of the next page, so stopping part-way through one would skip the
     // changes still in it.
+    const deadline = this.now() + SYNC_TIME_BUDGET_MS;
     let stoppedEarly = false;
     for await (const items of pages) {
       for (const change of items) {
@@ -704,7 +751,7 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
         if (envelope) events.push(envelope);
       }
       if (rejected) break;
-      if (events.length >= maxResults && resumeCursor) {
+      if ((events.length >= maxResults || this.now() >= deadline) && resumeCursor) {
         stoppedEarly = true;
         break;
       }
@@ -938,6 +985,13 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
       };
     }
 
+    // `changes.list` has no query parameter, so the folder exclusion the
+    // bootstrap applies at the listing has to be re-applied here or folders
+    // would leak back in one edit at a time. Checked before the trashed
+    // branch: a trashed folder is still a folder, and tombstoning one we
+    // never stored would write a row for something that was never there.
+    if (change.file.mimeType === FOLDER_MIME_TYPE) return null;
+
     if (change.file.trashed && !includeTrashed) {
       const trashedAt = change.time ? new Date(change.time) : new Date();
       return {
@@ -1126,6 +1180,11 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
         ...(searchIncomplete ? { search_incomplete: true } : {}),
       },
     };
+  }
+
+  /** Overridable so a test can drive the time budget without sleeping. */
+  protected now(): number {
+    return Date.now();
   }
 
   // Auth-aware client (Bearer + retry/backoff on transient 429/5xx). Built per

--- a/packages/connectors/src/google_drive.ts
+++ b/packages/connectors/src/google_drive.ts
@@ -1,0 +1,1137 @@
+/**
+ * Google Drive Connector (V1 runtime)
+ *
+ * Syncs Drive file metadata — and, for text-shaped files, the text itself —
+ * via the Drive API v3, and exposes a read action that returns one file's
+ * content on demand.
+ *
+ * Two Drive-specific facts shape this connector:
+ *
+ * 1. **Google-native files have no bytes.** A Doc/Sheet/Slide is not stored as
+ *    a file; `files.get?alt=media` fails on them with a 403. They must go
+ *    through `files.export` with a target MIME type, and Google caps an export
+ *    at 10 MB. Everything else (PDF, CSV, images, archives) downloads directly.
+ *    `EXPORT_MIME_TYPES` is the whole of that branch.
+ *
+ * 2. **`changes.list` is the incremental axis, and its page token is durable.**
+ *    Unlike Calendar's syncToken — handed back at the END of a traversal —
+ *    Drive mints the token UP FRONT via `changes.getStartPageToken`. So a full
+ *    sync must take the token BEFORE listing, or every file created during the
+ *    traversal is missed forever. See `syncFeed`.
+ */
+
+import {
+  type ActionContext,
+  type ActionResult,
+  ConnectorRuntime,
+  createHttpClient,
+  type EventEnvelope,
+  type HttpClient,
+  paginateByCursor,
+  type FeedReadContext,
+  type FeedReadResult,
+  type RuntimeConnectorDefinition,
+  type SyncContext,
+  type SyncResult,
+} from '@lobu/connector-sdk';
+
+// ---------------------------------------------------------------------------
+// Drive API types
+// ---------------------------------------------------------------------------
+
+interface DriveFile {
+  id: string;
+  name?: string;
+  mimeType?: string;
+  description?: string;
+  webViewLink?: string;
+  /** int64 as a decimal string — absent for Google-native files, which have no byte size. */
+  size?: string;
+  createdTime?: string;
+  modifiedTime?: string;
+  viewedByMeTime?: string;
+  trashed?: boolean;
+  owners?: Array<{ emailAddress?: string; displayName?: string }>;
+  lastModifyingUser?: { emailAddress?: string; displayName?: string };
+  parents?: string[];
+  fileExtension?: string;
+  md5Checksum?: string;
+}
+
+interface DriveFileListResponse {
+  files?: DriveFile[];
+  nextPageToken?: string;
+  incompleteSearch?: boolean;
+}
+
+interface DriveChange {
+  fileId?: string;
+  removed?: boolean;
+  time?: string;
+  file?: DriveFile;
+}
+
+interface DriveChangeListResponse {
+  changes?: DriveChange[];
+  nextPageToken?: string;
+  newStartPageToken?: string;
+}
+
+interface DriveStartPageTokenResponse {
+  startPageToken?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint + config
+// ---------------------------------------------------------------------------
+
+interface DriveCheckpoint {
+  /** `changes.list` page token. Its absence forces a full re-list. */
+  page_token?: string;
+  last_sync_at?: string;
+  /**
+   * Resumable-bootstrap state.
+   *
+   * A Drive larger than `max_results` cannot be listed in one run, and the
+   * change token must NOT take over until the listing has actually finished:
+   * `changes.list` only reports files that change, so anything never reached by
+   * the traversal would never arrive at all. So the token minted at the start of
+   * the bootstrap is parked in `pending_page_token` while `list_page_token`
+   * walks the remaining pages; only when the walk exhausts is the parked token
+   * promoted to `page_token` and the feed allowed to go incremental.
+   */
+  pending_page_token?: string;
+  /** `files.list` cursor for the next bootstrap slice. Absent once complete. */
+  list_page_token?: string;
+}
+
+interface DriveConfig extends Record<string, unknown> {
+  query?: string;
+  folder_id?: string;
+  include_trashed?: boolean;
+  include_content?: boolean;
+  max_results?: number;
+}
+
+/**
+ * Google-native MIME type -> the export format we ask for.
+ *
+ * Text targets on purpose: this connector's job is to make a file's CONTENT
+ * searchable and countable, not to reproduce its formatting. A Sheet exports
+ * to CSV because rows are the meaningful unit; a Doc to text/plain because
+ * paragraphs are.
+ *
+ * Types deliberately absent (folder, shortcut, form, map, site) have no
+ * useful text export — `exportMimeTypeFor` returns undefined and the sync
+ * records metadata only.
+ */
+const EXPORT_MIME_TYPES: Record<string, string> = {
+  'application/vnd.google-apps.document': 'text/plain',
+  'application/vnd.google-apps.spreadsheet': 'text/csv',
+  'application/vnd.google-apps.presentation': 'text/plain',
+  'application/vnd.google-apps.script': 'application/vnd.google-apps.script+json',
+};
+
+/** MIME types we will inline as `payload_text` when they are not Google-native. */
+const TEXTUAL_MIME_PREFIXES = ['text/'];
+const TEXTUAL_MIME_TYPES = new Set([
+  'application/json',
+  'application/xml',
+  'application/x-yaml',
+  'application/yaml',
+  'application/javascript',
+  'application/typescript',
+  'application/sql',
+  'application/x-sh',
+]);
+
+/**
+ * Cap on text inlined into `payload_text`.
+ *
+ * This is NOT the artifact limit — it is an embedding-cost limit. Every event's
+ * payload is chunked and embedded, so a 10 MB CSV inlined here would produce
+ * hundreds of vectors of almost no retrieval value. Files above the cap sync as
+ * metadata and their content is fetched on demand through `get_file_content`.
+ */
+const MAX_INLINE_TEXT_BYTES = 256 * 1024;
+
+/**
+ * Grace window subtracted from `last_sync_at` before deciding a file's content
+ * is unchanged.
+ *
+ * `modifiedTime` comes from Google's clock and `last_sync_at` from ours. Only a
+ * file modified strictly BEFORE the previous sync can be safely skipped, and a
+ * few minutes of skew in the wrong direction would otherwise make a genuinely
+ * edited file look old and get skipped. Erring by this much only costs a
+ * redundant fetch; erring the other way loses an edit.
+ */
+const CONTENT_SKEW_GRACE_MS = 5 * 60 * 1000;
+
+/** Google's own hard cap on `files.export`. Requesting more returns a 403. */
+const MAX_EXPORT_BYTES = 10 * 1024 * 1024;
+
+/** Field mask for files.list / changes.list. Drive v3 returns almost nothing without it. */
+const FILE_FIELDS =
+  'id,name,mimeType,description,webViewLink,size,createdTime,modifiedTime,viewedByMeTime,trashed,owners(emailAddress,displayName),lastModifyingUser(emailAddress,displayName),parents,fileExtension,md5Checksum';
+
+const DRIVE_FILE_COLUMNS = [
+  { name: 'id', type: 'text' },
+  { name: 'name', type: 'text' },
+  { name: 'mime_type', type: 'text' },
+  { name: 'size_bytes', type: 'number' },
+  { name: 'owner', type: 'text' },
+  { name: 'last_modified_by', type: 'text' },
+  { name: 'created_at', type: 'text' },
+  { name: 'modified_at', type: 'text' },
+  { name: 'trashed', type: 'boolean' },
+  { name: 'url', type: 'text' },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Does this `changes.list` failure mean "the stored page token is unusable"
+ * rather than "your credentials are wrong"?
+ *
+ * Drive answers a dead token with 404 NOT FOUND (Calendar uses 410 for the
+ * same condition — see `google_calendar.ts`). 410 is accepted here too because
+ * Drive documents it for a token that has aged out of the change log, and the
+ * recovery is identical either way: drop the token and re-list once.
+ *
+ * Deliberately NOT matched: 401/403. Those are credential or scope problems,
+ * and treating them as a stale token would turn a missing-scope install into an
+ * unbounded full-resync loop.
+ */
+function isPageTokenRejection(status: number): boolean {
+  return status === 404 || status === 410;
+}
+
+/**
+ * Truncate encoded UTF-8 to at most `maxBytes` WITHOUT splitting a character.
+ *
+ * A plain `slice(0, maxBytes)` can cut mid-sequence, and the decoder turns the
+ * orphaned bytes into U+FFFD — a garbage character that then gets stored and
+ * embedded. Back off up to three bytes (the longest UTF-8 tail) until the slice
+ * decodes cleanly, so a legitimate U+FFFD already in the source is preserved
+ * while a manufactured one is impossible.
+ */
+function decodeTruncated(encoded: Uint8Array, maxBytes: number): string {
+  const strict = new TextDecoder('utf-8', { fatal: true });
+  for (let end = maxBytes; end > maxBytes - 4 && end >= 0; end--) {
+    try {
+      return strict.decode(encoded.slice(0, end));
+    } catch {
+      // Slice ended mid-sequence — drop a byte and retry.
+    }
+  }
+  return new TextDecoder().decode(encoded.slice(0, Math.max(0, maxBytes - 3)));
+}
+
+function exportMimeTypeFor(mimeType: string | undefined): string | undefined {
+  if (!mimeType) return undefined;
+  return EXPORT_MIME_TYPES[mimeType];
+}
+
+function isGoogleNative(mimeType: string | undefined): boolean {
+  return Boolean(mimeType?.startsWith('application/vnd.google-apps.'));
+}
+
+function isTextualMimeType(mimeType: string | undefined): boolean {
+  if (!mimeType) return false;
+  const base = mimeType.split(';')[0]!.trim().toLowerCase();
+  if (TEXTUAL_MIME_TYPES.has(base)) return true;
+  return TEXTUAL_MIME_PREFIXES.some((prefix) => base.startsWith(prefix));
+}
+
+/** Drive reports size as a decimal string, and omits it entirely for native files. */
+function parseSize(size: string | undefined): number | undefined {
+  if (typeof size !== 'string' || size.length === 0) return undefined;
+  const parsed = Number.parseInt(size, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function personLabel(
+  person: { emailAddress?: string; displayName?: string } | undefined
+): string | undefined {
+  return person?.displayName || person?.emailAddress || undefined;
+}
+
+/**
+ * Build the `q` for files.list.
+ *
+ * `trashed = false` is applied unless the feed opts in, because a trashed file
+ * is still returned by an unqualified query and would otherwise resurface on
+ * every full sync as if it were live.
+ */
+function buildListQuery(config: DriveConfig): string | undefined {
+  const clauses: string[] = [];
+  if (!config.include_trashed) clauses.push('trashed = false');
+  if (typeof config.folder_id === 'string' && config.folder_id.trim()) {
+    clauses.push(`'${config.folder_id.trim().replace(/'/g, "\\'")}' in parents`);
+  }
+  const raw = typeof config.query === 'string' ? config.query.trim() : '';
+  if (raw) clauses.push(`(${raw})`);
+  return clauses.length > 0 ? clauses.join(' and ') : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Connector
+// ---------------------------------------------------------------------------
+
+export default class GoogleDriveConnector extends ConnectorRuntime<
+  Record<string, unknown>,
+  DriveConfig
+> {
+  private readonly BASE_URL = 'https://www.googleapis.com/drive/v3';
+
+  readonly definition: RuntimeConnectorDefinition<Record<string, unknown>, DriveConfig> = {
+    key: 'google.drive',
+    name: 'Google Drive',
+    description:
+      'Syncs Google Drive file metadata and text content, and reads a file on demand.',
+    version: '1.0.0',
+    faviconDomain: 'drive.google.com',
+    authSchema: {
+      methods: [
+        {
+          type: 'oauth',
+          provider: 'google',
+          requiredScopes: ['https://www.googleapis.com/auth/drive.readonly'],
+          loginScopes: ['openid', 'email', 'profile'],
+          clientIdKey: 'GOOGLE_CLIENT_ID',
+          clientSecretKey: 'GOOGLE_CLIENT_SECRET',
+          tokenUrl: 'https://oauth2.googleapis.com/token',
+          tokenEndpointAuthMethod: 'client_secret_post',
+          loginProvisioning: {
+            autoCreateConnection: true,
+          },
+        },
+      ],
+    },
+    feeds: {
+      files: {
+        key: 'files',
+        name: 'Files',
+        requiredScopes: ['https://www.googleapis.com/auth/drive.readonly'],
+        description:
+          'Google Drive files can sync into memory and be read directly from Drive.',
+        sync: (ctx) => this.syncFeed(ctx),
+        read: (ctx) => this.readFeed(ctx),
+        configSchema: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description:
+                'Optional Drive query in Google\'s `q` syntax, e.g. "mimeType = \'application/pdf\'". Combined with the feed\'s own filters using AND.',
+            },
+            folder_id: {
+              type: 'string',
+              description: 'Restrict to files whose parent is this folder ID.',
+            },
+            include_trashed: {
+              type: 'boolean',
+              default: false,
+              description: 'Include files in the trash.',
+            },
+            include_content: {
+              type: 'boolean',
+              default: true,
+              description:
+                'Fetch text content for text files and exportable Google Docs/Sheets/Slides. Disable for a metadata-only feed.',
+            },
+            max_results: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 2000,
+              default: 500,
+              description:
+                'Files collected per run. Initial collection resumes across runs until the whole Drive is walked, so this bounds one run rather than the total.',
+            },
+          },
+        },
+        eventKinds: {
+          drive_file: {
+            description: 'A Google Drive file',
+            metadataSchema: {
+              type: 'object',
+              properties: {
+                mime_type: { type: 'string' },
+                size_bytes: { type: 'number' },
+                owner: { type: 'string' },
+                last_modified_by: { type: 'string' },
+                created_at: { type: 'string' },
+                modified_at: { type: 'string' },
+                trashed: { type: 'boolean' },
+                content_included: { type: 'boolean' },
+                content_truncated: { type: 'boolean' },
+                change_type: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    },
+    actions: {
+      get_file_content: {
+        key: 'get_file_content',
+        kind: 'read',
+        requiresApproval: false,
+        name: 'Get File Content',
+        description:
+          'Read one Drive file as text. Google Docs/Sheets/Slides are exported (text/plain, CSV); other files are downloaded as-is. Binary files are rejected rather than returned as mojibake.',
+        requiredScopes: ['https://www.googleapis.com/auth/drive.readonly'],
+        inputSchema: {
+          type: 'object',
+          required: ['file_id'],
+          properties: {
+            file_id: { type: 'string', description: 'Drive file ID to read.' },
+            max_bytes: {
+              type: 'integer',
+              minimum: 1,
+              maximum: MAX_EXPORT_BYTES,
+              description:
+                'Truncate the returned text to this many bytes (default 1048576).',
+            },
+          },
+        },
+      },
+      get_file: {
+        key: 'get_file',
+        kind: 'read',
+        requiresApproval: false,
+        name: 'Get File Metadata',
+        description: 'Get one Drive file\'s metadata without fetching its content.',
+        requiredScopes: ['https://www.googleapis.com/auth/drive.readonly'],
+        inputSchema: {
+          type: 'object',
+          required: ['file_id'],
+          properties: {
+            file_id: { type: 'string', description: 'Drive file ID.' },
+          },
+        },
+      },
+    },
+  };
+
+  // -------------------------------------------------------------------------
+  // read (live, non-persisting)
+  // -------------------------------------------------------------------------
+
+  private async readFeed(ctx: FeedReadContext<DriveConfig>): Promise<FeedReadResult> {
+    const token = ctx.credentials?.accessToken;
+    if (!token) {
+      throw new Error('Google Drive requires Google OAuth credentials.');
+    }
+
+    const http = this.client(token);
+    const config = (ctx.config ?? {}) as DriveConfig;
+    const limit = Math.min((config.max_results as number) ?? 100, 1000);
+
+    const params = new URLSearchParams({
+      pageSize: String(Math.max(1, Math.min(1000, limit))),
+      fields: `files(${FILE_FIELDS}),nextPageToken,incompleteSearch`,
+      orderBy: 'modifiedTime desc',
+      supportsAllDrives: 'true',
+      includeItemsFromAllDrives: 'true',
+    });
+    const q = buildListQuery(config);
+    if (q) params.set('q', q);
+    if (ctx.cursor) params.set('pageToken', ctx.cursor);
+
+    const response = await http.raw(`${this.BASE_URL}/files?${params.toString()}`);
+    if (!response.ok) {
+      throw new Error(
+        `Drive files.list error (${response.status}): ${await response.text()}`
+      );
+    }
+
+    const data = (await response.json()) as DriveFileListResponse;
+    const rows = (data.files ?? []).map((file) => this.driveFileToRow(file));
+
+    return {
+      rows,
+      columns: [...DRIVE_FILE_COLUMNS],
+      nextCursor: data.nextPageToken,
+      hasMore: Boolean(data.nextPageToken),
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // sync
+  // -------------------------------------------------------------------------
+
+  private async syncFeed(ctx: SyncContext): Promise<SyncResult> {
+    const token = ctx.credentials?.accessToken;
+    if (!token) {
+      throw new Error('Google Drive requires Google OAuth credentials.');
+    }
+
+    const http = this.client(token);
+    const config = (ctx.config ?? {}) as DriveConfig;
+    const checkpoint = (ctx.checkpoint ?? {}) as DriveCheckpoint;
+
+    // An unfinished bootstrap outranks everything: going incremental with pages
+    // still unread would strand every file the traversal never reached.
+    if (checkpoint.list_page_token && checkpoint.pending_page_token) {
+      return this.fullSync(http, config, {
+        startToken: checkpoint.pending_page_token,
+        listPageToken: checkpoint.list_page_token,
+        startedAt: checkpoint.last_sync_at,
+      });
+    }
+
+    if (checkpoint.page_token) {
+      const result = await this.syncWithPageToken(
+        http,
+        checkpoint.page_token,
+        config,
+        checkpoint.last_sync_at
+      );
+      if (result) {
+        // A partial run must NOT advance `last_sync_at`. The view-churn guard
+        // skips content for files modified before that stamp, so stamping now
+        // would make the next run treat the unread backlog as already-stored
+        // and drop its content on the floor.
+        return this.buildResult(
+          result.events,
+          result.nextPageToken,
+          result.partial ? checkpoint.last_sync_at : undefined
+        );
+      }
+      // Token rejected (see isPageTokenRejection). Fall through to ONE full
+      // re-list, exactly as the Calendar connector does — never a retry loop.
+    }
+
+    return this.fullSync(http, config);
+  }
+
+  /**
+   * Full re-list.
+   *
+   * The start page token is taken BEFORE listing, not after. Drive's change log
+   * is a moving cursor: a token minted after the traversal would silently skip
+   * every file created or edited while the traversal ran. Taking it first can
+   * only cause the next incremental run to re-report a file we already have,
+   * and a re-report supersedes on `origin_id` rather than duplicating.
+   */
+  private async fullSync(
+    http: HttpClient,
+    config: DriveConfig,
+    resume?: { startToken: string; listPageToken: string; startedAt?: string }
+  ): Promise<SyncResult> {
+    // A resumed bootstrap keeps the token minted when the traversal STARTED —
+    // re-minting here would open a gap covering everything changed since.
+    const startToken = resume?.startToken ?? (await this.fetchStartPageToken(http));
+
+    // The whole bootstrap reflects Drive as of the moment it BEGAN, so every
+    // slice carries that one timestamp. Stamping each slice with its own finish
+    // time would push `last_sync_at` past edits made while the bootstrap ran,
+    // and the view-churn guard would then skip re-fetching their content — the
+    // edit would land as metadata with stale text behind it.
+    const bootstrapStartedAt = resume?.startedAt ?? new Date().toISOString();
+
+    const maxResults = Math.min((config.max_results as number) ?? 500, 2000);
+    const includeContent = config.include_content !== false;
+    const q = buildListQuery(config);
+    const events: EventEnvelope[] = [];
+
+    // 1000 is Drive's max pageSize, so 200 pages is 200k files — far past any
+    // configurable max_results. Defensive bound against a self-referential
+    // page token, matching the Calendar connector's MAX_PAGES.
+    const MAX_PAGES = 200;
+
+    // Where the traversal stopped, so the next run can pick it up. `undefined`
+    // once the listing is exhausted — that is what completes the bootstrap.
+    let nextListPageToken: string | undefined;
+    let seededCursor: string | undefined = resume?.listPageToken;
+    let searchIncomplete = false;
+
+    const pages = paginateByCursor<DriveFile, string>(
+      async (pageToken) => {
+        const cursor = pageToken ?? seededCursor;
+        seededCursor = undefined;
+        const params = new URLSearchParams({
+          // Sized to the cap so the two coincide. Drive's list cursor
+          // addresses PAGES, not offsets: stopping mid-page and resuming at
+          // the next cursor drops the rest of that page permanently, because
+          // the change feed only ever replays what changes after the
+          // bootstrap. Above 1000 the cap becomes a soft floor instead —
+          // overshooting by part of a page is safe, skipping one is not.
+          pageSize: String(Math.min(1000, Math.max(1, maxResults))),
+          fields: `files(${FILE_FIELDS}),nextPageToken,incompleteSearch`,
+          orderBy: 'modifiedTime desc',
+          supportsAllDrives: 'true',
+          includeItemsFromAllDrives: 'true',
+        });
+        if (q) params.set('q', q);
+        if (cursor) params.set('pageToken', cursor);
+
+        const response = await http.raw(`${this.BASE_URL}/files?${params.toString()}`);
+        if (!response.ok) {
+          throw new Error(
+            `Drive files.list error (${response.status}): ${await response.text()}`
+          );
+        }
+        const data = (await response.json()) as DriveFileListResponse;
+        nextListPageToken = data.nextPageToken;
+        // Google sets this when an `allDrives` search could not reach every
+        // corpus — the listing is then NOT authoritative, and files missing
+        // from it are indistinguishable from files that do not exist. We list
+        // across all drives, so this is reachable; record it rather than let a
+        // partial traversal look like a complete one.
+        if (data.incompleteSearch) searchIncomplete = true;
+        return { items: data.files ?? [], nextCursor: data.nextPageToken };
+      },
+      { maxPages: MAX_PAGES }
+    );
+
+    let capped = false;
+    for await (const items of pages) {
+      for (const file of items) {
+        events.push(await this.driveFileToEnvelope(http, file, includeContent, 'upserted'));
+      }
+      // Tested only BETWEEN pages: a page is consumed whole or not at all, so
+      // `nextListPageToken` always addresses the first file we have not read.
+      if (events.length >= maxResults) {
+        capped = true;
+        break;
+      }
+    }
+
+    // Stopping on the cap with pages still unread means the bootstrap is
+    // unfinished: park the change token and resume the listing next run.
+    // Without a start token there is nothing to park — fall through, which
+    // leaves `page_token` unset and re-lists next run rather than going
+    // incremental over a traversal that never finished.
+    if (capped && nextListPageToken && startToken) {
+      return this.buildBootstrapResult(
+        events,
+        startToken,
+        nextListPageToken,
+        bootstrapStartedAt,
+        searchIncomplete
+      );
+    }
+
+    return this.buildResult(
+      events,
+      startToken,
+      bootstrapStartedAt,
+      searchIncomplete
+    );
+  }
+
+  /**
+   * Incremental pass over `changes.list`.
+   *
+   * Returns null when the stored token was rejected, so the caller can fall
+   * through to one full re-list.
+   */
+  private async syncWithPageToken(
+    http: HttpClient,
+    pageToken: string,
+    config: DriveConfig,
+    lastSyncAt?: string
+  ): Promise<{
+    events: EventEnvelope[];
+    nextPageToken?: string;
+    partial: boolean;
+  } | null> {
+    const includeContent = config.include_content !== false;
+    const includeTrashed = Boolean(config.include_trashed);
+    const maxResults = Math.min((config.max_results as number) ?? 500, 2000);
+    const events: EventEnvelope[] = [];
+    let nextPageToken: string | undefined;
+    // The cursor for the page AFTER the one just consumed. A run that stops
+    // early persists this instead of dropping back to a full re-list — a
+    // `changes.list` page token is a resumable position in the change stream,
+    // so the next run continues from exactly where this one stopped.
+    let resumeCursor: string | undefined;
+    let rejected = false;
+
+    const MAX_PAGES = 200;
+
+    const pages = paginateByCursor<DriveChange, string>(
+      async (cursor) => {
+        const params = new URLSearchParams({
+          pageToken: cursor ?? pageToken,
+          // Aligned to the cap so a bounded run does not overshoot by most of
+          // a 1000-change page; floored so a tiny cap cannot thrash the API.
+          pageSize: String(Math.min(1000, Math.max(100, maxResults))),
+          fields: `changes(fileId,removed,time,file(${FILE_FIELDS})),nextPageToken,newStartPageToken`,
+          supportsAllDrives: 'true',
+          includeItemsFromAllDrives: 'true',
+        });
+
+        const response = await http.raw(`${this.BASE_URL}/changes?${params.toString()}`);
+        if (!response.ok) {
+          if (isPageTokenRejection(response.status)) {
+            rejected = true;
+            return { items: [], nextCursor: undefined };
+          }
+          throw new Error(
+            `Drive changes.list error (${response.status}): ${await response.text()}`
+          );
+        }
+
+        const data = (await response.json()) as DriveChangeListResponse;
+        // Drive returns newStartPageToken only on the final page. Capture it
+        // whenever present so the trailing value is the one we persist.
+        if (data.newStartPageToken) nextPageToken = data.newStartPageToken;
+        resumeCursor = data.nextPageToken;
+        return { items: data.changes ?? [], nextCursor: data.nextPageToken };
+      },
+      { maxPages: MAX_PAGES }
+    );
+
+    // Bounded at PAGE boundaries, never mid-page: `resumeCursor` addresses the
+    // start of the next page, so stopping part-way through one would skip the
+    // changes still in it.
+    let stoppedEarly = false;
+    for await (const items of pages) {
+      for (const change of items) {
+        if (rejected) break;
+        const envelope = await this.changeToEnvelope(
+          http,
+          change,
+          includeContent,
+          includeTrashed,
+          lastSyncAt
+        );
+        if (envelope) events.push(envelope);
+      }
+      if (rejected) break;
+      if (events.length >= maxResults && resumeCursor) {
+        stoppedEarly = true;
+        break;
+      }
+    }
+
+    if (rejected) return null;
+
+    // Either we stopped on the cap, or the paginator ran out of pages with the
+    // stream still open (MAX_PAGES). Both leave changes unread, and both must
+    // hand back the cursor: discarding it would silently demote the next run to
+    // a full re-list and restart the whole bootstrap.
+    const unread = stoppedEarly || (!nextPageToken && Boolean(resumeCursor));
+    if (unread && resumeCursor) {
+      return { events, nextPageToken: resumeCursor, partial: true };
+    }
+
+    return { events, nextPageToken, partial: false };
+  }
+
+  private async fetchStartPageToken(http: HttpClient): Promise<string | undefined> {
+    const params = new URLSearchParams({ supportsAllDrives: 'true' });
+    const response = await http.raw(
+      `${this.BASE_URL}/changes/startPageToken?${params.toString()}`
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Drive changes.getStartPageToken error (${response.status}): ${await response.text()}`
+      );
+    }
+    const data = (await response.json()) as DriveStartPageTokenResponse;
+    return data.startPageToken;
+  }
+
+  // -------------------------------------------------------------------------
+  // execute
+  // -------------------------------------------------------------------------
+
+  async execute(ctx: ActionContext): Promise<ActionResult> {
+    try {
+      const token = ctx.credentials?.accessToken;
+      if (!token) {
+        return {
+          success: false,
+          error: 'Google Drive actions require Google OAuth credentials.',
+        };
+      }
+
+      const http = this.client(token);
+
+      switch (ctx.actionKey) {
+        case 'get_file_content':
+          return await this.getFileContent(http, ctx.input);
+        case 'get_file':
+          return await this.getFile(http, ctx.input);
+        default:
+          return { success: false, error: `Unknown action: ${ctx.actionKey}` };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private async getFile(
+    http: HttpClient,
+    input: Record<string, unknown>
+  ): Promise<ActionResult> {
+    const fileId = input.file_id as string;
+    if (!fileId) return { success: false, error: 'file_id is required.' };
+
+    const file = await this.fetchFileMetadata(http, fileId);
+    if (!file) {
+      return { success: false, error: `Drive file not found: ${fileId}` };
+    }
+    return { success: true, output: this.driveFileToRow(file) };
+  }
+
+  private async getFileContent(
+    http: HttpClient,
+    input: Record<string, unknown>
+  ): Promise<ActionResult> {
+    const fileId = input.file_id as string;
+    if (!fileId) return { success: false, error: 'file_id is required.' };
+
+    const maxBytes = Math.min(
+      (input.max_bytes as number) ?? 1024 * 1024,
+      MAX_EXPORT_BYTES
+    );
+
+    const file = await this.fetchFileMetadata(http, fileId);
+    if (!file) {
+      return { success: false, error: `Drive file not found: ${fileId}` };
+    }
+
+    const fetched = await this.fetchTextContent(http, file, maxBytes);
+    if (!fetched.ok) {
+      return { success: false, error: fetched.error };
+    }
+
+    return {
+      success: true,
+      output: {
+        file_id: file.id,
+        name: file.name ?? '',
+        mime_type: file.mimeType ?? '',
+        exported_as: fetched.exportedAs,
+        truncated: fetched.truncated,
+        byte_count: fetched.byteCount,
+        line_count: fetched.text.length === 0 ? 0 : fetched.text.split('\n').length,
+        content: fetched.text,
+      },
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Content fetching
+  // -------------------------------------------------------------------------
+
+  /**
+   * Fetch a file's text, choosing export vs. direct download by MIME type.
+   *
+   * Binary files are refused rather than decoded: running a PDF through
+   * `response.text()` yields replacement characters that look like content to
+   * a model and would be indistinguishable from a genuinely empty file.
+   */
+  private async fetchTextContent(
+    http: HttpClient,
+    file: DriveFile,
+    maxBytes: number
+  ): Promise<
+    | {
+        ok: true;
+        text: string;
+        truncated: boolean;
+        byteCount: number;
+        exportedAs?: string;
+      }
+    | { ok: false; error: string }
+  > {
+    const exportMime = exportMimeTypeFor(file.mimeType);
+
+    if (isGoogleNative(file.mimeType) && !exportMime) {
+      return {
+        ok: false,
+        error: `Google Drive item of type ${file.mimeType} has no text export (folders, shortcuts and forms carry no content).`,
+      };
+    }
+
+    if (!exportMime && !isTextualMimeType(file.mimeType)) {
+      return {
+        ok: false,
+        error: `File ${file.name ?? file.id} is binary (${file.mimeType ?? 'unknown type'}); its bytes are not text and were not decoded.`,
+      };
+    }
+
+    const url = exportMime
+      ? `${this.BASE_URL}/files/${encodeURIComponent(file.id)}/export?mimeType=${encodeURIComponent(exportMime)}`
+      : `${this.BASE_URL}/files/${encodeURIComponent(file.id)}?alt=media&supportsAllDrives=true`;
+
+    const response = await http.raw(url);
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: `Drive ${exportMime ? 'files.export' : 'files.get'} error (${response.status}): ${await response.text()}`,
+      };
+    }
+
+    const raw = await response.text();
+    const encoded = new TextEncoder().encode(raw);
+    const truncated = encoded.byteLength > maxBytes;
+    const text = truncated ? decodeTruncated(encoded, maxBytes) : raw;
+
+    return {
+      ok: true,
+      text,
+      truncated,
+      byteCount: encoded.byteLength,
+      ...(exportMime ? { exportedAs: exportMime } : {}),
+    };
+  }
+
+  private async fetchFileMetadata(
+    http: HttpClient,
+    fileId: string
+  ): Promise<DriveFile | null> {
+    const params = new URLSearchParams({
+      fields: FILE_FIELDS,
+      supportsAllDrives: 'true',
+    });
+    const response = await http.raw(
+      `${this.BASE_URL}/files/${encodeURIComponent(fileId)}?${params.toString()}`
+    );
+    if (response.status === 404) return null;
+    if (!response.ok) {
+      throw new Error(
+        `Drive files.get error (${response.status}): ${await response.text()}`
+      );
+    }
+    return (await response.json()) as DriveFile;
+  }
+
+  // -------------------------------------------------------------------------
+  // Envelope construction
+  // -------------------------------------------------------------------------
+
+  private async changeToEnvelope(
+    http: HttpClient,
+    change: DriveChange,
+    includeContent: boolean,
+    includeTrashed: boolean,
+    lastSyncAt?: string
+  ): Promise<EventEnvelope | null> {
+    const fileId = change.fileId ?? change.file?.id;
+    if (!fileId) return null;
+
+    // A removed file (deleted outright, or moved out of scope) has no metadata
+    // in the change record. Emit a tombstone that supersedes the prior version
+    // on origin_id rather than dropping it, so a deleted file stops looking
+    // live in memory.
+    if (change.removed || !change.file) {
+      const removedAt = change.time ? new Date(change.time) : new Date();
+      return {
+        origin_id: fileId,
+        origin_type: 'drive_file',
+        title: '(removed Drive file)',
+        payload_text: '',
+        occurred_at: Number.isNaN(removedAt.getTime()) ? new Date() : removedAt,
+        metadata: { change_type: 'removed' },
+      };
+    }
+
+    if (change.file.trashed && !includeTrashed) {
+      const trashedAt = change.time ? new Date(change.time) : new Date();
+      return {
+        origin_id: fileId,
+        origin_type: 'drive_file',
+        title: change.file.name ?? '(trashed Drive file)',
+        payload_text: '',
+        occurred_at: Number.isNaN(trashedAt.getTime()) ? new Date() : trashedAt,
+        metadata: { change_type: 'trashed', trashed: true },
+      };
+    }
+
+    return this.driveFileToEnvelope(http, change.file, includeContent, 'upserted', lastSyncAt);
+  }
+
+  private async driveFileToEnvelope(
+    http: HttpClient,
+    file: DriveFile,
+    includeContent: boolean,
+    changeType: string,
+    lastSyncAt?: string
+  ): Promise<EventEnvelope> {
+    const modified = file.modifiedTime || file.createdTime;
+    const occurredAt = modified ? new Date(modified) : new Date();
+
+    let payloadText = file.description ?? '';
+    let contentIncluded = false;
+    let contentTruncated = false;
+    let contentError: string | undefined;
+
+    // Content is best-effort: one unreadable file must not fail the whole sync,
+    // so a failed fetch degrades to metadata-only rather than throwing.
+    //
+    // The failure is RECORDED rather than retried. A file that syncs once and
+    // never changes again is never revisited, so a silent miss would be
+    // permanent and indistinguishable from "this file has no text by design".
+    // `content_error` makes the two tellable apart, and the `get_file_content`
+    // action can still fetch on demand — which is the recovery path, not a
+    // retry queue whose state would grow without bound.
+    if (includeContent && this.shouldInlineContent(file, lastSyncAt)) {
+      const fetched = await this.fetchTextContent(http, file, MAX_INLINE_TEXT_BYTES);
+      if (fetched.ok) {
+        payloadText = fetched.text;
+        contentIncluded = true;
+        contentTruncated = fetched.truncated;
+      } else {
+        contentError = fetched.error;
+      }
+    }
+
+    const sizeBytes = parseSize(file.size);
+
+    return {
+      origin_id: file.id,
+      origin_type: 'drive_file',
+      title: file.name ?? '(untitled)',
+      payload_text: payloadText,
+      author_name: personLabel(file.owners?.[0]),
+      source_url: file.webViewLink,
+      occurred_at: Number.isNaN(occurredAt.getTime()) ? new Date() : occurredAt,
+      metadata: {
+        change_type: changeType,
+        ...(file.mimeType ? { mime_type: file.mimeType } : {}),
+        ...(sizeBytes !== undefined ? { size_bytes: sizeBytes } : {}),
+        ...(personLabel(file.owners?.[0])
+          ? { owner: personLabel(file.owners?.[0]) }
+          : {}),
+        ...(personLabel(file.lastModifyingUser)
+          ? { last_modified_by: personLabel(file.lastModifyingUser) }
+          : {}),
+        ...(file.createdTime ? { created_at: file.createdTime } : {}),
+        ...(file.modifiedTime ? { modified_at: file.modifiedTime } : {}),
+        trashed: Boolean(file.trashed),
+        content_included: contentIncluded,
+        content_truncated: contentTruncated,
+        ...(contentError ? { content_error: contentError } : {}),
+      },
+    };
+  }
+
+  /**
+   * Worth spending an HTTP round trip on this file's content?
+   *
+   * Size is checked against the byte cap for real files only — Google-native
+   * files report no size at all, so an exportable Doc always qualifies and its
+   * export is bounded by `fetchTextContent`'s own cap instead.
+   */
+  private shouldInlineContent(file: DriveFile, lastSyncAt?: string): boolean {
+    // A file can appear in `changes.list` because somebody merely OPENED it —
+    // that bumps `viewedByMeTime` and `version` while leaving `modifiedTime`
+    // untouched (verified against the live API). Re-exporting a document on
+    // every human view is pure waste, so when the file was last modified before
+    // our previous sync, its content is already what we stored.
+    if (lastSyncAt && file.modifiedTime) {
+      const modified = Date.parse(file.modifiedTime);
+      const since = Date.parse(lastSyncAt);
+      if (
+        Number.isFinite(modified) &&
+        Number.isFinite(since) &&
+        modified < since - CONTENT_SKEW_GRACE_MS
+      ) {
+        return false;
+      }
+    }
+    if (exportMimeTypeFor(file.mimeType)) return true;
+    if (isGoogleNative(file.mimeType)) return false;
+    if (!isTextualMimeType(file.mimeType)) return false;
+    const size = parseSize(file.size);
+    return size === undefined || size <= MAX_INLINE_TEXT_BYTES;
+  }
+
+  private driveFileToRow(file: DriveFile): Record<string, unknown> {
+    return {
+      id: file.id,
+      name: file.name ?? '',
+      mime_type: file.mimeType ?? '',
+      size_bytes: parseSize(file.size) ?? 0,
+      owner: personLabel(file.owners?.[0]) ?? '',
+      last_modified_by: personLabel(file.lastModifyingUser) ?? '',
+      created_at: file.createdTime ?? '',
+      modified_at: file.modifiedTime ?? '',
+      trashed: Boolean(file.trashed),
+      url: file.webViewLink ?? '',
+    };
+  }
+
+  /**
+   * Checkpoint for a bootstrap that stopped on `max_results` with pages left.
+   *
+   * `page_token` is deliberately absent: while it is missing the feed cannot go
+   * incremental, which is exactly the property that keeps the unread files
+   * reachable. `bootstrap_complete: false` is surfaced in metadata so an
+   * operator can see the traversal is still catching up rather than guessing
+   * from a suspiciously round item count.
+   */
+  private buildBootstrapResult(
+    events: EventEnvelope[],
+    pendingPageToken: string,
+    listPageToken: string,
+    startedAt: string,
+    searchIncomplete = false
+  ): SyncResult {
+    events.sort((a, b) => b.occurred_at.getTime() - a.occurred_at.getTime());
+
+    const checkpoint: DriveCheckpoint = {
+      pending_page_token: pendingPageToken,
+      list_page_token: listPageToken,
+      last_sync_at: startedAt,
+    };
+
+    return {
+      events,
+      checkpoint: checkpoint as Record<string, unknown>,
+      metadata: {
+        items_found: events.length,
+        bootstrap_complete: false,
+        ...(searchIncomplete ? { search_incomplete: true } : {}),
+      },
+    };
+  }
+
+  private buildResult(
+    events: EventEnvelope[],
+    pageToken: string | undefined,
+    /** Preserved stamp for a partial run; omit to advance to now. */
+    keepLastSyncAt?: string,
+    searchIncomplete = false
+  ): SyncResult {
+    events.sort((a, b) => b.occurred_at.getTime() - a.occurred_at.getTime());
+
+    // Rebuilt rather than spread over the previous checkpoint so a run that
+    // recovered from a rejected token cannot leave that token behind. Without a
+    // new token the key is absent and the next run correctly re-lists.
+    const newCheckpoint: DriveCheckpoint = {
+      ...(pageToken ? { page_token: pageToken } : {}),
+      last_sync_at: keepLastSyncAt ?? new Date().toISOString(),
+    };
+
+    return {
+      events,
+      checkpoint: newCheckpoint as Record<string, unknown>,
+      metadata: {
+        items_found: events.length,
+        bootstrap_complete: true,
+        ...(keepLastSyncAt ? { changes_pending: true } : {}),
+        ...(searchIncomplete ? { search_incomplete: true } : {}),
+      },
+    };
+  }
+
+  // Auth-aware client (Bearer + retry/backoff on transient 429/5xx). Built per
+  // token so each sync/action uses its own credentials. `.raw()` preserves the
+  // status-code branching the page-token and export paths depend on.
+  private client(token: string): HttpClient {
+    return createHttpClient({ token, errorPrefix: 'Drive API' });
+  }
+}

--- a/packages/connectors/src/google_drive.ts
+++ b/packages/connectors/src/google_drive.ts
@@ -133,7 +133,6 @@ const EXPORT_MIME_TYPES: Record<string, string> = {
 };
 
 /** MIME types we will inline as `payload_text` when they are not Google-native. */
-const TEXTUAL_MIME_PREFIXES = ['text/'];
 const TEXTUAL_MIME_TYPES = new Set([
   'application/json',
   'application/xml',
@@ -226,7 +225,10 @@ function decodeTruncated(encoded: Uint8Array, maxBytes: number): string {
       // Slice ended mid-sequence — drop a byte and retry.
     }
   }
-  return new TextDecoder().decode(encoded.slice(0, Math.max(0, maxBytes - 3)));
+  // Unreachable: `encoded` always comes from TextEncoder, so one of the four
+  // slices above lands on a character boundary. Returning lossily here would
+  // manufacture the very U+FFFD this function exists to prevent.
+  return '';
 }
 
 function exportMimeTypeFor(mimeType: string | undefined): string | undefined {
@@ -241,8 +243,7 @@ function isGoogleNative(mimeType: string | undefined): boolean {
 function isTextualMimeType(mimeType: string | undefined): boolean {
   if (!mimeType) return false;
   const base = mimeType.split(';')[0]!.trim().toLowerCase();
-  if (TEXTUAL_MIME_TYPES.has(base)) return true;
-  return TEXTUAL_MIME_PREFIXES.some((prefix) => base.startsWith(prefix));
+  return TEXTUAL_MIME_TYPES.has(base) || base.startsWith('text/');
 }
 
 /** Drive reports size as a decimal string, and omits it entirely for native files. */
@@ -258,13 +259,6 @@ function personLabel(
   return person?.displayName || person?.emailAddress || undefined;
 }
 
-/**
- * Build the `q` for files.list.
- *
- * `trashed = false` is applied unless the feed opts in, because a trashed file
- * is still returned by an unqualified query and would otherwise resurface on
- * every full sync as if it were live.
- */
 /**
  * Drive models a folder as a file with a reserved MIME type, so an unfiltered
  * `files.list` returns the directory tree interleaved with the documents. A
@@ -303,15 +297,23 @@ const SYNC_TIME_BUDGET_MS = HOST_RUN_TIMEOUT_MS * 0.4;
  * Escapes a value for a single-quoted Drive query literal.
  *
  * Backslashes go FIRST: escaping quotes first would then double-escape the
- * backslashes it just introduced. Escaping only quotes — as this did — leaves
- * a value ending in a backslash able to escape its own closing quote and run
- * on into query syntax (`js/incomplete-sanitization`).
+ * backslashes it just introduced. Escaping quotes ALONE is not enough — a value
+ * ending in a backslash would escape its own closing quote and run on into
+ * query syntax (`js/incomplete-sanitization`).
  */
 function escapeQueryLiteral(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 
-function buildListQuery(config: DriveConfig): string | undefined {
+/**
+ * Build the `q` for files.list.
+ *
+ * Always non-empty: the folder exclusion is unconditional. `trashed = false` is
+ * applied on top unless the feed opts in, because a trashed file is still
+ * returned by an unqualified query and would otherwise resurface on every full
+ * sync as if it were live.
+ */
+function buildListQuery(config: DriveConfig): string {
   const clauses: string[] = [`mimeType != '${FOLDER_MIME_TYPE}'`];
   if (!config.include_trashed) clauses.push('trashed = false');
   if (typeof config.folder_id === 'string' && config.folder_id.trim()) {
@@ -319,7 +321,7 @@ function buildListQuery(config: DriveConfig): string | undefined {
   }
   const raw = typeof config.query === 'string' ? config.query.trim() : '';
   if (raw) clauses.push(`(${raw})`);
-  return clauses.length > 0 ? clauses.join(' and ') : undefined;
+  return clauses.join(' and ');
 }
 
 // ---------------------------------------------------------------------------
@@ -413,6 +415,7 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
                 trashed: { type: 'boolean' },
                 content_included: { type: 'boolean' },
                 content_truncated: { type: 'boolean' },
+                content_error: { type: 'string' },
                 change_type: { type: 'string' },
               },
             },
@@ -474,17 +477,18 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
 
     const http = this.client(token);
     const config = (ctx.config ?? {}) as DriveConfig;
-    const limit = Math.min((config.max_results as number) ?? 100, 1000);
 
     const params = new URLSearchParams({
-      pageSize: String(Math.max(1, Math.min(1000, limit))),
+      // Nothing materialises configSchema defaults, so the fallback here is
+      // what `max_results` actually defaults to and must match what the schema
+      // advertises. 1000 is Drive's own pageSize ceiling.
+      pageSize: String(Math.max(1, Math.min(config.max_results ?? 500, 1000))),
       fields: `files(${FILE_FIELDS}),nextPageToken,incompleteSearch`,
       orderBy: 'modifiedTime desc',
       supportsAllDrives: 'true',
       includeItemsFromAllDrives: 'true',
+      q: buildListQuery(config),
     });
-    const q = buildListQuery(config);
-    if (q) params.set('q', q);
     if (ctx.cursor) params.set('pageToken', ctx.cursor);
 
     const response = await http.raw(`${this.BASE_URL}/files?${params.toString()}`);
@@ -544,7 +548,8 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
         return this.buildResult(
           result.events,
           result.nextPageToken,
-          result.partial ? checkpoint.last_sync_at : undefined
+          result.partial ? checkpoint.last_sync_at : undefined,
+          { changesPending: result.partial }
         );
       }
       // Token rejected (see isPageTokenRejection). Fall through to ONE full
@@ -579,7 +584,7 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
     // edit would land as metadata with stale text behind it.
     const bootstrapStartedAt = resume?.startedAt ?? new Date().toISOString();
 
-    const maxResults = Math.min((config.max_results as number) ?? 500, 2000);
+    const maxResults = Math.min(config.max_results ?? 500, 2000);
     const includeContent = config.include_content !== false;
     const q = buildListQuery(config);
     const events: EventEnvelope[] = [];
@@ -592,13 +597,10 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
     // Where the traversal stopped, so the next run can pick it up. `undefined`
     // once the listing is exhausted — that is what completes the bootstrap.
     let nextListPageToken: string | undefined;
-    let seededCursor: string | undefined = resume?.listPageToken;
     let searchIncomplete = false;
 
     const pages = paginateByCursor<DriveFile, string>(
-      async (pageToken) => {
-        const cursor = pageToken ?? seededCursor;
-        seededCursor = undefined;
+      async (cursor) => {
         const params = new URLSearchParams({
           // Drive's list cursor addresses PAGES, not offsets: stopping
           // mid-page and resuming at the next cursor drops the rest of that
@@ -612,8 +614,8 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
           orderBy: 'modifiedTime desc',
           supportsAllDrives: 'true',
           includeItemsFromAllDrives: 'true',
+          q,
         });
-        if (q) params.set('q', q);
         if (cursor) params.set('pageToken', cursor);
 
         const response = await http.raw(`${this.BASE_URL}/files?${params.toString()}`);
@@ -632,7 +634,7 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
         if (data.incompleteSearch) searchIncomplete = true;
         return { items: data.files ?? [], nextCursor: data.nextPageToken };
       },
-      { maxPages: MAX_PAGES }
+      { maxPages: MAX_PAGES, initialCursor: resume?.listPageToken ?? null }
     );
 
     const deadline = this.now() + SYNC_TIME_BUDGET_MS;
@@ -650,12 +652,10 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
       }
     }
 
-    // Stopping on the cap with pages still unread means the bootstrap is
-    // unfinished: park the change token and resume the listing next run.
-    // Without a start token there is nothing to park — fall through, which
-    // leaves `page_token` unset and re-lists next run rather than going
-    // incremental over a traversal that never finished.
-    if (capped && nextListPageToken && startToken) {
+    // Stopping on the cap or the clock with pages still unread means the
+    // bootstrap is unfinished: park the change token and resume the listing
+    // next run.
+    if (capped && nextListPageToken) {
       return this.buildBootstrapResult(
         events,
         startToken,
@@ -665,12 +665,9 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
       );
     }
 
-    return this.buildResult(
-      events,
-      startToken,
-      bootstrapStartedAt,
-      searchIncomplete
-    );
+    return this.buildResult(events, startToken, bootstrapStartedAt, {
+      searchIncomplete,
+    });
   }
 
   /**
@@ -691,7 +688,7 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
   } | null> {
     const includeContent = config.include_content !== false;
     const includeTrashed = Boolean(config.include_trashed);
-    const maxResults = Math.min((config.max_results as number) ?? 500, 2000);
+    const maxResults = Math.min(config.max_results ?? 500, 2000);
     const events: EventEnvelope[] = [];
     let nextPageToken: string | undefined;
     // The cursor for the page AFTER the one just consumed. A run that stops
@@ -746,7 +743,6 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
     let stoppedEarly = false;
     for await (const items of pages) {
       for (const change of items) {
-        if (rejected) break;
         const envelope = await this.changeToEnvelope(
           http,
           change,
@@ -777,7 +773,7 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
     return { events, nextPageToken, partial: false };
   }
 
-  private async fetchStartPageToken(http: HttpClient): Promise<string | undefined> {
+  private async fetchStartPageToken(http: HttpClient): Promise<string> {
     const params = new URLSearchParams({ supportsAllDrives: 'true' });
     const response = await http.raw(
       `${this.BASE_URL}/changes/startPageToken?${params.toString()}`
@@ -788,6 +784,12 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
       );
     }
     const data = (await response.json()) as DriveStartPageTokenResponse;
+    // Failing here is the honest outcome: without a token the traversal cannot
+    // hand off to the change stream, and reporting it as a finished bootstrap
+    // would hide a broken feed behind a permanent full re-list.
+    if (!data.startPageToken) {
+      throw new Error('Drive changes.getStartPageToken returned no startPageToken.');
+    }
     return data.startPageToken;
   }
 
@@ -1049,25 +1051,23 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
     }
 
     const sizeBytes = parseSize(file.size);
+    const owner = personLabel(file.owners?.[0]);
+    const lastModifiedBy = personLabel(file.lastModifyingUser);
 
     return {
       origin_id: file.id,
       origin_type: 'drive_file',
       title: file.name ?? '(untitled)',
       payload_text: payloadText,
-      author_name: personLabel(file.owners?.[0]),
+      author_name: owner,
       source_url: file.webViewLink,
       occurred_at: Number.isNaN(occurredAt.getTime()) ? new Date() : occurredAt,
       metadata: {
         change_type: changeType,
         ...(file.mimeType ? { mime_type: file.mimeType } : {}),
         ...(sizeBytes !== undefined ? { size_bytes: sizeBytes } : {}),
-        ...(personLabel(file.owners?.[0])
-          ? { owner: personLabel(file.owners?.[0]) }
-          : {}),
-        ...(personLabel(file.lastModifyingUser)
-          ? { last_modified_by: personLabel(file.lastModifyingUser) }
-          : {}),
+        ...(owner ? { owner } : {}),
+        ...(lastModifiedBy ? { last_modified_by: lastModifiedBy } : {}),
         ...(file.createdTime ? { created_at: file.createdTime } : {}),
         ...(file.modifiedTime ? { modified_at: file.modifiedTime } : {}),
         trashed: Boolean(file.trashed),
@@ -1162,9 +1162,9 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
   private buildResult(
     events: EventEnvelope[],
     pageToken: string | undefined,
-    /** Preserved stamp for a partial run; omit to advance to now. */
-    keepLastSyncAt?: string,
-    searchIncomplete = false
+    /** Stamp to persist as-is; omit to advance `last_sync_at` to now. */
+    keepLastSyncAt: string | undefined,
+    flags: { changesPending?: boolean; searchIncomplete?: boolean } = {}
   ): SyncResult {
     events.sort((a, b) => b.occurred_at.getTime() - a.occurred_at.getTime());
 
@@ -1182,8 +1182,8 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
       metadata: {
         items_found: events.length,
         bootstrap_complete: true,
-        ...(keepLastSyncAt ? { changes_pending: true } : {}),
-        ...(searchIncomplete ? { search_incomplete: true } : {}),
+        ...(flags.changesPending ? { changes_pending: true } : {}),
+        ...(flags.searchIncomplete ? { search_incomplete: true } : {}),
       },
     };
   }

--- a/packages/connectors/src/google_drive.ts
+++ b/packages/connectors/src/google_drive.ts
@@ -49,13 +49,10 @@ interface DriveFile {
   size?: string;
   createdTime?: string;
   modifiedTime?: string;
-  viewedByMeTime?: string;
   trashed?: boolean;
   owners?: Array<{ emailAddress?: string; displayName?: string }>;
   lastModifyingUser?: { emailAddress?: string; displayName?: string };
   parents?: string[];
-  fileExtension?: string;
-  md5Checksum?: string;
 }
 
 interface DriveFileListResponse {
@@ -171,7 +168,7 @@ const MAX_EXPORT_BYTES = 10 * 1024 * 1024;
 
 /** Field mask for files.list / changes.list. Drive v3 returns almost nothing without it. */
 const FILE_FIELDS =
-  'id,name,mimeType,description,webViewLink,size,createdTime,modifiedTime,viewedByMeTime,trashed,owners(emailAddress,displayName),lastModifyingUser(emailAddress,displayName),parents,fileExtension,md5Checksum';
+  'id,name,mimeType,description,webViewLink,size,createdTime,modifiedTime,trashed,owners(emailAddress,displayName),lastModifyingUser(emailAddress,displayName),parents';
 
 const DRIVE_FILE_COLUMNS = [
   { name: 'id', type: 'text' },
@@ -373,11 +370,12 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
             query: {
               type: 'string',
               description:
-                'Optional Drive query in Google\'s `q` syntax, e.g. "mimeType = \'application/pdf\'". Combined with the feed\'s own filters using AND.',
+                'Optional Drive query in Google\'s `q` syntax, e.g. "mimeType = \'application/pdf\'". Combined with the feed\'s own filters using AND. Drive cannot apply a query to its change log, so a feed that sets one keeps re-listing instead of switching to incremental sync.',
             },
             folder_id: {
               type: 'string',
-              description: 'Restrict to files whose parent is this folder ID.',
+              description:
+                'Restrict to files whose parent is this folder ID. Enforced on both the initial listing and every later change.',
             },
             include_trashed: {
               type: 'boolean',
@@ -663,9 +661,17 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
       );
     }
 
-    return this.buildResult(events, startToken, bootstrapStartedAt, {
-      searchIncomplete,
-    });
+    // A Drive `q` has no equivalent on `changes.list` and cannot be re-evaluated
+    // client-side against a change record, so the only way to keep honouring it
+    // is to keep listing. Withholding the token re-lists next run; promoting it
+    // would silently widen the feed to every changed file in the Drive.
+    const hasCustomQuery = typeof config.query === 'string' && config.query.trim() !== '';
+    return this.buildResult(
+      events,
+      hasCustomQuery ? undefined : startToken,
+      bootstrapStartedAt,
+      { searchIncomplete }
+    );
   }
 
   /**
@@ -686,6 +692,10 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
   } | null> {
     const includeContent = config.include_content !== false;
     const includeTrashed = Boolean(config.include_trashed);
+    const folderId =
+      typeof config.folder_id === 'string' && config.folder_id.trim()
+        ? config.folder_id.trim()
+        : undefined;
     const maxResults = Math.min(config.max_results ?? 500, 2000);
     const events: EventEnvelope[] = [];
     let nextPageToken: string | undefined;
@@ -746,6 +756,7 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
           change,
           includeContent,
           includeTrashed,
+          folderId,
           lastSyncAt
         );
         if (envelope) events.push(envelope);
@@ -970,6 +981,7 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
     change: DriveChange,
     includeContent: boolean,
     includeTrashed: boolean,
+    folderId: string | undefined,
     lastSyncAt?: string
   ): Promise<EventEnvelope | null> {
     const fileId = change.fileId ?? change.file?.id;
@@ -1003,6 +1015,18 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
     // branch: a trashed folder is still a folder, and tombstoning one we
     // never stored would write a row for something that was never there.
     if (change.file.mimeType === FOLDER_MIME_TYPE) return null;
+
+    // `changes.list` takes no `q`, so the feed's folder scope has to be
+    // re-applied here or the feed widens to the whole Drive the moment the
+    // bootstrap completes — quietly inlining the text of documents the
+    // operator never scoped it to. `parents` is already in FILE_FIELDS.
+    //
+    // Dropped, never tombstoned: a change for a file that MOVED OUT of the
+    // folder is indistinguishable from one that was never in it, so emitting a
+    // tombstone would write a row for every changed file in the Drive and leak
+    // the existence of out-of-scope files in the very corpus the scope exists
+    // to bound.
+    if (folderId && !change.file.parents?.includes(folderId)) return null;
 
     if (change.file.trashed && !includeTrashed) {
       const trashedAt = change.time ? new Date(change.time) : new Date();

--- a/packages/connectors/src/google_drive.ts
+++ b/packages/connectors/src/google_drive.ts
@@ -638,7 +638,6 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
     );
 
     const deadline = this.now() + SYNC_TIME_BUDGET_MS;
-    let capped = false;
     for await (const items of pages) {
       for (const file of items) {
         events.push(await this.driveFileToEnvelope(http, file, includeContent, 'upserted'));
@@ -646,16 +645,15 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
       // Tested only BETWEEN pages: a page is consumed whole or not at all, so
       // `nextListPageToken` always addresses the first file we have not read.
       // Stopping on the clock parks a checkpoint; being killed on it does not.
-      if (events.length >= maxResults || this.now() >= deadline) {
-        capped = true;
-        break;
-      }
+      if (events.length >= maxResults || this.now() >= deadline) break;
     }
 
-    // Stopping on the cap or the clock with pages still unread means the
-    // bootstrap is unfinished: park the change token and resume the listing
-    // next run.
-    if (capped && nextListPageToken) {
+    // Unread pages mean the bootstrap is unfinished, and WHY it stopped is
+    // irrelevant: the item cap, the clock, and the paginator's own MAX_PAGES
+    // ceiling all leave files the change feed will never replay. Only Drive
+    // withholding a nextPageToken proves the traversal exhausted, so that —
+    // not the reason for stopping — is what may promote the change token.
+    if (nextListPageToken) {
       return this.buildBootstrapResult(
         events,
         startToken,
@@ -981,6 +979,12 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
     // in the change record. Emit a tombstone that supersedes the prior version
     // on origin_id rather than dropping it, so a deleted file stops looking
     // live in memory.
+    //
+    // Accepted noise: with no `file` on the change record, a removed FOLDER is
+    // indistinguishable from a removed file, so deleting one writes a tombstone
+    // for an origin_id we never stored. Suppressing it would need prior state
+    // the connector cannot see. The row supersedes nothing and is bounded by
+    // the deletion rate, which is why this is tolerated rather than guessed at.
     if (change.removed || !change.file) {
       const removedAt = change.time ? new Date(change.time) : new Date();
       return {

--- a/packages/server/src/catalog/__tests__/connector-lifecycle-matrix.test.ts
+++ b/packages/server/src/catalog/__tests__/connector-lifecycle-matrix.test.ts
@@ -5,6 +5,7 @@ const EXPECTED_BUNDLED_CONNECTORS = [
 	"discord",
 	"github",
 	"google.calendar",
+	"google.drive",
 	"google.gmail",
 	"gchat",
 	"hackernews",
@@ -77,6 +78,7 @@ describe("bundled connector lifecycle matrix", () => {
 		expect(actionCounts).toEqual({
 			github: 6,
 			"google.calendar": 4,
+			"google.drive": 2,
 			"os.shell": 1,
 			"google.gmail": 5,
 			"market.quotes": 1,


### PR DESCRIPTION
## Summary
- Adds the `google.drive` connector: a `files` feed plus `get_file_content` and `get_file` actions, using `files.list` for the initial catalog walk and `changes.list` for incremental sync.
- The hard part is reachability. Drive's change log only reports items that **change**, so anything a bounded bootstrap never reaches appears in neither source — permanently absent, not merely late. The checkpoint therefore **parks** the change token (`pending_page_token`) while the listing walks (`list_page_token`), and promotes it only when the listing exhausts.
- The per-run cap is enforced **between pages**. A list cursor addresses pages, not offsets, so stopping mid-page and resuming at the next cursor skips the remainder of that page forever. Overshooting the cap by part of a page is safe; skipping part of one is not.
- A run is also bounded by **wall clock**, not just item count. The host kills a feed run at 600s and a killed run persists no checkpoint, so a slow run does not merely stall — it loses all progress and restarts from the same place forever.
- `files.list` returns folders as files. They are excluded at the listing query *and* re-excluded in `changeToEnvelope`, since `changes.list` takes no query parameter and folders would otherwise leak back one edit at a time.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` clean (exit 0). Full Linux graph green on CI for this PR.
- [x] `bun test packages/connectors/src/__tests__/google_drive.test.ts` → **56 pass / 0 fail**, 139 expect() calls.
- [x] Bug fixes: red→fix→green pasted below.

### red → green (page-boundary truncation)

A two-run bootstrap where the cap lands mid-page. Page 1 holds 5 files, cap is 3, page 2 holds 2.

Before:

```
expect(received).toEqual(expected)
@@ -4,4 +4,2 @@
    "a2",
-   "a3",
-   "a4",
    "b0",
- Expected  - 2
+ Received  + 0
(fail) bootstrap page-boundary > every file is collected across a resumed bootstrap
 0 pass  1 fail
```

`a3` and `a4` were dropped permanently: the run stored `nextPageToken` (the cursor for the page *after* the one it was consuming), so the resume skipped the rest of page 1, and the change feed never replays it.

Two existing tests had encoded the old behaviour as correct and were rewritten rather than deleted — `stops appending at max_results` became `stops at the first page boundary at or past max_results`, asserting the overshoot and the resulting `list_page_token`.

### red → green (run killed on the clock, checkpoint lost)

Run 1034 against a real Drive:

```
Feed execution timed out after 600000ms
items=700  elapsed=602s  checkpoint=NULL
```

The run was killed mid-flight, so nothing was persisted and the next run began from the same cursor. An item cap cannot prevent this because item cost varies ~30x — measured on one real Drive, 0.61–0.86 s/item when a content export is involved against 0.01–0.03 s/item for metadata only. The same cap is therefore either wasteful or fatal depending on what the page happens to contain, which is why the bound has to be a clock. Budget is `HOST_RUN_TIMEOUT_MS * 0.4` (240s), tested only at page boundaries; worst case is budget + one page = 240s + 86s = 326s, ~54% of the host limit. Both budget checks are mutation-proven.

### live proof — full bootstrap to completion

Against a real Drive on a local install, checkpoint reset, `max_results: 500`:

```
run 1 (id=1114) completed in 307s items=500
run 2 (id=1132) completed in 200s items=500
run 3 (id=1150) completed in 144s items=500
run 4 (id=1155) completed in 145s items=238   <- listing exhausted
```

1,738 files, then the checkpoint promoted exactly once, at the end of the walk:

```
 live | walking | parked | last_sync_status
------+---------+--------+------------------
 t    | f       | f      | success
```

`page_token` present, `list_page_token` and `pending_page_token` both gone — the parked change cursor became the live one only after the listing was exhausted, which is the whole invariant. Runs 1–3 stop at the cap; run 4 returns a short page and promotes.

The earlier pre-fix walk on the same Drive produced 8,258 folder rows against 942 real files; 8,258 + 1,738 = 9,996 live rows, matching the database exactly.

### CodeQL

`js/incomplete-sanitization` (high) on the query-literal escape: the folder filter escaped quotes but not backslashes, so a folder id ending in a backslash escaped its own closing quote. Fixed by escaping backslashes **first** — escaping quotes first would then double-escape the backslashes it just introduced. Mutation-proven: reverting to quote-only produces `'EVIL\' in parents` and fails the test. CodeQL is green on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Google Drive connector with OAuth authentication.
  * Supports file listing, metadata synchronization, incremental updates, resumable syncing, and removal tracking.
  * Added content retrieval for supported Google Docs and text files, with safe size limits.
  * Added metadata and content read actions.
  * Added Google Drive to the bundled connector catalog and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->