### PR TITLE
refactor(core): manage_conversations is a union of per-action variants

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3051,44 +3051,69 @@ export type ManageAgentsResponse =
   ManageAgentsResponses[keyof ManageAgentsResponses];
 
 export type ManageConversationsData = {
-  body: {
-    /**
-     * Action to perform
-     */
-    action: "list" | "get" | "send";
-    /**
-     * Target agent id (lowercase slug, e.g. "researcher"). Required for every action.
-     */
-    agent_id: string;
-    /**
-     * [get] Conversation platform ("web" for app-owned conversations, or a channel platform like "slack"). Defaults to "web".
-     */
-    platform?: string;
-    /**
-     * [get] The stored conversation id. For [send], omit to target the caller's default web thread, or pass a `thread` to open/resume a named web thread.
-     */
-    conversation_id?: string;
-    /**
-     * [send] Optional web thread name. Distinct threads keep separate history + separate pinned sandbox. Omit for the default thread.
-     */
-    thread?: string;
-    /**
-     * [send] Message text to deliver to the agent.
-     */
-    text?: string;
-    /**
-     * [send] Optional per-message model override as a `provider/model` ref. Wins over the agent/org default.
-     */
-    model?: string;
-    /**
-     * [send] When true (default), block until the agent's turn completes and return its reply. When false, enqueue and return immediately with the message id.
-     */
-    wait?: boolean;
-    /**
-     * [send, wait=true] Max time to wait for the reply. Default 45000, capped at 170000 — kept inside run_sdk's own wall-clock budget so a no-reply call returns a graceful status:"timeout" instead of aborting the whole script. For a longer wait, raise BOTH this and the run_sdk/query_sdk timeout_ms. On timeout the turn keeps running (the answer is not lost); the reply is not retrievable through `get`.
-     */
-    timeout_ms?: number;
-  };
+  body:
+    | {
+        /**
+         * List an agent's conversations, newest-first.
+         */
+        action: "list";
+        /**
+         * Target agent id (lowercase slug, e.g. "researcher").
+         */
+        agent_id: string;
+      }
+    | {
+        /**
+         * Fetch one conversation by its (platform, conversation_id).
+         */
+        action: "get";
+        /**
+         * Target agent id (lowercase slug, e.g. "researcher").
+         */
+        agent_id: string;
+        /**
+         * Conversation platform ("web" for app-owned conversations, or a channel platform like "slack"). Defaults to "web".
+         */
+        platform?: string;
+        /**
+         * The stored conversation id. Required for `get`; optional for `send`, where it resumes that exact web conversation and wins over `thread` (omit it to target the caller's default web thread).
+         */
+        conversation_id: string;
+      }
+    | {
+        /**
+         * Send a message to an agent conversation and (by default) return its reply. Runs the turn against the conversation's pinned sandbox realm.
+         */
+        action: "send";
+        /**
+         * Target agent id (lowercase slug, e.g. "researcher").
+         */
+        agent_id: string;
+        /**
+         * The stored conversation id. Required for `get`; optional for `send`, where it resumes that exact web conversation and wins over `thread` (omit it to target the caller's default web thread).
+         */
+        conversation_id?: string;
+        /**
+         * Optional web thread name. Distinct threads keep separate history + separate pinned sandbox. Omit for the default thread.
+         */
+        thread?: string;
+        /**
+         * Message text to deliver to the agent.
+         */
+        text: string;
+        /**
+         * Optional per-message model override as a `provider/model` ref. Wins over the agent/org default.
+         */
+        model?: string;
+        /**
+         * When true (default), block until the agent's turn completes and return its reply. When false, enqueue and return immediately with the message id.
+         */
+        wait?: boolean;
+        /**
+         * [wait=true] Max time to wait for the reply. Default 45000, capped at 170000 — kept inside run_sdk's own wall-clock budget so a no-reply call returns a graceful status:"timeout" instead of aborting the whole script. For a longer wait, raise BOTH this and the run_sdk/query_sdk timeout_ms. On timeout the turn keeps running (the answer is not lost); the reply is not retrievable through `get`.
+         */
+        timeout_ms?: number;
+      };
   path: {
     /**
      * Organization slug (workspace identifier)

--- a/packages/core/src/contracts/tools/manage-conversations.ts
+++ b/packages/core/src/contracts/tools/manage-conversations.ts
@@ -1,75 +1,77 @@
 import { type Static, Type } from "@sinclair/typebox";
+import type { ActionInput } from "./action-input";
 
 // ============================================
-// Typebox Schema (Flattened for MCP)
+// Schema
 // ============================================
 
-export const ManageConversationsSchema = Type.Object({
-  action: Type.Union(
-    [
-      Type.Literal("list", {
-        description: "List an agent's conversations, newest-first.",
-      }),
-      Type.Literal("get", {
-        description:
-          "Fetch one conversation by its (platform, conversation_id).",
-      }),
-      Type.Literal("send", {
-        description:
-          "Send a message to an agent conversation and (by default) return its reply. " +
-          "Runs the turn against the conversation's pinned sandbox realm.",
-      }),
-    ],
-    { description: "Action to perform" }
-  ),
+const AgentId = Type.String({
+  description: 'Target agent id (lowercase slug, e.g. "researcher").',
+});
 
-  agent_id: Type.String({
-    description:
-      'Target agent id (lowercase slug, e.g. "researcher"). Required for every action.',
+// The wire schema flattens this union into ONE MCP object and merges duplicate
+// properties first-occurrence-wins, so a property carried by more than one
+// variant must read true for every one of them.
+const ConversationId = Type.String({
+  description:
+    "The stored conversation id. Required for `get`; optional for `send`, " +
+    "where it resumes that exact web conversation and wins over `thread` " +
+    "(omit it to target the caller's default web thread).",
+});
+
+export const ListConversationsAction = Type.Object({
+  action: Type.Literal("list", {
+    description: "List an agent's conversations, newest-first.",
   }),
+  agent_id: AgentId,
+});
 
+export const GetConversationAction = Type.Object({
+  action: Type.Literal("get", {
+    description: "Fetch one conversation by its (platform, conversation_id).",
+  }),
+  agent_id: AgentId,
   platform: Type.Optional(
     Type.String({
       description:
-        '[get] Conversation platform ("web" for app-owned conversations, or a channel platform like "slack"). Defaults to "web".',
+        'Conversation platform ("web" for app-owned conversations, or a channel platform like "slack"). Defaults to "web".',
     })
   ),
-  conversation_id: Type.Optional(
-    Type.String({
-      description:
-        "[get] The stored conversation id. For [send], omit to target the caller's default web thread, " +
-        "or pass a `thread` to open/resume a named web thread.",
-    })
-  ),
+  conversation_id: ConversationId,
+});
 
+export const SendConversationMessageAction = Type.Object({
+  action: Type.Literal("send", {
+    description:
+      "Send a message to an agent conversation and (by default) return its reply. " +
+      "Runs the turn against the conversation's pinned sandbox realm.",
+  }),
+  agent_id: AgentId,
+  conversation_id: Type.Optional(ConversationId),
   thread: Type.Optional(
     Type.String({
       description:
-        "[send] Optional web thread name. Distinct threads keep separate history + separate pinned sandbox. Omit for the default thread.",
+        "Optional web thread name. Distinct threads keep separate history + separate pinned sandbox. Omit for the default thread.",
     })
   ),
-  text: Type.Optional(
-    Type.String({
-      description: "[send] Message text to deliver to the agent.",
-    })
-  ),
+  text: Type.String({ description: "Message text to deliver to the agent." }),
   model: Type.Optional(
     Type.String({
       description:
-        "[send] Optional per-message model override as a `provider/model` ref. Wins over the agent/org default.",
+        "Optional per-message model override as a `provider/model` ref. Wins over the agent/org default.",
     })
   ),
   wait: Type.Optional(
     Type.Boolean({
       description:
-        "[send] When true (default), block until the agent's turn completes and return its reply. " +
+        "When true (default), block until the agent's turn completes and return its reply. " +
         "When false, enqueue and return immediately with the message id.",
     })
   ),
   timeout_ms: Type.Optional(
     Type.Number({
       description:
-        "[send, wait=true] Max time to wait for the reply. Default 45000, capped at 170000 — " +
+        "[wait=true] Max time to wait for the reply. Default 45000, capped at 170000 — " +
         "kept inside run_sdk's own wall-clock budget so a no-reply call returns a graceful " +
         'status:"timeout" instead of aborting the whole script. For a longer wait, raise BOTH ' +
         "this and the run_sdk/query_sdk timeout_ms. On timeout the turn keeps running (the answer " +
@@ -80,11 +82,27 @@ export const ManageConversationsSchema = Type.Object({
   ),
 });
 
+export const ManageConversationsSchema = Type.Union([
+  ListConversationsAction,
+  GetConversationAction,
+  SendConversationMessageAction,
+]);
+
 // ============================================
 // Type Definitions
 // ============================================
 
 export type ManageConversationsArgs = Static<typeof ManageConversationsSchema>;
+
+export type ConversationListInput = ActionInput<
+  ManageConversationsArgs,
+  "list"
+>;
+export type ConversationGetInput = ActionInput<ManageConversationsArgs, "get">;
+export type ConversationSendInput = ActionInput<
+  ManageConversationsArgs,
+  "send"
+>;
 
 /** One conversation as surfaced by list/get. */
 export interface ConversationRecord {

--- a/packages/server/src/__tests__/unit/manage-conversations-contract.test.ts
+++ b/packages/server/src/__tests__/unit/manage-conversations-contract.test.ts
@@ -1,0 +1,112 @@
+/**
+ * `manage_conversations` is a union of per-action variants, so the schema —
+ * not the handler — decides what each action requires and accepts. These pin
+ * the three consequences the flat contract could not express: a field can be
+ * required for one action while staying optional (or absent) for the others,
+ * a field belonging to `send` is an error on `list` rather than silently
+ * ignored, and the registry's per-action access filtering — which only ever
+ * applied to union variants — now keeps write-tier `send` out of a read-scope
+ * client's listing.
+ */
+import { describe, expect, it } from "bun:test";
+import { ManageConversationsSchema } from "@lobu/core/contracts/tools/manage-conversations";
+import { getAllTools } from "../../tools/registry";
+import { validateToolArgs } from "../../tools/validate-args";
+import { ToolUserError } from "../../utils/errors";
+
+const validate = (args: unknown) =>
+	validateToolArgs("manage_conversations", ManageConversationsSchema, args);
+
+function messageOf(fn: () => unknown): string {
+	try {
+		fn();
+	} catch (err) {
+		expect(err).toBeInstanceOf(ToolUserError);
+		return (err as ToolUserError).message;
+	}
+	throw new Error("expected validation to throw");
+}
+
+describe("manage_conversations union contract", () => {
+	it("requires conversation_id for get and text for send, at the schema", () => {
+		expect(messageOf(() => validate({ action: "get", agent_id: "researcher" }))).toMatch(
+			/conversation_id/,
+		);
+		expect(messageOf(() => validate({ action: "send", agent_id: "researcher" }))).toMatch(
+			/text/,
+		);
+	});
+
+	it("rejects a send field on list instead of ignoring it", () => {
+		const msg = messageOf(() =>
+			validate({ action: "list", agent_id: "researcher", text: "hi", wait: true }),
+		);
+		expect(msg).toMatch(/unknown argument\(s\): text, wait/);
+		expect(msg).toMatch(/valid arguments for action 'list' are: action, agent_id/);
+	});
+
+	it("accepts each action's full field set", () => {
+		expect(validate({ action: "list", agent_id: "researcher" })).toEqual({
+			action: "list",
+			agent_id: "researcher",
+		});
+		expect(
+			validate({ action: "get", agent_id: "researcher", platform: "slack", conversation_id: "c1" }),
+		).toMatchObject({ conversation_id: "c1" });
+		expect(
+			validate({
+				action: "send",
+				agent_id: "researcher",
+				thread: "daily",
+				text: "hi",
+				model: "openai/gpt-5",
+				wait: false,
+				timeout_ms: 5000,
+			}),
+		).toMatchObject({ text: "hi", timeout_ms: 5000 });
+	});
+});
+
+/**
+ * What an MCP client actually sees: the union is flattened to one object
+ * (hosts reject a top-level `anyOf`), so per-action requirements survive only
+ * as prose on the `action` enum — and a duplicated property keeps the FIRST
+ * variant's description, which is why `conversation_id` documents both the
+ * action that requires it and the one that treats it as optional.
+ */
+describe("manage_conversations wire schema", () => {
+	const listedFor = (maxAccessLevel: "read" | "admin") =>
+		getAllTools({ publicOnly: false, maxAccessLevel }).find(
+			(tool) => tool.name === "manage_conversations",
+		);
+
+	it("hides write-tier send from a read-scope listing", () => {
+		expect(listedFor("read")?.inputSchema.properties.action.enum).toEqual([
+			"list",
+			"get",
+		]);
+		expect(listedFor("admin")?.inputSchema.properties.action.enum).toEqual([
+			"list",
+			"get",
+			"send",
+		]);
+	});
+
+	it("names each action's required fields on the flattened enum", () => {
+		const description: string =
+			listedFor("admin")?.inputSchema.properties.action.description ?? "";
+		const lineFor = (action: string) =>
+			description.split("\n").find((line) => line.startsWith(`- ${action}:`));
+		expect(lineFor("list")).toContain("Required: agent_id.");
+		expect(lineFor("get")).toContain("Required: agent_id, conversation_id.");
+		expect(lineFor("send")).toContain("Required: agent_id, text.");
+	});
+
+	it("documents conversation_id for both actions that carry it", () => {
+		const description: string =
+			listedFor("admin")?.inputSchema.properties.conversation_id.description ??
+			"";
+		expect(description).toContain("`get`");
+		expect(description).toContain("`send`");
+	});
+});

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -77,8 +77,9 @@ export const MEMBER_WRITE_ACTIONS: Record<string, Set<string> | null> = {
 	]),
 	// A member sends a message to their own agent's conversation. `send` runs the
 	// turn in the conversation's pinned sandbox; the handler binds the
-	// conversation to ctx.userId and fences on agent-in-org. list/get are
-	// read-tier (PUBLIC_READ_ACTIONS).
+	// conversation to ctx.userId and fences on agent-in-org. list/get carry no
+	// write/admin entry, so they fall through to the READ tier — they are NOT
+	// public-readable (a listing exposes conversation titles).
 	manage_conversations: new Set(["send"]),
 };
 

--- a/packages/server/src/sandbox/namespaces/conversations.ts
+++ b/packages/server/src/sandbox/namespaces/conversations.ts
@@ -6,6 +6,11 @@
  * turn against one; the reply reads back on the same conversation id.
  */
 
+import type {
+  ConversationGetInput,
+  ConversationListInput,
+  ConversationSendInput,
+} from "@lobu/core/contracts/tools/manage-conversations";
 import { Type } from "@sinclair/typebox";
 import type { Env } from "../../index";
 import { setCurrentMcpConversationTitle } from "../../lobu/stores/mcp-client-conversations";
@@ -17,39 +22,13 @@ import { createActionCaller } from "./action-call";
 
 const SetTitleSchema = Type.Object({ title: Type.String() });
 
-export interface ConversationsListInput {
-  agent_id: string;
-}
-
-export interface ConversationsGetInput {
-  agent_id: string;
-  /** Defaults to "web" (the app-owned realm). */
-  platform?: string;
-  conversation_id: string;
-}
-
-export interface ConversationsSendInput {
-  agent_id: string;
-  /** Resume an exact conversation; wins over `thread`. */
-  conversation_id?: string;
-  /** Open/resume a named web thread (own history + own pinned sandbox). */
-  thread?: string;
-  text: string;
-  /** Per-message `provider/model` override. */
-  model?: string;
-  /** Await the reply (default true); false returns immediately with the id. */
-  wait?: boolean;
-  /** [wait=true] Max wait (ms). Default 45000, capped at 170000. */
-  timeout_ms?: number;
-}
-
 export interface ConversationsNamespace {
   /** Set display-only text for the current MCP host conversation. */
   setTitle(input: { title: string }): Promise<{ title: string }>;
   manage(input: Record<string, unknown>): Promise<unknown>;
-  list(input: ConversationsListInput): Promise<unknown>;
-  get(input: ConversationsGetInput): Promise<unknown>;
-  send(input: ConversationsSendInput): Promise<unknown>;
+  list(input: ConversationListInput): Promise<unknown>;
+  get(input: ConversationGetInput): Promise<unknown>;
+  send(input: ConversationSendInput): Promise<unknown>;
 }
 
 export function buildConversationsNamespace(

--- a/packages/server/src/tools/__tests__/manage-conversations-send.test.ts
+++ b/packages/server/src/tools/__tests__/manage-conversations-send.test.ts
@@ -356,7 +356,7 @@ describe("manage_conversations send", () => {
 				env,
 				ctx,
 			),
-		).rejects.toThrow(/text is required/);
+		).rejects.toThrow(/text must not be blank/);
 	});
 
 	it("rejects an unauthenticated caller (no user id to bind the conversation)", async () => {

--- a/packages/server/src/tools/admin/manage_conversations.ts
+++ b/packages/server/src/tools/admin/manage_conversations.ts
@@ -22,9 +22,12 @@
 
 import { randomUUID } from "node:crypto";
 import {
-  type ManageConversationsArgs,
+  GetConversationAction,
+  ListConversationsAction,
   ManageConversationsSchema,
+  SendConversationMessageAction,
 } from "@lobu/core/contracts/tools/manage-conversations";
+import type { Static } from "@sinclair/typebox";
 import { createDbClientFromEnv } from "../../db/client";
 import { buildApiConversationId } from "../../gateway/services/api-conversation-id";
 import {
@@ -43,8 +46,7 @@ import { getLobuCoreServices } from "../../lobu/gateway";
 import { ToolUserError } from "../../utils/errors";
 import { isAdminOrOwnerRole } from "../access-control";
 import type { ToolContext } from "../registry";
-import { withValidatedArgs } from "../validate-args";
-import { defineFlatActionTool, flatAction } from "./action-tool";
+import { action, defineActionTool } from "./action-tool";
 
 export { ManageConversationsSchema };
 
@@ -89,7 +91,7 @@ async function assertAgentInOrg(
 }
 
 async function handleList(
-  args: ManageConversationsArgs,
+  args: Static<typeof ListConversationsAction>,
   ctx: ToolContext,
   env: Env,
 ) {
@@ -120,13 +122,10 @@ async function handleList(
 }
 
 async function handleGet(
-  args: ManageConversationsArgs,
+  args: Static<typeof GetConversationAction>,
   ctx: ToolContext,
   env: Env,
 ) {
-  if (!args.conversation_id) {
-    throw new ToolUserError("conversation_id is required for get action");
-  }
   if (!ctx.userId) {
     throw new ToolUserError("get requires an authenticated caller", 401);
   }
@@ -169,13 +168,13 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 }
 
 async function handleSend(
-  args: ManageConversationsArgs,
+  args: Static<typeof SendConversationMessageAction>,
   ctx: ToolContext,
   env: Env,
 ) {
-  const text = typeof args.text === "string" ? args.text : "";
+  const text = args.text;
   if (!text.trim()) {
-    throw new ToolUserError("text is required for send action");
+    throw new ToolUserError("text must not be blank for send action");
   }
   if (!ctx.userId) {
     throw new ToolUserError(
@@ -374,23 +373,19 @@ async function handleSend(
   };
 }
 
-const runManageConversations = defineFlatActionTool<
-  ManageConversationsArgs,
-  Awaited<ReturnType<typeof handleList | typeof handleGet | typeof handleSend>>
->("manage_conversations", {
-  list: flatAction((args, ctx, env) => handleList(args, ctx, env)),
-  get: flatAction((args, ctx, env) => handleGet(args, ctx, env)),
-  send: flatAction((args, ctx, env) => handleSend(args, ctx, env)),
+const manageConversationsTool = defineActionTool("manage_conversations", {
+  list: action(ListConversationsAction, handleList),
+  get: action(GetConversationAction, handleGet),
+  send: action(SendConversationMessageAction, handleSend),
 });
 
-// Access is enforced per-action by routeAction (inside runManageConversations)
-// against tool-access.ts: send → MEMBER_WRITE_ACTIONS (any member), list/get →
-// PUBLIC_READ_ACTIONS. Do NOT re-gate here with requireOrg{Read,Write}Access —
-// canWriteOrg requires owner/admin, which would contradict the member-tier
-// `send` grant and reject a plain member the policy explicitly allows. Ownership
-// is fenced per-handler (agent-in-org + user-owned conversation).
-export const manageConversations = withValidatedArgs(
-  "manage_conversations",
-  ManageConversationsSchema,
-  runManageConversations,
-);
+// Access is enforced per-action by routeAction (inside the tool runner) against
+// tool-access.ts: send → MEMBER_WRITE_ACTIONS (any member); list/get carry no
+// write/admin entry, so they fall through to the READ tier — they are NOT
+// public-readable, and the handler requires an authenticated caller because a
+// listing exposes conversation titles. Do NOT re-gate here with
+// requireOrg{Read,Write}Access — canWriteOrg requires owner/admin, which would
+// contradict the member-tier `send` grant and reject a plain member the policy
+// explicitly allows. Ownership is fenced per-handler (agent-in-org +
+// user-owned conversation).
+export const manageConversations = manageConversationsTool.run;


### PR DESCRIPTION
## Summary
- `manage_conversations` becomes a union of three action variants — `ListConversationsAction`, `GetConversationAction`, `SendConversationMessageAction` — instead of one flat object with every field optional and `[get]`/`[send]` tags in prose. The schema now says what each action needs: `conversation_id` is required on `get`, `text` on `send`, and a field that belongs to `send` is an error on `list` rather than silently ignored. The two hand checks in the handlers that stood in for this (`conversation_id is required for get action`, the `typeof args.text` guard) are gone.
- The ClientSDK namespace's three hand-written input interfaces are replaced by core's derived `ConversationListInput` / `ConversationGetInput` / `ConversationSendInput` (`ActionInput<…>`, #3359), so this tool now has one definition site like the six union-backed tools before it.
- Server wiring moves from `defineFlatActionTool` + a separate `withValidatedArgs` wrapper to `defineActionTool`/`action()` — the same shape as `manage_schedules`. Per-action access filtering (`filterSchemaForAccessLevel`) now applies to this tool's MCP schema: a read-only token sees `list`/`get` only, which matches `tool-access.ts` (`send` is `MEMBER_WRITE`).
- First of the seven flat→union conversions (agreed order: one tool per PR, each gated on a prod payload census). Chosen first because it is the smallest (3 actions, 121 lines).

### Prod census before tightening (read-only, 60 days, `events.payload_data->'sdk_call_trace'`)
| path | calls | key-sets that change outcome |
|---|---|---|
| `conversations.send` | 119 | none — every valid call carried `agent_id`+`text`; the ones with `message`/`content` instead of `text` already fail as unknown arguments |
| `conversations.list` | 17 | **1** key-set (`action,agent_id,text,timeout_ms,wait`) — send fields on `list`, ignored today, now `unknown argument(s)` |
| `conversations.get` | 9 | none — `agent_id,thread` (no `conversation_id`) already failed in the handler; it now fails at the schema with the same field named |
| `conversations.manage` | 4 | raw wrapper, unchanged |

No stored `automations.reaction_script` calls `client.conversations.*` (0 rows).

## Test plan
- [x] New `packages/server/src/__tests__/unit/manage-conversations-contract.test.ts` (bun:test, `validateToolArgs` against the contract): required-per-action, send-field-on-list rejected with the action-scoped valid list, each action's full field set accepted. **Red** against `origin/main`'s flat contract (same test, import pointed at a copy of the old file) → pasted below. **Green**: 3/3.
- [x] `manage-wire-schema` (flat-on-the-wire + every action described), `validate-args`, `tool-registry-split`, `unit/sandbox/**` → pasted below.
- [x] Integration (vitest, real DB): `all-tools-e2e` (drives `list` model-free) and `conversations-store-reads`.
- [x] Generated client regenerated against this worktree's booted server (`LOBU_OPENAPI_URL=http://127.0.0.1:<port>/lobu/api/docs/openapi.json bun run generate`) — verified the served document already carried the union (`anyOf`) before trusting the output; one hunk, `ManageConversationsData.body` becomes the three-variant union like `ManageSchedulesData`.
- [x] `make pre-pr` clean.
- [ ] No bot runtime change.

### Proof (red → green)
Same unit test, import pointed at a copy of `origin/main`'s flat contract:
```
(fail) manage_conversations union contract > requires conversation_id for get and text for send, at the schema
       error: expected validation to throw
(fail) manage_conversations union contract > rejects a send field on list instead of ignoring it
       error: expected validation to throw
 1 pass / 2 fail
```
Against this branch:
```
unit (bun:test; manage-conversations-contract, manage-wire-schema, validate-args, tool-registry-split, unit/sandbox/**): 212 pass / 0 fail
vitest (all-tools-e2e, conversations-store-reads):                                                                   Test Files 2 passed · Tests 36 passed
```

## Notes
- The MCP `inputSchema` stays flat: the registry's `flattenUnionSchema` merges variants into one object with an `action` enum whose description now carries the generated per-action `Required:` lines. The REST/OpenAPI document exposes the raw `anyOf`, hence the generated-client diff.
- `make review-fix` found one real wire-level gap and it is fixed here: the MCP flattener keeps the **first** variant's description for a property carried by several variants, so `send`'s `conversation_id` semantics ("resume this exact web conversation; wins over `thread`") would have vanished from the wire behind `get`'s terser text. Both variants now share one `ConversationId` schema whose description reads true for each. The fixer also added three wire-schema tests (read-scope listing hides `send`; the generated `Required:` lines per action; `conversation_id` documents both actions), corrected two comments that wrongly said `list`/`get` were `PUBLIC_READ_ACTIONS` (they are read-tier but require an authenticated caller — verified against `tool-access.ts`), and renamed the blank-text error to `text must not be blank` now that presence is the schema's job (its existing vitest suite updated accordingly, 17/17).
- `search_sdk` entries for `conversations.*` had no hand-written `signature:` strings, so nothing to update there.

**Reviewer disclosure:** codex is at its usage limit until 2026-09-07, so `make review-fix` / `make review` ran as `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus` — same-model self-review rather than the cross-harness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation management actions now provide clearer, action-specific inputs for listing, retrieving, and sending messages.
  * Retrieving a conversation requires a conversation ID, and sending a message requires non-blank text.

* **Bug Fixes**
  * Improved validation and error messages for invalid conversation actions and message content.
  * Conversation listings are correctly handled as authenticated reads rather than public access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->