### PR TITLE
fix(connector-worker): preserve shell supervisor failures

### DIFF
--- a/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
+++ b/packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
@@ -183,6 +183,42 @@ describe('daemon-builtin os.shell', () => {
     });
   });
 
+  test('preserves a signal instead of collapsing it to exit code -1', async () => {
+    if (process.platform === 'win32') return;
+
+    const result = await executeDaemonBuiltin({
+      connectorKey: 'os.shell',
+      actionKey: 'run',
+      input: { command: 'kill -TERM $$', cwd: process.cwd() },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'operation_execution_failed',
+      error: 'Shell command terminated by SIGTERM',
+      output: {
+        exit_code: -1,
+        exit_signal: 'SIGTERM',
+        process_stage: 'target_exit',
+      },
+    });
+  });
+
+  test('keeps short-lived command outcomes stable under process churn', async () => {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const output = await runShellBuiltin({
+        command: "printf 'lobu-shell-self-check\\n'",
+        cwd: process.cwd(),
+      });
+      expect(output).toMatchObject({
+        success: true,
+        stdout: 'lobu-shell-self-check\n',
+        stderr: '',
+        exit_code: 0,
+      });
+    }
+  });
+
   test('executes without compiled connector code or connector SDK resolution', async () => {
     const { client, completions } = stubClient();
     const result = await executeRun(
@@ -430,7 +466,19 @@ describe('daemon-builtin os.shell', () => {
         actionKey: 'run',
         input: { command: 'printf nope', cwd: file },
       });
-      expect(spawnFault).toMatchObject({ ok: false, code: 'operation_execution_failed' });
+      expect(spawnFault).toMatchObject({
+        ok: false,
+        code: 'operation_execution_failed',
+        output: {
+          exit_code: -1,
+          process_stage: 'supervisor_spawn',
+          process_error_code: 'ENOTDIR',
+        },
+      });
+      if (!spawnFault.ok) {
+        expect(spawnFault.error).toContain('Shell supervisor failed to start');
+        expect(spawnFault.error).toContain('ENOTDIR');
+      }
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -36,11 +36,14 @@ function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): vo
   const finish = (
     code: number | null,
     signal: NodeJS.Signals | null,
-    error: string | null
+    error: string | null,
+    errorCode: string | null,
+    stage: TargetExitStage
   ) => {
     if (targetFinished) return;
     targetFinished = true;
-    if (!parentLost) send({ type: 'target-exit', code, signal, error });
+    if (!parentLost)
+      send({ type: 'target-exit', code, signal, error, errorCode, stage });
   };
   const stopAfterParentLoss = () => {
     if (parentLost) return;
@@ -101,7 +104,7 @@ function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): vo
     process.exit(0);
   });
   if (!binary) {
-    finish(127, null, 'automation supervisor missing target binary');
+    finish(127, null, 'automation supervisor missing target binary', null, 'target_spawn');
   } else {
     try {
       target = spawnChild(binary, args, {
@@ -114,12 +117,28 @@ function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): vo
         process.stdin.pipe(target.stdin);
       }
     } catch (error) {
-      finish(127, null, error instanceof Error ? error.message : String(error));
+      const code = (error as NodeJS.ErrnoException).code;
+      finish(
+        127,
+        null,
+        error instanceof Error ? error.message : String(error),
+        typeof code === 'string' ? code : null,
+        'target_spawn'
+      );
     }
     target?.once('error', (error) => {
-      finish(127, null, error instanceof Error ? error.message : String(error));
+      const code = (error as NodeJS.ErrnoException).code;
+      finish(
+        127,
+        null,
+        error.message,
+        typeof code === 'string' ? code : null,
+        'target_spawn'
+      );
     });
-    target?.once('exit', (code, signal) => finish(code, signal, null));
+    target?.once('exit', (code, signal) =>
+      finish(code, signal, null, null, 'target_exit')
+    );
   }
   setImmediate(() => {
     if (!process.connected) stopAfterParentLoss();
@@ -128,10 +147,18 @@ function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): vo
 
 export const CLI_SUPERVISOR_SOURCE = `(${runCliSupervisor.toString()})(require('node:child_process').spawn, ${TREE_TERM_GRACE_MS});`;
 
-interface TargetExit {
+export type TargetExitStage =
+  | 'target_exit'
+  | 'target_spawn'
+  | 'supervisor_spawn'
+  | 'supervisor_exit';
+
+export interface TargetExit {
   exitCode: number | null;
   signalCode: NodeJS.Signals | null;
   error: string | null;
+  errorCode: string | null;
+  stage: TargetExitStage;
 }
 
 interface SupervisedCli {
@@ -361,20 +388,40 @@ export function spawnSupervisedCli(
       if (typeof message !== 'object' || message == null) return;
       const value = message as Record<string, unknown>;
       if (value.type !== 'target-exit') return;
+      const stage =
+        value.stage === 'target_exit' || value.stage === 'target_spawn'
+          ? value.stage
+          : 'target_exit';
       settle({
         exitCode: typeof value.code === 'number' ? value.code : null,
-        signalCode: typeof value.signal === 'string' ? (value.signal as NodeJS.Signals) : null,
+        signalCode:
+          typeof value.signal === 'string'
+            ? (value.signal as NodeJS.Signals)
+            : null,
         error: typeof value.error === 'string' ? value.error : null,
+        errorCode:
+          typeof value.errorCode === 'string' ? value.errorCode : null,
+        stage,
       });
     });
     supervisor.once('error', (error) => {
-      settle({ exitCode: null, signalCode: null, error: error.message });
+      const code = (error as NodeJS.ErrnoException).code;
+      settle({
+        exitCode: null,
+        signalCode: null,
+        error: error.message,
+        errorCode: typeof code === 'string' ? code : null,
+        stage: 'supervisor_spawn',
+      });
     });
     supervisor.once('exit', (code, signal) => {
       settle({
         exitCode: code,
         signalCode: signal,
-        error: 'automation process supervisor exited before reporting the CLI outcome',
+        error:
+          'automation process supervisor exited before reporting the CLI outcome',
+        errorCode: null,
+        stage: 'supervisor_exit',
       });
     });
   });

--- a/packages/connector-worker/src/daemon/builtins/index.ts
+++ b/packages/connector-worker/src/daemon/builtins/index.ts
@@ -1,4 +1,4 @@
-import { ShellInputError, runShellBuiltin } from './os-shell.js';
+import { ShellInputError, type ShellRunOutput, runShellBuiltin } from './os-shell.js';
 
 export type DaemonBuiltinErrorCode =
   | 'invalid_operation_input'
@@ -8,6 +8,32 @@ export type DaemonBuiltinErrorCode =
 export type DaemonBuiltinResult =
   | { ok: true; output: Record<string, unknown> }
   | { ok: false; code: DaemonBuiltinErrorCode; error: string; output?: Record<string, unknown> };
+
+function describeShellFailure(output: ShellRunOutput): string {
+  if (output.timed_out) {
+    return `Shell command timed out after ${output.duration_ms}ms`;
+  }
+  if (output.process_error) {
+    const code = output.process_error_code
+      ? ` (${output.process_error_code})`
+      : '';
+    const prefix =
+      output.process_stage === 'supervisor_spawn'
+        ? 'Shell supervisor failed to start'
+        : output.process_stage === 'target_spawn'
+          ? 'Shell command failed to start'
+          : output.process_stage === 'supervisor_exit'
+            ? 'Shell supervisor exited before reporting the command outcome'
+            : output.process_stage === 'shutdown'
+              ? 'Shell command was aborted during daemon shutdown'
+              : 'Shell execution failed';
+    return `${prefix}${code}: ${output.process_error}`;
+  }
+  if (output.exit_signal) {
+    return `Shell command terminated by ${output.exit_signal}`;
+  }
+  return `Shell command exited with code ${output.exit_code}`;
+}
 
 export async function executeDaemonBuiltin(params: {
   connectorKey: string;
@@ -29,9 +55,7 @@ export async function executeDaemonBuiltin(params: {
       return {
         ok: false,
         code: 'operation_execution_failed',
-        error: output.timed_out
-          ? `Shell command timed out after ${output.duration_ms}ms`
-          : `Shell command exited with code ${output.exit_code}`,
+        error: describeShellFailure(output),
         output: { ...output },
       };
     }

--- a/packages/connector-worker/src/daemon/builtins/os-shell.ts
+++ b/packages/connector-worker/src/daemon/builtins/os-shell.ts
@@ -11,6 +11,7 @@ import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { isAbsolute } from 'node:path';
 import {
+  type TargetExit,
   releaseSupervisor,
   signalOwnedPosixProcessGroup,
   spawnSupervisedCli,
@@ -33,9 +34,21 @@ export interface ShellRunOutput {
   stdout: string;
   stderr: string;
   exit_code: number;
+  exit_signal?: NodeJS.Signals;
+  process_error?: string;
+  process_error_code?: string;
+  process_stage?: TargetExit['stage'] | 'timeout' | 'shutdown';
   success: boolean;
   timed_out: boolean;
   duration_ms: number;
+}
+
+interface TerminatedShellOutcome {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  error: string | null;
+  errorCode: string | null;
+  stage: 'timeout' | 'shutdown';
 }
 
 const DEFAULT_TIMEOUT_MS = 60_000;
@@ -96,9 +109,29 @@ export async function runShellBuiltin(
 
   const startedAt = Date.now();
   return await new Promise<ShellRunOutput>((resolve) => {
-    const supervised = spawnSupervisedCli(
-      'bash', ['--noprofile', '--norc', '-c', command], shellEnvironment(), { stdin: 'pipe', cwd },
-    );
+    let supervised: ReturnType<typeof spawnSupervisedCli>;
+    try {
+      supervised = spawnSupervisedCli(
+        'bash',
+        ['--noprofile', '--norc', '-c', command],
+        shellEnvironment(),
+        { stdin: 'pipe', cwd }
+      );
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      resolve({
+        stdout: '',
+        stderr: '',
+        exit_code: -1,
+        process_error: error instanceof Error ? error.message : String(error),
+        ...(typeof code === 'string' ? { process_error_code: code } : {}),
+        process_stage: 'supervisor_spawn',
+        success: false,
+        timed_out: false,
+        duration_ms: Date.now() - startedAt,
+      });
+      return;
+    }
     const child = supervised.supervisor;
     let stdout = '';
     let stderr = '';
@@ -107,8 +140,13 @@ export async function runShellBuiltin(
     let finishing = false;
     let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
 
-    const waitForClose = (stream: NodeJS.ReadableStream | null | undefined): Promise<void> => {
-      if (!stream || (stream as NodeJS.ReadableStream & { destroyed?: boolean }).destroyed) {
+    const waitForClose = (
+      stream: NodeJS.ReadableStream | null | undefined
+    ): Promise<void> => {
+      if (
+        !stream ||
+        (stream as NodeJS.ReadableStream & { destroyed?: boolean }).destroyed
+      ) {
         return Promise.resolve();
       }
       return new Promise((resolve) => stream.once('close', resolve));
@@ -116,54 +154,95 @@ export async function runShellBuiltin(
     const stdoutClosed = waitForClose(child.stdout);
     const stderrClosed = waitForClose(child.stderr);
 
-    // Only the group this daemon owns. A command that deliberately detaches a
-    // new session is outside that ownership contract and belongs to whoever
-    // created it: signalling a numeric PGID we no longer own risks hitting a
-    // reused one, so ownership ending is the end of our reach.
-    const killOwnedProcessGroup = (signal: NodeJS.Signals): void => {
-      try {
-        if (child.pid != null) {
-          if (signalOwnedPosixProcessGroup(child, signal)) return;
-        }
-      } catch {}
-      try { child.kill(signal); } catch {}
-    };
-
-    const abortHandler = () => {
-      if (!settled) void terminateChild(child).finally(() => finishAfterOutputDrain(child.exitCode ?? -1));
-    };
-    // Let the finish closure initialize before handling an already-aborted
-    // signal; this path is common during daemon shutdown.
-    if (shutdownSignal?.aborted) queueMicrotask(abortHandler);
-    else shutdownSignal?.addEventListener('abort', abortHandler, { once: true });
-
-    // Synchronous by construction: the only caller drains and destroys both
-    // pipes before calling this, so there is nothing left to await here.
-    const finish = (exitCode: number): void => {
-      if (settled || finishing) return;
+    const reserveFinish = (): boolean => {
+      if (settled || finishing) return false;
       finishing = true;
       if (timeoutTimer) clearTimeout(timeoutTimer);
       shutdownSignal?.removeEventListener('abort', abortHandler);
+      return true;
+    };
+
+    const finish = (outcome: TargetExit | TerminatedShellOutcome): void => {
+      if (settled) return;
       settled = true;
       resolve({
         stdout,
         stderr,
-        exit_code: exitCode,
-        success: !timedOut && exitCode === 0,
+        exit_code: outcome.exitCode ?? -1,
+        ...(outcome.signalCode ? { exit_signal: outcome.signalCode } : {}),
+        ...(outcome.error ? { process_error: outcome.error } : {}),
+        ...(outcome.errorCode
+          ? { process_error_code: outcome.errorCode }
+          : {}),
+        ...(outcome.stage !== 'target_exit' ||
+        outcome.signalCode ||
+        outcome.error
+          ? { process_stage: outcome.stage }
+          : {}),
+        success:
+          !timedOut &&
+          outcome.exitCode === 0 &&
+          outcome.signalCode === null &&
+          outcome.error === null,
         timed_out: timedOut,
         duration_ms: Date.now() - startedAt,
       });
     };
 
-    const finishAfterOutputDrain = async (exitCode: number): Promise<void> => {
+    const finishAfterOutputDrain = async (
+      outcome: TargetExit | TerminatedShellOutcome
+    ): Promise<void> => {
       await Promise.race([
         Promise.all([stdoutClosed, stderrClosed]),
-        new Promise((resolve) => setTimeout(resolve, OUTPUT_DRAIN_GRACE_MS).unref()),
+        new Promise((resolve) =>
+          setTimeout(resolve, OUTPUT_DRAIN_GRACE_MS).unref()
+        ),
       ]);
       if (!settled) child.stdout?.destroy();
       if (!settled) child.stderr?.destroy();
-      finish(exitCode);
+      finish(outcome);
     };
+
+    const terminateAndFinish = (
+      stage: TerminatedShellOutcome['stage'],
+      error: string | null
+    ): void => {
+      if (!reserveFinish()) return;
+      void terminateChild(child)
+        .then((signal) =>
+          finishAfterOutputDrain({
+            exitCode: child.exitCode,
+            signalCode: child.signalCode ?? signal,
+            error,
+            errorCode: null,
+            stage,
+          })
+        )
+        .catch((terminationError) => {
+          const code = (terminationError as NodeJS.ErrnoException).code;
+          return finishAfterOutputDrain({
+            exitCode: child.exitCode,
+            signalCode: child.signalCode,
+            error:
+              terminationError instanceof Error
+                ? terminationError.message
+                : String(terminationError),
+            errorCode: typeof code === 'string' ? code : null,
+            stage,
+          });
+        });
+    };
+
+    const abortHandler = () => {
+      terminateAndFinish(
+        'shutdown',
+        'shell execution aborted during daemon shutdown'
+      );
+    };
+    // Let all finish closures initialize before handling an already-aborted
+    // signal; this path is common during daemon shutdown.
+    if (shutdownSignal?.aborted) queueMicrotask(abortHandler);
+    else shutdownSignal?.addEventListener('abort', abortHandler, { once: true });
 
     child.stdout?.setEncoding('utf8');
     child.stderr?.setEncoding('utf8');
@@ -174,23 +253,45 @@ export async function runShellBuiltin(
       stderr = appendCapped(stderr, chunk);
     });
     child.stdin?.on('error', (error: NodeJS.ErrnoException) => {
-      if (error.code !== 'EPIPE') stderr = appendCapped(stderr, `stdin error: ${error.message}\n`);
+      if (error.code !== 'EPIPE')
+        stderr = appendCapped(stderr, `stdin error: ${error.message}\n`);
     });
     child.stdin?.end(stdin);
 
     timeoutTimer = setTimeout(() => {
       timedOut = true;
-      void terminateChild(child).finally(() => finishAfterOutputDrain(child.exitCode ?? -1));
+      terminateAndFinish('timeout', null);
     }, timeoutMs);
 
     supervised.targetExit.then((target) => {
-      if (process.platform !== 'win32') killOwnedProcessGroup('SIGKILL');
-      else void terminateChild(child);
-      void releaseSupervisor(child).finally(() => finishAfterOutputDrain(target.exitCode ?? -1));
-    });
-    child.on('error', (error) => {
-      stderr = appendCapped(stderr, `spawn error: ${error.message}`);
-      void finishAfterOutputDrain(-1);
+      if (!reserveFinish()) return;
+      if (target.stage === 'supervisor_spawn') {
+        void finishAfterOutputDrain(target);
+        return;
+      }
+      // Only the group this daemon owns. A command that deliberately detaches a
+      // new session is outside that ownership contract and belongs to whoever
+      // created it: signalling a numeric PGID we no longer own risks hitting a
+      // reused one, so ownership ending is the end of our reach.
+      if (process.platform !== 'win32') {
+        try {
+          if (
+            child.pid == null ||
+            !signalOwnedPosixProcessGroup(child, 'SIGKILL')
+          ) {
+            child.kill('SIGKILL');
+          }
+        } catch {
+          try {
+            child.kill('SIGKILL');
+          } catch {}
+        }
+      } else {
+        void terminateChild(child);
+      }
+      void releaseSupervisor(child).finally(() =>
+        finishAfterOutputDrain(target)
+      );
     });
   });
 }

--- a/packages/connector-worker/src/self-check/index.ts
+++ b/packages/connector-worker/src/self-check/index.ts
@@ -478,7 +478,12 @@ export async function runConnectorRuntimeSelfCheck(
 			actionKey: "run",
 			input: { command: "printf 'lobu-shell-self-check\\n'", cwd: process.cwd() },
 		});
-		if (!result.ok) throw new Error(`${result.code}: ${result.error}`);
+		if (!result.ok) {
+			const output = result.output
+				? `; output=${JSON.stringify(result.output)}`
+				: "";
+			throw new Error(`${result.code}: ${result.error}${output}`);
+		}
 		if (result.output.stdout !== "lobu-shell-self-check\n") {
 			throw new Error(`Unexpected stdout: ${JSON.stringify(result.output.stdout)}.`);
 		}


### PR DESCRIPTION
## Summary

- preserve target exit signal, process stage, and errno across the shell supervisor IPC boundary
- remove the competing supervisor error settlement path that collapsed failures to exit code -1
- distinguish supervisor spawn, target spawn, signal termination, timeout, and shutdown failures
- include structured shell output in the packaged runtime self-check failure
- add regression coverage for signal exits, synchronous spawn failures, and short-lived process churn

## Context

Main CI run 33868088567 intermittently failed the daemon-builtin:os.shell/run probe with only:

operation_execution_failed: Shell command exited with code -1

The old path discarded the signal or error that explained the null exit code. This keeps successful action output backward-compatible while adding diagnostic fields only when a process-level failure occurs.

## Validation

- bun test packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts — 18 passed
- bun run --cwd packages/connector-worker typecheck
- make pre-pr
- packaged lobu connector runtime-self-check --json — 12/12 checks passed, including daemon-builtin:os.shell/run
- repository pre-commit Biome and TypeScript hooks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell command reliability during timeouts, shutdowns, and rapid process changes.
  * Preserved termination details, including signals, exit codes, and failure stages.
  * Supervisor startup failures now return structured results instead of unexpected failures.
  * Improved cleanup to avoid affecting unrelated processes.

* **Error Reporting**
  * Shell execution failures now provide clearer, more specific messages, including timeout, signal, and process error details.
  * Self-check failures now include available command output to aid troubleshooting.

* **Tests**
  * Added coverage for termination metadata, process churn, and structured spawn errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->