### PR TITLE
feat(cli): display action approval management link on daemon startup

### DIFF
--- a/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
+++ b/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
@@ -110,6 +110,23 @@ describe("lobu daemon", () => {
     expect(start.mock.calls[0]?.[0]?.apiUrl).toBe("https://app.lobu.ai");
   });
 
+  test("forwards activeOrg to startDaemonCommand for permission management link", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "prod",
+      url: "https://app.lobu.ai/api/v1",
+      source: "config",
+    });
+    spyOn(context, "getActiveOrg").mockResolvedValue("test-org");
+    spyOn(deviceState, "loadDeviceState").mockResolvedValue(null);
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({});
+
+    expect(start.mock.calls[0]?.[0]?.activeOrg).toBe("test-org");
+  });
+
   test("an explicit --api-url passes through without context-backed setup", async () => {
     (process.stdin as { isTTY?: boolean }).isTTY = true;
     (process.stdout as { isTTY?: boolean }).isTTY = true;

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -8,6 +8,7 @@ import {
   addContext,
   apiUrlToGatewayOrigin,
   findContextByOrigin,
+  getActiveOrg,
   loadContextConfig,
   type ResolvedContext,
   resolveContext,
@@ -257,6 +258,8 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
         })
       : undefined;
 
+  const activeOrg = await getActiveOrg(contextName);
+
   await startDaemonCommand({
     apiUrl: target.gatewayOrigin,
     version: options.cliVersion,
@@ -269,6 +272,7 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
       .map((entry) => entry.trim())
       .filter(Boolean),
     workerApiToken,
+    activeOrg,
     ...(workerCredentialMaintenance ? { workerCredentialMaintenance } : {}),
     debug: options.debug === true,
     ...(options.interactiveSession === false

--- a/packages/connector-worker/src/__tests__/device-mode-requires-durable-token.test.ts
+++ b/packages/connector-worker/src/__tests__/device-mode-requires-durable-token.test.ts
@@ -41,6 +41,7 @@ async function runDaemon(
       OPENCODE_SESSION_ID: undefined,
       LOBU_OPENCODE_BRIDGE_SOCKET: undefined,
       LOBU_OPENCODE_BRIDGE_TOKEN: undefined,
+      LOBU_ORG: undefined,
       ...env,
     },
     stderr: "pipe",

--- a/packages/connector-worker/src/__tests__/device-mode-requires-durable-token.test.ts
+++ b/packages/connector-worker/src/__tests__/device-mode-requires-durable-token.test.ts
@@ -96,6 +96,7 @@ describe("device mode requires a durable token", () => {
     expect(stderr).not.toContain("device mode requires a durable");
     expect(stderr).toContain("Starting worker daemon");
     expect(stderr).toContain("device mode: platform=macos");
+    expect(stderr).toContain("Manage action permissions (Approval vs Auto) at:");
   }, 20000);
 
   test("a fleet worker with no PAT is unaffected", async () => {

--- a/packages/connector-worker/src/__tests__/device-mode-requires-durable-token.test.ts
+++ b/packages/connector-worker/src/__tests__/device-mode-requires-durable-token.test.ts
@@ -90,13 +90,28 @@ describe("device mode requires a durable token", () => {
     // Pins the guard as targeted — rejecting everything would satisfy both
     // assertions above while making device mode unusable.
     const stderr = await runDaemon(
-      { WORKER_API_TOKEN: "owl_pat_durabletoken0123456789" },
+      {
+        WORKER_API_TOKEN: "owl_pat_durabletoken0123456789",
+        LOBU_ORG: "test-org",
+      },
       DEVICE_ARGS
     );
     expect(stderr).not.toContain("device mode requires a durable");
     expect(stderr).toContain("Starting worker daemon");
     expect(stderr).toContain("device mode: platform=macos");
-    expect(stderr).toContain("Manage action permissions (Approval vs Auto) at:");
+    expect(stderr).toContain(
+      "Manage action permissions (Approval vs Auto) at: http://127.0.0.1:1/test-org/connectors"
+    );
+  }, 20000);
+
+  test("device mode without active org omits permission management link", async () => {
+    const stderr = await runDaemon(
+      { WORKER_API_TOKEN: "owl_pat_durabletoken0123456789" },
+      DEVICE_ARGS
+    );
+    expect(stderr).toContain("Starting worker daemon");
+    expect(stderr).toContain("device mode: platform=macos");
+    expect(stderr).not.toContain("Manage action permissions");
   }, 20000);
 
   test("a fleet worker with no PAT is unaffected", async () => {

--- a/packages/connector-worker/src/bin.ts
+++ b/packages/connector-worker/src/bin.ts
@@ -138,6 +138,7 @@ async function main(): Promise<void> {
           platform,
           label,
           capabilities: declared,
+          activeOrg: (options['active-org'] || process.env.LOBU_ORG)?.trim() || undefined,
           workerApiToken: process.env.WORKER_API_TOKEN,
           debug: options.debug === 'true',
         });

--- a/packages/connector-worker/src/bin.ts
+++ b/packages/connector-worker/src/bin.ts
@@ -37,6 +37,7 @@ Options:
                      e.g. os.files. The server drops anything the platform's
                      allowlist does not grant.
   --label <name>     Human-readable device name shown on the Devices page
+  --active-org <slug> Org slug used for the action-permissions link printed in device mode
   --debug            Log poll/heartbeat/retry detail (default: one line per run)
   --json             (self-check) Emit machine-readable JSON to stdout
   --help             Show this help message
@@ -52,6 +53,7 @@ Environment Variables:
   WORKER_PLATFORM   Host platform (same as --platform)
   WORKER_CAPABILITIES Comma-separated capabilities (same as --capabilities)
   WORKER_LABEL      Human-readable device name (same as --label)
+  LOBU_ORG          Active org slug (same as --active-org)
 
 Examples:
   # Worker daemon

--- a/packages/connector-worker/src/daemon/start.ts
+++ b/packages/connector-worker/src/daemon/start.ts
@@ -50,6 +50,8 @@ export interface DaemonStartOptions {
   /** False only when the operator explicitly disables inherited-session delivery. */
   interactiveSession?: false;
   workerCredentialMaintenance?: (activate: (workerApiToken: string) => void) => Promise<void>;
+  /** Active organization slug for action permission management URL. */
+  activeOrg?: string;
 }
 
 export function resolveDaemonWorkerId(
@@ -193,6 +195,11 @@ export async function startDaemonCommand(
   if (platform) {
     log.info(
       `[cli] device mode: platform=${platform} capabilities=${capabilities.join(',') || '(none)'}`
+    );
+    const connectorsPath = opts.activeOrg ? `${opts.activeOrg}/connectors` : 'connectors';
+    const connectorsUrl = `${opts.apiUrl.replace(/\/+$/, '')}/${connectorsPath}`;
+    log.info(
+      `[cli] Manage action permissions (Approval vs Auto) at: ${connectorsUrl}`
     );
   }
   if (detected) {

--- a/packages/connector-worker/src/daemon/start.ts
+++ b/packages/connector-worker/src/daemon/start.ts
@@ -196,11 +196,12 @@ export async function startDaemonCommand(
     log.info(
       `[cli] device mode: platform=${platform} capabilities=${capabilities.join(',') || '(none)'}`
     );
-    const connectorsPath = opts.activeOrg ? `${opts.activeOrg}/connectors` : 'connectors';
-    const connectorsUrl = `${opts.apiUrl.replace(/\/+$/, '')}/${connectorsPath}`;
-    log.info(
-      `[cli] Manage action permissions (Approval vs Auto) at: ${connectorsUrl}`
-    );
+    if (opts.activeOrg) {
+      const connectorsUrl = `${opts.apiUrl.replace(/\/+$/, '')}/${opts.activeOrg}/connectors`;
+      log.info(
+        `[cli] Manage action permissions (Approval vs Auto) at: ${connectorsUrl}`
+      );
+    }
   }
   if (detected) {
     log.info(


### PR DESCRIPTION
## Summary
* Pass `activeOrg` from the CLI daemon command down to `startDaemonCommand`.
* In device mode, log a direct link to the organization's connectors page (`https://app.lobu.ai/<activeOrg>/connectors`) so users know where to manage action permissions and toggle `auto` mode for device operations.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: targeted `bun test`
- [x] Red→fix→green outputs pasted below

### Red output:
```
error: expect(received).toContain(expected)
Expected to contain: "Manage action permissions (Approval vs Auto) at:"
Received: "[cli] Starting worker daemon (ID: test-device, API: http://127.0.0.1:1)\n[cli] device mode: platform=macos capabilities=os.files\nError: Backend health check failed\n"

error: expect(received).toBe(expected)
Expected: "test-org"
Received: undefined
```

### Green output:
```
packages/cli/src/__tests__/daemon-gateway-origin.test.ts:
(pass) lobu daemon > forwards activeOrg to startDaemonCommand for permission management link [0.11ms]

packages/connector-worker/src/__tests__/device-mode-requires-durable-token.test.ts:
(pass) device mode requires a durable token > accepts a durable PAT and proceeds to start [238.64ms]

34 pass
0 fail
106 expect() calls
```