### PR TITLE
refactor(sdk): derive union-backed namespace inputs from their contracts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -159,6 +159,12 @@
       "import": "./dist/contracts/tools/manage-entity.js",
       "require": "./dist/contracts/tools/manage-entity.js"
     },
+    "./contracts/tools/action-input": {
+      "types": "./dist/contracts/tools/action-input.d.ts",
+      "bun": "./src/contracts/tools/action-input.ts",
+      "import": "./dist/contracts/tools/action-input.js",
+      "require": "./dist/contracts/tools/action-input.js"
+    },
     "./contracts/tools/manage-automations": {
       "types": "./dist/contracts/tools/manage-automations.d.ts",
       "bun": "./src/contracts/tools/manage-automations.ts",

--- a/packages/core/src/contracts/tools/action-input.ts
+++ b/packages/core/src/contracts/tools/action-input.ts
@@ -3,19 +3,25 @@
  * that action's variant, minus the `action` discriminator the SDK method fills
  * in itself.
  *
- * The ClientSDK sandbox namespaces derive their per-method input types through
- * this instead of restating the fields, because a hand-written copy drifts in
- * the direction that hurts most: a field the schema accepts but the copy omits
- * is invisible to every typed caller. `catalog.listInstalled` had exactly that
- * gap — the action schema and the method's own documented signature both
- * carried `include_catalog`, the copied input type did not, so no typed caller
- * could pass it.
+ * Each contract exports its per-action inputs through this (`FeedCreateInput`,
+ * `ScheduleUpdateInput`, …) and every typed caller — the ClientSDK sandbox
+ * namespaces, the published connector SDK — imports those names rather than
+ * restating the fields. A hand-written copy drifts in the direction that hurts
+ * most: a field the schema accepts but the copy omits is invisible to every
+ * typed caller. `catalog.listInstalled` had exactly that gap — the action
+ * schema and the method's own documented signature both carried
+ * `include_catalog`, the copied input type did not, so no typed caller could
+ * pass it.
+ *
+ * `Action` is constrained to the contract's own action names, so a typo fails
+ * at the declaration rather than producing a type nothing can satisfy.
  *
  * Only for contracts whose input schema is a `Type.Union` of per-action
- * variants. A flat `Type.Object` contract has nothing to `Extract` — its
- * `action` is a union-typed field, not a discriminator.
+ * variants, each carrying a single-literal `action`. A flat `Type.Object`
+ * contract has nothing to `Extract` — its `action` is a union-typed field, not
+ * a discriminator.
  */
-export type ActionInput<Args, Action extends string> = Omit<
-  Extract<Args, { action: Action }>,
-  "action"
->;
+export type ActionInput<
+  Args extends { action: string },
+  Action extends Args["action"],
+> = Omit<Extract<Args, { action: Action }>, "action">;

--- a/packages/core/src/contracts/tools/action-input.ts
+++ b/packages/core/src/contracts/tools/action-input.ts
@@ -1,0 +1,21 @@
+/**
+ * The input a caller supplies for one action of a union-shaped tool contract:
+ * that action's variant, minus the `action` discriminator the SDK method fills
+ * in itself.
+ *
+ * The ClientSDK sandbox namespaces derive their per-method input types through
+ * this instead of restating the fields, because a hand-written copy drifts in
+ * the direction that hurts most: a field the schema accepts but the copy omits
+ * is invisible to every typed caller. `catalog.listInstalled` had exactly that
+ * gap — the action schema and the method's own documented signature both
+ * carried `include_catalog`, the copied input type did not, so no typed caller
+ * could pass it.
+ *
+ * Only for contracts whose input schema is a `Type.Union` of per-action
+ * variants. A flat `Type.Object` contract has nothing to `Extract` — its
+ * `action` is a union-typed field, not a discriminator.
+ */
+export type ActionInput<Args, Action extends string> = Omit<
+  Extract<Args, { action: Action }>,
+  "action"
+>;

--- a/packages/core/src/contracts/tools/manage-auth-profiles.ts
+++ b/packages/core/src/contracts/tools/manage-auth-profiles.ts
@@ -5,6 +5,18 @@ import type { ActionInput } from "./action-input";
 // Schema
 // ============================================
 
+/**
+ * The four caller-manageable kinds. The stored enum also has `interactive`,
+ * which this contract deliberately omits: interactive-connection setup mints
+ * those profiles itself.
+ */
+const AuthProfileKind = Type.Union([
+  Type.Literal("env"),
+  Type.Literal("oauth_app"),
+  Type.Literal("oauth_account"),
+  Type.Literal("browser_session"),
+]);
+
 export const ListAuthProfilesAction = Type.Object({
   action: Type.Literal("list_auth_profiles", {
     description: "List reusable auth profiles with filters.",
@@ -16,15 +28,9 @@ export const ListAuthProfilesAction = Type.Object({
     Type.String({ description: 'Filter by OAuth provider (e.g. "google")' })
   ),
   profile_kind: Type.Optional(
-    Type.Union(
-      [
-        Type.Literal("env"),
-        Type.Literal("oauth_app"),
-        Type.Literal("oauth_account"),
-        Type.Literal("browser_session"),
-      ],
-      { description: "Filter by auth profile kind" }
-    )
+    Type.Union(AuthProfileKind.anyOf, {
+      description: "Filter by auth profile kind",
+    })
   ),
 });
 
@@ -53,12 +59,7 @@ export const CreateAuthProfileAction = Type.Object({
         "Connector key (e.g. x, google.gmail). Required for env/oauth profiles; optional for browser_session (device-scoped resource).",
     })
   ),
-  profile_kind: Type.Union([
-    Type.Literal("env"),
-    Type.Literal("oauth_app"),
-    Type.Literal("oauth_account"),
-    Type.Literal("browser_session"),
-  ]),
+  profile_kind: AuthProfileKind,
   display_name: Type.String({ description: "User-facing auth profile name" }),
   slug: Type.Optional(
     Type.String({

--- a/packages/core/src/contracts/tools/manage-auth-profiles.ts
+++ b/packages/core/src/contracts/tools/manage-auth-profiles.ts
@@ -1,4 +1,5 @@
 import { type Static, Type } from "@sinclair/typebox";
+import type { ActionInput } from "./action-input";
 
 // ============================================
 // Schema
@@ -221,3 +222,20 @@ export const ManageAuthProfilesSchema = Type.Union([
 ]);
 
 export type ManageAuthProfilesArgs = Static<typeof ManageAuthProfilesSchema>;
+
+export type AuthProfileListInput = ActionInput<
+  ManageAuthProfilesArgs,
+  "list_auth_profiles"
+>;
+export type AuthProfileCreateInput = ActionInput<
+  ManageAuthProfilesArgs,
+  "create_auth_profile"
+>;
+export type AuthProfileUpdateInput = ActionInput<
+  ManageAuthProfilesArgs,
+  "update_auth_profile"
+>;
+export type AuthProfileDeleteInput = ActionInput<
+  ManageAuthProfilesArgs,
+  "delete_auth_profile"
+>;

--- a/packages/core/src/contracts/tools/manage-catalog.ts
+++ b/packages/core/src/contracts/tools/manage-catalog.ts
@@ -95,3 +95,4 @@ export const ManageCatalogResultSchema = Type.Union([
 export type ManageCatalogResult = Static<typeof ManageCatalogResultSchema>;
 export type ListCatalogArgs = Static<typeof ListCatalogAction>;
 export type ListInstalledArgs = Static<typeof ListInstalledAction>;
+export type ManageCatalogArgs = Static<typeof ManageCatalogSchema>;

--- a/packages/core/src/contracts/tools/manage-catalog.ts
+++ b/packages/core/src/contracts/tools/manage-catalog.ts
@@ -1,4 +1,5 @@
 import { type Static, Type } from "@sinclair/typebox";
+import type { ActionInput } from "./action-input";
 
 export const ListCatalogAction = Type.Object({
   action: Type.Literal("list_catalog", {
@@ -96,3 +97,9 @@ export type ManageCatalogResult = Static<typeof ManageCatalogResultSchema>;
 export type ListCatalogArgs = Static<typeof ListCatalogAction>;
 export type ListInstalledArgs = Static<typeof ListInstalledAction>;
 export type ManageCatalogArgs = Static<typeof ManageCatalogSchema>;
+
+export type CatalogListInput = ActionInput<ManageCatalogArgs, "list_catalog">;
+export type CatalogListInstalledInput = ActionInput<
+  ManageCatalogArgs,
+  "list_installed"
+>;

--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -978,6 +978,20 @@ export type RollbackConnectorVersionInput = ActionInput<
   "rollback_connector_version"
 >;
 
+export type ConnectionListInput = ActionInput<ConnectionsArgs, "list">;
+export type ToggleConnectorLoginInput = ActionInput<
+  ConnectionsArgs,
+  "toggle_connector_login"
+>;
+export type UpdateConnectorAuthInput = ActionInput<
+  ConnectionsArgs,
+  "update_connector_auth"
+>;
+export type UpdateConnectorDefaultConfigInput = ActionInput<
+  ConnectionsArgs,
+  "update_connector_default_config"
+>;
+
 /**
  * Union of all action variants. Defined from the variants directly (rather
  * than from the derived union schema in manage_connections.ts) so the handler

--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -3,6 +3,7 @@
  */
 
 import { type Static, Type } from "@sinclair/typebox";
+import type { ActionInput } from "./action-input";
 import { paginationFields } from "./pagination";
 
 const ConnectionFacetsSchema = Type.Object({
@@ -949,35 +950,32 @@ export type ManageConnectionsResult = Static<
   typeof ManageConnectionsResultSchema
 >;
 
-export type ConnectionConnectInput = Omit<
-  Static<typeof ConnectAction>,
-  "action"
+export type ConnectionConnectInput = ActionInput<ConnectionsArgs, "connect">;
+export type ConnectionConnectManagedInput = ActionInput<
+  ConnectionsArgs,
+  "connect_managed"
 >;
-export type ConnectionConnectManagedInput = Omit<
-  Static<typeof ConnectManagedAction>,
-  "action"
+export type ConnectionCreateInput = ActionInput<ConnectionsArgs, "create">;
+export type ConnectionUpdateInput = ActionInput<ConnectionsArgs, "update">;
+export type InstallConnectorInput = ActionInput<
+  ConnectionsArgs,
+  "install_connector"
 >;
-export type ConnectionCreateInput = Omit<Static<typeof CreateAction>, "action">;
-export type ConnectionUpdateInput = Omit<Static<typeof UpdateAction>, "action">;
-export type InstallConnectorInput = Omit<
-  Static<typeof InstallConnectorAction>,
-  "action"
+export type GetConnectorSourceInput = ActionInput<
+  ConnectionsArgs,
+  "get_connector_source"
 >;
-export type GetConnectorSourceInput = Omit<
-  Static<typeof GetConnectorSourceAction>,
-  "action"
+export type ValidateConnectorSourceInput = ActionInput<
+  ConnectionsArgs,
+  "validate_connector_source"
 >;
-export type ValidateConnectorSourceInput = Omit<
-  Static<typeof ValidateConnectorSourceAction>,
-  "action"
+export type UpdateConnectorSourceInput = ActionInput<
+  ConnectionsArgs,
+  "update_connector_source"
 >;
-export type UpdateConnectorSourceInput = Omit<
-  Static<typeof UpdateConnectorSourceAction>,
-  "action"
->;
-export type RollbackConnectorVersionInput = Omit<
-  Static<typeof RollbackConnectorVersionAction>,
-  "action"
+export type RollbackConnectorVersionInput = ActionInput<
+  ConnectionsArgs,
+  "rollback_connector_version"
 >;
 
 /**

--- a/packages/core/src/contracts/tools/manage-feeds.ts
+++ b/packages/core/src/contracts/tools/manage-feeds.ts
@@ -1,4 +1,5 @@
 import { type Static, Type } from "@sinclair/typebox";
+import type { ActionInput } from "./action-input";
 import { paginationFields } from "./pagination";
 
 // ============================================
@@ -300,3 +301,11 @@ export const ManageFeedsSchema = Type.Union([
 ]);
 
 export type ManageFeedsArgs = Static<typeof ManageFeedsSchema>;
+
+export type FeedListInput = ActionInput<ManageFeedsArgs, "list_feeds">;
+export type FeedReadInput = ActionInput<ManageFeedsArgs, "read_feed">;
+export type FeedReadManyInput = ActionInput<ManageFeedsArgs, "read_feeds">;
+export type FeedCreateInput = ActionInput<ManageFeedsArgs, "create_feed">;
+export type FeedUpdateInput = ActionInput<ManageFeedsArgs, "update_feed">;
+export type FeedDeleteInput = ActionInput<ManageFeedsArgs, "delete_feed">;
+export type FeedTriggerInput = ActionInput<ManageFeedsArgs, "trigger_feed">;

--- a/packages/core/src/contracts/tools/manage-operations.ts
+++ b/packages/core/src/contracts/tools/manage-operations.ts
@@ -1,4 +1,5 @@
 import { type Static, Type } from "@sinclair/typebox";
+import type { ActionInput } from "./action-input";
 import { MAX_TOOL_PAGE_OFFSET, MAX_TOOL_PAGE_SIZE } from "./pagination";
 
 // manage_operations is flattened to one MCP object, so duplicate properties
@@ -525,3 +526,21 @@ export const ManageOperationsSchema = Type.Union([
 ]);
 
 export type ManageOperationsArgs = Static<typeof ManageOperationsSchema>;
+
+export type OperationListAvailableInput = ActionInput<
+  ManageOperationsArgs,
+  "list_available"
+>;
+export type OperationExecuteInput = ActionInput<
+  ManageOperationsArgs,
+  "execute"
+>;
+export type OperationListRunsInput = ActionInput<
+  ManageOperationsArgs,
+  "list_runs"
+>;
+export type OperationApproveInput = ActionInput<
+  ManageOperationsArgs,
+  "approve"
+>;
+export type OperationRejectInput = ActionInput<ManageOperationsArgs, "reject">;

--- a/packages/core/src/contracts/tools/manage-schedules.ts
+++ b/packages/core/src/contracts/tools/manage-schedules.ts
@@ -1,4 +1,5 @@
 import { type Static, Type } from "@sinclair/typebox";
+import type { ActionInput } from "./action-input";
 
 // ============================================
 // Schema
@@ -155,3 +156,9 @@ export const ManageSchedulesSchema = Type.Union([
 ]);
 
 export type ManageSchedulesArgs = Static<typeof ManageSchedulesSchema>;
+
+export type ScheduleListInput = ActionInput<ManageSchedulesArgs, "list">;
+export type ScheduleCreateInput = ActionInput<ManageSchedulesArgs, "create">;
+export type ScheduleUpdateInput = ActionInput<ManageSchedulesArgs, "update">;
+export type SchedulePauseInput = ActionInput<ManageSchedulesArgs, "pause">;
+export type ScheduleCancelInput = ActionInput<ManageSchedulesArgs, "cancel">;

--- a/packages/core/src/contracts/tools/manage-schedules.ts
+++ b/packages/core/src/contracts/tools/manage-schedules.ts
@@ -1,4 +1,4 @@
-import { Type } from "@sinclair/typebox";
+import { type Static, Type } from "@sinclair/typebox";
 
 // ============================================
 // Schema
@@ -153,3 +153,5 @@ export const ManageSchedulesSchema = Type.Union([
   PauseAction,
   CancelAction,
 ]);
+
+export type ManageSchedulesArgs = Static<typeof ManageSchedulesSchema>;

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -953,7 +953,7 @@ export default async (_ctx, client) => {
 		summary: "List reusable auth profiles.",
 		access: "read",
 		signature:
-			"authProfiles.list(input?: { connector_key?: string; provider?: string; profile_kind?: AuthProfileKind }): Promise<unknown> // not paginated",
+			"authProfiles.list(input?: { connector_key?: string; provider?: string; profile_kind?: 'env' | 'oauth_app' | 'oauth_account' | 'browser_session' }): Promise<unknown> // not paginated",
 	},
 	"authProfiles.get": {
 		summary:

--- a/packages/server/src/sandbox/namespaces/auth-profiles.ts
+++ b/packages/server/src/sandbox/namespaces/auth-profiles.ts
@@ -22,10 +22,6 @@ import { manageAuthProfiles } from "../../tools/admin/manage_auth_profiles";
 import type { ToolContext } from "../../tools/registry";
 import { createActionCaller, idArg } from "./action-call";
 
-// The `profile_kind` on list/create covers the four caller-manageable kinds
-// only. The stored enum also has `interactive`, which the contract deliberately
-// omits: interactive-connection setup mints those profiles itself.
-
 export interface AuthProfilesNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
 	list(input?: AuthProfileListInput): Promise<unknown>;

--- a/packages/server/src/sandbox/namespaces/auth-profiles.ts
+++ b/packages/server/src/sandbox/namespaces/auth-profiles.ts
@@ -11,8 +11,12 @@
  *     session state).
  */
 
-import type { ActionInput } from "@lobu/core/contracts/tools/action-input";
-import type { ManageAuthProfilesArgs } from "@lobu/core/contracts/tools/manage-auth-profiles";
+import type {
+	AuthProfileCreateInput,
+	AuthProfileDeleteInput,
+	AuthProfileListInput,
+	AuthProfileUpdateInput,
+} from "@lobu/core/contracts/tools/manage-auth-profiles";
 import type { Env } from "../../index";
 import { manageAuthProfiles } from "../../tools/admin/manage_auth_profiles";
 import type { ToolContext } from "../../tools/registry";
@@ -21,23 +25,6 @@ import { createActionCaller, idArg } from "./action-call";
 // The `profile_kind` on list/create covers the four caller-manageable kinds
 // only. The stored enum also has `interactive`, which the contract deliberately
 // omits: interactive-connection setup mints those profiles itself.
-export type AuthProfileListInput = ActionInput<
-	ManageAuthProfilesArgs,
-	"list_auth_profiles"
->;
-export type AuthProfileCreateInput = ActionInput<
-	ManageAuthProfilesArgs,
-	"create_auth_profile"
->;
-export type AuthProfileUpdateInput = ActionInput<
-	ManageAuthProfilesArgs,
-	"update_auth_profile"
->;
-/** `delete` takes the slug positionally; the rest of the action rides in `options`. */
-export type AuthProfileDeleteOptions = Omit<
-	ActionInput<ManageAuthProfilesArgs, "delete_auth_profile">,
-	"auth_profile_slug"
->;
 
 export interface AuthProfilesNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
@@ -48,7 +35,7 @@ export interface AuthProfilesNamespace {
 	update(input: AuthProfileUpdateInput): Promise<unknown>;
 	delete(
 		auth_profile_slug: string,
-		options?: AuthProfileDeleteOptions,
+		options?: Omit<AuthProfileDeleteInput, "auth_profile_slug">,
 	): Promise<unknown>;
 }
 

--- a/packages/server/src/sandbox/namespaces/auth-profiles.ts
+++ b/packages/server/src/sandbox/namespaces/auth-profiles.ts
@@ -11,53 +11,44 @@
  *     session state).
  */
 
+import type { ActionInput } from "@lobu/core/contracts/tools/action-input";
+import type { ManageAuthProfilesArgs } from "@lobu/core/contracts/tools/manage-auth-profiles";
 import type { Env } from "../../index";
 import { manageAuthProfiles } from "../../tools/admin/manage_auth_profiles";
 import type { ToolContext } from "../../tools/registry";
-import type { AuthProfileKind as StoredAuthProfileKind } from "../../utils/auth-profiles";
 import { createActionCaller, idArg } from "./action-call";
 
-/** Kinds manageable through the SDK — the stored kinds minus the internal-only `interactive`. */
-export type AuthProfileKind = Exclude<StoredAuthProfileKind, "interactive">;
-
-export interface AuthProfileCreateInput {
-	profile_kind: AuthProfileKind;
-	connector_key: string;
-	display_name: string;
-	/** Optional stable slug for the new profile. Auto-derived when omitted. */
-	slug?: string;
-	credentials?: Record<string, string>;
-	auth_data?: Record<string, unknown>;
-	requested_scopes?: string[];
-}
-
-export interface AuthProfileUpdateInput {
-	/** Identifies the profile to mutate. */
-	auth_profile_slug: string;
-	display_name?: string;
-	/** Rename the profile. */
-	slug?: string;
-	credentials?: Record<string, string>;
-	auth_data?: Record<string, unknown>;
-	requested_scopes?: string[];
-	status?: string;
-	reconnect?: boolean;
-}
+// The `profile_kind` on list/create covers the four caller-manageable kinds
+// only. The stored enum also has `interactive`, which the contract deliberately
+// omits: interactive-connection setup mints those profiles itself.
+export type AuthProfileListInput = ActionInput<
+	ManageAuthProfilesArgs,
+	"list_auth_profiles"
+>;
+export type AuthProfileCreateInput = ActionInput<
+	ManageAuthProfilesArgs,
+	"create_auth_profile"
+>;
+export type AuthProfileUpdateInput = ActionInput<
+	ManageAuthProfilesArgs,
+	"update_auth_profile"
+>;
+/** `delete` takes the slug positionally; the rest of the action rides in `options`. */
+export type AuthProfileDeleteOptions = Omit<
+	ActionInput<ManageAuthProfilesArgs, "delete_auth_profile">,
+	"auth_profile_slug"
+>;
 
 export interface AuthProfilesNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	list(input?: {
-		connector_key?: string;
-		provider?: string;
-		profile_kind?: AuthProfileKind;
-	}): Promise<unknown>;
+	list(input?: AuthProfileListInput): Promise<unknown>;
 	get(auth_profile_slug: string): Promise<unknown>;
 	test(auth_profile_slug: string): Promise<unknown>;
 	create(input: AuthProfileCreateInput): Promise<unknown>;
 	update(input: AuthProfileUpdateInput): Promise<unknown>;
 	delete(
 		auth_profile_slug: string,
-		options?: { force?: boolean },
+		options?: AuthProfileDeleteOptions,
 	): Promise<unknown>;
 }
 

--- a/packages/server/src/sandbox/namespaces/catalog.ts
+++ b/packages/server/src/sandbox/namespaces/catalog.ts
@@ -1,21 +1,14 @@
-import type { ActionInput } from "@lobu/core/contracts/tools/action-input";
-import type { ManageCatalogArgs } from "@lobu/core/contracts/tools/manage-catalog";
+import type {
+	CatalogListInput,
+	CatalogListInstalledInput,
+} from "@lobu/core/contracts/tools/manage-catalog";
 import type { Env } from "../../index";
 import { manageCatalog } from "../../tools/admin/manage_catalog";
 import type { ToolContext } from "../../tools/registry";
 import { createActionCaller } from "./action-call";
 
-export type CatalogListCatalogInput = ActionInput<
-	ManageCatalogArgs,
-	"list_catalog"
->;
-export type CatalogListInstalledInput = ActionInput<
-	ManageCatalogArgs,
-	"list_installed"
->;
-
 export interface CatalogNamespace {
-	listCatalog(input?: CatalogListCatalogInput): Promise<unknown>;
+	listCatalog(input?: CatalogListInput): Promise<unknown>;
 	listInstalled(input?: CatalogListInstalledInput): Promise<unknown>;
 }
 

--- a/packages/server/src/sandbox/namespaces/catalog.ts
+++ b/packages/server/src/sandbox/namespaces/catalog.ts
@@ -1,15 +1,22 @@
+import type { ActionInput } from "@lobu/core/contracts/tools/action-input";
+import type { ManageCatalogArgs } from "@lobu/core/contracts/tools/manage-catalog";
 import type { Env } from "../../index";
-import type { ListCatalogArgs } from "@lobu/core/contracts/tools/manage-catalog";
 import { manageCatalog } from "../../tools/admin/manage_catalog";
 import type { ToolContext } from "../../tools/registry";
 import { createActionCaller } from "./action-call";
 
+export type CatalogListCatalogInput = ActionInput<
+	ManageCatalogArgs,
+	"list_catalog"
+>;
+export type CatalogListInstalledInput = ActionInput<
+	ManageCatalogArgs,
+	"list_installed"
+>;
+
 export interface CatalogNamespace {
-	listCatalog(input?: Omit<ListCatalogArgs, "action">): Promise<unknown>;
-	listInstalled(input?: {
-		kinds?: string[];
-		agent_id?: string;
-	}): Promise<unknown>;
+	listCatalog(input?: CatalogListCatalogInput): Promise<unknown>;
+	listInstalled(input?: CatalogListInstalledInput): Promise<unknown>;
 }
 
 export function buildCatalogNamespace(

--- a/packages/server/src/sandbox/namespaces/connections.ts
+++ b/packages/server/src/sandbox/namespaces/connections.ts
@@ -7,16 +7,18 @@
  * follow the handler schema.
  */
 
-import type { ActionInput } from "@lobu/core/contracts/tools/action-input";
 import type {
 	ConnectionConnectInput,
 	ConnectionConnectManagedInput,
 	ConnectionCreateInput,
-	ConnectionsArgs,
+	ConnectionListInput,
 	ConnectionUpdateInput,
 	GetConnectorSourceInput,
 	InstallConnectorInput,
 	RollbackConnectorVersionInput,
+	ToggleConnectorLoginInput,
+	UpdateConnectorAuthInput,
+	UpdateConnectorDefaultConfigInput,
 	UpdateConnectorSourceInput,
 	ValidateConnectorSourceInput,
 } from "@lobu/core/contracts/tools/manage-connections";
@@ -25,38 +27,19 @@ import { manageConnections } from "../../tools/admin/manage_connections";
 import type { ToolContext } from "../../tools/registry";
 import { createActionCaller, idArg } from "./action-call";
 
-export type ConnectionsConnectInput = ConnectionConnectInput;
-export type ConnectionsConnectManagedInput = ConnectionConnectManagedInput;
-export type ConnectionsCreateInput = ConnectionCreateInput;
-export type ConnectionsUpdateInput = ConnectionUpdateInput;
-export type ConnectionsInstallConnectorInput = InstallConnectorInput;
-export type ConnectionsListInput = ActionInput<ConnectionsArgs, "list">;
-export type ConnectionsToggleConnectorLoginInput = ActionInput<
-	ConnectionsArgs,
-	"toggle_connector_login"
->;
-export type ConnectionsUpdateConnectorAuthInput = ActionInput<
-	ConnectionsArgs,
-	"update_connector_auth"
->;
-export type ConnectionsUpdateConnectorDefaultConfigInput = ActionInput<
-	ConnectionsArgs,
-	"update_connector_default_config"
->;
-
 export interface ConnectionsNamespace {
 	/** Raw escape hatch for any manage_connections action. Prefer named methods. */
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	list(input?: ConnectionsListInput): Promise<unknown>;
+	list(input?: ConnectionListInput): Promise<unknown>;
 	get(connection_id: number): Promise<unknown>;
-	create(input: ConnectionsCreateInput): Promise<unknown>;
-	connect(input: ConnectionsConnectInput): Promise<unknown>;
-	connectManaged(input: ConnectionsConnectManagedInput): Promise<unknown>;
-	update(input: ConnectionsUpdateInput): Promise<unknown>;
+	create(input: ConnectionCreateInput): Promise<unknown>;
+	connect(input: ConnectionConnectInput): Promise<unknown>;
+	connectManaged(input: ConnectionConnectManagedInput): Promise<unknown>;
+	update(input: ConnectionUpdateInput): Promise<unknown>;
 	delete(connection_id: number): Promise<unknown>;
 	reauthenticate(connection_id: number): Promise<unknown>;
 	test(connection_id: number): Promise<unknown>;
-	installConnector(input: ConnectionsInstallConnectorInput): Promise<unknown>;
+	installConnector(input: InstallConnectorInput): Promise<unknown>;
 	uninstallConnector(connector_key: string): Promise<unknown>;
 	getConnectorSource(input: GetConnectorSourceInput): Promise<unknown>;
 	validateConnectorSource(
@@ -67,13 +50,13 @@ export interface ConnectionsNamespace {
 		input: RollbackConnectorVersionInput,
 	): Promise<unknown>;
 	toggleConnectorLogin(
-		input: ConnectionsToggleConnectorLoginInput,
+		input: ToggleConnectorLoginInput,
 	): Promise<unknown>;
 	updateConnectorAuth(
-		input: ConnectionsUpdateConnectorAuthInput,
+		input: UpdateConnectorAuthInput,
 	): Promise<unknown>;
 	updateConnectorDefaultConfig(
-		input: ConnectionsUpdateConnectorDefaultConfigInput,
+		input: UpdateConnectorDefaultConfigInput,
 	): Promise<unknown>;
 }
 

--- a/packages/server/src/sandbox/namespaces/connections.ts
+++ b/packages/server/src/sandbox/namespaces/connections.ts
@@ -7,10 +7,12 @@
  * follow the handler schema.
  */
 
+import type { ActionInput } from "@lobu/core/contracts/tools/action-input";
 import type {
 	ConnectionConnectInput,
 	ConnectionConnectManagedInput,
 	ConnectionCreateInput,
+	ConnectionsArgs,
 	ConnectionUpdateInput,
 	GetConnectorSourceInput,
 	InstallConnectorInput,
@@ -28,20 +30,24 @@ export type ConnectionsConnectManagedInput = ConnectionConnectManagedInput;
 export type ConnectionsCreateInput = ConnectionCreateInput;
 export type ConnectionsUpdateInput = ConnectionUpdateInput;
 export type ConnectionsInstallConnectorInput = InstallConnectorInput;
+export type ConnectionsListInput = ActionInput<ConnectionsArgs, "list">;
+export type ConnectionsToggleConnectorLoginInput = ActionInput<
+	ConnectionsArgs,
+	"toggle_connector_login"
+>;
+export type ConnectionsUpdateConnectorAuthInput = ActionInput<
+	ConnectionsArgs,
+	"update_connector_auth"
+>;
+export type ConnectionsUpdateConnectorDefaultConfigInput = ActionInput<
+	ConnectionsArgs,
+	"update_connector_default_config"
+>;
 
 export interface ConnectionsNamespace {
 	/** Raw escape hatch for any manage_connections action. Prefer named methods. */
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	list(input?: {
-		connector_key?: string;
-		status?: string;
-		entity_id?: number;
-		created_by?: string;
-		connection_ids?: number[];
-		setup_attempt_id?: string;
-		limit?: number;
-		offset?: number;
-	}): Promise<unknown>;
+	list(input?: ConnectionsListInput): Promise<unknown>;
 	get(connection_id: number): Promise<unknown>;
 	create(input: ConnectionsCreateInput): Promise<unknown>;
 	connect(input: ConnectionsConnectInput): Promise<unknown>;
@@ -60,18 +66,15 @@ export interface ConnectionsNamespace {
 	rollbackConnectorVersion(
 		input: RollbackConnectorVersionInput,
 	): Promise<unknown>;
-	toggleConnectorLogin(input: {
-		connector_key: string;
-		enabled: boolean;
-	}): Promise<unknown>;
-	updateConnectorAuth(input: {
-		connector_key: string;
-		auth_values: Record<string, string>;
-	}): Promise<unknown>;
-	updateConnectorDefaultConfig(input: {
-		connector_key: string;
-		default_connection_config: Record<string, unknown>;
-	}): Promise<unknown>;
+	toggleConnectorLogin(
+		input: ConnectionsToggleConnectorLoginInput,
+	): Promise<unknown>;
+	updateConnectorAuth(
+		input: ConnectionsUpdateConnectorAuthInput,
+	): Promise<unknown>;
+	updateConnectorDefaultConfig(
+		input: ConnectionsUpdateConnectorDefaultConfigInput,
+	): Promise<unknown>;
 }
 
 export function buildConnectionsNamespace(

--- a/packages/server/src/sandbox/namespaces/feeds.ts
+++ b/packages/server/src/sandbox/namespaces/feeds.ts
@@ -5,67 +5,30 @@
  * data surface this feed will sync.
  */
 
+import type { ActionInput } from "@lobu/core/contracts/tools/action-input";
+import type { ManageFeedsArgs } from "@lobu/core/contracts/tools/manage-feeds";
 import type { Env } from "../../index";
 import { manageFeeds } from "../../tools/admin/manage_feeds";
 import type { ToolContext } from "../../tools/registry";
 import { createActionCaller } from "./action-call";
 
-export interface FeedsCreateInput {
-	connection_id: number;
-	feed_key: string;
-	display_name?: string;
-	entity_ids?: number[];
-	config?: Record<string, unknown>;
-	schedule?: string | null;
-	/** IANA zone the schedule is evaluated in; omit for server time (UTC). */
-	timezone?: string;
-}
+export type FeedsListInput = ActionInput<ManageFeedsArgs, "list_feeds">;
+export type FeedsGetInput = ActionInput<ManageFeedsArgs, "read_feed">;
+export type FeedsReadManyInput = ActionInput<ManageFeedsArgs, "read_feeds">;
+export type FeedsCreateInput = ActionInput<ManageFeedsArgs, "create_feed">;
+export type FeedsUpdateInput = ActionInput<ManageFeedsArgs, "update_feed">;
+export type FeedsDeleteInput = ActionInput<ManageFeedsArgs, "delete_feed">;
+export type FeedsTriggerInput = ActionInput<ManageFeedsArgs, "trigger_feed">;
 
 export interface FeedsNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	list(input?: {
-		connection_id?: number;
-		feed_ids?: number[];
-		entity_id?: number;
-		status?: "active" | "paused";
-		health?: "healthy" | "failing";
-		limit?: number;
-		offset?: number;
-	}): Promise<unknown>;
-	get(input: { feed_id: number }): Promise<unknown>;
-	readMany(input: {
-		reads: Array<{
-			feed_id: number;
-			query?: string;
-			limit?: number;
-			cursor?: string;
-			sort?: { column: string; order: "asc" | "desc" };
-		}>;
-		timeout_ms?: number;
-	}): Promise<unknown>;
+	list(input?: FeedsListInput): Promise<unknown>;
+	get(input: FeedsGetInput): Promise<unknown>;
+	readMany(input: FeedsReadManyInput): Promise<unknown>;
 	create(input: FeedsCreateInput): Promise<unknown>;
-	update(input: {
-		feed_id: number;
-		display_name?: string;
-		status?: "active" | "paused";
-		entity_ids?: number[];
-		config?: Record<string, unknown>;
-		replace_config?: boolean;
-		schedule?: string | null;
-		/** IANA zone for the schedule; null clears it (server time). */
-		timezone?: string | null;
-	}): Promise<unknown>;
-	delete(input: { feed_id: number }): Promise<unknown>;
-	trigger(input: {
-		feed_id: number;
-		/**
-		 * Run the connector for real but persist nothing — no events, entities or
-		 * attachments, and the feed's checkpoint and sync state stay put. Once the
-		 * run completes, a capped preview of what would have been ingested is on
-		 * its `dry_run_preview`, readable via `feeds.get`.
-		 */
-		dry_run?: boolean;
-	}): Promise<unknown>;
+	update(input: FeedsUpdateInput): Promise<unknown>;
+	delete(input: FeedsDeleteInput): Promise<unknown>;
+	trigger(input: FeedsTriggerInput): Promise<unknown>;
 }
 
 export function buildFeedsNamespace(

--- a/packages/server/src/sandbox/namespaces/feeds.ts
+++ b/packages/server/src/sandbox/namespaces/feeds.ts
@@ -5,30 +5,29 @@
  * data surface this feed will sync.
  */
 
-import type { ActionInput } from "@lobu/core/contracts/tools/action-input";
-import type { ManageFeedsArgs } from "@lobu/core/contracts/tools/manage-feeds";
+import type {
+	FeedCreateInput,
+	FeedDeleteInput,
+	FeedListInput,
+	FeedReadInput,
+	FeedReadManyInput,
+	FeedTriggerInput,
+	FeedUpdateInput,
+} from "@lobu/core/contracts/tools/manage-feeds";
 import type { Env } from "../../index";
 import { manageFeeds } from "../../tools/admin/manage_feeds";
 import type { ToolContext } from "../../tools/registry";
 import { createActionCaller } from "./action-call";
 
-export type FeedsListInput = ActionInput<ManageFeedsArgs, "list_feeds">;
-export type FeedsGetInput = ActionInput<ManageFeedsArgs, "read_feed">;
-export type FeedsReadManyInput = ActionInput<ManageFeedsArgs, "read_feeds">;
-export type FeedsCreateInput = ActionInput<ManageFeedsArgs, "create_feed">;
-export type FeedsUpdateInput = ActionInput<ManageFeedsArgs, "update_feed">;
-export type FeedsDeleteInput = ActionInput<ManageFeedsArgs, "delete_feed">;
-export type FeedsTriggerInput = ActionInput<ManageFeedsArgs, "trigger_feed">;
-
 export interface FeedsNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	list(input?: FeedsListInput): Promise<unknown>;
-	get(input: FeedsGetInput): Promise<unknown>;
-	readMany(input: FeedsReadManyInput): Promise<unknown>;
-	create(input: FeedsCreateInput): Promise<unknown>;
-	update(input: FeedsUpdateInput): Promise<unknown>;
-	delete(input: FeedsDeleteInput): Promise<unknown>;
-	trigger(input: FeedsTriggerInput): Promise<unknown>;
+	list(input?: FeedListInput): Promise<unknown>;
+	get(input: FeedReadInput): Promise<unknown>;
+	readMany(input: FeedReadManyInput): Promise<unknown>;
+	create(input: FeedCreateInput): Promise<unknown>;
+	update(input: FeedUpdateInput): Promise<unknown>;
+	delete(input: FeedDeleteInput): Promise<unknown>;
+	trigger(input: FeedTriggerInput): Promise<unknown>;
 }
 
 export function buildFeedsNamespace(

--- a/packages/server/src/sandbox/namespaces/operations.ts
+++ b/packages/server/src/sandbox/namespaces/operations.ts
@@ -5,75 +5,39 @@
  * (PR-2) intercepts these calls instead of sending them.
  */
 
+import type { ActionInput } from "@lobu/core/contracts/tools/action-input";
+import type { ManageOperationsArgs } from "@lobu/core/contracts/tools/manage-operations";
 import type { Env } from "../../index";
 import { manageOperations } from "../../tools/admin/manage_operations";
 import type { ToolContext } from "../../tools/registry";
 import { createActionCaller, idArg } from "./action-call";
 
-export interface OperationsExecuteInput {
-	connection_id: number;
-	operation_key: string;
-	input?: Record<string, unknown>;
-	idempotency_key?: string;
-	activation?: {
-		kind: "page_visit";
-		urls: string[];
-		expires_in_seconds?: number;
-	};
-	/**
-	 * Automation provenance when this operation fires from a reaction. Both ids are
-	 * numeric.
-	 */
-	automation_source?: { automation_id: number; run_id: number };
-}
+export type OperationsListAvailableInput = ActionInput<
+	ManageOperationsArgs,
+	"list_available"
+>;
+export type OperationsExecuteInput = ActionInput<
+	ManageOperationsArgs,
+	"execute"
+>;
+export type OperationsListRunsInput = ActionInput<
+	ManageOperationsArgs,
+	"list_runs"
+>;
+export type OperationsApproveInput = ActionInput<
+	ManageOperationsArgs,
+	"approve"
+>;
+export type OperationsRejectInput = ActionInput<ManageOperationsArgs, "reject">;
 
 export interface OperationsNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	listAvailable(input?: {
-		connector_key?: string;
-		connection_id?: number;
-		entity_id?: number;
-		kind?: "read" | "write";
-		backend?: "local_action" | "mcp_tool" | "http_operation";
-		query?: string;
-		include_disconnected?: boolean;
-		include_input_schema?: boolean;
-		include_output_schema?: boolean;
-		limit?: number;
-		offset?: number;
-	}): Promise<unknown>;
+	listAvailable(input?: OperationsListAvailableInput): Promise<unknown>;
 	execute(input: OperationsExecuteInput): Promise<unknown>;
-	listRuns(input?: {
-		connection_id?: number;
-		connection_ids?: number[];
-		feed_ids?: number[];
-		device_worker_id?: string;
-		connector_key?: string;
-		operation_key?: string;
-		status?: string;
-		approval_status?: string;
-		/**
-		 * Omit to list every OPERATIONAL run type (sync, action, automation, auth,
-		 * …). Chat-message transport runs (streaming deltas) are excluded by
-		 * default; pass run_types: ['chat_message'] for the trace view.
-		 */
-		run_types?: string[];
-		automation_ids?: number[];
-		/** ISO 8601 inclusive lower bound on created_at. */
-		created_after?: string;
-		/** ISO 8601 exclusive upper bound on created_at. */
-		created_before?: string;
-		before_id?: number;
-		before_created_at?: string;
-		limit?: number;
-		offset?: number;
-	}): Promise<unknown>;
+	listRuns(input?: OperationsListRunsInput): Promise<unknown>;
 	getRun(run_id: number): Promise<unknown>;
-	approve(input: {
-		run_id: number;
-		input?: Record<string, unknown>;
-	}): Promise<unknown>;
-	reject(input: { run_id: number; reason?: string }): Promise<unknown>;
+	approve(input: OperationsApproveInput): Promise<unknown>;
+	reject(input: OperationsRejectInput): Promise<unknown>;
 }
 
 export function buildOperationsNamespace(

--- a/packages/server/src/sandbox/namespaces/operations.ts
+++ b/packages/server/src/sandbox/namespaces/operations.ts
@@ -5,39 +5,26 @@
  * (PR-2) intercepts these calls instead of sending them.
  */
 
-import type { ActionInput } from "@lobu/core/contracts/tools/action-input";
-import type { ManageOperationsArgs } from "@lobu/core/contracts/tools/manage-operations";
+import type {
+	OperationApproveInput,
+	OperationExecuteInput,
+	OperationListAvailableInput,
+	OperationListRunsInput,
+	OperationRejectInput,
+} from "@lobu/core/contracts/tools/manage-operations";
 import type { Env } from "../../index";
 import { manageOperations } from "../../tools/admin/manage_operations";
 import type { ToolContext } from "../../tools/registry";
 import { createActionCaller, idArg } from "./action-call";
 
-export type OperationsListAvailableInput = ActionInput<
-	ManageOperationsArgs,
-	"list_available"
->;
-export type OperationsExecuteInput = ActionInput<
-	ManageOperationsArgs,
-	"execute"
->;
-export type OperationsListRunsInput = ActionInput<
-	ManageOperationsArgs,
-	"list_runs"
->;
-export type OperationsApproveInput = ActionInput<
-	ManageOperationsArgs,
-	"approve"
->;
-export type OperationsRejectInput = ActionInput<ManageOperationsArgs, "reject">;
-
 export interface OperationsNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	listAvailable(input?: OperationsListAvailableInput): Promise<unknown>;
-	execute(input: OperationsExecuteInput): Promise<unknown>;
-	listRuns(input?: OperationsListRunsInput): Promise<unknown>;
+	listAvailable(input?: OperationListAvailableInput): Promise<unknown>;
+	execute(input: OperationExecuteInput): Promise<unknown>;
+	listRuns(input?: OperationListRunsInput): Promise<unknown>;
 	getRun(run_id: number): Promise<unknown>;
-	approve(input: OperationsApproveInput): Promise<unknown>;
-	reject(input: OperationsRejectInput): Promise<unknown>;
+	approve(input: OperationApproveInput): Promise<unknown>;
+	reject(input: OperationRejectInput): Promise<unknown>;
 }
 
 export function buildOperationsNamespace(

--- a/packages/server/src/sandbox/namespaces/schedules.ts
+++ b/packages/server/src/sandbox/namespaces/schedules.ts
@@ -2,44 +2,26 @@
  * ClientSDK `schedules` namespace. Thin wrapper over `manageSchedules`.
  */
 
+import type { ActionInput } from "@lobu/core/contracts/tools/action-input";
+import type { ManageSchedulesArgs } from "@lobu/core/contracts/tools/manage-schedules";
 import type { Env } from "../../index";
 import { manageSchedules } from "../../tools/admin/manage_schedules";
 import type { ToolContext } from "../../tools/registry";
 import { createActionCaller } from "./action-call";
 
-export interface SchedulesListInput {
-	agent_id?: string;
-	user_id?: string;
-	action_type?: string;
-	include_paused?: boolean;
-}
-
-export interface SchedulesCreateInput {
-	description: string;
-	run_at: string;
-	cron?: string;
-	payload: Record<string, unknown>;
-	source_run_id?: number;
-	source_event_id?: number;
-	source_thread_id?: string;
-}
-
-export interface SchedulesUpdateInput {
-	id: string;
-	description?: string;
-	run_at?: string;
-	cron?: string | null;
-	prompt?: string;
-	model?: string;
-}
+export type SchedulesListInput = ActionInput<ManageSchedulesArgs, "list">;
+export type SchedulesCreateInput = ActionInput<ManageSchedulesArgs, "create">;
+export type SchedulesUpdateInput = ActionInput<ManageSchedulesArgs, "update">;
+export type SchedulesPauseInput = ActionInput<ManageSchedulesArgs, "pause">;
+export type SchedulesCancelInput = ActionInput<ManageSchedulesArgs, "cancel">;
 
 export interface SchedulesNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
 	list(input?: SchedulesListInput): Promise<unknown>;
 	create(input: SchedulesCreateInput): Promise<unknown>;
 	update(input: SchedulesUpdateInput): Promise<unknown>;
-	pause(input: { id: string; paused?: boolean }): Promise<unknown>;
-	cancel(input: { id: string }): Promise<unknown>;
+	pause(input: SchedulesPauseInput): Promise<unknown>;
+	cancel(input: SchedulesCancelInput): Promise<unknown>;
 }
 
 export function buildSchedulesNamespace(

--- a/packages/server/src/sandbox/namespaces/schedules.ts
+++ b/packages/server/src/sandbox/namespaces/schedules.ts
@@ -2,26 +2,25 @@
  * ClientSDK `schedules` namespace. Thin wrapper over `manageSchedules`.
  */
 
-import type { ActionInput } from "@lobu/core/contracts/tools/action-input";
-import type { ManageSchedulesArgs } from "@lobu/core/contracts/tools/manage-schedules";
+import type {
+	ScheduleCancelInput,
+	ScheduleCreateInput,
+	ScheduleListInput,
+	SchedulePauseInput,
+	ScheduleUpdateInput,
+} from "@lobu/core/contracts/tools/manage-schedules";
 import type { Env } from "../../index";
 import { manageSchedules } from "../../tools/admin/manage_schedules";
 import type { ToolContext } from "../../tools/registry";
 import { createActionCaller } from "./action-call";
 
-export type SchedulesListInput = ActionInput<ManageSchedulesArgs, "list">;
-export type SchedulesCreateInput = ActionInput<ManageSchedulesArgs, "create">;
-export type SchedulesUpdateInput = ActionInput<ManageSchedulesArgs, "update">;
-export type SchedulesPauseInput = ActionInput<ManageSchedulesArgs, "pause">;
-export type SchedulesCancelInput = ActionInput<ManageSchedulesArgs, "cancel">;
-
 export interface SchedulesNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	list(input?: SchedulesListInput): Promise<unknown>;
-	create(input: SchedulesCreateInput): Promise<unknown>;
-	update(input: SchedulesUpdateInput): Promise<unknown>;
-	pause(input: SchedulesPauseInput): Promise<unknown>;
-	cancel(input: SchedulesCancelInput): Promise<unknown>;
+	list(input?: ScheduleListInput): Promise<unknown>;
+	create(input: ScheduleCreateInput): Promise<unknown>;
+	update(input: ScheduleUpdateInput): Promise<unknown>;
+	pause(input: SchedulePauseInput): Promise<unknown>;
+	cancel(input: ScheduleCancelInput): Promise<unknown>;
 }
 
 export function buildSchedulesNamespace(

--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -24,6 +24,8 @@
  * - update_connector_auth: Update reusable default auth profiles for an installed org connector
  */
 
+import type { Static } from "@sinclair/typebox";
+import type { ConnectionsArgs } from "./manage_connections/schemas";
 import { action, defineActionTool } from "./action-tool";
 import {
 	handleReauthenticate,
@@ -136,5 +138,17 @@ const manageConnectionsTool = defineActionTool("manage_connections", {
 
 export const ManageConnectionsSchema = manageConnectionsTool.schema;
 export const manageConnections = manageConnectionsTool.run;
+
+type AssertTrue<T extends true> = T;
+type SameUnion<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+/**
+ * @internal Compile-time fixture. core hand-lists `ConnectionsArgs` (it cannot
+ * see this tool's union without a circular type) and derives every
+ * `*Input` from that list, so a variant dispatched here but missing there
+ * would have no derivable input and nothing would say so. Pin the two.
+ */
+export type ConnectionsArgsCoverEveryDispatchedVariant = AssertTrue<
+	SameUnion<Static<typeof ManageConnectionsSchema>, ConnectionsArgs>
+>;
 // Re-export so the admin registry entry can wire `outputSchema`.
 export { ManageConnectionsResultSchema } from "./manage_connections/schemas";

--- a/scripts/check-exposed-surface-naming.ts
+++ b/scripts/check-exposed-surface-naming.ts
@@ -197,10 +197,10 @@ function scanTypeBoxSchemas(file: string, violations: Violation[]): void {
 /**
  * Workspace packages whose types are part of the agent-facing surface. A
  * namespace signature reaches into these directly — `listCatalog(input?:
- * Omit<ListCatalogArgs, "action">)` imports `ListCatalogArgs` from
- * `@lobu/core/...` — so treating "not relative" as "not ours" would skip a
- * live wire contract. Third-party packages stay out of scope: node_modules is
- * not our surface to police.
+ * CatalogListCatalogInput)` resolves through `ActionInput<ManageCatalogArgs,
+ * "list_catalog">`, both imported from `@lobu/core/...` — so treating "not
+ * relative" as "not ours" would skip a live wire contract. Third-party
+ * packages stay out of scope: node_modules is not our surface to police.
  */
 const WORKSPACE_ALIASES: ReadonlyArray<readonly [string, string]> = [
   ["@lobu/core/", join(REPO_ROOT, "packages/core/src/")],

--- a/scripts/check-exposed-surface-naming.ts
+++ b/scripts/check-exposed-surface-naming.ts
@@ -197,10 +197,10 @@ function scanTypeBoxSchemas(file: string, violations: Violation[]): void {
 /**
  * Workspace packages whose types are part of the agent-facing surface. A
  * namespace signature reaches into these directly — `listCatalog(input?:
- * CatalogListCatalogInput)` resolves through `ActionInput<ManageCatalogArgs,
- * "list_catalog">`, both imported from `@lobu/core/...` — so treating "not
- * relative" as "not ours" would skip a live wire contract. Third-party
- * packages stay out of scope: node_modules is not our surface to police.
+ * CatalogListInput)` imports `CatalogListInput` from `@lobu/core/...` — so
+ * treating "not relative" as "not ours" would skip a live wire contract.
+ * Third-party packages stay out of scope: node_modules is not our surface to
+ * police.
  */
 const WORKSPACE_ALIASES: ReadonlyArray<readonly [string, string]> = [
   ["@lobu/core/", join(REPO_ROOT, "packages/core/src/")],


### PR DESCRIPTION
## Summary
- Six ClientSDK namespaces — `authProfiles`, `catalog`, `connections`, `feeds`, `operations`, `schedules` — sit on contracts whose input schema is already a `Type.Union` of per-action variants, yet restated every method's fields by hand. Every copy had drifted toward advertising **less** than the tool accepts (table below).
- **core now owns one named input type per action** (`FeedCreateInput`, `ScheduleUpdateInput`, `AuthProfileDeleteInput`, …), each derived through one helper, `ActionInput<Args, Action>` — the action's variant minus the `action` discriminator the SDK method fills in. The namespaces import those names and declare no input types of their own; the published connector SDK will import the same names next (PR B), so each input has exactly one definition site. This is the shape `connections` and the `#3349` knowledge types already had — the tree now has one derivation idiom instead of three.
- `Action` is constrained to `Args["action"]`, so a typo fails at the declaration. A compile-time pin in `manage_connections.ts` keeps core's hand-listed `ConnectionsArgs` (it cannot see the server's union without a circular type) equal to the union the tool actually dispatches — mutation-proven: dropping one variant turns it red.
- **No hand-written field list remains in a union-backed namespace.**

### Drift this fixes (compile-time; the runtime already accepted all of it)
| method | hand-written type said | contract says |
|---|---|---|
| `schedules.create` | no `timezone`, `until_at`, `idempotency_key`; `payload: Record<string, unknown>` | all three present; `payload` is the `send_notification \| wake_agent` union |
| `schedules.update` | no `timezone`, `until_at` | both present (nullable, to clear) |
| `authProfiles.create` | `connector_key` **required** | optional — `browser_session` profiles are device-scoped |
| `catalog.listInstalled` | no `include_catalog` | present — its own `search_sdk` signature already advertised it |

### Deliberately out of scope
The seven **flat**-schema contracts (`agents`, `automations`, `classifiers`, `conversations`, `entity`, `entity-schema`, `view-templates`) have no per-action variant to `Extract` from. Converting them to unions makes runtime validation stricter (an extra field goes from silently ignored to a 400) and starts applying `filterSchemaForAccessLevel` to them — so they go one tool per PR, each gated on a prod-payload check. The published `connector-sdk` types are the same bug class with live drift (`operations.listAvailable` omits 9 accepted fields) and are the next PR; they will import the names this PR adds to core.

## Test plan
- [x] Intended paths staged explicitly (`--pathspec-from-file`); `git diff --name-only origin/main...HEAD` diffed against the list → exact. `make pre-pr` clean (build, per-package typecheck incl. `connector-sdk`, knip, biome, naming, gateway-LLM + entity-write funnel gates).
- [x] Tests: `bun test packages/server/src/__tests__/unit/sandbox/` → **154 pass / 0 fail** (covers `createActionCaller`, method access, signature contract). Runtime path through the converted namespaces via `TestWorkspace`: 11 integration files (`feeds-*`, `connections-*`, `manage-feeds-*`, `client-sdk-business-errors`, `automations-feeds-timezone`, …) → **79 pass**.
- [x] Types-only refactor, so red→green is a compile-time proof, pasted below.
- [ ] No bot runtime change.

### Drift proof (red → green)
A scratch file with schema-valid calls, typechecked against the **old** hand-written declarations:
```
__drift_proof.ts(9,2):  error TS2353: 'timezone' does not exist in type 'SchedulesCreateInput'.
__drift_proof.ts(17,2): error TS2353: 'timezone' does not exist in type 'SchedulesUpdateInput'.
__drift_proof.ts(23,14): error TS2741: Property 'connector_key' is missing in type
                          '{ profile_kind: "browser_session"; display_name: string; }'
                          but required in type 'AuthProfileCreateInput'.
```
The same calls (plus `catalog.listInstalled({ include_catalog: true })`) against core's derived names: `tsc --noEmit` → **exit 0**. Scratch file removed; derivation itself is the guard, so no fixture is committed for these — a field added to the contract reaches every typed caller by construction.

### Pin proof (`ConnectionsArgs` ≡ dispatched union)
Removed `| Static<typeof TestAction>` from core's `ConnectionsArgs`, rebuilt core:
```
src/tools/admin/manage_connections.ts(151,2): error TS2344: Type 'false' does not satisfy the constraint 'true'.
```
Restored → clean.

## Notes
**`[client-regen-not-needed]`, with the proof rather than the assertion:** the only lines that changed under `packages/core/src/contracts/tools/` are `export type` declarations, a type-only `import`, and comments — no TypeBox schema object moved, so the served OpenAPI document (and therefore `packages/client/src/generated/**`) is byte-identical. Verified by grepping the staged core-contract diff for any non-type line.

**One behavioural narrowing worth knowing:** `ScheduleCreateInput.payload` goes from `Record<string, unknown>` to the discriminated union. Nothing in-repo breaks, and it is the type the runtime always enforced — but an out-of-repo script that built a payload dynamically would now need to type it.

**Reviewer disclosure:** codex is at its usage limit until 2026-09-07, so `make review-fix`/`make review` ran as `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus` — same-model self-review, not the intended cross-harness check. `review-fix` found the `catalog.listInstalled` / `include_catalog` drift and the stale `authProfiles.list` signature string that named the type this PR deletes; both re-verified above.

**Second round:** the first `make review` verdict (0 bugs, 0 blockers) carried one note — the `interactive`-kind comment left floating in `auth-profiles.ts` after its types moved to core. It now sits on the single `AuthProfileKind` schema in core, which also replaces two identical four-literal lists; `JSON.stringify(ManageAuthProfilesSchema)` before and after is byte-identical, so `[client-regen-not-needed]` still holds. The branch was also rebased so its Owletto pointer matches `main` (ui-review had read the stale pointer as a backwards bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oUgNdUxpeUSpjJhYFFyRa
