### PR TITLE
docs: cite the mechanism, not a scratch file on someone's laptop

### DIFF
--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -29,9 +29,7 @@ import {
  * `updatedAt` is excluded (store-owned, set by the DB).
  *
  * This is the compile-time drift guarantee: the declarative mapper cannot
- * forget a field. The proof is the `-?` above — it makes every key REQUIRED on
- * the projection, so a field added to the stored schema and not handled here
- * fails to typecheck at the object literal that builds it.
+ * forget a field.
  */
 type AgentSettingsProjection = {
   [K in Exclude<keyof AgentSettingsStored, "updatedAt" | "authProfiles">]-?:

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -29,7 +29,9 @@ import {
  * `updatedAt` is excluded (store-owned, set by the DB).
  *
  * This is the compile-time drift guarantee: the declarative mapper cannot
- * forget a field. See /tmp/lobu-spike-4b-finding.md for the proof.
+ * forget a field. The proof is the `-?` above — it makes every key REQUIRED on
+ * the projection, so a field added to the stored schema and not handled here
+ * fails to typecheck at the object literal that builds it.
  */
 type AgentSettingsProjection = {
   [K in Exclude<keyof AgentSettingsStored, "updatedAt" | "authProfiles">]-?:

--- a/packages/server/src/gateway/services/declared-agent-registry.ts
+++ b/packages/server/src/gateway/services/declared-agent-registry.ts
@@ -6,7 +6,8 @@ import { buildProviderCatalog } from "../auth/provider-catalog.js";
 import type { AgentConfig } from "../config/index.js";
 
 /**
- * Compile-time exhaustiveness guard (see /tmp/lobu-spike-4b-finding.md).
+ * Compile-time exhaustiveness guard, the same `-?` projection the CLI's
+ * `AgentSettingsProjection` uses (packages/cli/src/commands/_lib/apply/map-config.ts).
  * Adding a field to AgentSettingsStoredSchema that this converter doesn't
  * handle is a compile error, not a silent drop. `authProfiles` excluded
  * (separate-store), `updatedAt` excluded (store-owned).


### PR DESCRIPTION
## What

Two exhaustiveness guards cited `/tmp/lobu-spike-4b-finding.md` for "the proof":

- `packages/cli/src/commands/_lib/apply/map-config.ts:32`
- `packages/server/src/gateway/services/declared-agent-registry.ts:9`

That path exists on no one's machine, so the comment sent every future reader to a dead end. Both now name the mechanism instead — the `-?` mapped-type projection sitting directly above each comment — and cross-link so the shared pattern is findable.

## Why

`AGENTS.md`: "Never commit live tenant identifiers or personal machine state. No ... personal absolute paths ... in shipping code."

Found while reviewing #3346, which touches `map-config.ts`. Kept separate because it is unrelated to that branch's concern.

## Scope

Class-wide sweep of `origin/main` for personal absolute paths:

```
git grep -nE "/Users/[a-z]+|/tmp/lobu-[a-z0-9-]+\.md" origin/main -- packages/ examples/ scripts/
```

The only other hits are clearly synthetic test fixtures (`/Users/x`, `/Users/me`, `/Users/alice`, `/Users/dev`), which the rule explicitly permits. These two were the whole class.

## Testing

Comment-only; no behavior change. `make pre-pr` clean (build, typecheck, knip, biome, naming gates).