### PR TITLE
fix(sdk): derive the knowledge input types from one shared contract

### DIFF
--- a/packages/connector-sdk/src/reaction-client-types.ts
+++ b/packages/connector-sdk/src/reaction-client-types.ts
@@ -12,6 +12,13 @@
  *     await client.knowledge.save({ content: "...", semantic_type: "digest" });
  *   };
  */
+// Type-only imports: they erase at compile time, so nothing new enters the
+// isolate bundle. Core SUBPATH imports are permitted here; the root is not
+// (see AGENTS.md).
+import type { PublicGetContentArgs } from "@lobu/core/contracts/tools/read-knowledge";
+import type { PublicSearchArgs } from "@lobu/core/contracts/tools/search-memory";
+import type {} from "./reaction-client-types.typecheck";
+
 /**
  * A rich card for chat delivery, as a plain serializable object — a `chat`
  * `CardElement` built with the card primitives (`Card`, `Section`, `Field`,
@@ -24,14 +31,13 @@ export type CardElement = Record<string, unknown>;
 
 // ── Knowledge ────────────────────────────────────────────────────────────────
 
-export interface KnowledgeSearchInput {
-  query?: string;
-  entity_type?: string;
-  entity_id?: number;
-  fuzzy?: boolean;
-  min_similarity?: number;
-  limit?: number;
-}
+/**
+ * Derived from the `search_memory` contract rather than re-declared: the
+ * hand-written copy listed 6 of the 16 filters the handler accepts, so ten
+ * were undiscoverable from the published types. Pinned by
+ * `ReactionKnowledgeSearchContract` in `./reaction-client-types.typecheck`.
+ */
+export type KnowledgeSearchInput = PublicSearchArgs;
 
 export interface KnowledgeSaveInput {
   entity_ids?: number[];
@@ -53,17 +59,16 @@ export interface KnowledgeSaveInput {
   automation_source?: { automation_id: number; run_id: number };
 }
 
-export interface KnowledgeReadInput {
-  /** Fetch specific content events by id (read_knowledge takes an array). */
-  content_ids?: number[];
-  automation_id?: number;
-  /** Bind the read to the exact queued Automation run and trigger snapshot. */
-  run_id?: number;
-  since?: string;
-  until?: string;
-  limit?: number;
-  entity_ids?: number[];
-}
+/**
+ * Derived from the `read_knowledge` contract rather than re-declared. The
+ * hand-written copy named 6 of the 36 filters the handler accepts, hiding 30
+ * (`semantic_type`, `entity_types`, `query`, `entity_id`, cursor pagination,
+ * …), and its seventh field was `entity_ids`, which `getContent` only ever
+ * reads off the ROW — never off the input — so filtering by it was a hard
+ * `unknown argument(s)` error from the server's argument validator. Pinned by
+ * `ReactionKnowledgeReadContract` in `./reaction-client-types.typecheck`.
+ */
+export type KnowledgeReadInput = PublicGetContentArgs;
 
 export interface KnowledgeSaveResult {
   id: number;

--- a/packages/connector-sdk/src/reaction-client-types.typecheck.ts
+++ b/packages/connector-sdk/src/reaction-client-types.typecheck.ts
@@ -1,0 +1,77 @@
+/**
+ * @internal Compile-time fixtures pinning the published reaction-client input
+ * types to the server schemas they forward to.
+ *
+ * These types must mirror the `read_knowledge` / `search_memory` schemas
+ * exactly, and the server's `validate-args` rejects any unknown argument. So a
+ * field declared here that the schema does not accept is a HARD error for the
+ * reaction author, and a schema filter omitted here is a capability they
+ * cannot discover.
+ *
+ * This lives in `src/` rather than beside the tests on purpose: `tsconfig.json`
+ * excludes `**\/__tests__/**`, and `bun test` only transpiles, so a compile-time
+ * assert written in a test file is never actually checked.
+ *
+ * Keyed on `keyof`, not assignability: every field is optional, so a stray
+ * object structurally extends the type and an accepts/rejects pair passes no
+ * matter what the interface declares.
+ */
+import type { PublicGetContentArgs } from "@lobu/core/contracts/tools/read-knowledge";
+import type { PublicSearchArgs } from "@lobu/core/contracts/tools/search-memory";
+import type {
+  KnowledgeReadInput,
+  KnowledgeSearchInput,
+} from "./reaction-client-types";
+
+type Assert<T extends true> = T;
+
+type HasReadKey<K extends string> = K extends keyof KnowledgeReadInput ? true : false;
+type HasSearchKey<K extends string> = K extends keyof KnowledgeSearchInput ? true : false;
+
+export type ReactionKnowledgeReadContract = [
+  Assert<HasReadKey<"semantic_type">>,
+  Assert<HasReadKey<"entity_types">>,
+  Assert<HasReadKey<"query">>,
+  Assert<HasReadKey<"entity_id">>,
+  Assert<HasReadKey<"before_occurred_at">>,
+  Assert<HasReadKey<"before_id">>,
+  // `getContent` reads `entity_ids` off the ROW, never off the input, so
+  // filtering by it was an `unknown argument(s)` error, not a silent no-op.
+  Assert<HasReadKey<"entity_ids"> extends false ? true : false>,
+  // Accepted at the REST/tool boundary, never an SDK affordance.
+  Assert<HasReadKey<"mcp_activity_id"> extends false ? true : false>,
+];
+
+export type ReactionKnowledgeSearchContract = [
+  Assert<HasSearchKey<"title">>,
+  Assert<HasSearchKey<"content_limit">>,
+  Assert<HasSearchKey<"metadata_filter">>,
+  Assert<HasSearchKey<"include_public_catalogs">>,
+  Assert<HasSearchKey<"workspace">>,
+  Assert<HasSearchKey<"parent_id">>,
+  Assert<HasSearchKey<"market">>,
+  Assert<HasSearchKey<"category">>,
+  Assert<HasSearchKey<"include_connections">>,
+  Assert<HasSearchKey<"include_content">>,
+  // Accepted by the handler but never advertised: a pre-computed vector the
+  // content layer re-derives, and the caller's bound agent, resolved from auth
+  // context rather than asserted by a client.
+  Assert<HasSearchKey<"query_embedding"> extends false ? true : false>,
+  Assert<HasSearchKey<"agent_id"> extends false ? true : false>,
+];
+
+/**
+ * Exhaustive counterpart to the sampled asserts above. Those name the fields
+ * whose loss caused a real defect and say why each matters; this one catches
+ * ANY divergence, including a field added to a schema years from now.
+ *
+ * It needs no upkeep: while these types stay derived it holds by construction,
+ * and it fails the moment someone replaces a derivation with a hand-written
+ * interface — the regression this whole fixture exists to prevent.
+ */
+type ExactKeys<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+export type ReactionKnowledgeKeysExhaustive = [
+  Assert<ExactKeys<keyof KnowledgeReadInput, keyof PublicGetContentArgs>>,
+  Assert<ExactKeys<keyof KnowledgeSearchInput, keyof PublicSearchArgs>>,
+];

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -176,6 +176,18 @@
       "bun": "./src/refs.ts",
       "import": "./dist/refs.js",
       "require": "./dist/refs.js"
+    },
+    "./contracts/tools/read-knowledge": {
+      "types": "./dist/contracts/tools/read-knowledge.d.ts",
+      "bun": "./src/contracts/tools/read-knowledge.ts",
+      "import": "./dist/contracts/tools/read-knowledge.js",
+      "require": "./dist/contracts/tools/read-knowledge.js"
+    },
+    "./contracts/tools/search-memory": {
+      "types": "./dist/contracts/tools/search-memory.d.ts",
+      "bun": "./src/contracts/tools/search-memory.ts",
+      "import": "./dist/contracts/tools/search-memory.js",
+      "require": "./dist/contracts/tools/search-memory.js"
     }
   },
   "scripts": {

--- a/packages/core/src/contracts/tools/read-knowledge.ts
+++ b/packages/core/src/contracts/tools/read-knowledge.ts
@@ -1,0 +1,296 @@
+/**
+ * Tool contract: `read_knowledge`.
+ *
+ * Lives in core because it crosses package boundaries: the server validates
+ * against it, and `@lobu/connector-sdk` derives the input type it publishes to
+ * reaction authors. Both derive from this one declaration so neither can drift
+ * from the schema the handler actually enforces.
+ *
+ * Typebox only — no `node:` imports and nothing from core's root index, so the
+ * connector isolate lane can bundle it (`packages/connector-sdk/AGENTS.md`).
+ */
+
+import { type Static, Type } from "@sinclair/typebox";
+
+export const GetContentSchema = Type.Object({
+  query: Type.Optional(
+    Type.String({
+      description:
+        "Search query text (min 3 characters). If provided, performs semantic/full-text search. If omitted, lists content ordered by date.",
+      minLength: 3,
+    })
+  ),
+  entity_id: Type.Optional(
+    Type.Number({
+      description:
+        "Entity ID to filter by. Required unless automation_id is provided.",
+    })
+  ),
+  automation_id: Type.Optional(
+    Type.Number({
+      description:
+        "Persisted Automation ID (`automation_id`) to fetch content for. With run_id, uses that run's queued version/window; otherwise computes the Automation's pending window. Returns window_token for complete_window action.",
+    })
+  ),
+  template_version_id: Type.Optional(
+    Type.Number({
+      description:
+        "Pin an interactive or legacy Automation read to a persisted version. When run_id is present, the run's snapshotted version is authoritative and a conflicting value is rejected. Without run_id, omission defaults to the Automation's current version.",
+    })
+  ),
+  connection_ids: Type.Optional(
+    Type.Array(Type.Number(), {
+      description: "Connection IDs to filter by",
+    })
+  ),
+  feed_ids: Type.Optional(
+    Type.Array(Type.Number(), {
+      description: "Feed IDs to filter by (events.feed_id)",
+    })
+  ),
+  run_ids: Type.Optional(
+    Type.Array(Type.Number(), {
+      description:
+        "Run IDs to filter by (events.run_id — the run that produced the event)",
+    })
+  ),
+  agent_id: Type.Optional(
+    Type.String({
+      description:
+        "Limit results to memory written by this agent. Filters events where metadata.agent_id matches.",
+    })
+  ),
+  client_ids: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        "OAuth client IDs to filter by (events.client_id — the connected client that produced the event, e.g. a ChatGPT or CLI registration). Pass several ids to cover one client that registered more than once.",
+    })
+  ),
+  mcp_activity_id: Type.Optional(
+    Type.String({
+      maxLength: 512,
+      description:
+        "Internal Connected App filter: exact materialized MCP conversation or transport-session activity id. Requires client_ids.",
+    })
+  ),
+  platforms: Type.Optional(
+    Type.Array(Type.String(), {
+      description: "Platform types to filter by (reddit, trustpilot, etc.)",
+    })
+  ),
+  run_id: Type.Optional(
+    Type.Number({
+      description:
+        "Run ID. With automation_id, binds the Automation read to that run's queued version, window, and trigger inputs. Without automation_id, filters to content analyzed in this run.",
+    })
+  ),
+  analyzed_by_automation_id: Type.Optional(
+    Type.Number({
+      description:
+        "Limit results to events this Automation has analyzed in any run. Distinct from automation_id, which enters Automation read mode.",
+    })
+  ),
+  produced_by_automation_id: Type.Optional(
+    Type.Number({
+      description:
+        "Limit results to events this Automation WROTE — its outputs, entity change sets, and notifications. The counterpart to analyzed_by_automation_id, which returns what it READ; the two are not interchangeable.",
+    })
+  ),
+  since: Type.Optional(
+    Type.String({
+      description:
+        'Filter events published since this date. Supports: ISO 8601 ("2025-01-01"), named aliases ("yesterday", "last_week"), or relative ("7d", "30d", "1m", "1y"). When used with automation_id, also sets window_start in the generated token.',
+    })
+  ),
+  until: Type.Optional(
+    Type.String({
+      description:
+        'Filter events published until this date. Supports: ISO 8601 ("2025-01-31"), named aliases ("today", "yesterday"), or relative ("7d", "30d", "1m", "1y"). When used with automation_id, also sets window_end in the generated token.',
+    })
+  ),
+  min_similarity: Type.Optional(
+    Type.Number({
+      description:
+        "Minimum vector similarity threshold for semantic search (0.0-1.0, default: 0.6). Only used when query is provided.",
+      minimum: 0.0,
+      maximum: 1.0,
+      default: 0.6,
+    })
+  ),
+  vector_weight: Type.Optional(
+    Type.Number({
+      description:
+        "Weight of vector similarity vs text rank in combined_score (0.0-1.0, default: 0.6). Higher values favor semantic match over keyword overlap. Only applies when a query and embeddings are both present.",
+      minimum: 0.0,
+      maximum: 1.0,
+    })
+  ),
+  classification_filters: Type.Optional(
+    Type.Record(Type.String(), Type.Array(Type.String()), {
+      description:
+        'Filter by classification values, e.g. {"sentiment": ["positive", "neutral"], "bug-severity": ["critical"]}',
+    })
+  ),
+  limit: Type.Optional(
+    Type.Number({
+      description: "Number of results to return (default: 50, max: 2000)",
+      default: 50,
+    })
+  ),
+  offset: Type.Optional(
+    Type.Number({
+      description: "Number of results to skip for pagination (default: 0)",
+      default: 0,
+    })
+  ),
+  before_occurred_at: Type.Optional(
+    Type.String({
+      description:
+        "Chronological cursor anchor for older results. Pair with before_id. Only used when sort_by=date and sort_order=desc.",
+    })
+  ),
+  before_id: Type.Optional(
+    Type.Number({
+      description:
+        "Stable tie-breaker for before_occurred_at. Only used when sort_by=date and sort_order=desc.",
+      minimum: 1,
+    })
+  ),
+  after_occurred_at: Type.Optional(
+    Type.String({
+      description:
+        "Chronological cursor anchor for newer results. Pair with after_id. Only used when sort_by=date and sort_order=desc.",
+    })
+  ),
+  after_id: Type.Optional(
+    Type.Number({
+      description:
+        "Stable tie-breaker for after_occurred_at. Only used when sort_by=date and sort_order=desc.",
+      minimum: 1,
+    })
+  ),
+  include_classification: Type.Optional(
+    Type.String({
+      description:
+        'Include classification data. Use "summary" to include aggregated classification stats for filter UI.',
+    })
+  ),
+  engagement_min: Type.Optional(
+    Type.Number({
+      description: "Minimum engagement score (0-100)",
+      minimum: 0,
+      maximum: 100,
+    })
+  ),
+  engagement_max: Type.Optional(
+    Type.Number({
+      description: "Maximum engagement score (0-100)",
+      minimum: 0,
+      maximum: 100,
+    })
+  ),
+  sort_by: Type.Optional(
+    Type.Union([Type.Literal("date"), Type.Literal("score")], {
+      description:
+        "Sort content by: date (newest first) or score (cross-platform smart ranking). Search queries respect date sorting for chronological feed browsing; score sorting remains relevance-weighted. Default: score",
+      default: "score",
+    })
+  ),
+  sort_order: Type.Optional(
+    Type.Union([Type.Literal("asc"), Type.Literal("desc")], {
+      description:
+        "Sort order: asc (ascending) or desc (descending). Default: desc",
+      default: "desc",
+    })
+  ),
+  include_superseded: Type.Optional(
+    Type.Boolean({
+      description:
+        "When true and listing entity content without a query, include superseded historical events in addition to current records. Useful for explicit historical lookups such as original or previous values.",
+      default: false,
+    })
+  ),
+  classification_source: Type.Optional(
+    Type.Union(
+      [Type.Literal("user"), Type.Literal("embedding"), Type.Literal("llm")],
+      {
+        description:
+          "Filter content by classification source: user (manual), embedding (system), or llm (AI-generated)",
+      }
+    )
+  ),
+  content_ids: Type.Optional(
+    Type.Array(Type.Number(), {
+      description:
+        "Filter to specific content IDs. This is the full-fidelity read: list and Automation reads return a bounded payload_text head (payload_truncated: true, with the full character count in content_length) and drop oversized attachments (attachments_truncated: true), so re-read those ids here to get the complete payload. With automation_id, these exact durable rows are added to the Automation read and signed into its window token in addition to authored sources; this is how workspace-sourced event activations pass bounded event pointers without copying payloads.",
+    })
+  ),
+  exclude_automation_id: Type.Optional(
+    Type.Number({
+      description:
+        "Exclude content already analyzed by any run of this Automation. Returns only unprocessed content for client-driven Automation generation.",
+    })
+  ),
+  semantic_type: Type.Optional(
+    Type.Union([Type.String(), Type.Array(Type.String(), { minItems: 1 })], {
+      description:
+        'Filter by semantic type. Pass a single value (e.g. "note") or an array (e.g. ["note","summary"]) to match any. The reserved "notification" value matches events with notification targets, including kind-backed notifications whose stored semantic_type is their content kind.',
+    })
+  ),
+  entity_types: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        "Org-wide filter: limit to events linked to entities whose type slug is in this list. Ignored when entity_id is set.",
+    })
+  ),
+  interaction_status: Type.Optional(
+    Type.Union(
+      [
+        Type.Literal("pending"),
+        Type.Literal("approved"),
+        Type.Literal("rejected"),
+        Type.Literal("completed"),
+        Type.Literal("failed"),
+      ],
+      {
+        description:
+          'Filter by interaction status (e.g. "pending" for pending approvals)',
+      }
+    )
+  ),
+});
+
+/**
+ * Accepted at the REST/tool boundary but NOT an MCP or SDK discovery
+ * affordance. The Connected App UI receives this exact pair from an
+ * authenticated internal endpoint; external callers have no route that
+ * constructs it.
+ *
+ * The server stamps these onto the schema for its argument validator
+ * (`markAcceptedInternalFields`); that call belongs to the runtime validator
+ * and stays in the server. The field NAMES are contract data and belong here,
+ * so every consumer subtracts the same set.
+ */
+export const GET_CONTENT_INTERNAL_FIELDS = ["mcp_activity_id"] as const;
+
+export const PublicGetContentSchema = Type.Object(
+  Object.fromEntries(
+    Object.entries(GetContentSchema.properties).filter(
+      ([key]) =>
+        !(GET_CONTENT_INTERNAL_FIELDS as readonly string[]).includes(key)
+    )
+  )
+);
+
+export type GetContentArgs = Static<typeof GetContentSchema>;
+
+/**
+ * The `read_knowledge` input an external caller may actually construct: every
+ * declared filter minus the accepted-but-unadvertised internal fields. SDK
+ * surfaces that forward straight to `getContent` derive their input type from
+ * this so the declared shape cannot drift from the enforced schema.
+ */
+export type PublicGetContentArgs = Omit<
+  GetContentArgs,
+  (typeof GET_CONTENT_INTERNAL_FIELDS)[number]
+>;

--- a/packages/core/src/contracts/tools/search-memory.ts
+++ b/packages/core/src/contracts/tools/search-memory.ts
@@ -1,0 +1,180 @@
+/**
+ * Tool contract: `search_memory`.
+ *
+ * Lives in core because it crosses package boundaries: the server validates
+ * against it, and `@lobu/connector-sdk` derives the input type it publishes to
+ * reaction authors. Both derive from this one declaration so neither can drift
+ * from the schema the handler actually enforces.
+ *
+ * Typebox only — no `node:` imports and nothing from core's root index, so the
+ * connector isolate lane can bundle it (`packages/connector-sdk/AGENTS.md`).
+ */
+
+import { type Static, Type } from "@sinclair/typebox";
+
+export const SearchSchema = Type.Object({
+  title: Type.Optional(
+    Type.String({
+      description:
+        'Optional human-friendly heading for this result (e.g. "What we know about Acme"). When set, the UI renders it above the search result.',
+      maxLength: 200,
+    })
+  ),
+  query: Type.Optional(
+    Type.String({
+      description:
+        "Search query (entity name). Required unless entity_id is provided.",
+      minLength: 1,
+    })
+  ),
+  entity_type: Type.Optional(
+    Type.String({
+      description:
+        "Entity type filter. If not provided, searches all entities.",
+    })
+  ),
+  entity_id: Type.Optional(
+    Type.Number({
+      description:
+        "Entity ID for direct lookup. Can be used instead of query for exact fetch.",
+    })
+  ),
+  parent_id: Type.Optional(
+    Type.Number({
+      description: "Filter by parent entity ID.",
+    })
+  ),
+  market: Type.Optional(
+    Type.String({
+      description: "Market/region code (ISO 3166-1 alpha-2)",
+    })
+  ),
+  category: Type.Optional(
+    Type.String({
+      description: "Filter by category metadata field",
+    })
+  ),
+  fuzzy: Type.Optional(
+    Type.Boolean({
+      description: "Enable fuzzy name matching",
+      default: true,
+    })
+  ),
+  min_similarity: Type.Optional(
+    Type.Number({
+      description:
+        "Minimum similarity threshold (0.0-1.0) applied to BOTH fuzzy entity-name matching and recalled content. Raise it to cut weak matches, lower it to widen recall.",
+      default: 0.3,
+      minimum: 0,
+      maximum: 1,
+    })
+  ),
+  include_connections: Type.Optional(
+    Type.Boolean({
+      description:
+        "Include connection details in response (max 20, active first)",
+      default: true,
+    })
+  ),
+  include_content: Type.Optional(
+    Type.Boolean({
+      description:
+        "Include semantic content search results alongside entity matches (default: true). Uses the query for vector similarity search across all content in the organization.",
+      default: true,
+    })
+  ),
+  content_limit: Type.Optional(
+    Type.Number({
+      description:
+        "Max content results when include_content is enabled (default: 5, max: 50)",
+      default: 5,
+      minimum: 1,
+      maximum: 50,
+    })
+  ),
+  query_embedding: Type.Optional(
+    Type.Array(Type.Number(), {
+      description:
+        "Embedding vector for semantic similarity search. When provided, results are ranked by cosine similarity.",
+    })
+  ),
+  metadata_filter: Type.Optional(
+    Type.Record(Type.String(), Type.String(), {
+      description:
+        'Filter entities by metadata key-value pairs (e.g. {"category": "preference"})',
+    })
+  ),
+  agent_id: Type.Optional(
+    Type.String({
+      description:
+        "Scope recalled CONTENT to memory written by this agent — filters events where `metadata.agent_id` matches the given id. Entity resolution is NOT filtered by it: entities are workspace nouns with no writing agent, so scoping them here would report an existing entity as not-found.",
+    })
+  ),
+  limit: Type.Optional(
+    Type.Number({
+      description: "Max results (default: 5, max: 100)",
+      minimum: 1,
+      maximum: 100,
+    })
+  ),
+  include_public_catalogs: Type.Optional(
+    Type.Boolean({
+      description:
+        "Also search public-catalog orgs (visibility=public) — canonical world entities like HMRC, banks, currencies. Defaults to true so agents can discover entities to reference cross-org.",
+      default: true,
+    })
+  ),
+  workspace: Type.Optional(
+    Type.String({
+      description:
+        "Narrow this read to one workspace granted to the connection. Omit it on a direct bare OAuth search to search every currently accessible granted workspace.",
+      minLength: 1,
+      maxLength: 200,
+    })
+  ),
+});
+
+/**
+ * Accepted by the handler, but NOT advertised on `tools/list` (see
+ * {@link PublicSearchSchema}): `query_embedding` is a pre-computed vector the
+ * content-search layer re-derives itself when absent, and `agent_id` is the
+ * caller's bound agent, resolved from auth context — a client asserting it
+ * cross-agent within an org is a footgun, not an affordance.
+ *
+ * Naming them keeps the argument validator treating them as VALID while
+ * omitting them from the "valid arguments are: …" text of an unknown-argument
+ * error; otherwise a mistyped arg teaches an agent that they exist, which is
+ * exactly the accepted-but-unadvertised trap this split closes. The server
+ * stamps them onto the schema (`markAcceptedInternalFields`) — that call
+ * belongs to the runtime validator and stays there. The field NAMES are
+ * contract data and belong here, so every consumer subtracts the same set.
+ */
+export const PUBLIC_SEARCH_SCHEMA_INTERNAL_FIELDS = [
+  "query_embedding",
+  "agent_id",
+] as const;
+
+/** Schema advertised on `tools/list`. See `ToolDefinition.publicInputSchema`. */
+export const PublicSearchSchema = Type.Object(
+  Object.fromEntries(
+    Object.entries(SearchSchema.properties).filter(
+      ([key]) =>
+        !(PUBLIC_SEARCH_SCHEMA_INTERNAL_FIELDS as readonly string[]).includes(
+          key
+        )
+    )
+  )
+);
+
+export type SearchArgs = Static<typeof SearchSchema>;
+
+/**
+ * The `search_memory` input an external caller may actually construct: every
+ * declared filter minus the accepted-but-unadvertised internal fields. SDK
+ * surfaces that forward straight to `search` derive their input type from this
+ * so the declared shape cannot drift from the enforced schema.
+ */
+export type PublicSearchArgs = Omit<
+  SearchArgs,
+  (typeof PUBLIC_SEARCH_SCHEMA_INTERNAL_FIELDS)[number]
+>;

--- a/packages/server/src/sandbox/namespaces/knowledge.ts
+++ b/packages/server/src/sandbox/namespaces/knowledge.ts
@@ -11,23 +11,18 @@ import { deleteContent } from "../../tools/delete_content";
 import { getContent, type PublicGetContentArgs } from "../../tools/get_content";
 import type { ToolContext } from "../../tools/registry";
 import { saveContent } from "../../tools/save_content";
-import { search } from "../../tools/search";
+import { type PublicSearchArgs, search } from "../../tools/search";
 import { createValidatedSdkMethod } from "../sdk-preflight";
 import type {} from "./knowledge.typecheck";
 
-export interface KnowledgeSearchInput {
-	query?: string;
-	entity_type?: string;
-	entity_id?: number;
-	parent_id?: number;
-	market?: string;
-	category?: string;
-	fuzzy?: boolean;
-	min_similarity?: number;
-	include_connections?: boolean;
-	include_content?: boolean;
-	limit?: number;
-}
+/**
+ * Derived from `SearchSchema`, not hand-listed: the hand-written version had
+ * dropped `title`, `content_limit`, `metadata_filter`,
+ * `include_public_catalogs` and `workspace`, advertising a narrower filter set
+ * than `search_memory` actually accepts. Pinned by
+ * `KnowledgeSearchInputContract` in `./knowledge.typecheck`.
+ */
+export type KnowledgeSearchInput = PublicSearchArgs;
 
 interface KnowledgeSaveBase {
 	entity_ids?: number[];
@@ -65,9 +60,10 @@ export type KnowledgeSaveInput =
  * `client.knowledge.read` forwards straight to `getContent`, so its input IS
  * the tool's public schema. Hand-listing the fields drifted: it had grown to
  * omit real filters the handler accepts (`semantic_type`, `entity_types`,
- * `query`, …) while advertising `entity_ids`, which `getContent` never read as
- * an input — a caller filtering by it silently got unfiltered results. Deriving
- * the type keeps the two in lockstep.
+ * `query`, …) while advertising `entity_ids`, which `getContent` only ever
+ * reads off the ROW — never off the input — so a caller filtering by it got a
+ * hard `unknown argument(s)` error from the argument validator, not unfiltered
+ * results. Deriving the type keeps the two in lockstep.
  */
 export type KnowledgeReadInput = PublicGetContentArgs;
 

--- a/packages/server/src/sandbox/namespaces/knowledge.typecheck.ts
+++ b/packages/server/src/sandbox/namespaces/knowledge.typecheck.ts
@@ -1,4 +1,10 @@
-import type { KnowledgeReadInput, KnowledgeSaveInput } from "./knowledge";
+import type { PublicGetContentArgs } from "../../tools/get_content";
+import type { PublicSearchArgs } from "../../tools/search";
+import type {
+	KnowledgeReadInput,
+	KnowledgeSaveInput,
+	KnowledgeSearchInput,
+} from "./knowledge";
 
 type Assert<T extends true> = T;
 type Accepts<T> = T extends KnowledgeSaveInput ? true : false;
@@ -42,4 +48,41 @@ export type KnowledgeReadInputContract = [
 	Assert<HasReadKey<"entity_ids"> extends false ? true : false>,
 	// Accepted at the boundary but deliberately never an SDK affordance.
 	Assert<HasReadKey<"mcp_activity_id"> extends false ? true : false>,
+];
+
+/**
+ * @internal Compile-time fixture pinning `knowledge.search` to `SearchSchema`.
+ *
+ * Same `keyof` keying as the read fixture above, and for the same reason: the
+ * fields are all optional, so assignability proves nothing.
+ */
+type HasSearchKey<K extends string> = K extends keyof KnowledgeSearchInput
+	? true
+	: false;
+
+export type KnowledgeSearchInputContract = [
+	// Schema filters the hand-listed interface had dropped.
+	Assert<HasSearchKey<"title">>,
+	Assert<HasSearchKey<"content_limit">>,
+	Assert<HasSearchKey<"metadata_filter">>,
+	Assert<HasSearchKey<"include_public_catalogs">>,
+	Assert<HasSearchKey<"workspace">>,
+	// Accepted by the handler but deliberately never advertised: a pre-computed
+	// vector the content layer re-derives, and the caller's bound agent, which
+	// is resolved from auth context rather than asserted by a client.
+	Assert<HasSearchKey<"query_embedding"> extends false ? true : false>,
+	Assert<HasSearchKey<"agent_id"> extends false ? true : false>,
+];
+
+/**
+ * Exhaustive counterpart to the sampled asserts above: those name the fields
+ * whose loss caused a real defect, this one catches ANY divergence. It needs no
+ * upkeep — while the types stay derived it holds by construction, and it fails
+ * the moment one is replaced by a hand-written interface.
+ */
+type ExactKeys<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+export type KnowledgeInputKeysExhaustive = [
+	Assert<ExactKeys<keyof KnowledgeReadInput, keyof PublicGetContentArgs>>,
+	Assert<ExactKeys<keyof KnowledgeSearchInput, keyof PublicSearchArgs>>,
 ];

--- a/packages/server/src/tools/get_content/schema.ts
+++ b/packages/server/src/tools/get_content/schema.ts
@@ -1,287 +1,36 @@
 /**
- * Tool: read_knowledge — Typebox schema and argument validation.
+ * Tool: read_knowledge — argument validation.
+ *
+ * The schema itself lives in `@lobu/core/contracts/tools/read-knowledge` so the
+ * connector SDK can derive its published input type from the SAME declaration
+ * the handler enforces. Re-exported here because server call sites import it
+ * from the tool it belongs to.
+ *
+ * Inside the server, always import these from this module rather than reaching
+ * for the core contract directly: the `markAcceptedInternalFields` stamp below
+ * runs on THIS module's load, so a caller that bypasses it can validate against
+ * a schema that has not been stamped yet.
  */
 
-import { type Static, Type } from '@sinclair/typebox';
+import {
+  GET_CONTENT_INTERNAL_FIELDS,
+  type GetContentArgs,
+  GetContentSchema,
+} from '@lobu/core/contracts/tools/read-knowledge';
 import { markAcceptedInternalFields } from '../validate-args';
 
-// ============================================
-// Typebox Schema
-// ============================================
-
-export const GetContentSchema = Type.Object({
-  query: Type.Optional(
-    Type.String({
-      description:
-        'Search query text (min 3 characters). If provided, performs semantic/full-text search. If omitted, lists content ordered by date.',
-      minLength: 3,
-    })
-  ),
-  entity_id: Type.Optional(
-    Type.Number({
-      description: 'Entity ID to filter by. Required unless automation_id is provided.',
-    })
-  ),
-  automation_id: Type.Optional(
-    Type.Number({
-      description:
-        "Persisted Automation ID (`automation_id`) to fetch content for. With run_id, uses that run's queued version/window; otherwise computes the Automation's pending window. Returns window_token for complete_window action.",
-    })
-  ),
-  template_version_id: Type.Optional(
-    Type.Number({
-      description:
-        "Pin an interactive or legacy Automation read to a persisted version. When run_id is present, the run's snapshotted version is authoritative and a conflicting value is rejected. Without run_id, omission defaults to the Automation's current version.",
-    })
-  ),
-  connection_ids: Type.Optional(
-    Type.Array(Type.Number(), {
-      description: 'Connection IDs to filter by',
-    })
-  ),
-  feed_ids: Type.Optional(
-    Type.Array(Type.Number(), {
-      description: 'Feed IDs to filter by (events.feed_id)',
-    })
-  ),
-  run_ids: Type.Optional(
-    Type.Array(Type.Number(), {
-      description: 'Run IDs to filter by (events.run_id — the run that produced the event)',
-    })
-  ),
-  agent_id: Type.Optional(
-    Type.String({
-      description:
-        'Limit results to memory written by this agent. Filters events where metadata.agent_id matches.',
-    })
-  ),
-  client_ids: Type.Optional(
-    Type.Array(Type.String(), {
-      description:
-        'OAuth client IDs to filter by (events.client_id — the connected client that produced the event, e.g. a ChatGPT or CLI registration). Pass several ids to cover one client that registered more than once.',
-    })
-  ),
-  mcp_activity_id: Type.Optional(
-    Type.String({
-      maxLength: 512,
-      description:
-        'Internal Connected App filter: exact materialized MCP conversation or transport-session activity id. Requires client_ids.',
-    })
-  ),
-  platforms: Type.Optional(
-    Type.Array(Type.String(), {
-      description: 'Platform types to filter by (reddit, trustpilot, etc.)',
-    })
-  ),
-  run_id: Type.Optional(
-    Type.Number({
-      description:
-        'Run ID. With automation_id, binds the Automation read to that run\'s queued version, window, and trigger inputs. Without automation_id, filters to content analyzed in this run.',
-    })
-  ),
-  analyzed_by_automation_id: Type.Optional(
-    Type.Number({
-      description:
-        'Limit results to events this Automation has analyzed in any run. Distinct from automation_id, which enters Automation read mode.',
-    })
-  ),
-  produced_by_automation_id: Type.Optional(
-    Type.Number({
-      description:
-        'Limit results to events this Automation WROTE — its outputs, entity change sets, and notifications. The counterpart to analyzed_by_automation_id, which returns what it READ; the two are not interchangeable.',
-    })
-  ),
-  since: Type.Optional(
-    Type.String({
-      description:
-        'Filter events published since this date. Supports: ISO 8601 ("2025-01-01"), named aliases ("yesterday", "last_week"), or relative ("7d", "30d", "1m", "1y"). When used with automation_id, also sets window_start in the generated token.',
-    })
-  ),
-  until: Type.Optional(
-    Type.String({
-      description:
-        'Filter events published until this date. Supports: ISO 8601 ("2025-01-31"), named aliases ("today", "yesterday"), or relative ("7d", "30d", "1m", "1y"). When used with automation_id, also sets window_end in the generated token.',
-    })
-  ),
-  min_similarity: Type.Optional(
-    Type.Number({
-      description:
-        'Minimum vector similarity threshold for semantic search (0.0-1.0, default: 0.6). Only used when query is provided.',
-      minimum: 0.0,
-      maximum: 1.0,
-      default: 0.6,
-    })
-  ),
-  vector_weight: Type.Optional(
-    Type.Number({
-      description:
-        'Weight of vector similarity vs text rank in combined_score (0.0-1.0, default: 0.6). Higher values favor semantic match over keyword overlap. Only applies when a query and embeddings are both present.',
-      minimum: 0.0,
-      maximum: 1.0,
-    })
-  ),
-  classification_filters: Type.Optional(
-    Type.Record(Type.String(), Type.Array(Type.String()), {
-      description:
-        'Filter by classification values, e.g. {"sentiment": ["positive", "neutral"], "bug-severity": ["critical"]}',
-    })
-  ),
-  limit: Type.Optional(
-    Type.Number({
-      description: 'Number of results to return (default: 50, max: 2000)',
-      default: 50,
-    })
-  ),
-  offset: Type.Optional(
-    Type.Number({
-      description: 'Number of results to skip for pagination (default: 0)',
-      default: 0,
-    })
-  ),
-  before_occurred_at: Type.Optional(
-    Type.String({
-      description:
-        'Chronological cursor anchor for older results. Pair with before_id. Only used when sort_by=date and sort_order=desc.',
-    })
-  ),
-  before_id: Type.Optional(
-    Type.Number({
-      description:
-        'Stable tie-breaker for before_occurred_at. Only used when sort_by=date and sort_order=desc.',
-      minimum: 1,
-    })
-  ),
-  after_occurred_at: Type.Optional(
-    Type.String({
-      description:
-        'Chronological cursor anchor for newer results. Pair with after_id. Only used when sort_by=date and sort_order=desc.',
-    })
-  ),
-  after_id: Type.Optional(
-    Type.Number({
-      description:
-        'Stable tie-breaker for after_occurred_at. Only used when sort_by=date and sort_order=desc.',
-      minimum: 1,
-    })
-  ),
-  include_classification: Type.Optional(
-    Type.String({
-      description:
-        'Include classification data. Use "summary" to include aggregated classification stats for filter UI.',
-    })
-  ),
-  engagement_min: Type.Optional(
-    Type.Number({
-      description: 'Minimum engagement score (0-100)',
-      minimum: 0,
-      maximum: 100,
-    })
-  ),
-  engagement_max: Type.Optional(
-    Type.Number({
-      description: 'Maximum engagement score (0-100)',
-      minimum: 0,
-      maximum: 100,
-    })
-  ),
-  sort_by: Type.Optional(
-    Type.Union([Type.Literal('date'), Type.Literal('score')], {
-      description:
-        'Sort content by: date (newest first) or score (cross-platform smart ranking). Search queries respect date sorting for chronological feed browsing; score sorting remains relevance-weighted. Default: score',
-      default: 'score',
-    })
-  ),
-  sort_order: Type.Optional(
-    Type.Union([Type.Literal('asc'), Type.Literal('desc')], {
-      description: 'Sort order: asc (ascending) or desc (descending). Default: desc',
-      default: 'desc',
-    })
-  ),
-  include_superseded: Type.Optional(
-    Type.Boolean({
-      description:
-        'When true and listing entity content without a query, include superseded historical events in addition to current records. Useful for explicit historical lookups such as original or previous values.',
-      default: false,
-    })
-  ),
-  classification_source: Type.Optional(
-    Type.Union([Type.Literal('user'), Type.Literal('embedding'), Type.Literal('llm')], {
-      description:
-        'Filter content by classification source: user (manual), embedding (system), or llm (AI-generated)',
-    })
-  ),
-  content_ids: Type.Optional(
-    Type.Array(Type.Number(), {
-      description:
-        'Filter to specific content IDs. This is the full-fidelity read: list and Automation reads return a bounded payload_text head (payload_truncated: true, with the full character count in content_length) and drop oversized attachments (attachments_truncated: true), so re-read those ids here to get the complete payload. With automation_id, these exact durable rows are added to the Automation read and signed into its window token in addition to authored sources; this is how workspace-sourced event activations pass bounded event pointers without copying payloads.',
-    })
-  ),
-  exclude_automation_id: Type.Optional(
-    Type.Number({
-      description:
-        'Exclude content already analyzed by any run of this Automation. Returns only unprocessed content for client-driven Automation generation.',
-    })
-  ),
-  semantic_type: Type.Optional(
-    Type.Union(
-      [
-        Type.String(),
-        Type.Array(Type.String(), { minItems: 1 }),
-      ],
-      {
-        description:
-          'Filter by semantic type. Pass a single value (e.g. "note") or an array (e.g. ["note","summary"]) to match any. The reserved "notification" value matches events with notification targets, including kind-backed notifications whose stored semantic_type is their content kind.',
-      }
-    )
-  ),
-  entity_types: Type.Optional(
-    Type.Array(Type.String(), {
-      description:
-        'Org-wide filter: limit to events linked to entities whose type slug is in this list. Ignored when entity_id is set.',
-    })
-  ),
-  interaction_status: Type.Optional(
-    Type.Union(
-      [
-        Type.Literal('pending'),
-        Type.Literal('approved'),
-        Type.Literal('rejected'),
-        Type.Literal('completed'),
-        Type.Literal('failed'),
-      ],
-      {
-        description: 'Filter by interaction status (e.g. "pending" for pending approvals)',
-      }
-    )
-  ),
-});
-
-const GET_CONTENT_INTERNAL_FIELDS = ['mcp_activity_id'] as const;
-// The Connected App UI receives this exact pair from an authenticated internal
-// endpoint. It is accepted by the REST/tool boundary but is not an MCP or SDK
-// discovery affordance: external callers have no route that constructs it.
+// Keeps the accepted-but-unadvertised internal fields VALID for the argument
+// validator while omitting them from its "valid arguments are: …" error text.
+// Which fields those are is contract data and lives with the schema; stamping
+// them onto it is the validator's job and stays here.
 markAcceptedInternalFields(GetContentSchema, GET_CONTENT_INTERNAL_FIELDS);
 
-export const PublicGetContentSchema = Type.Object(
-  Object.fromEntries(
-    Object.entries(GetContentSchema.properties).filter(
-      ([key]) => !(GET_CONTENT_INTERNAL_FIELDS as readonly string[]).includes(key)
-    )
-  )
-);
-
-export type GetContentArgs = Static<typeof GetContentSchema>;
-
-/**
- * The `get_content` input an external caller may actually construct: every
- * declared filter minus the accepted-but-unadvertised internal fields. SDK
- * surfaces that forward straight to `getContent` derive their input type from
- * this so the declared shape cannot drift from the schema the handler enforces.
- */
-export type PublicGetContentArgs = Omit<
-  GetContentArgs,
-  (typeof GET_CONTENT_INTERNAL_FIELDS)[number]
->;
+export {
+  type GetContentArgs,
+  GetContentSchema,
+  type PublicGetContentArgs,
+  PublicGetContentSchema,
+} from '@lobu/core/contracts/tools/read-knowledge';
 
 export function getIncludeSupersededValidationErrors(args: Partial<GetContentArgs>): string[] {
   const errors: string[] = [];

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -45,155 +45,38 @@ import { getContent } from './get_content';
 import type { ToolContext } from './registry';
 import { markAcceptedInternalFields, withValidatedArgs } from './validate-args';
 import { getErrorMessage } from '@lobu/core';
+import {
+  PUBLIC_SEARCH_SCHEMA_INTERNAL_FIELDS,
+  type SearchArgs,
+  SearchSchema,
+} from '@lobu/core/contracts/tools/search-memory';
 
 // ============================================
 // Typebox Schema
 // ============================================
+//
+// `SearchSchema` lives in `@lobu/core/contracts/tools/search-memory` so the
+// connector SDK can derive its published input type from the SAME declaration
+// this handler enforces. Re-exported below because `registry.ts` imports it
+// from this module.
+//
+// Inside the server, always import these from here rather than reaching for
+// the core contract directly: the `markAcceptedInternalFields` stamp runs on
+// THIS module's load, so a caller that bypasses it can validate against a
+// schema that has not been stamped yet.
 
-export const SearchSchema = Type.Object({
-  title: Type.Optional(
-    Type.String({
-      description:
-        'Optional human-friendly heading for this result (e.g. "What we know about Acme"). When set, the UI renders it above the search result.',
-      maxLength: 200,
-    })
-  ),
-  query: Type.Optional(
-    Type.String({
-      description: 'Search query (entity name). Required unless entity_id is provided.',
-      minLength: 1,
-    })
-  ),
-  entity_type: Type.Optional(
-    Type.String({
-      description: 'Entity type filter. If not provided, searches all entities.',
-    })
-  ),
-  entity_id: Type.Optional(
-    Type.Number({
-      description: 'Entity ID for direct lookup. Can be used instead of query for exact fetch.',
-    })
-  ),
-  parent_id: Type.Optional(
-    Type.Number({
-      description: 'Filter by parent entity ID.',
-    })
-  ),
-  market: Type.Optional(
-    Type.String({
-      description: 'Market/region code (ISO 3166-1 alpha-2)',
-    })
-  ),
-  category: Type.Optional(
-    Type.String({
-      description: 'Filter by category metadata field',
-    })
-  ),
-  fuzzy: Type.Optional(
-    Type.Boolean({
-      description: 'Enable fuzzy name matching',
-      default: true,
-    })
-  ),
-  min_similarity: Type.Optional(
-    Type.Number({
-      description:
-        'Minimum similarity threshold (0.0-1.0) applied to BOTH fuzzy entity-name matching and recalled content. Raise it to cut weak matches, lower it to widen recall.',
-      default: 0.3,
-      minimum: 0,
-      maximum: 1,
-    })
-  ),
-  include_connections: Type.Optional(
-    Type.Boolean({
-      description: 'Include connection details in response (max 20, active first)',
-      default: true,
-    })
-  ),
-  include_content: Type.Optional(
-    Type.Boolean({
-      description:
-        'Include semantic content search results alongside entity matches (default: true). Uses the query for vector similarity search across all content in the organization.',
-      default: true,
-    })
-  ),
-  content_limit: Type.Optional(
-    Type.Number({
-      description: 'Max content results when include_content is enabled (default: 5, max: 50)',
-      default: 5,
-      minimum: 1,
-      maximum: 50,
-    })
-  ),
-  query_embedding: Type.Optional(
-    Type.Array(Type.Number(), {
-      description:
-        'Embedding vector for semantic similarity search. When provided, results are ranked by cosine similarity.',
-    })
-  ),
-  metadata_filter: Type.Optional(
-    Type.Record(Type.String(), Type.String(), {
-      description: 'Filter entities by metadata key-value pairs (e.g. {"category": "preference"})',
-    })
-  ),
-  agent_id: Type.Optional(
-    Type.String({
-      description:
-        "Scope recalled CONTENT to memory written by this agent — filters events where `metadata.agent_id` matches the given id. Entity resolution is NOT filtered by it: entities are workspace nouns with no writing agent, so scoping them here would report an existing entity as not-found.",
-    })
-  ),
-  limit: Type.Optional(
-    Type.Number({
-      description: 'Max results (default: 5, max: 100)',
-      minimum: 1,
-      maximum: 100,
-    })
-  ),
-  include_public_catalogs: Type.Optional(
-    Type.Boolean({
-      description:
-        'Also search public-catalog orgs (visibility=public) — canonical world entities like HMRC, banks, currencies. Defaults to true so agents can discover entities to reference cross-org.',
-      default: true,
-    })
-  ),
-  workspace: Type.Optional(
-    Type.String({
-      description:
-        'Narrow this read to one workspace granted to the connection. Omit it on a direct bare OAuth search to search every currently accessible granted workspace.',
-      minLength: 1,
-      maxLength: 200,
-    })
-  ),
-});
-
-/**
- * Accepted by the handler, but NOT advertised on `tools/list` (see
- * {@link PublicSearchSchema}). Listed here so the arg validator keeps them
- * VALID while omitting them from the "valid arguments are: …" text of an
- * unknown-argument error — otherwise a mistyped arg teaches an agent that
- * `agent_id` / `query_embedding` exist, which is exactly the accepted-but-
- * unadvertised trap this split is meant to close.
- */
-const PUBLIC_SEARCH_SCHEMA_INTERNAL_FIELDS = ['query_embedding', 'agent_id'];
+// Keeps `query_embedding` / `agent_id` VALID for the argument validator while
+// omitting them from its "valid arguments are: …" error text — otherwise a
+// mistyped arg teaches an agent that they exist. Which fields those are is
+// contract data and lives with the schema; stamping them on is the
+// validator's job and stays here.
 markAcceptedInternalFields(SearchSchema, PUBLIC_SEARCH_SCHEMA_INTERNAL_FIELDS);
 
-/**
- * Schema advertised on `tools/list`. Drops the server-internal fields that
- * `SearchSchema` still accepts (so validation passes for internal callers and
- * tests): `query_embedding` (a pre-computed vector the content-search layer
- * re-derives itself when absent) and `agent_id` (the caller's bound agent,
- * resolved from auth context — clients asserting it cross-agent within an org
- * is a footgun, not an affordance). See `ToolDefinition.publicInputSchema`.
- */
-export const PublicSearchSchema = Type.Object(
-  Object.fromEntries(
-    Object.entries(SearchSchema.properties).filter(
-      ([key]) => !PUBLIC_SEARCH_SCHEMA_INTERNAL_FIELDS.includes(key)
-    )
-  )
-);
-
-type SearchArgs = Static<typeof SearchSchema>;
+export {
+  PublicSearchSchema,
+  type PublicSearchArgs,
+  SearchSchema,
+} from '@lobu/core/contracts/tools/search-memory';
 
 export function resolveEntityLimit(args: SearchArgs): number {
   const defaultLimit = args.query_embedding?.length ? 20 : (args.fuzzy ?? true) ? 5 : 1;


### PR DESCRIPTION
## Summary
- `read_knowledge` / `search_memory` each declared their schema in `packages/server` and hand-listed the SDK input type twice more — server sandbox namespace, plus a byte-copy in `@lobu/connector-sdk`. Nothing kept the three in sync.
- The connector-SDK copy was a **live defect**: it declared `entity_ids`, which `getContent` only reads off the ROW and never off the input, so a reaction filtering by it got a hard `unknown argument(s): entity_ids` rejection. It also named 6 of the 36 filters the handler accepts (hiding 30) and 6 of 16 for search (hiding ten).
- Both schemas move to `@lobu/core/contracts/tools/`, joining the 16 contracts already there, and all three declarations become derivations. This is finishing an existing migration, not new architecture: `connector-sdk/AGENTS.md:8` already permits core **subpath** imports (only the root is banned — it drags winston/Sentry/OTel into every connector bundle), and `automation-triggers.ts:11` already imports `@lobu/core/contracts/tools/manage-automations` for this exact reason.

Follow-up to #3340 / #3343, which fixed the same class for one type.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (all 5 gates: build, per-package typecheck, knip, naming, gateway-LLM + entity-write funnel)
- [x] Tests run: targeted `bun test` + Vitest — connector-sdk **271**, server sandbox/unit **159**, `search-memory-recall-contract` + `search-memory-federation` + `content-read-bounds` **34**, `connector-isolate-lane` **3**. All pass.
- [x] Bug fix: red→green pasted below

### Red

```
# packages/server — new search-input asserts, before the fix
knowledge.typecheck.ts(63,9): error TS2344: Type 'false' does not satisfy the constraint 'true'.
knowledge.typecheck.ts(64,9): error TS2344: ...   # title, content_limit, metadata_filter,
knowledge.typecheck.ts(65,9): error TS2344: ...   # include_public_catalogs, workspace
knowledge.typecheck.ts(66,9): error TS2344: ...
knowledge.typecheck.ts(67,9): error TS2344: ...
→ 5 errors

# packages/connector-sdk — before the fix
reaction-client-types.typecheck.ts(27..32): 6 errors   # missing read filters
reaction-client-types.typecheck.ts(35):     1 error    # phantom entity_ids
reaction-client-types.typecheck.ts(41..50): 10 errors  # missing search filters
→ 17 errors
```

### Green

```
core            tsc --noEmit → 0 errors
connector-sdk   tsc --noEmit → 0 errors   (was 17)
server          tsc --noEmit → 0 errors   (was 5)
```

### The fixtures actually bite

Typecheck passing is only evidence if the asserts can fail. Each mutation below was applied, observed, and reverted:

| mutation | result |
|---|---|
| positive assert on a field no schema has | `TS2344` |
| re-introduce the phantom `entity_ids` | `TS2344` |
| derivation quietly loses a field (`Omit<…, "workspace">`) | `TS2344` (sampled + `ExactKeys`) |
| derivation gains a field the schema lacks | `TS2344` (**`ExactKeys` only**) |

The last row is why the sampled asserts aren't enough on their own: a phantom field — this PR's own bug class — slips past them.

### Runtime parity, probed through the real validator

The one thing the type move could plausibly break is the internal-field split, since the field names now live in core while the `markAcceptedInternalFields` stamp stays in the server. Probed via `validateToolArgs`:

```
READ  + entity_ids  → unknown argument(s): entity_ids — valid arguments are: query, entity_id, …
        mentions mcp_activity_id (internal, must be HIDDEN): false
        advertises semantic_type (public, must be SHOWN):    true
SEARCH + bogus      → unknown argument(s): bogus_filter — valid arguments are: title, query, …
        mentions query_embedding / agent_id (must be HIDDEN): false / false
        advertises workspace (public, must be SHOWN):        true
Internal fields still ACCEPTED by the validator: mcp_activity_id ✓  query_embedding ✓
```

So internal fields stay valid yet unadvertised, exactly as before the move.

## Notes

**Breaking-change callout.** `KnowledgeReadInput` loses `entity_ids` from a published connector-SDK type, and `connector-sdk/AGENTS.md:6` asks for additive changes only. No working connector can depend on it — passing it was already a hard validator rejection — and keeping it would preserve the lie the rest of this change removes. Every other type change here is purely additive (the SDK's read input goes 6 → 36 fields, search 6 → 16). Flagging it rather than burying it.

**Review disclosure.** `make review-fix` ran as `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus` — codex is out of credits until Sep 7, so this was **same-model self-review, not the usual cross-harness verdict**. It earned its keep: it caught a **hard CI failure** (four new comments used a word `scripts/check-exposed-surface-naming.ts:35` bans outright) plus a pre-existing comment from #3343 that described the `entity_ids` failure mode as "silently unfiltered" when it is actually a hard rejection. Every claim it made was verified against source before acceptance; one of its field counts I initially thought wrong turned out correct — my own scratch check was the thing that was off.

**Not in this PR, deliberately:**
- `save_memory` — `KnowledgeSaveInput` is a discriminated `payload_type` union pinned by existing asserts, and `SaveContentSchema` is a flat `Type.Object`. Deriving it naively would silently weaken that contract, so it gets its own PR.
- Five more duplicated input types (`EntityCreate/Update/Link/ListFilter`, `OperationsListRunsInput`) can be derived from `manage-entity.ts` / `manage-operations.ts` **today, with no new core surface** — their contracts are already in core. Audited during this work; field parity on `OperationsListRunsInput` is currently exact.
- `NotificationsSendInput` flows *backwards* (`sandbox/namespaces/notifications.ts:29` has the server importing from connector-sdk). Un-inverting it needs a direction decision, since core can't carry its `card` field.
- The other ~27 server `*Schema` exports are `*ResultSchema` / `Resolved*` / `ResolvePath*` output and internal-resolution schemas that nothing outside `packages/server` consumes. Moving them would be churn with no de-duplication payoff.

**Incidental finding, not fixed here:** `packages/connector-sdk/tsconfig.json` excludes `**/__tests__/**` and `**/*.test.ts`, and `bun test` only transpiles — so the "Compile-time contract" comment in `__tests__/reaction-client-types.test.ts` describes a check nothing ever ran. That's why the new fixtures live in `src/`, anchored by `import type {}` the way `knowledge.typecheck.ts` already is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015244GcNCjdbEcecyK4vtBm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Knowledge search and read operations now support the complete set of public filters and options.
  - Invalid `entity_ids` inputs are rejected with a validation error instead of being ignored.
  - Public SDK and server inputs now remain aligned with the supported tool contracts.

- **Developer Experience**
  - Shared contracts improve consistency between server validation and connector integrations.
  - Internal-only search and read fields remain unavailable through public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->