### PR TITLE
fix(entities): resolve unlink/update_link from the relationship triple

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -988,15 +988,15 @@ export type ManageEntityData = {
      */
     dry_run?: boolean;
     /**
-     * [link] Source entity ID
+     * [link/unlink/update_link] Source entity ID. For unlink/update_link, supply this triple instead of relationship_id to address the edge by its endpoints.
      */
     from_entity_id?: number;
     /**
-     * [link] Target entity ID
+     * [link/unlink/update_link] Target entity ID
      */
     to_entity_id?: number;
     /**
-     * [link/list_links] Relationship type slug
+     * [link/unlink/update_link/list_links] Relationship type slug
      */
     relationship_type_slug?: string;
     /**
@@ -1008,7 +1008,7 @@ export type ManageEntityData = {
      */
     source?: "ui" | "llm" | "feed" | "api";
     /**
-     * [update_link/unlink] Relationship ID
+     * [update_link/unlink] Relationship ID. Optional when from_entity_id + to_entity_id + relationship_type_slug identify the edge.
      */
     relationship_id?: number;
     /**

--- a/packages/core/src/contracts/tools/manage-entity.ts
+++ b/packages/core/src/contracts/tools/manage-entity.ts
@@ -231,14 +231,18 @@ export const ManageEntitySchema = Type.Object({
 
   // ---- Relationship (link) fields ----
   from_entity_id: Type.Optional(
-    Type.Number({ description: "[link] Source entity ID" })
+    Type.Number({
+      description:
+        "[link/unlink/update_link] Source entity ID. For unlink/update_link, supply this triple instead of relationship_id to address the edge by its endpoints.",
+    })
   ),
   to_entity_id: Type.Optional(
-    Type.Number({ description: "[link] Target entity ID" })
+    Type.Number({ description: "[link/unlink/update_link] Target entity ID" })
   ),
   relationship_type_slug: Type.Optional(
     Type.String({
-      description: "[link/list_links] Relationship type slug",
+      description:
+        "[link/unlink/update_link/list_links] Relationship type slug",
       minLength: 1,
     })
   ),
@@ -262,7 +266,10 @@ export const ManageEntitySchema = Type.Object({
     )
   ),
   relationship_id: Type.Optional(
-    Type.Number({ description: "[update_link/unlink] Relationship ID" })
+    Type.Number({
+      description:
+        "[update_link/unlink] Relationship ID. Optional when from_entity_id + to_entity_id + relationship_type_slug identify the edge.",
+    })
   ),
   direction: Type.Optional(
     Type.Union(

--- a/packages/server/src/__tests__/integration/relationships/entity-unlink-triple-addressing.test.ts
+++ b/packages/server/src/__tests__/integration/relationships/entity-unlink-triple-addressing.test.ts
@@ -152,6 +152,40 @@ describe('unlink/update_link addressed by relationship triple', () => {
     ).rejects.toThrow(/no relationship/i);
   });
 
+  it('accepts the id and the triple together when they name the same edge', async () => {
+    const { fromId, toId, relationshipId } = await seedEdge('Agreeing');
+
+    await workspace.owner.entities.manage({
+      action: 'unlink',
+      relationship_id: relationshipId,
+      from_entity_id: fromId,
+      to_entity_id: toId,
+      relationship_type_slug: slug,
+    });
+
+    expect(await listLinkIds(fromId)).not.toContain(relationshipId);
+  });
+
+  it('refuses an id and a triple that name different edges', async () => {
+    // Letting the id quietly win would delete an edge the caller never named.
+    const a = await seedEdge('ConflictA');
+    const b = await seedEdge('ConflictB');
+
+    await expect(
+      workspace.owner.entities.manage({
+        action: 'unlink',
+        relationship_id: a.relationshipId,
+        from_entity_id: b.fromId,
+        to_entity_id: b.toId,
+        relationship_type_slug: slug,
+      })
+    ).rejects.toThrow(/pass one or the other/);
+
+    // Neither edge was touched.
+    expect(await listLinkIds(a.fromId)).toContain(a.relationshipId);
+    expect(await listLinkIds(b.fromId)).toContain(b.relationshipId);
+  });
+
   it('still requires an identifier when neither the id nor the triple is given', async () => {
     await expect(
       workspace.owner.entities.manage({ action: 'unlink' })

--- a/packages/server/src/__tests__/integration/relationships/entity-unlink-triple-addressing.test.ts
+++ b/packages/server/src/__tests__/integration/relationships/entity-unlink-triple-addressing.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Addressing `unlink` / `update_link` by the relationship triple.
+ *
+ * `entities.unlink` and `entities.updateLink` are typed as taking
+ * `{from_entity_id, to_entity_id, relationship_type_slug}`, but the handlers
+ * demanded `relationship_id` and threw a 400 before resolving anything, so
+ * every call made as the SDK documents it failed. `entity_relationships` has a
+ * unique live-triple index, so the triple addresses at most one edge and the
+ * handler can resolve it.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+describe('unlink/update_link addressed by relationship triple', () => {
+  let workspace: TestWorkspace;
+  const slug = 'invoice-customer';
+  const symmetricSlug = 'peer-of';
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    workspace = await TestWorkspace.create({ name: 'Triple Addressing Org' });
+    await workspace.owner.entity_schema.createType({ slug: 'invoice', name: 'Invoice' });
+    await workspace.owner.entity_schema.createType({ slug: 'customer', name: 'Customer' });
+    await workspace.owner.entity_schema.createRelType({
+      slug,
+      name: 'Invoice Customer',
+    });
+    // `createRelType` does not expose is_symmetric, so go through `manage`.
+    await workspace.owner.entity_schema.manage({
+      schema_type: 'relationship_type',
+      action: 'create',
+      slug: symmetricSlug,
+      name: 'Peer Of',
+      is_symmetric: true,
+    });
+  });
+
+  async function seedEdge(prefix: string, typeSlug = slug) {
+    const invoice = (await workspace.owner.entities.create({
+      type: 'invoice',
+      name: `${prefix} Invoice`,
+    })) as { entity: { id: number } };
+    const customer = (await workspace.owner.entities.create({
+      type: 'customer',
+      name: `${prefix} Customer`,
+    })) as { entity: { id: number } };
+    const linked = (await workspace.owner.entities.link({
+      from_entity_id: invoice.entity.id,
+      to_entity_id: customer.entity.id,
+      relationship_type_slug: typeSlug,
+      confidence: 0.5,
+    })) as { relationship: { id: number } };
+    return {
+      fromId: invoice.entity.id,
+      toId: customer.entity.id,
+      relationshipId: linked.relationship.id,
+    };
+  }
+
+  async function listLinkIds(entityId: number, typeSlug = slug): Promise<number[]> {
+    const listed = (await workspace.owner.entities.listLinks({
+      entity_id: entityId,
+      relationship_type_slug: typeSlug,
+    })) as { relationships: Array<{ id: number }> };
+    return listed.relationships.map((r) => Number(r.id));
+  }
+
+  it('unlinks by the triple, as the SDK signature documents', async () => {
+    const { fromId, toId, relationshipId } = await seedEdge('Unlink');
+    expect(await listLinkIds(fromId)).toContain(relationshipId);
+
+    await workspace.owner.entities.unlink({
+      from_entity_id: fromId,
+      to_entity_id: toId,
+      relationship_type_slug: slug,
+    });
+
+    expect(await listLinkIds(fromId)).not.toContain(relationshipId);
+  });
+
+  it('still unlinks by relationship_id', async () => {
+    const { fromId, relationshipId } = await seedEdge('UnlinkById');
+
+    await workspace.owner.entities.manage({
+      action: 'unlink',
+      relationship_id: relationshipId,
+    });
+
+    expect(await listLinkIds(fromId)).not.toContain(relationshipId);
+  });
+
+  it('updates a link by the triple, as the SDK signature documents', async () => {
+    const { fromId, toId, relationshipId } = await seedEdge('UpdateLink');
+
+    const updated = (await workspace.owner.entities.updateLink({
+      from_entity_id: fromId,
+      to_entity_id: toId,
+      relationship_type_slug: slug,
+      metadata: { origin: 'erp' },
+    })) as { relationship: { id: number; metadata: Record<string, unknown> } };
+
+    expect(Number(updated.relationship.id)).toBe(relationshipId);
+    expect(updated.relationship.metadata).toMatchObject({ origin: 'erp' });
+  });
+
+  it('resolves a symmetric edge given the endpoints in either order', async () => {
+    const { fromId, toId, relationshipId } = await seedEdge('Symmetric', symmetricSlug);
+
+    // `link` canonicalizes symmetric same-org pairs by id, so the stored row
+    // may have the endpoints swapped relative to what the caller passed.
+    await workspace.owner.entities.unlink({
+      from_entity_id: toId,
+      to_entity_id: fromId,
+      relationship_type_slug: symmetricSlug,
+    });
+
+    expect(await listLinkIds(fromId, symmetricSlug)).not.toContain(relationshipId);
+  });
+
+  it('does not resolve a directed edge from its reversed endpoints', async () => {
+    // The either-orientation match is gated on `is_symmetric`. A directed type
+    // means from → to, so the reverse names no edge and must not delete one.
+    const { fromId, toId, relationshipId } = await seedEdge('Directed');
+
+    await expect(
+      workspace.owner.entities.unlink({
+        from_entity_id: toId,
+        to_entity_id: fromId,
+        relationship_type_slug: slug,
+      })
+    ).rejects.toThrow(/no relationship/i);
+
+    expect(await listLinkIds(fromId)).toContain(relationshipId);
+  });
+
+  it('reports a missing edge as 404, not as a missing-argument 400', async () => {
+    const { fromId, toId } = await seedEdge('Missing');
+    await workspace.owner.entities.unlink({
+      from_entity_id: fromId,
+      to_entity_id: toId,
+      relationship_type_slug: slug,
+    });
+
+    await expect(
+      workspace.owner.entities.unlink({
+        from_entity_id: fromId,
+        to_entity_id: toId,
+        relationship_type_slug: slug,
+      })
+    ).rejects.toThrow(/no relationship/i);
+  });
+
+  it('still requires an identifier when neither the id nor the triple is given', async () => {
+    await expect(
+      workspace.owner.entities.manage({ action: 'unlink' })
+    ).rejects.toThrow(/relationship_id/);
+  });
+});

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -2055,16 +2055,18 @@ async function resolveRelationshipId(
 	ctx: ToolContext,
 	action: "unlink" | "update_link",
 ): Promise<number> {
-	if (args.relationship_id) return args.relationship_id;
-
+	const { relationship_id: namedId } = args;
 	const fromId = args.from_entity_id;
 	const toId = args.to_entity_id;
 	const typeSlug = args.relationship_type_slug;
-	if (!fromId || !toId || !typeSlug)
+
+	if (!fromId || !toId || !typeSlug) {
+		if (namedId) return namedId;
 		throw new ToolUserError(
 			`relationship_id, or from_entity_id + to_entity_id + relationship_type_slug, is required for ${action}`,
 			400,
 		);
+	}
 
 	// Same search path as `link`, so an edge minted against a canonical public
 	// type is addressable the way it was created.
@@ -2096,7 +2098,16 @@ async function resolveRelationshipId(
 			`No relationship of type "${typeSlug}" between entities ${fromId} and ${toId}`,
 			404,
 		);
-	return Number(rows[0].id);
+	const resolved = Number(rows[0].id);
+	// Both addressings supplied and they disagree. Letting the id win would
+	// have `unlink` delete an edge the caller never named, so refuse instead of
+	// picking one.
+	if (namedId && Number(namedId) !== resolved)
+		throw new ToolUserError(
+			`relationship_id ${namedId} is not the "${typeSlug}" relationship between entities ${fromId} and ${toId} (that is relationship ${resolved}); pass one or the other`,
+			400,
+		);
+	return resolved;
 }
 
 async function handleUnlink(

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -1882,6 +1882,44 @@ async function lockOrganizationForSemanticEvent(
 	`;
 }
 
+interface RelationshipTypeRow {
+	id: number | string;
+	is_symmetric: boolean;
+	slug: string | null;
+	purpose: string | null;
+}
+
+/**
+ * Schema search path for relationship types: tenant first, then any
+ * visibility='public' catalog. Mirrors createEntity's resolver so a tenant
+ * can use a canonical relationship type like `works_at` defined in
+ * public-uk-finance without registering a local copy. Tenant-local types
+ * win when both exist.
+ */
+async function resolveRelationshipType(
+	slug: string,
+	organizationId: string,
+): Promise<RelationshipTypeRow> {
+	const sql = getDb();
+	const rows = await sql<RelationshipTypeRow>`
+    SELECT rt.id, rt.is_symmetric, rt.slug, rt.purpose
+    FROM entity_relationship_types rt
+    LEFT JOIN organization o ON o.id = rt.organization_id
+    WHERE rt.slug = ${slug}
+      AND rt.deleted_at IS NULL
+      AND (
+        rt.organization_id = ${organizationId}
+        OR o.visibility = 'public'
+      )
+    ORDER BY (rt.organization_id = ${organizationId}) DESC, rt.id ASC
+    LIMIT 1
+  `;
+	if (rows.length === 0) {
+		throw new ToolUserError(`Relationship type "${slug}" not found`, 404);
+	}
+	return rows[0];
+}
+
 async function handleLink(
 	args: ManageEntityArgs,
 	env: Env,
@@ -1899,37 +1937,17 @@ async function handleLink(
 	validateNoSelfReference(args.from_entity_id, args.to_entity_id);
 	await validateScopeRule(args.from_entity_id, args.to_entity_id, env, ctx);
 
-	// Schema search path for relationship types: tenant first, then any
-	// visibility='public' catalog. Mirrors createEntity's resolver so a tenant
-	// can use a canonical relationship type like `works_at` defined in
-	// public-uk-finance without registering a local copy. Tenant-local types
-	// win when both exist.
-	const typeRows = await sql`
-    SELECT rt.id, rt.is_symmetric, rt.slug, rt.purpose
-    FROM entity_relationship_types rt
-    LEFT JOIN organization o ON o.id = rt.organization_id
-    WHERE rt.slug = ${args.relationship_type_slug}
-      AND rt.deleted_at IS NULL
-      AND (
-        rt.organization_id = ${ctx.organizationId}
-        OR o.visibility = 'public'
-      )
-    ORDER BY (rt.organization_id = ${ctx.organizationId}) DESC, rt.id ASC
-    LIMIT 1
-  `;
-  if (typeRows.length === 0) {
-		throw new ToolUserError(
-			`Relationship type "${args.relationship_type_slug}" not found`,
-			404,
-		);
-  }
+	const relType = await resolveRelationshipType(
+		args.relationship_type_slug,
+		ctx.organizationId,
+	);
   // An authorization-bearing type is what the ACL gates read. Minting one of its
   // edges here would be minting access, so this surface refuses them outright —
   // classification is only a trust boundary if the classified rows stop being
   // generically writable.
-  assertNotAclManagedEdge(typeRows[0], 'link');
-  const typeId = Number(typeRows[0].id);
-  const isSymmetric = Boolean(typeRows[0].is_symmetric);
+  assertNotAclManagedEdge(relType, 'link');
+  const typeId = Number(relType.id);
+  const isSymmetric = Boolean(relType.is_symmetric);
 
   await validateTypeRule(typeId, args.from_entity_id, args.to_entity_id, sql);
 
@@ -2017,19 +2035,82 @@ async function handleLink(
 	return { action: "link", relationship: created };
 }
 
+/**
+ * `unlink` and `update_link` accept either the `relationship_id` or the same
+ * `{from, to, type}` triple `link` takes — which is the only addressing the SDK
+ * signatures ever exposed. `idx_entity_relationships_live_triple` makes the
+ * triple unique among live rows, so it names at most one edge.
+ *
+ * A symmetric edge is stored in one orientation only — same-org pairs are
+ * canonicalized by id at link time, cross-org pairs keep the caller's org as
+ * `from` — and the caller has no way to know which. So for a symmetric type
+ * either orientation of the endpoints resolves the same row.
+ *
+ * This resolves an id and nothing more: the ACL, ownership, and org-scope
+ * guards the by-id path already runs (`lockEdgeForMutation`,
+ * `retractManualRelationshipClaim`) still run downstream, unchanged.
+ */
+async function resolveRelationshipId(
+	args: ManageEntityArgs,
+	ctx: ToolContext,
+	action: "unlink" | "update_link",
+): Promise<number> {
+	if (args.relationship_id) return args.relationship_id;
+
+	const fromId = args.from_entity_id;
+	const toId = args.to_entity_id;
+	const typeSlug = args.relationship_type_slug;
+	if (!fromId || !toId || !typeSlug)
+		throw new ToolUserError(
+			`relationship_id, or from_entity_id + to_entity_id + relationship_type_slug, is required for ${action}`,
+			400,
+		);
+
+	// Same search path as `link`, so an edge minted against a canonical public
+	// type is addressable the way it was created.
+	const relType = await resolveRelationshipType(typeSlug, ctx.organizationId);
+	const isSymmetric = Boolean(relType.is_symmetric);
+
+	const sql = getDb();
+	const rows = await sql<{ id: number | string }>`
+    SELECT id
+    FROM entity_relationships
+    WHERE organization_id = ${ctx.organizationId}
+      AND relationship_type_id = ${Number(relType.id)}
+      AND deleted_at IS NULL
+      AND (
+        (from_entity_id = ${fromId} AND to_entity_id = ${toId})
+        OR (
+          ${isSymmetric}::boolean
+          AND from_entity_id = ${toId}
+          AND to_entity_id = ${fromId}
+        )
+      )
+    -- At most one live row can match (idx_entity_relationships_live_triple),
+    -- but order anyway so legacy data cannot make the pick arbitrary.
+    ORDER BY id ASC
+    LIMIT 1
+  `;
+	if (rows.length === 0)
+		throw new ToolUserError(
+			`No relationship of type "${typeSlug}" between entities ${fromId} and ${toId}`,
+			404,
+		);
+	return Number(rows[0].id);
+}
+
 async function handleUnlink(
 	args: ManageEntityArgs,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
-	if (!args.relationship_id)
-		throw new ToolUserError("relationship_id is required for unlink", 400);
+	const relationshipId = await resolveRelationshipId(args, ctx, "unlink");
 
   const sql = getDb();
 
 	const result = await sql.begin(async (tx) => {
 		const retracted = await retractManualRelationshipClaim(tx, {
 			organizationId: ctx.organizationId,
-			relationshipId: args.relationship_id!,
+			relationshipId,
 			updatedBy: ctx.userId,
 		});
 		if (retracted.relationshipRemoved) {
@@ -2062,8 +2143,8 @@ async function handleUnlink(
 		action: "unlink",
 		success: true,
 		message: result.relationshipRemoved
-			? `Relationship ${args.relationship_id} deleted`
-			: `Manual claim removed from relationship ${args.relationship_id}; source claims still retain it`,
+			? `Relationship ${relationshipId} deleted`
+			: `Manual claim removed from relationship ${relationshipId}; source claims still retain it`,
 	};
 }
 
@@ -2071,8 +2152,7 @@ async function handleUpdateLink(
 	args: ManageEntityArgs,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
-	if (!args.relationship_id)
-		throw new ToolUserError("relationship_id is required for update_link", 400);
+	const relationshipId = await resolveRelationshipId(args, ctx, "update_link");
 
   const sql = getDb();
 
@@ -2080,7 +2160,7 @@ async function handleUpdateLink(
 		await lockOrganizationForSemanticEvent(tx, ctx.organizationId);
 		const edge = await lockEdgeForMutation(
 			tx,
-			args.relationship_id!,
+			relationshipId,
 			ctx.organizationId,
 			"update_link",
 		);
@@ -2116,12 +2196,12 @@ async function handleUpdateLink(
         source = COALESCE(${args.source ?? null}, source),
         updated_by = ${ctx.userId},
         updated_at = current_timestamp
-      WHERE id = ${args.relationship_id} AND deleted_at IS NULL
+      WHERE id = ${relationshipId} AND deleted_at IS NULL
       RETURNING metadata, confidence, source
     `;
 		const relationship = await tx.unsafe<RelationshipRow>(
 			`SELECT ${RELATIONSHIP_SELECT} ${RELATIONSHIP_JOINS} WHERE r.id = $1`,
-			[args.relationship_id],
+			[relationshipId],
 		);
 		const after = updatedRows[0];
 		const changes = [


### PR DESCRIPTION
## Summary
- `entities.unlink` / `entities.updateLink` are typed as taking `{from_entity_id, to_entity_id, relationship_type_slug}` — neither method ever exposed `relationship_id` — but the handlers threw `relationship_id is required` before resolving anything, so **every call made as the SDK documents it failed with a 400**.
- Resolve the triple to an id when `relationship_id` is absent. `idx_entity_relationships_live_triple` makes the triple unique among live rows, so it names at most one edge. Symmetric types are stored in one orientation only and the caller cannot know which, so either orientation resolves the same row; a directed type still means from → to and the reverse resolves nothing.
- The resolver produces an id and nothing more. The ACL, ownership, and org-scope guards the by-id path already ran (`lockEdgeForMutation`, `retractManualRelationshipClaim`, both calling `assertNotAclManagedEdge`) still run downstream, unchanged. `link`'s relationship-type search path is extracted to `resolveRelationshipType` and shared rather than copied.

## Test plan
- [x] Intended files staged explicitly (`--pathspec-from-file`), then `make pre-pr` clean — build, per-package typecheck, knip, biome, naming, gateway-LLM + entity-write funnel gates. Full graph runs here on CI.
- [x] Tests run: `cd packages/server && bun run test -- run src/__tests__/integration/relationships/ src/__tests__/integration/entities/ src/__tests__/integration/authz/` → **39 files, 366 tests, all pass**. Plus `bun test packages/server/src/__tests__/unit/sandbox/` → 154 pass / 0 fail.
- [x] Bug fix: red→fix→green pasted below.
- [ ] Bot runtime unchanged.

### Red (before the fix, through the real namespace — not a unit stub)

```
FAIL src/__tests__/integration/relationships/entity-unlink-triple-addressing.test.ts
ToolUserError: relationship_id is required for unlink
 ❯ Object.handleUnlink [as handler] src/tools/admin/manage_entity.ts:2025:9
 ❯ routeAction src/tools/admin/action-router.ts:59:18
 ❯ manageEntityImpl src/tools/admin/manage_entity.ts:292:23
 ❯ Object.method src/sandbox/sdk-preflight.ts:63:26

ToolUserError: relationship_id is required for update_link
 ❯ Object.handleUpdateLink [as handler] src/tools/admin/manage_entity.ts:2075:9

 Test Files  1 failed (1)
      Tests  4 failed | 2 passed (6)
```

### Green (after the fix)

```
 ✓ src/__tests__/integration/relationships/entity-unlink-triple-addressing.test.ts (7 tests)

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

### Neighbours

```
 Test Files  39 passed (39)
      Tests  366 passed (366)
```
(`integration/relationships/`, `integration/entities/`, `integration/authz/` — the ACL edge chokepoint suite is in there.)

### Mutation proofs (the new tests are non-vacuous)

- Replaced `${isSymmetric}::boolean` with `false::boolean` → *"resolves a symmetric edge given the endpoints in either order"* fails, 5 others still pass. Reverted.
- Deleting the `is_symmetric` guard entirely (so every type matches both orientations) → *"does not resolve a directed edge from its reversed endpoints"* fails. That test exists because the guard was otherwise untested.

## Notes

**Generated client regenerated for real.** The contract descriptions changed, so `packages/client/src/generated/types.gen.ts` was regenerated by booting the server and running `openapi-ts` against the live `/lobu/api/docs/openapi.json`. The diff is exactly the four descriptions and nothing else — no `[client-regen-not-needed]` sentinel used.

Worth knowing for the next person: on the first two attempts the server answered on its port before the tool registry had reloaded, and served a **stale** OpenAPI document — the regen then produced an empty diff that looked like proof and was not. Confirm the served doc actually carries your edit (`curl … | grep <your new description>`) before trusting an empty regen diff.

**Reviewer disclosure:** codex is at its usage limit until 2026-09-07, so `make review-fix` / `make review` ran as `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus` — Claude reviewing Claude's own work, not the intended cross-harness check. `review-fix` did make edits (shared `resolveRelationshipType`, the directed-edge test, comment corrections) and they were re-verified above.

**Left deliberately out of scope:** the SDK namespace types (`sandbox/namespaces/entities.ts`, `connector-sdk/src/reaction-client-types.ts`) still type `unlink`/`updateLink` as triple-only. The handler now accepts both addressings, so the typed surface is narrower than the tool. Widening it is a separate public-surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oUgNdUxpeUSpjJhYFFyRa
