### PR TITLE
fix(sdk): entities.create forwards every contract field; `type` is an alias

### DIFF
--- a/packages/server/src/__tests__/integration/sandbox/entities-create-passthrough.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/entities-create-passthrough.test.ts
@@ -1,0 +1,102 @@
+/**
+ * `entities.create` forwards every contract field the handler honors.
+ *
+ * The namespace used to rebuild the payload from a hand-written field list, so
+ * `domain`, `category`, `platform_type`, `main_market`, `market` and `link` —
+ * accepted by `manage_entity` and merged into the row's metadata by
+ * `handleCreate` — were silently dropped, and so was `entity_type`, the name
+ * the contract itself declares (and the one `entities.list` accepts). The
+ * payload now passes straight through; `type` survives as a registered alias
+ * for the callers that guess it.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import { buildClientSDK, type ClientSDK } from "../../../sandbox/client-sdk";
+import type { EntityCreateInput } from "../../../sandbox/namespaces/entities";
+import type { ToolContext } from "../../../tools/registry";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestOrganization,
+	createTestUser,
+	seedSystemEntityTypes,
+} from "../../setup/test-fixtures";
+
+const testEnv: Env = {
+	ENVIRONMENT: "test",
+	DATABASE_URL: process.env.DATABASE_URL,
+};
+
+const profile = {
+	domain: "acme.example",
+	category: "saas",
+	platform_type: "b2b",
+	main_market: "US",
+	market: "DE",
+	link: "https://acme.example",
+};
+
+describe("ClientSDK entities.create field pass-through", () => {
+	let sdk: ClientSDK;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await seedSystemEntityTypes();
+		await initWorkspaceProvider();
+		const org = await createTestOrganization({
+			name: "Passthrough Org",
+			slug: "passthrough-sdk",
+		});
+		const user = await createTestUser({
+			email: "passthrough-sdk@test.example.com",
+		});
+		await addUserToOrganization(user.id, org.id, "owner");
+		const ctx: ToolContext = {
+			organizationId: org.id,
+			userId: user.id,
+			memberRole: "owner",
+			isAuthenticated: true,
+			tokenType: "oauth",
+			scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+			scopedToOrg: false,
+			allowCrossOrg: true,
+		};
+		sdk = buildClientSDK(ctx, testEnv);
+		await sdk.entitySchema.createType({ slug: "vendor", name: "Vendor" });
+	});
+
+	it("persists the profile fields the handler accepts", async () => {
+		const result = (await sdk.entities.create({
+			entity_type: "vendor",
+			name: "Passthrough Co",
+			...profile,
+		})) as { entity: { id: number; entity_type: string } };
+		expect(result.entity.entity_type).toBe("vendor");
+		// `createEntity` folds the convenience fields into the row's metadata.
+		// Assert on the stored row rather than the handler's echo, so this proves
+		// persistence and not just an argument round-trip.
+		const rows = await getTestDb()`
+			SELECT metadata FROM entities WHERE id = ${result.entity.id}`;
+		expect(rows).toHaveLength(1);
+		expect(rows[0].metadata).toMatchObject(profile);
+	});
+
+	it("accepts `type` as an alias for `entity_type`", async () => {
+		const result = (await sdk.entities.create({
+			type: "vendor",
+			name: "Alias Co",
+		} as unknown as EntityCreateInput)) as { entity: { entity_type: string } };
+		expect(result.entity.entity_type).toBe("vendor");
+	});
+
+	it("rejects a field the contract does not accept instead of dropping it", async () => {
+		await expect(
+			sdk.entities.create({
+				entity_type: "vendor",
+				name: "Bogus Co",
+				identities: [],
+			} as unknown as EntityCreateInput),
+		).rejects.toThrow(/unknown argument\(s\): identities/);
+	});
+});

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -101,7 +101,7 @@ export default async (_ctx, client) => {
 		access: "write",
 		throws: ["ValidationError"],
 		example:
-			"await client.entities.create({ type: 'company', name: 'Acme', metadata: {} });",
+			"await client.entities.create({ entity_type: 'company', name: 'Acme', metadata: {} });",
 		usageExample: `// Two-hop: ensure the entity type exists, THEN create the entity.
 // A first-of-its-kind type must be created before any entity of it.
 export default async (_ctx, client) => {
@@ -119,7 +119,7 @@ export default async (_ctx, client) => {
     }
   }
   return client.entities.create({
-    type: 'company',
+    entity_type: 'company',
     name: 'Acme',
     metadata: { team_size: 50 },
   });

--- a/packages/server/src/sandbox/namespaces/entities.ts
+++ b/packages/server/src/sandbox/namespaces/entities.ts
@@ -24,13 +24,19 @@ export interface EntityListFilter {
 }
 
 export interface EntityCreateInput {
-	type: string;
+	entity_type: string;
 	name: string;
 	slug?: string;
 	content?: string;
 	parent_id?: number;
 	metadata?: Record<string, unknown>;
 	enabled_classifiers?: string[];
+	domain?: string;
+	category?: string;
+	platform_type?: string;
+	main_market?: string;
+	market?: string;
+	link?: string;
 }
 
 export interface EntityUpdateInput {
@@ -40,9 +46,18 @@ export interface EntityUpdateInput {
 	content?: string;
 	metadata?: Record<string, unknown>;
 	enabled_classifiers?: string[];
+	domain?: string;
+	category?: string;
+	platform_type?: string;
+	main_market?: string;
+	market?: string;
+	link?: string;
 	/** Optional note explaining a human correction; stored on the per-field
 	 *  ownership marker for the metadata fields this update sets. */
 	field_note?: string;
+	/** Metadata field names whose current value the human approves as-is:
+	 *  no value change, but each becomes human-owned. */
+	affirm_fields?: string[];
 }
 
 export interface EntityLinkInput {
@@ -103,17 +118,7 @@ export function buildEntitiesNamespace(
 		manage,
 		list: method("list"),
 		get: method("get"),
-		create: method("create", {
-			mapArgs: (input) => ({
-				entity_type: input.type,
-				name: input.name,
-				slug: input.slug,
-				content: input.content,
-				parent_id: input.parent_id,
-				metadata: input.metadata,
-				enabled_classifiers: input.enabled_classifiers,
-			}),
-		}),
+		create: method("create"),
 		update: method("update"),
 		delete: method("delete"),
 		link: method("link"),

--- a/packages/server/src/sandbox/sdk-aliases.ts
+++ b/packages/server/src/sandbox/sdk-aliases.ts
@@ -15,6 +15,8 @@ export const SDK_FIELD_ALIASES: Readonly<
 	// intuitive `id` for the entity/feed id field
 	"entities.get": { id: "entity_id" },
 	"entities.delete": { id: "entity_id" },
+	// runtime field is `entity_type` (as `entities.list` exposes it); callers guess `type`
+	"entities.create": { type: "entity_type" },
 	"feeds.get": { id: "feed_id" },
 	// schedules use plain `id`; callers guess `schedule_id`
 	"schedules.update": { schedule_id: "id" },

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -620,7 +620,7 @@ function buildEmptySearchSuggestion(
   // Only a single-workspace text search names one entity worth pre-filling:
   // federated results span workspaces, and an embedding-only call has no query
   // text at all. Both fall back to a placeholder in the SAME angle-bracket
-  // shape as `<entity_type>` below — a bare `...` reads as copyable literal.
+  // shape as `<slug>` below — a bare `...` reads as copyable literal.
   const newEntityName = !isFederated && query ? query : '<entity_name>';
   // `entitySchema.createType` is admin-tier while `entities.create` is write.
   // Telling a member to create the type sends them at a call that will deny,
@@ -628,8 +628,8 @@ function buildEmptySearchSuggestion(
   const canCreateEntityType = callerMax === 'admin';
   lines.push(
     canCreateEntityType
-      ? `- To create a new entity: its type must exist first (\`client.entitySchema.listTypes()\` to check, \`client.entitySchema.createType(...)\` for a type new to this workspace), then call \`run_sdk\` with \`await client.entities.create({ type: '<entity_type>', name: '${newEntityName}' })\`.`
-      : `- To create a new entity: pick a type that already exists (\`client.entitySchema.listTypes()\`), then call \`run_sdk\` with \`await client.entities.create({ type: '<entity_type>', name: '${newEntityName}' })\`. Creating a brand-new entity type needs admin access, so ask a workspace admin if none of the existing types fit.`
+      ? `- To create a new entity: its type must exist first (\`client.entitySchema.listTypes()\` to check, \`client.entitySchema.createType(...)\` for a type new to this workspace), then call \`run_sdk\` with \`await client.entities.create({ entity_type: '<slug>', name: '${newEntityName}' })\`.`
+      : `- To create a new entity: pick a type that already exists (\`client.entitySchema.listTypes()\`), then call \`run_sdk\` with \`await client.entities.create({ entity_type: '<slug>', name: '${newEntityName}' })\`. Creating a brand-new entity type needs admin access, so ask a workspace admin if none of the existing types fit.`
   );
 
   return lines.join('\n');


### PR DESCRIPTION
## Summary
- `client.entities.create` rebuilt its payload from a hand-written seven-field list, so six fields the contract accepts and `handleCreate` persists — `domain`, `category`, `platform_type`, `main_market`, `market`, `link` — were silently dropped, and so was `entity_type`, the field every other `entities.*` method (and the contract) uses. The list is gone: the input passes through like every other action method, and `type` is a registered alias for `entity_type` in `SDK_FIELD_ALIASES`, so existing callers keep working.
- `entity_type` becomes the documented name (`search_sdk` example, the recall hint in `search.ts`, the namespace interface); the alias registry test already requires the docs to name the canonical field. Nothing else in the tree hand-mapped `type`.
- `EntityUpdateInput` gains the same six fields plus `affirm_fields`, which `update` already passed through but the interface hid.

### Prod census before tightening (read-only, 60 days, `events.payload_data->'sdk_call_trace'`)
| `entities.create` callers | count |
|---|---|
| `type` only | 5001 |
| `entity_type` only — **fails today** (`entity_type is required for create action`) | 36 |
| both | 3 |
| neither / non-object | 7 |

No caller passed any of the six dropped fields to `create`, and no stored `automations.reaction_script` calls `entities.create` at all (0 rows). The one behavioural tightening — an unknown field now fails with `unknown argument(s): …` instead of being dropped, as it already does for every other `entities.*` method — only reaches payloads that already fail (`identities`, `entity`, test probes named `zzz_bogus`).

## Test plan
- [x] `packages/server/src/__tests__/integration/sandbox/entities-create-passthrough.test.ts` (vitest, real DB): profile fields land in the row's `metadata`; `type` alias resolves; an unknown field is rejected. **Red** against the pre-change namespace (`git show HEAD:…entities.ts`): 3/3 fail —
  ```
  × persists the profile fields the handler accepts     ToolUserError: entity_type is required for create action
  × accepts `type` as an alias for `entity_type`        (alias not registered → whitelist path)
  × rejects a field the contract does not accept        expected … to throw /unknown argument\(s\): identities/ but got 'entity_type is required…'
  ```
  **Green** after: `Tests 3 passed (3)`.
- [x] Neighbouring suites: `namespace-dispatch`, `execute-wire`, `search-memory-recall-contract` (vitest) and `bun test src/__tests__/unit/sandbox/` → 154 pass / 0 fail (alias registry ↔ docs test included).
- [x] `make pre-pr` clean; `make review-fix` run before the first `make review`.
- [ ] No bot runtime change; no contract/route change, so no generated-client impact.

## Notes
The published `@lobu/connector-sdk` `EntityCreateInput` still says `type: string`; that keeps working through the alias. It is hand-written for the same reason this namespace was — `manage_entity` is a flat contract with no per-action variant to derive from — and is replaced by a derived type when that contract goes union (next PR in this series).

`make review-fix` proposed two further edits that were declined: renaming the published `@lobu/connector-sdk` `EntityCreateInput.type` to `entity_type` (a breaking change to a public type, deferred to the derived version above) and a hand-written `signature:` string for `entities.create` (a fourth copy of the field list — the class of duplication the next PRs remove). Its two comment clarifications were kept.

**Reviewer disclosure:** codex is at its usage limit until 2026-09-07, so `make review-fix` / `make review` ran as `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus` — same-model self-review rather than the cross-harness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Entity creation now supports metadata including domain, category, platform type, main market, market, and link.
  - Entity updates now support the same metadata fields plus affirmation fields.
  - Entity creation accepts `entity_type` as the standard field, while `type` remains supported as an alias.
  - Unsupported arguments are now rejected instead of being silently ignored.

- **Documentation**
  - Updated examples and search guidance to use `entity_type`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->