### PR TITLE
fix(automations): recover expired external trigger claims

### DIFF
--- a/packages/server/src/__tests__/integration/automations/trigger-execution.test.ts
+++ b/packages/server/src/__tests__/integration/automations/trigger-execution.test.ts
@@ -400,18 +400,45 @@ describe("Automation trigger execution contract", () => {
 		},
 	);
 
-	it.each(["expired", "unrecognized", "malformed_external"] as const)(
+	it("expires an external lease before retriggering fresh work", async () => {
+		const { sql, workspace, automation, claim } =
+			await createExternallyClaimedAutomation("device_worker");
+		await sql`
+      UPDATE runs
+      SET expires_at = NOW() - INTERVAL '1 second'
+      WHERE id = ${claim.run_id}
+    `;
+
+		const retriggered = (await workspace.owner.automations.trigger({
+			automation_id: automation.automation_id,
+		})) as AutomationTriggerResult;
+
+		expect(retriggered.run_id).not.toBe(claim.run_id);
+		expect(retriggered.created).toBe(true);
+		expect(retriggered.execution.lane).toBe("device_worker");
+		const [expired] = await sql<{ status: string; error_message: string | null }>`
+      SELECT status, error_message
+      FROM runs
+      WHERE id = ${claim.run_id}
+    `;
+		expect(expired).toEqual({
+			status: "timeout",
+			error_message: "External Automation window lease expired",
+		});
+		await expect(
+			workspace.owner.automations.claimNextWindow({
+				automation_id: automation.automation_id,
+				run_id: claim.run_id,
+			}),
+		).rejects.toThrow(/does not own an active lease/);
+	});
+
+	it.each(["unrecognized", "malformed_external"] as const)(
 		"fails closed for an %s claimed execution",
 		async (claimState) => {
 			const { sql, workspace, automation, claim } =
 				await createExternallyClaimedAutomation("managed_agent");
-			if (claimState === "expired") {
-				await sql`
-          UPDATE runs
-          SET expires_at = NOW() - INTERVAL '1 second'
-          WHERE id = ${claim.run_id}
-        `;
-			} else if (claimState === "unrecognized") {
+			if (claimState === "unrecognized") {
 				await sql`
           UPDATE runs
           SET claimed_by = 'unrecognized-trigger-claim', expires_at = NULL
@@ -437,9 +464,7 @@ describe("Automation trigger execution contract", () => {
         WHERE id = ${claim.run_id}
       `;
 			expect(after.status).toBe("running");
-			if (claimState === "expired") {
-				expect(after.claimed_by).toMatch(/^external:/);
-			} else if (claimState === "unrecognized") {
+			if (claimState === "unrecognized") {
 				expect(after.claimed_by).toBe("unrecognized-trigger-claim");
 			} else {
 				expect(after.claimed_by).toBe('external:{"user_id":"partial"}');

--- a/packages/server/src/tools/admin/manage_automations/claim-next-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/claim-next-window.ts
@@ -343,7 +343,7 @@ export async function handleClaimNextWindow(
   }
 }
 
-async function expireExternalClaims(tx: DbClient, automationId: number): Promise<void> {
+export async function expireExternalClaims(tx: DbClient, automationId: number): Promise<void> {
   await tx`
     UPDATE runs
     SET status = 'timeout', outcome = ${classifyRunOutcome({ status: 'timeout' })},

--- a/packages/server/src/tools/admin/manage_automations/trigger.ts
+++ b/packages/server/src/tools/admin/manage_automations/trigger.ts
@@ -31,6 +31,7 @@ import { requireExists } from "../helpers/db-helpers";
 import type { ManageAutomationsArgs } from "../manage_automations";
 import {
   encodeExternalAutomationClaimOwner,
+  expireExternalClaims,
   isExternalAutomationClaimOwner,
 } from "./claim-next-window";
 import { resolveAutomationExecutor } from "./executors";
@@ -192,6 +193,10 @@ export async function handleTrigger(
   const automationId = Number(automationIdString);
 
   const queued = await sql.begin(async (tx) => {
+    // Manual trigger recovery must reconcile an expired external window lease
+    // before enqueueing, otherwise the queue reuses that still-"active" run
+    // and loadTriggerExecution fails closed instead of creating fresh work.
+    await expireExternalClaims(tx, automationId);
     const run = await enqueueAutomationRunForAutomationInTransaction(
       automationId,
       "manual",


### PR DESCRIPTION
## Summary

Recover manual Automation triggers from expired external window leases instead of reusing the expired run and failing with `no recognized active claimant`.

## Root cause

`automations.trigger` enqueued/reused an active run before reconciling expired external claims. Because expired external runs still had `status IN ('claimed','running')`, queue reuse returned the stale run and `loadTriggerExecution` then rejected its expired lease. The existing `claimNextWindow` path already reconciles this state with `expireExternalClaims`.

## Fix

- share `expireExternalClaims` with the trigger path
- reconcile expired external claims inside the trigger transaction before enqueue/reuse
- preserve fail-closed behavior for unrecognized/malformed claimants
- add a regression proving the expired run becomes `timeout`, fresh work is created, and the stale claimant cannot resume the old run

## Validation

- targeted integration suite: 10/10 passing
- server TypeScript typecheck: passing
- pre-commit Biome + TypeScript checks: passing
- full server lint still reports existing unrelated repository diagnostics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Expired external automation windows are now correctly marked as timed out instead of remaining active.
  - Retrying an automation after an expired window now creates a fresh run.
  - Manual triggers no longer reuse stale external automation runs, improving reliability when leases expire.
- **Tests**
  - Added coverage for expired-window handling, retry behavior, and rejection of expired runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->