### PR TITLE
fix(connectors): preserve feeds across transient browser failures

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -2109,41 +2109,62 @@ describe("LinkedInConnector home_feed", () => {
     });
   });
 
-  test("fails the batch when an advertised comment thread remains incomplete", async () => {
-    await expect(
-      syncHomeFeedDom(`
-        <div componentkey="expandedincomplete_threadFeedType_MAIN_FEED_RELEVANCE">
-          <button aria-label="Open control menu for post by Incomplete Thread Author"></button>
-          <span id="translatable-commentary-urn:li:activity:8333333333333333333"></span>
-          <p>An incomplete-thread home-feed post with enough useful text to pass the filter</p>
-          <div role="button" class="comment-count">4 comments</div>
-          <div id="replaceableComment_urn:li:comment:(urn:li:activity:8333333333333333333,8444444444444444441)"><p>Commenter One • First rendered fixture comment</p></div>
-          <div id="replaceableComment_urn:li:comment:(urn:li:activity:8333333333333333333,8444444444444444442)"><p>Commenter Two • Second rendered fixture comment</p></div>
-          <div id="replaceableComment_urn:li:comment:(urn:li:activity:8333333333333333333,8444444444444444443)"><p>Commenter Three • Third rendered fixture comment</p></div>
-        </div>`)
-    ).rejects.toThrow(/captured 3 of 4 advertised comments/i);
+  test("persists durable posts when advertised comment coverage remains incomplete", async () => {
+    const res = await syncHomeFeedDom(`
+      <div componentkey="expandedincomplete_threadFeedType_MAIN_FEED_RELEVANCE">
+        <button aria-label="Open control menu for post by Incomplete Thread Author"></button>
+        <span id="translatable-commentary-urn:li:activity:8333333333333333333"></span>
+        <p>An incomplete-thread home-feed post with enough useful text to pass the filter</p>
+        <div role="button" class="comment-count">4 comments</div>
+        <div id="replaceableComment_urn:li:comment:(urn:li:activity:8333333333333333333,8444444444444444441)"><p>Commenter One • First rendered fixture comment</p></div>
+        <div id="replaceableComment_urn:li:comment:(urn:li:activity:8333333333333333333,8444444444444444442)"><p>Commenter Two • Second rendered fixture comment</p></div>
+        <div id="replaceableComment_urn:li:comment:(urn:li:activity:8333333333333333333,8444444444444444443)"><p>Commenter Three • Third rendered fixture comment</p></div>
+      </div>`);
+
+    expect(res.events.map((event: any) => event.origin_id)).toEqual([
+      "li_home_activity_8333333333333333333",
+      "li_comment_8444444444444444441",
+      "li_comment_8444444444444444442",
+      "li_comment_8444444444444444443",
+    ]);
+    expect(res.metadata).toMatchObject({
+      comment_threads_complete: false,
+      comment_threads_checked: 1,
+      comment_threads_incomplete: 1,
+      comments_expected: 4,
+      comments_collected: 3,
+    });
+    expect(res.metadata.comment_coverage_details).toEqual(["4/4/3"]);
   });
 
-  test("names the expansion budget when a thread times out mid-expansion", async () => {
+  test("surfaces expansion timeout as incomplete coverage metadata", async () => {
     const activityId = "8555555555555555555";
-    // `more` never resolves the thread, so expansion can only end on its
-    // deadline — the branch that must be reported as a budget timeout rather
-    // than as a stale-extension or wrong-selector failure.
-    await expect(
-      syncHomeFeedDom(
-        `
-        <div componentkey="expandedtimeout_threadFeedType_MAIN_FEED_RELEVANCE">
-          <button aria-label="Open control menu for post by Timed Out Thread Author"></button>
-          <span id="translatable-commentary-urn:li:activity:${activityId}"></span>
-          <p>A timed-out-thread home-feed post with enough useful text to pass the filter</p>
-          <div role="button" class="comment-count">4 comments</div>
-          <div id="replaceableComment_urn:li:comment:(urn:li:activity:${activityId},8666666666666666661)"><p>Commenter One • First rendered fixture comment</p></div>
-          <div role="button" class="more-comments">See 3 more comments</div>
-        </div>`,
-        undefined,
-        { maxDurationMs: 1, waitMs: 5 }
+    const res = await syncHomeFeedDom(
+      `
+      <div componentkey="expandedtimeout_threadFeedType_MAIN_FEED_RELEVANCE">
+        <button aria-label="Open control menu for post by Timed Out Thread Author"></button>
+        <span id="translatable-commentary-urn:li:activity:${activityId}"></span>
+        <p>A timed-out-thread home-feed post with enough useful text to pass the filter</p>
+        <div role="button" class="comment-count">4 comments</div>
+        <div id="replaceableComment_urn:li:comment:(urn:li:activity:${activityId},8666666666666666661)"><p>Commenter One • First rendered fixture comment</p></div>
+        <div role="button" class="more-comments">See 3 more comments</div>
+      </div>`,
+      undefined,
+      { maxDurationMs: 1, waitMs: 5 }
+    );
+
+    expect(
+      res.events.some(
+        (event: any) => event.origin_id === `li_home_activity_${activityId}`
       )
-    ).rejects.toThrow(/Expansion hit its 55s budget on 1 thread/i);
+    ).toBe(true);
+    expect(res.metadata).toMatchObject({
+      comment_threads_complete: false,
+      comment_threads_incomplete: 1,
+      comment_threads_timed_out: 1,
+      comments_expected: 4,
+      comments_collected: 1,
+    });
   });
 
   test("ignores FeedType helper rows nested inside a real post", async () => {
@@ -3090,7 +3111,7 @@ describe("prepare_comment helpers", () => {
     expect(action?.inputSchema?.properties).not.toHaveProperty(
       "browser_connection_id"
     );
-    expect(c.definition.version).toBe("3.11.8");
+    expect(c.definition.version).toBe("3.11.9");
     expect(String(action?.description ?? "")).toMatch(
       /NEVER opens a tab or submits/i
     );

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -2879,7 +2879,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft for the human to Post; verify_staged_comment checks whether that draft appeared as a comment.",
-    version: "3.11.8",
+    version: "3.11.9",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com
@@ -3534,21 +3534,6 @@ export default class LinkedInConnector extends ConnectorRuntime<
     }
 
     const commentCoverage = summarizeHomeFeedCommentCoverage(resolvedRows);
-    if (commentCoverage.incomplete > 0) {
-      const hints: string[] = [];
-      if (commentCoverage.unsupported)
-        hints.push(
-          `The paired Owletto extension omitted expansion coverage for ${commentCoverage.unsupported} thread${commentCoverage.unsupported === 1 ? "" : "s"}; reload the current extension build.`
-        );
-      if (commentCoverage.timedOut)
-        hints.push(
-          `Expansion hit its ${HOME_FEED_SCRAPE_CONFIG.expandRows.maxDurationMs / 1000}s budget on ${commentCoverage.timedOut} thread${commentCoverage.timedOut === 1 ? "" : "s"}; retry with fewer scrolls so each thread gets more of the run.`
-        );
-      const runtimeHint = hints.length ? ` ${hints.join(" ")}` : "";
-      throw new Error(
-        `LinkedIn captured ${commentCoverage.collected} of ${commentCoverage.expected} advertised comments across ${commentCoverage.incomplete} incomplete post thread${commentCoverage.incomplete === 1 ? "" : "s"} (advertised/runtime/collected: ${commentCoverage.details.join(", ")}).${runtimeHint} No partial home-feed batch was persisted.`
-      );
-    }
 
     const events = buildHomeFeedEvents(resolvedRows, new Date());
     if (events.length === 0) {
@@ -3574,8 +3559,12 @@ export default class LinkedInConnector extends ConnectorRuntime<
         scrolls_this_run: maxScrolls,
         backend: "extension-cs-scrape",
         object_all_supported: objectAllSupported,
-        comment_threads_complete: true,
+        comment_threads_complete: commentCoverage.incomplete === 0,
         comment_threads_checked: commentCoverage.threads,
+        comment_threads_incomplete: commentCoverage.incomplete,
+        comment_threads_unsupported: commentCoverage.unsupported,
+        comment_threads_timed_out: commentCoverage.timedOut,
+        comment_coverage_details: commentCoverage.details,
         comments_expected: commentCoverage.expected,
         comments_collected: commentCoverage.collected,
       },

--- a/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
@@ -473,6 +473,34 @@ describe("sync over the generic chrome bridge", () => {
     ]);
   });
 
+  it("marks persistent store hydration as a transient dependency failure", async () => {
+    const realNow = Date.now;
+    let calls = 0;
+    const { dispatcher } = makeDispatcher({
+      probe: () => {
+        calls += 1;
+        if (calls === 1) Date.now = () => realNow() + 60_000;
+        return {
+          ok: false,
+          error: { state: "hydrating", reason: "stores_settling" },
+        };
+      },
+    });
+    try {
+      await expect(
+        messagesFeed().sync(syncCtx(null, dispatcher))
+      ).rejects.toThrow(
+        /^\[lobu:dependency_unavailable:browser_source_hydrating\] WhatsApp Web hydrating: stores_settling/
+      );
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  it("bumps the WhatsApp connector version for readiness semantics", () => {
+    expect(connector.definition.version).toBe("1.0.1");
+  });
+
   it("names the remedy when WhatsApp Web is signed out", async () => {
     const { dispatcher } = makeDispatcher({
       probe: {

--- a/packages/connectors/src/whatsapp_web.ts
+++ b/packages/connectors/src/whatsapp_web.ts
@@ -283,6 +283,23 @@ async function invokeAdapter<T extends object>(
 }
 
 const LOGGED_OUT_PATTERN = /logged_out|qr_code_visible/;
+const TRANSIENT_READINESS_PATTERN = /hydrating|stores_settling/i;
+const DEPENDENCY_UNAVAILABLE_PREFIX =
+  "[lobu:dependency_unavailable:browser_source_hydrating]";
+
+/**
+ * Only readiness-phase WhatsApp failures are transient. Authentication, adapter
+ * corruption, unsupported operations, and collection errors remain ordinary
+ * connector failures and still count toward source health.
+ */
+function classifyWhatsAppReadinessFailure(error: unknown): string | null {
+  if (!(error instanceof Error)) return null;
+  // MAIN-world adapter failures may cross the extension/worker boundary without
+  // preserving their prototype, so classify on the connector-owned message.
+  if (!error.message.startsWith("WhatsApp Web ")) return null;
+  if (!TRANSIENT_READINESS_PATTERN.test(error.message)) return null;
+  return `${DEPENDENCY_UNAVAILABLE_PREFIX} ${error.message}`;
+}
 
 /**
  * Open the persistent tab, install the adapter, and poll `probe` until
@@ -312,6 +329,8 @@ async function readyWhatsAppTab(
     }
     await new Promise((resolve) => setTimeout(resolve, READY_POLL_INTERVAL_MS));
   } while (Date.now() < deadline);
+  const transient = classifyWhatsAppReadinessFailure(lastError);
+  if (transient) throw new Error(transient);
   throw (
     lastError ??
     new Error("WhatsApp Web did not become ready within the run budget")
@@ -559,7 +578,7 @@ export default class WhatsAppWebConnector extends ConnectorRuntime<
     name: "WhatsApp",
     description:
       "Personal WhatsApp messages read from WhatsApp Web in the paired Owletto Chrome. Syncs one-to-one and group chats, progressively hydrates history, and can search, draft, send, edit, react to, and revoke messages.",
-    version: "1.0.0",
+    version: "1.0.1",
     faviconDomain: "whatsapp.com",
     // Implicit auth: the user is already signed into WhatsApp Web in the
     // paired Chrome. There is no artifact to relay — the QR is rendered by

--- a/packages/server/src/__tests__/integration/dispatch-chrome-action-parent.test.ts
+++ b/packages/server/src/__tests__/integration/dispatch-chrome-action-parent.test.ts
@@ -49,7 +49,9 @@ describe('dispatchChromeAction parent run authorization', () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
       status: 'failed',
-      error_message: expect.stringContaining('No online paired Owletto'),
+      error_message: expect.stringMatching(
+        /^\[lobu:dependency_unavailable:browser_offline\].*No online paired Owletto/,
+      ),
     });
   });
 
@@ -349,8 +351,8 @@ describe('dispatchChromeAction target browser routing', () => {
 
     const body = await dispatchWithTarget(runId, Number(conn.id));
     expect(body.status).toBe('failed');
-    expect(body.error_message).toContain(
-      'The browser this action is set to open in is offline'
+    expect(body.error_message).toMatch(
+      /^\[lobu:dependency_unavailable:browser_offline\].*The browser this action is set to open in is offline/
     );
   });
 

--- a/packages/server/src/__tests__/integration/feed-failure-backoff.test.ts
+++ b/packages/server/src/__tests__/integration/feed-failure-backoff.test.ts
@@ -157,6 +157,60 @@ describe('feed failure backoff + auto-pause (#2033)', () => {
     await cleanupTestDatabase();
   });
 
+  it('does not charge a temporarily unavailable browser dependency to source-health failures', async () => {
+    const org = await createTestOrganization();
+    const connId = await insertConnection(org.id);
+    const feedId = await insertFeed(org.id, connId, PAUSE_THRESHOLD - 1);
+    const runId = await insertRunningRun(org.id, connId, feedId);
+    const sql = getTestDb();
+
+    await sql`
+      UPDATE feeds
+      SET last_sync_status = 'success',
+          last_sync_at = current_timestamp - INTERVAL '5 minutes',
+          first_failure_at = NULL
+      WHERE id = ${feedId}
+    `;
+    const before = (await sql`
+      SELECT last_sync_at FROM feeds WHERE id = ${feedId}
+    `) as Array<{ last_sync_at: Date | string | null }>;
+
+    const { ctx, result } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: WORKER_ID,
+      status: 'failed',
+      items_collected: 0,
+      error_message:
+        '[lobu:dependency_unavailable:browser_offline] The selected browser is offline.',
+    });
+    await completeWorkerJob(ctx);
+    expect(result().body).toEqual({ success: true });
+
+    const after = (await sql`
+      SELECT status, consecutive_failures, last_sync_status, last_sync_at,
+             first_failure_at, last_error, next_run_at
+      FROM feeds WHERE id = ${feedId}
+    `) as Array<{
+      status: string;
+      consecutive_failures: number;
+      last_sync_status: string | null;
+      last_sync_at: Date | string | null;
+      first_failure_at: Date | string | null;
+      last_error: string | null;
+      next_run_at: Date | string | null;
+    }>;
+
+    expect(after[0].status).toBe('active');
+    expect(Number(after[0].consecutive_failures)).toBe(PAUSE_THRESHOLD - 1);
+    expect(after[0].last_sync_status).toBe('success');
+    expect(new Date(String(after[0].last_sync_at)).getTime()).toBe(
+      new Date(String(before[0].last_sync_at)).getTime(),
+    );
+    expect(after[0].first_failure_at).toBeNull();
+    expect(after[0].last_error).toBe('The selected browser is offline.');
+    expect(after[0].next_run_at).not.toBeNull();
+  });
+
   it('5a: a failed completion backs off next_run_at beyond the plain cadence', async () => {
     const org = await createTestOrganization();
     const connId = await insertConnection(org.id);

--- a/packages/server/src/connectors/dependency-unavailable.ts
+++ b/packages/server/src/connectors/dependency-unavailable.ts
@@ -1,0 +1,21 @@
+/**
+ * Internal marker for connector failures caused by a temporarily unavailable
+ * execution dependency. Workers already round-trip connector error strings, so
+ * this stays server-local rather than widening the public worker/SDK protocol.
+ */
+const PREFIX = "[lobu:dependency_unavailable:";
+
+export function dependencyUnavailableError(reason: string, message: string): string {
+  return `${PREFIX}${reason}] ${message}`;
+}
+
+export function parseDependencyUnavailableError(
+  value: string | null | undefined
+): { reason: string; message: string } | null {
+  if (!value?.startsWith(PREFIX)) return null;
+  const end = value.indexOf("] ", PREFIX.length);
+  if (end < 0) return null;
+  const reason = value.slice(PREFIX.length, end).trim();
+  if (!reason) return null;
+  return { reason, message: value.slice(end + 2) };
+}

--- a/packages/server/src/worker-api/dispatch-chrome-action.ts
+++ b/packages/server/src/worker-api/dispatch-chrome-action.ts
@@ -28,6 +28,7 @@ import type { Env } from '../index';
 import { waitForDeviceActionRun } from '../tools/admin/device-action-wait';
 import { DEVICE_ONLINE_WINDOW_SECONDS } from '../utils/device-liveness';
 import { DEVICE_PIN_TOMBSTONE_MESSAGES } from '../utils/device-pin-tombstones';
+import { dependencyUnavailableError } from '../connectors/dependency-unavailable';
 import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
 import { isUniqueViolation } from '../utils/pg-errors';
@@ -760,11 +761,14 @@ export async function dispatchChromeActionToExtension(params: {
   if (!chromeConnection) {
     return {
       status: 'failed',
-      error_message: targetedBrowser
-        ? 'The browser this action is set to open in is offline. Open Chrome with the Owletto extension on that machine and try again.'
-        : preferredDeviceWorkerId
-          ? 'The Chrome extension selected for this connection is offline. Open Owletto in that browser (and stay signed in) to continue.'
-          : 'No online paired Owletto Chrome extension in this organization. Pair a Chrome extension first (and make sure it is running).',
+      error_message: dependencyUnavailableError(
+        'browser_offline',
+        targetedBrowser
+          ? 'The browser this action is set to open in is offline. Open Chrome with the Owletto extension on that machine and try again.'
+          : preferredDeviceWorkerId
+            ? 'The Chrome extension selected for this connection is offline. Open Owletto in that browser (and stay signed in) to continue.'
+            : 'No online paired Owletto Chrome extension in this organization. Pair a Chrome extension first (and make sure it is running).',
+      ),
     };
   }
 

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -31,6 +31,7 @@ import {
 } from "../automations/connector-derived";
 import { materializeConnectorAutomationSignal } from "../automations/connector-signal";
 import { feedBackoff } from "../connectors/feed-backoff";
+import { parseDependencyUnavailableError } from "../connectors/dependency-unavailable";
 import { maybeEmitFeedAutoPausedAfterFailure } from "../automations/platform-events";
 import { getDb, parsePgNumberArray } from "../db/client";
 import { eventArtifactBinding } from "../gateway/files/artifact-store";
@@ -916,6 +917,11 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 			>;
 		}
 		if (req.error_message) req.error_message = stripNul(req.error_message);
+		const dependencyUnavailable =
+			req.status === "failed"
+				? parseDependencyUnavailableError(req.error_message)
+				: null;
+		if (dependencyUnavailable) req.error_message = dependencyUnavailable.message;
 		if (req.output_tail) req.output_tail = stripNul(req.output_tail);
 
 		const denied = await authorizeRunForWorker(c, req.run_id, req.worker_id);
@@ -1040,6 +1046,19 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 				: null;
 			const isSuccess = req.status === "success";
 
+			// A connector that could not reach a required execution dependency never
+			// reached the source. Preserve the last real source-health result, do not
+			// consume the hard-pause budget, and keep the ordinary schedule armed.
+			if (dependencyUnavailable) {
+				await sql`
+          UPDATE feeds
+          SET last_error = ${req.error_message ?? null},
+              next_run_at = ${nextRun},
+              updated_at = current_timestamp
+          WHERE id = ${feedId}
+        `;
+			} else {
+
 			// Failure rescheduling (item 5, #2033):
 			//  - On success: reset consecutive_failures to 0 and use the plain cron
 			//    next_run_at so a recovered feed immediately resumes normal cadence.
@@ -1113,6 +1132,7 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 						"[completeWorkerJob] maybeEmitFeedAutoPausedAfterFailure threw"
 					);
 				}
+			}
 			}
 		}
 


### PR DESCRIPTION
Fix browser-backed feed reliability without deleting/recreating existing feeds or weakening source-integrity checks.

Platform: browser-offline dispatch failures are classified as transient dependency unavailability; they preserve the last real source-health result, do not increment consecutive_failures or consume auto-pause budget, keep the schedule armed, and still run the rest of completion processing.

WhatsApp: persistent hydrating/stores_settling readiness is transient; genuine auth/adapter/collection failures still count. Version 1.0.1.

LinkedIn: durable posts/comments persist even when advertised comments are incomplete or expansion times out; missing durable post identity still fails closed. Coverage metadata is emitted. Version 3.11.9.

Validation: WhatsApp 37/37; LinkedIn 135/135; server integration 20/20; personal-agent 300/300; server/connectors typecheck; pre-commit Biome+TypeScript; git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LinkedIn home-feed syncs now preserve successfully collected posts and comments when some comment threads time out or cannot be expanded, while reporting incomplete coverage details.
  * Temporary browser availability issues are now identified separately from other connector errors.

* **Bug Fixes**
  * Partial LinkedIn feed results are no longer discarded when comment expansion is incomplete.
  * Browser-offline failures no longer count toward feed health failure thresholds or trigger unnecessary pauses.
  * WhatsApp Web hydration timeouts now return clearer transient availability errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->