### PR TITLE
fix(personal-agent): declare the cadence apply would otherwise strip

### DIFF
--- a/examples/personal-agent/__tests__/duplicate-entity-resolution.config.test.ts
+++ b/examples/personal-agent/__tests__/duplicate-entity-resolution.config.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import config from "../lobu.config";
+
+describe("duplicate entity resolution configuration", () => {
+  // Automation `triggers` are always-managed by apply: an omitted key projects
+  // to `[]` and CLEARS the stored cron, unlike an omitted feed `schedule`.
+  // Dropping this declaration would silently strand the Automation with no
+  // cadence, so assert the whole trigger list rather than just its presence.
+  test("declares the daily cadence apply would otherwise strip", () => {
+    const automation = config.automations?.find(
+      (candidate) =>
+        candidate.slug === "duplicate-entity-resolution-real-v3-final"
+    );
+    expect(automation).toBeDefined();
+    expect(automation?.triggers).toEqual([
+      { kind: "schedule", cron: "0 6 * * *", timezone: "Europe/London" },
+    ]);
+  });
+
+  // Every Automation this config declares needs a reachable trigger for the
+  // same reason. Naming only the one Automation above would let the next
+  // trigger-less declaration through — the guard has to cover the class.
+  test("every declared Automation has at least one trigger", () => {
+    const triggerless = (config.automations ?? [])
+      .filter((automation) => (automation.triggers ?? []).length === 0)
+      .map((automation) => automation.slug);
+    expect(triggerless).toEqual([]);
+  });
+});

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -1483,10 +1483,9 @@ const duplicateEntityResolution = defineAutomation({
   // OUT does not mean "unmanaged" the way an omitted feed `schedule` does — it
   // projects to `[]` and would clear the cron, leaving the Automation
   // unreachable. `execution`, `active_run` and `skip_if_unchanged` are omitted
-  // because their schema defaults already match what prod stores.
-  triggers: [
-    { kind: "schedule", cron: "0 6 * * *", timezone: "Europe/London" },
-  ],
+  // because the stored row carries exactly the schema defaults (verified:
+  // execution=window, active_run=coalesce, skip_if_unchanged=true).
+  triggers: [every("0 6 * * *", { timezone: "Europe/London" })],
   sources: {
     // context-only: duplicate candidates for analysis (not window body)
     people: context(

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -1357,7 +1357,7 @@ const socialSignal = defineEntityType({
   key: "social-signal",
   name: "Social Signal",
   description:
-    "Historical entity rows from the former Social Interest Radar output path.",
+    "Deprecated historical entity rows from the former Social Interest Radar output path.",
   metadata: { icon: "radar" },
   properties: {
     platform: {
@@ -1478,6 +1478,15 @@ const duplicateEntityResolution = defineAutomation({
   slug: "duplicate-entity-resolution-real-v3-final",
   name: "Duplicate entity resolution — real contacts",
   tags: ["identity", "deduplication", "world-model"],
+  // Adopted from prod, where this cadence was set outside the config. Apply
+  // treats Automation `triggers` as always-managed (diff.ts), so LEAVING THIS
+  // OUT does not mean "unmanaged" the way an omitted feed `schedule` does — it
+  // projects to `[]` and would clear the cron, leaving the Automation
+  // unreachable. `execution`, `active_run` and `skip_if_unchanged` are omitted
+  // because their schema defaults already match what prod stores.
+  triggers: [
+    { kind: "schedule", cron: "0 6 * * *", timezone: "Europe/London" },
+  ],
   sources: {
     // context-only: duplicate candidates for analysis (not window body)
     people: context(


### PR DESCRIPTION
## What

Declares two pieces of live prod state the config had stopped describing:

- `duplicate-entity-resolution-real-v3-final` runs on `0 6 * * *` (Europe/London) in prod. The config declared no `triggers` at all.
- `social-signal`'s prod description carries a `Deprecated ` prefix the config had dropped.

## Why it matters

Automation `triggers` are **always-managed** by apply — `diff.ts` documents them that way and `projectDesiredAutomation` maps an omitted key to `[]`. That is deliberately *unlike* an omitted feed `schedule`, which #3346 just made mean "unmanaged". So an Automation whose config omits `triggers` does not keep its cron; it loses it.

The org's apply is currently blocked, which is the only reason this has not fired yet. The next unblocked apply would have cleared the cron and left the Automation unreachable — the same failure mode as the cron-less feeds in #3338.

## Evidence

Prod, before:

```
automation duplicate-entity-resolution-real-v3-final
  .triggers: [{"cron": "0 6 * * *", "kind": "schedule", "timezone": "Europe/London", ...}]
        ->  []          # what the config projected
```

`lobu apply --dry-run` against the real org, before and after:

```
before:  ✖ BLOCKED — 9 remote changes not declared in this config
after:   ✖ BLOCKED — 7 remote changes not declared in this config
         = entity-type social-signal
         = automation duplicate-entity-resolution-real-v3-final
```

Both rows move from blocking drift to noop. The remaining 7 blockers are separate items needing prod-side decisions.

## Scope

Example-owned config only — no shared runtime, per the tenant-state rule.

## Follow-up surfaced, not changed here

46 prod Automations across 7 orgs carry a cron. Any whose config omits `triggers` is exposed to the same silent clear. Whether always-managed is the right semantics for `triggers` is a design call on a published package, so it is deliberately not touched in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a daily schedule for duplicate-entity resolution automation, using London time.
- **Updates**
  - Updated the description of the `social-signal` entity to reflect its current status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->