### PR TITLE
refactor(core,server): manage_agents as a union of per-action variants

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -2985,32 +2985,85 @@ export type ManageCatalogResponse =
   ManageCatalogResponses[keyof ManageCatalogResponses];
 
 export type ManageAgentsData = {
-  body: {
-    /**
-     * Action to perform
-     */
-    action: "list" | "get" | "create" | "update" | "delete";
-    /**
-     * [get/create/update/delete] Agent ID (lowercase slug, e.g. "support").
-     */
-    agent_id?: string;
-    /**
-     * [create/update] Display name for the agent.
-     */
-    name?: string;
-    /**
-     * [create/update] Agent description.
-     */
-    description?: string;
-    /**
-     * [create/update] Agent identity / system prompt (Markdown).
-     */
-    identity_md?: string;
-    /**
-     * [create/update] Default model as an explicit "<provider>/<model>" ref (e.g. "anthropic/claude-sonnet-5"). Validated against the org's connected providers. Without it the agent inherits the org default model; if the org has none the agent is not runnable. Pass an empty string to clear it and fall back to the org default.
-     */
-    default_model?: string;
-  };
+  body:
+    | {
+        /**
+         * List org agents.
+         */
+        action: "list";
+      }
+    | {
+        /**
+         * Fetch one agent.
+         */
+        action: "get";
+        /**
+         * Agent ID (lowercase slug, e.g. "support").
+         */
+        agent_id: string;
+      }
+    | {
+        /**
+         * Create an agent owned by the caller (queued for approval).
+         */
+        action: "create";
+        /**
+         * Agent ID (lowercase slug, e.g. "support").
+         */
+        agent_id: string;
+        /**
+         * [create/update] Display name for the agent.
+         */
+        name: string;
+        /**
+         * [create/update] Agent description.
+         */
+        description?: string;
+        /**
+         * [create/update] Agent identity / system prompt (Markdown).
+         */
+        identity_md?: string;
+        /**
+         * [create/update] Default model as an explicit "<provider>/<model>" ref (e.g. "anthropic/claude-sonnet-5"). Validated against the org's connected providers. Without it the agent inherits the org default model; if the org has none the agent is not runnable. Pass an empty string to clear it and fall back to the org default.
+         */
+        default_model?: string;
+      }
+    | {
+        /**
+         * Patch agent fields (queued for approval).
+         */
+        action: "update";
+        /**
+         * Agent ID (lowercase slug, e.g. "support").
+         */
+        agent_id: string;
+        /**
+         * [create/update] Display name for the agent.
+         */
+        name?: string;
+        /**
+         * [create/update] Agent description.
+         */
+        description?: string;
+        /**
+         * [create/update] Agent identity / system prompt (Markdown).
+         */
+        identity_md?: string;
+        /**
+         * [create/update] Default model as an explicit "<provider>/<model>" ref (e.g. "anthropic/claude-sonnet-5"). Validated against the org's connected providers. Without it the agent inherits the org default model; if the org has none the agent is not runnable. Pass an empty string to clear it and fall back to the org default.
+         */
+        default_model?: string;
+      }
+    | {
+        /**
+         * Delete an agent (queued for approval).
+         */
+        action: "delete";
+        /**
+         * Agent ID (lowercase slug, e.g. "support").
+         */
+        agent_id: string;
+      };
   path: {
     /**
      * Organization slug (workspace identifier)

--- a/packages/core/src/contracts/tools/manage-agents.ts
+++ b/packages/core/src/contracts/tools/manage-agents.ts
@@ -1,73 +1,98 @@
 import { type Static, Type } from "@sinclair/typebox";
+import type { ActionInput } from "./action-input";
 
 // ============================================
-// Typebox Schema (Flattened for MCP)
+// Typebox Schema (union of per-action variants)
 // ============================================
+//
+// The wire schema flattens this union into ONE MCP object and merges duplicate
+// properties first-occurrence-wins, so a property carried by more than one
+// variant must read true for every one of them.
 
-export const ManageAgentsSchema = Type.Object({
-  action: Type.Union(
-    [
-      Type.Literal("list", {
-        description: "List org agents.",
-      }),
-      Type.Literal("get", { description: "Fetch one agent." }),
-      Type.Literal("create", {
-        description:
-          "Create an agent owned by the caller (queued for approval).",
-      }),
-      Type.Literal("update", {
-        description: "Patch agent fields (queued for approval).",
-      }),
-      Type.Literal("delete", {
-        description: "Delete an agent (queued for approval).",
-      }),
-    ],
-    { description: "Action to perform" }
-  ),
-
-  agent_id: Type.Optional(
-    Type.String({
-      description:
-        '[get/create/update/delete] Agent ID (lowercase slug, e.g. "support").',
-    })
-  ),
-  // Editable fields carry an `x-lobu-field` annotation — the single source of
-  // truth the field engine loops over to drive create/update/proposal/pre-image
-  // (so adding a field is one annotated entry, not edits in seven places). The
-  // `store` routes the write: `column` = an `agents` table column; `model` =
-  // the settings row's `models[0]`.
-  name: Type.Optional(
-    Type.String({
-      description: "[create/update] Display name for the agent.",
-      "x-lobu-field": { store: "column" },
-    })
-  ),
-  description: Type.Optional(
-    Type.String({
-      description: "[create/update] Agent description.",
-      "x-lobu-field": { store: "column" },
-    })
-  ),
-  identity_md: Type.Optional(
-    Type.String({
-      description: "[create/update] Agent identity / system prompt (Markdown).",
-      "x-lobu-field": { store: "column" },
-    })
-  ),
-  default_model: Type.Optional(
-    Type.String({
-      description:
-        '[create/update] Default model as an explicit "<provider>/<model>" ref (e.g. "anthropic/claude-sonnet-5"). Validated against the org\'s connected providers. Without it the agent inherits the org default model; if the org has none the agent is not runnable. Pass an empty string to clear it and fall back to the org default.',
-      "x-lobu-field": { store: "model", emptyClears: true },
-    })
-  ),
+const AgentId = Type.String({
+  description: 'Agent ID (lowercase slug, e.g. "support").',
 });
+
+// Editable fields carry an `x-lobu-field` annotation — the single source of
+// truth the field engine loops over to drive create/update/proposal/pre-image
+// (so adding a field is one annotated entry, not edits in seven places). The
+// `store` routes the write: `column` = an `agents` table column; `model` =
+// the settings row's `models[0]`. `create` and `update` share this set; the
+// annotation survives `Type.Optional`.
+const AgentFields = {
+  name: Type.String({
+    description: "[create/update] Display name for the agent.",
+    "x-lobu-field": { store: "column" },
+  }),
+  description: Type.String({
+    description: "[create/update] Agent description.",
+    "x-lobu-field": { store: "column" },
+  }),
+  identity_md: Type.String({
+    description: "[create/update] Agent identity / system prompt (Markdown).",
+    "x-lobu-field": { store: "column" },
+  }),
+  default_model: Type.String({
+    description:
+      '[create/update] Default model as an explicit "<provider>/<model>" ref (e.g. "anthropic/claude-sonnet-5"). Validated against the org\'s connected providers. Without it the agent inherits the org default model; if the org has none the agent is not runnable. Pass an empty string to clear it and fall back to the org default.',
+    "x-lobu-field": { store: "model", emptyClears: true },
+  }),
+};
+
+export const ListAgentsAction = Type.Object({
+  action: Type.Literal("list", { description: "List org agents." }),
+});
+
+export const GetAgentAction = Type.Object({
+  action: Type.Literal("get", { description: "Fetch one agent." }),
+  agent_id: AgentId,
+});
+
+export const CreateAgentAction = Type.Object({
+  action: Type.Literal("create", {
+    description: "Create an agent owned by the caller (queued for approval).",
+  }),
+  agent_id: AgentId,
+  name: AgentFields.name,
+  description: Type.Optional(AgentFields.description),
+  identity_md: Type.Optional(AgentFields.identity_md),
+  default_model: Type.Optional(AgentFields.default_model),
+});
+
+export const UpdateAgentAction = Type.Object({
+  action: Type.Literal("update", {
+    description: "Patch agent fields (queued for approval).",
+  }),
+  agent_id: AgentId,
+  name: Type.Optional(AgentFields.name),
+  description: Type.Optional(AgentFields.description),
+  identity_md: Type.Optional(AgentFields.identity_md),
+  default_model: Type.Optional(AgentFields.default_model),
+});
+
+export const DeleteAgentAction = Type.Object({
+  action: Type.Literal("delete", {
+    description: "Delete an agent (queued for approval).",
+  }),
+  agent_id: AgentId,
+});
+
+export const ManageAgentsSchema = Type.Union([
+  ListAgentsAction,
+  GetAgentAction,
+  CreateAgentAction,
+  UpdateAgentAction,
+  DeleteAgentAction,
+]);
 
 // ============================================
 // Type Definitions
 // ============================================
 
 export type ManageAgentsArgs = Static<typeof ManageAgentsSchema>;
+
+export type AgentCreateInput = ActionInput<ManageAgentsArgs, "create">;
+export type AgentUpdateInput = ActionInput<ManageAgentsArgs, "update">;
 
 export interface AgentRecord {
   id: string;

--- a/packages/server/src/__tests__/integration/operations-approval-transition-atomicity.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-transition-atomicity.test.ts
@@ -190,9 +190,10 @@ async function seedAgentAskRun(
 
 /**
  * A pending `manage_agents` builder run whose apply is guaranteed to THROW:
- * `applyDelete` requires `agent_id`, and the family's `isValidProposal` only
- * checks the proposal is non-null, so the run claims cleanly and then fails in
- * the out-of-transaction apply — the window `failBuilderRun` writes back into.
+ * the `delete` variant requires `agent_id`, so re-validating the persisted
+ * proposal fails, and the family's `isValidProposal` only checks the proposal
+ * is non-null — the run claims cleanly and then fails in the out-of-transaction
+ * apply, the window `failBuilderRun` writes back into.
  */
 async function seedThrowingBuilderRun(
 	organizationId: string,
@@ -851,7 +852,7 @@ describe("approval-run transition atomicity", () => {
 		`;
 		expect(run.status).toBe("failed");
 		expect(String(run.claimed_by)).toMatch(/^gateway-inline-/);
-		expect(String(run.error_message)).toMatch(/agent_id is required/i);
+		expect(String(run.error_message)).toMatch(/Invalid arguments for manage_agents: .*agent_id/);
 		expect((await currentApprovalCard(runId, orgId))?.interaction_status).toBe(
 			"failed",
 		);

--- a/packages/server/src/__tests__/unit/manage-agents-contract.test.ts
+++ b/packages/server/src/__tests__/unit/manage-agents-contract.test.ts
@@ -1,0 +1,130 @@
+/**
+ * `manage_agents` is a union of per-action variants, so the schema — not the
+ * handler — decides what each action requires and accepts. These pin what the
+ * flat contract could not express: `agent_id` and `name` are required where
+ * they matter rather than checked by hand, a field that belongs to another
+ * action is an error on this one instead of a silent no-op (the flat object
+ * accepted `name` on `delete`), the editable-field annotation the field engine
+ * loops over survives the move onto per-variant `Type.Optional` properties,
+ * and the registry's per-action access filtering — which only ever applied to
+ * union variants — now keeps owner-admin writes out of a read-scope client's
+ * listing.
+ */
+import { describe, expect, it } from "bun:test";
+import { collectLobuFields } from "@lobu/core/contracts/field-engine";
+import {
+	CreateAgentAction,
+	ManageAgentsSchema,
+	UpdateAgentAction,
+} from "@lobu/core/contracts/tools/manage-agents";
+import { getAllTools } from "../../tools/registry";
+import { validateToolArgs } from "../../tools/validate-args";
+import { ToolUserError } from "../../utils/errors";
+
+const validate = (args: unknown) =>
+	validateToolArgs("manage_agents", ManageAgentsSchema, args);
+
+function messageOf(fn: () => unknown): string {
+	try {
+		fn();
+	} catch (err) {
+		expect(err).toBeInstanceOf(ToolUserError);
+		return (err as ToolUserError).message;
+	}
+	throw new Error("expected validation to throw");
+}
+
+describe("manage_agents union contract", () => {
+	it("requires agent_id for get/update/delete and name for create, at the schema", () => {
+		for (const action of ["get", "update", "delete"]) {
+			expect(messageOf(() => validate({ action }))).toMatch(/agent_id/);
+		}
+		expect(messageOf(() => validate({ action: "create", agent_id: "researcher" }))).toMatch(
+			/name/,
+		);
+	});
+
+	it("rejects a field another action takes instead of ignoring it", () => {
+		const list = messageOf(() => validate({ action: "list", agent_id: "researcher" }));
+		expect(list).toMatch(/unknown argument\(s\): agent_id/);
+		expect(list).toMatch(/valid arguments for action 'list' are: action$/);
+
+		const del = messageOf(() =>
+			validate({ action: "delete", agent_id: "researcher", name: "Researcher" }),
+		);
+		expect(del).toMatch(/unknown argument\(s\): name/);
+		expect(del).toMatch(/valid arguments for action 'delete' are: action, agent_id$/);
+	});
+
+	it("accepts each action's full field set", () => {
+		expect(validate({ action: "list" })).toEqual({ action: "list" });
+		expect(validate({ action: "get", agent_id: "researcher" })).toEqual({
+			action: "get",
+			agent_id: "researcher",
+		});
+		expect(
+			validate({
+				action: "create",
+				agent_id: "researcher",
+				name: "Researcher",
+				description: "Digs",
+				identity_md: "# You research",
+				default_model: "anthropic/claude-sonnet-5",
+			}),
+		).toMatchObject({ name: "Researcher", default_model: "anthropic/claude-sonnet-5" });
+		expect(
+			validate({ action: "update", agent_id: "researcher", default_model: "" }),
+		).toEqual({ action: "update", agent_id: "researcher", default_model: "" });
+		expect(validate({ action: "delete", agent_id: "researcher" })).toEqual({
+			action: "delete",
+			agent_id: "researcher",
+		});
+	});
+
+	it("keeps the x-lobu-field annotation on both write variants", () => {
+		const editable = ["name", "description", "identity_md", "default_model"];
+		expect(collectLobuFields(UpdateAgentAction).map((f) => f.key)).toEqual(editable);
+		expect(collectLobuFields(CreateAgentAction).map((f) => f.key)).toEqual(editable);
+		expect(collectLobuFields(UpdateAgentAction).map((f) => f.meta)).toEqual([
+			{ store: "column" },
+			{ store: "column" },
+			{ store: "column" },
+			{ store: "model", emptyClears: true },
+		]);
+	});
+});
+
+/**
+ * What an MCP client actually sees: the union is flattened to one object
+ * (hosts reject a top-level `anyOf`), so per-action requirements survive only
+ * as prose on the `action` enum.
+ */
+describe("manage_agents wire schema", () => {
+	const listedFor = (maxAccessLevel: "read" | "admin") =>
+		getAllTools({ publicOnly: false, maxAccessLevel }).find(
+			(tool) => tool.name === "manage_agents",
+		);
+
+	it("hides owner-admin writes from a read-scope listing", () => {
+		expect(listedFor("read")?.inputSchema.properties.action.enum).toEqual(["list", "get"]);
+		expect(listedFor("admin")?.inputSchema.properties.action.enum).toEqual([
+			"list",
+			"get",
+			"create",
+			"update",
+			"delete",
+		]);
+	});
+
+	it("names each action's required fields on the flattened enum", () => {
+		const description: string =
+			listedFor("admin")?.inputSchema.properties.action.description ?? "";
+		const lineFor = (action: string) =>
+			description.split("\n").find((line) => line.startsWith(`- ${action}:`));
+		expect(lineFor("list")).not.toContain("Required:");
+		expect(lineFor("get")).toContain("Required: agent_id.");
+		expect(lineFor("create")).toContain("Required: agent_id, name.");
+		expect(lineFor("update")).toContain("Required: agent_id.");
+		expect(lineFor("delete")).toContain("Required: agent_id.");
+	});
+});

--- a/packages/server/src/__tests__/unit/manage-wire-schema.test.ts
+++ b/packages/server/src/__tests__/unit/manage-wire-schema.test.ts
@@ -74,7 +74,7 @@ describe("manage_* wire schema: action discoverability", () => {
 		//    would render as a bare `- name` line — caught by asserting the
 		//    description line for each action contains a colon (prose follows).
 		//
-		//  - Flat tools (manage_entity, manage_agents, ...): `action.anyOf` of
+		//  - Flat tools (manage_entity, manage_automations, ...): `action.anyOf` of
 		//    `{const, description}` literals — the per-action prose lives on
 		//    each literal, not the field. Assert each anyOf entry has non-empty
 		//    description text.

--- a/packages/server/src/sandbox/namespaces/agents.ts
+++ b/packages/server/src/sandbox/namespaces/agents.ts
@@ -2,31 +2,21 @@
  * ClientSDK `agents` namespace. Thin wrapper over `manageAgents`.
  */
 
+import type {
+	AgentCreateInput,
+	AgentUpdateInput,
+} from "@lobu/core/contracts/tools/manage-agents";
 import type { Env } from "../../index";
 import { manageAgents } from "../../tools/admin/manage_agents";
 import type { ToolContext } from "../../tools/registry";
 import { createActionCaller, idArg } from "./action-call";
 
-export interface AgentsCreateInput {
-	agent_id: string;
-	name?: string;
-	description?: string;
-	identity_md?: string;
-}
-
-export interface AgentsUpdateInput {
-	agent_id: string;
-	name?: string;
-	description?: string;
-	identity_md?: string;
-}
-
 export interface AgentsNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
 	list(): Promise<unknown>;
 	get(agent_id: string): Promise<unknown>;
-	create(input: AgentsCreateInput): Promise<unknown>;
-	update(input: AgentsUpdateInput): Promise<unknown>;
+	create(input: AgentCreateInput): Promise<unknown>;
+	update(input: AgentUpdateInput): Promise<unknown>;
 	delete(agent_id: string): Promise<unknown>;
 }
 

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -8,7 +8,7 @@
  * - get: Get one agent when agent_config read allows that target
  * - create: Create an agent owned by the authenticated caller (owner_platform=
  *   'external' + an agent_users mapping, so the per-user chat path can reach it)
- * - update: Update name/description/identity_md on an agent
+ * - update: Patch an agent's editable fields (name/description/identity_md/default_model)
  * - delete: Delete an agent
  *
  *
@@ -23,13 +23,18 @@ import {
   type LobuField,
 } from '@lobu/core/contracts/field-engine';
 import {
+  CreateAgentAction,
+  DeleteAgentAction,
+  GetAgentAction,
+  ListAgentsAction,
   ManageAgentsSchema,
+  UpdateAgentAction,
   type AgentModelInfo,
   type AgentRecord,
-  type ManageAgentsArgs,
   type ManageAgentsProposal,
   type ManageAgentsResult,
 } from '@lobu/core/contracts/tools/manage-agents';
+import { Type, type Static } from '@sinclair/typebox';
 import {
   resolveActingPrincipal,
   resolveWritePolicyDecision,
@@ -37,7 +42,7 @@ import {
 } from '../../authz/entity-policy';
 import { resolveNewAgentProvisioningDefaults } from '../../auth/system-provider-resolution';
 
-import { createDbClientFromEnv, getDb } from '../../db/client';
+import { createDbClientFromEnv, getDb, type DbClient } from '../../db/client';
 import type { Env } from '../../index';
 import {
   currentMcpActivityAttribution,
@@ -69,12 +74,25 @@ import { ToolUserError } from '../../utils/errors';
 import { requireOrgReadAccess, requireOrgWriteAccess } from '../../utils/organization-access';
 import { resolveRunInitiator } from '../initiator';
 import type { ToolContext } from '../registry';
-import { withValidatedArgs } from '../validate-args';
+import { validateToolArgs } from '../validate-args';
 import { getOrgUrlContext } from '../view-urls';
-import { defineFlatActionTool, flatAction } from './action-tool';
+import { action, defineActionTool } from './action-tool';
 
 export { ManageAgentsSchema };
 export type { ManageAgentsProposal };
+
+type ListArgs = Static<typeof ListAgentsAction>;
+type GetArgs = Static<typeof GetAgentAction>;
+type CreateArgs = Static<typeof CreateAgentAction>;
+type UpdateArgs = Static<typeof UpdateAgentAction>;
+type DeleteArgs = Static<typeof DeleteAgentAction>;
+/**
+ * The three actions routed through the `agent_config` write-gate. Also a
+ * schema, so a persisted proposal naming a NON-write action is rejected by
+ * {@link applyManageAgentsProposal} instead of falling through its dispatch.
+ */
+const WriteActions = Type.Union([CreateAgentAction, UpdateAgentAction, DeleteAgentAction]);
+type WriteArgs = Static<typeof WriteActions>;
 
 /**
  * Synthetic `runs.action_key` tagging a manage_agents write held for approval.
@@ -135,20 +153,24 @@ async function assertDefaultModelValid(
 // ============================================
 //
 // The editable agent fields (name/description/identity_md/default_model) are
-// declared ONCE, on the `ManageAgentsSchema` contract via `x-lobu-field`
+// declared ONCE, in the contract's shared field set, via `x-lobu-field`
 // annotations. `collectLobuFields` reads them; the binding below says, per
 // storage kind, how to read the current value, validate a new one, and persist
 // it. create / update / buildProposal / pre-image all loop this single list —
 // adding a field is one annotated schema entry, not edits in seven places.
 
-/** The editable fields of this tool, in schema declaration order. */
-const AGENT_FIELDS: LobuField[] = collectLobuFields(ManageAgentsSchema);
+/**
+ * The editable fields of this tool, in schema declaration order. Read off the
+ * `update` variant: it is the patch shape, so by construction it carries every
+ * editable field and nothing else.
+ */
+const AGENT_FIELDS: LobuField[] = collectLobuFields(UpdateAgentAction);
 
 /** Column-backed fields (an `agents` table column). Their name IS the column. */
 const COLUMN_FIELDS = AGENT_FIELDS.filter((f) => f.meta.store === 'column');
 
-/** Read a field's requested value off the flat args object. */
-function argValue(args: ManageAgentsArgs, key: string): string | undefined {
+/** Read a field's requested value off a write action's args. */
+function argValue(args: WriteArgs, key: string): string | undefined {
   return (args as Record<string, unknown>)[key] as string | undefined;
 }
 
@@ -245,7 +267,7 @@ async function agentConfigReadAllowed(
 }
 
 async function handleList(
-  _args: ManageAgentsArgs,
+  _args: ListArgs,
   ctx: ToolContext,
   env: Env
 ): Promise<ManageAgentsResult> {
@@ -284,13 +306,10 @@ async function handleList(
 }
 
 async function handleGet(
-  args: ManageAgentsArgs,
+  args: GetArgs,
   ctx: ToolContext,
   env: Env
 ): Promise<ManageAgentsResult> {
-  if (!args.agent_id) {
-    throw new ToolUserError('agent_id is required for get action');
-  }
   // Gate before the lookup so a denied target does not distinguish "exists" vs
   // "forbidden" via timing alone more than a 404 would — we still 403 on deny
   // after confirming org membership of the id when found; missing stays 404.
@@ -315,22 +334,17 @@ async function handleGet(
   return { action: 'get', agent: rows[0] as unknown as AgentRecord, model };
 }
 
+/**
+ * Insert the agent. Every caller runs the args through {@link buildProposal}
+ * first — the immediate path right before dispatch, the queued path when the
+ * proposal was queued and again as it is applied — so the id/name rules are
+ * enforced there, once.
+ */
 export async function applyCreate(
-  args: ManageAgentsArgs,
+  args: CreateArgs,
   ctx: ToolContext,
   env: Env
 ): Promise<ManageAgentsResult> {
-  if (!args.agent_id) {
-    throw new ToolUserError('agent_id is required for create action');
-  }
-  if (!isValidAgentId(args.agent_id)) {
-    throw new ToolUserError(
-      `Invalid agent_id "${args.agent_id}": must match /^[a-z][a-z0-9-]{2,59}$/`
-    );
-  }
-  if (!args.name) {
-    throw new ToolUserError('name is required for create action');
-  }
   // Created agents must have an owner to attribute them to — without one the
   // agents row exists but the per-user ownership path can't reach it.
   if (!ctx.userId) {
@@ -404,7 +418,7 @@ export async function applyCreate(
 }
 
 export async function applyUpdate(
-  args: ManageAgentsArgs,
+  args: UpdateArgs,
   ctx: ToolContext,
   env: Env,
   /**
@@ -426,9 +440,6 @@ export async function applyUpdate(
    */
   requireBase = false
 ): Promise<ManageAgentsResult> {
-  if (!args.agent_id) {
-    throw new ToolUserError('agent_id is required for update action');
-  }
   const agentId = args.agent_id;
   const sql = createDbClientFromEnv(env);
 
@@ -536,13 +547,10 @@ export async function applyUpdate(
 }
 
 export async function applyDelete(
-  args: ManageAgentsArgs,
+  args: DeleteArgs,
   ctx: ToolContext,
   env: Env
 ): Promise<ManageAgentsResult> {
-  if (!args.agent_id) {
-    throw new ToolUserError('agent_id is required for delete action');
-  }
   const sql = createDbClientFromEnv(env);
   const rows = await sql`
     DELETE FROM agents
@@ -589,22 +597,20 @@ function actionLabel(action: 'create' | 'update' | 'delete', agentId: string): s
 
 /**
  * Build the proposed-change payload held on the run for a write action, after
- * validating the per-action required fields (so a malformed proposal is
- * rejected at request time, not at approve time).
+ * the per-action rules the schema cannot express (so a malformed proposal is
+ * rejected at request time, not at approve time). Presence of `agent_id` and
+ * `name` is the schema's job.
  */
-function buildProposal(args: ManageAgentsArgs): ManageAgentsProposal {
-  const action = args.action as 'create' | 'update' | 'delete';
-  if (!args.agent_id) {
-    throw new ToolUserError(`agent_id is required for ${action} action`);
-  }
+function buildProposal(args: WriteArgs): ManageAgentsProposal {
+  const { action } = args;
   if (action === 'create') {
     if (!isValidAgentId(args.agent_id)) {
       throw new ToolUserError(
         `Invalid agent_id "${args.agent_id}": must match /^[a-z][a-z0-9-]{2,59}$/`
       );
     }
-    if (!args.name) {
-      throw new ToolUserError('name is required for create action');
+    if (!args.name.trim()) {
+      throw new ToolUserError('name must not be blank for create action');
     }
   }
   if (action === 'update') {
@@ -636,7 +642,7 @@ function buildProposal(args: ManageAgentsArgs): ManageAgentsProposal {
  * manage_operations' approve handler via {@link applyManageAgentsProposal}.
  */
 async function queueWriteForApproval(
-  args: ManageAgentsArgs,
+  args: WriteArgs,
   ctx: ToolContext,
   env: Env
 ): Promise<ManageAgentsResult> {
@@ -816,22 +822,27 @@ export async function applyManageAgentsProposal(
   env: Env,
   ownerUserId: string | null
 ): Promise<ManageAgentsResult> {
-  // Rebuild the flat args from the proposal, loop-driven off the schema so an
-  // added field flows back through without editing this remap.
-  const args: ManageAgentsArgs = {
+  // Rebuild the action's args from the proposal, loop-driven off the schema so
+  // an added field flows back through without editing this remap. The proposal
+  // is a persisted row (`runs.action_input`), so it is re-validated against the
+  // action's variant rather than trusted as typed input.
+  const fields: Record<string, unknown> = {
     action: proposal.action,
     agent_id: proposal.agent_id,
   };
   for (const field of AGENT_FIELDS) {
     const value = (proposal as unknown as Record<string, unknown>)[field.key];
-    if (value !== undefined) {
-      (args as Record<string, unknown>)[field.key] = value;
-    }
+    if (value !== undefined) fields[field.key] = value;
   }
+  const args = validateToolArgs('manage_agents', WriteActions, fields) as WriteArgs;
+  // Re-run the rules the schema cannot express (agent_id shape, "update needs
+  // one field"); the rebuilt proposal itself is discarded — `proposal` is what
+  // the apply* handlers already carry.
+  buildProposal(args);
   // create attributes ownership to the ORIGINAL requester, not the approver.
   const applyCtx: ToolContext =
-    proposal.action === 'create' ? { ...ctx, userId: ownerUserId } : ctx;
-  switch (proposal.action) {
+    args.action === 'create' ? { ...ctx, userId: ownerUserId } : ctx;
+  switch (args.action) {
     case 'create':
       return applyCreate(args, applyCtx, env);
     case 'update':
@@ -847,27 +858,17 @@ export async function applyManageAgentsProposal(
 // Main Function
 // ============================================
 
-export const manageAgents = withValidatedArgs(
-  'manage_agents',
-  ManageAgentsSchema,
-  manageAgentsImpl
-);
+type Handler<A> = (args: A, ctx: ToolContext, env: Env) => Promise<ManageAgentsResult>;
 
-async function manageAgentsImpl(
-  args: ManageAgentsArgs,
-  env: Env,
-  ctx: ToolContext
-): Promise<ManageAgentsResult> {
-  const pgSql = createDbClientFromEnv(env);
-
-  // Validate organization access based on action type.
-  if (args.action === 'list' || args.action === 'get') {
-    await requireOrgReadAccess(pgSql, ctx);
-  } else {
-    await requireOrgWriteAccess(pgSql, ctx);
-  }
-
-  return runManageAgents(args, env, ctx);
+/** Run the org-level access check for the action's tier before its handler. */
+function orgGated<A>(
+  requireAccess: (sql: DbClient, ctx: ToolContext) => Promise<void>,
+  handler: Handler<A>
+): Handler<A> {
+  return async (args, ctx, env) => {
+    await requireAccess(createDbClientFromEnv(env), ctx);
+    return handler(args, ctx, env);
+  };
 }
 
 /**
@@ -878,11 +879,11 @@ async function manageAgentsImpl(
  * + card; `allow` → run the apply* handler now; `deny` → refuse.
  */
 async function dispatchAgentWrite(
-  action: 'create' | 'update' | 'delete',
-  args: ManageAgentsArgs,
+  args: WriteArgs,
   ctx: ToolContext,
   env: Env
 ): Promise<ManageAgentsResult> {
+  const { action } = args;
   // Resolve identity through the shared seam so an automation reaction (which sets
   // ctx.actingAutomationId but no agentId) binds its owning agent's `agent_config`
   // envelope — otherwise it would gate as a null-id agent and skip the owner's
@@ -890,8 +891,7 @@ async function dispatchAgentWrite(
   // trusted session rules apply.
   const actor = await actingPrincipalFor(ctx);
   // update/delete name the target agent; create has no target (blanket only).
-  const targetAgentId =
-    action === 'create' ? null : (args.agent_id?.trim() || null);
+  const targetAgentId = action === 'create' ? null : args.agent_id.trim() || null;
   const decision = await resolveWritePolicyDecision({
     organizationId: ctx.organizationId,
     resourceClass: 'agent_config',
@@ -914,7 +914,7 @@ async function dispatchAgentWrite(
   // allow → apply immediately (validate the proposal first so an immediate apply
   // enforces the same required-field checks the queued path does).
   buildProposal(args);
-  switch (action) {
+  switch (args.action) {
     case 'create':
       return applyCreate(args, ctx, env);
     case 'update':
@@ -924,16 +924,15 @@ async function dispatchAgentWrite(
   }
 }
 
-// create/update/delete consult the agent_config write-gate (human immediate;
-// agent/automation may queue approval). list/get honor agent_config `read` for
-// agent/automation principals.
-const runManageAgents = defineFlatActionTool<ManageAgentsArgs, ManageAgentsResult>(
-  'manage_agents',
-  {
-    list: flatAction((args, ctx, env) => handleList(args, ctx, env)),
-    get: flatAction((args, ctx, env) => handleGet(args, ctx, env)),
-    create: flatAction((args, ctx, env) => dispatchAgentWrite('create', args, ctx, env)),
-    update: flatAction((args, ctx, env) => dispatchAgentWrite('update', args, ctx, env)),
-    delete: flatAction((args, ctx, env) => dispatchAgentWrite('delete', args, ctx, env)),
-  }
-);
+// list/get are org-read and honor agent_config `read` for agent/automation
+// principals; create/update/delete are org-write and consult the agent_config
+// write-gate (human immediate; agent/automation may queue approval).
+const manageAgentsTool = defineActionTool('manage_agents', {
+  list: action(ListAgentsAction, orgGated(requireOrgReadAccess, handleList)),
+  get: action(GetAgentAction, orgGated(requireOrgReadAccess, handleGet)),
+  create: action(CreateAgentAction, orgGated(requireOrgWriteAccess, dispatchAgentWrite)),
+  update: action(UpdateAgentAction, orgGated(requireOrgWriteAccess, dispatchAgentWrite)),
+  delete: action(DeleteAgentAction, orgGated(requireOrgWriteAccess, dispatchAgentWrite)),
+});
+
+export const manageAgents = manageAgentsTool.run;


### PR DESCRIPTION
## Summary
- `manage_agents` moves from one flat object (an `action` enum plus every field optional, with `agent_id is required for … action` / `name is required for create action` re-checked by hand in five places) to a `Type.Union` of five per-action variants in core, dispatched through `defineActionTool`. The schema now says what each action requires and accepts; the handler keeps only the two rules a schema cannot express (the agent-id slug pattern, and "update needs at least one field").
- **core owns the SDK input types.** `AgentCreateInput` / `AgentUpdateInput` are derived from the variants through the same `ActionInput<Args, Action>` helper the six union-backed namespaces adopted in #3359; the hand-written `AgentsCreateInput` / `AgentsUpdateInput` interfaces in the namespace are deleted. They had drifted: neither advertised `default_model`, which the tool has accepted since #2047.
- **The editable-field engine keeps its single source of truth.** The four `x-lobu-field` annotations now live on one shared field set that both write variants spread; `collectLobuFields(UpdateAgentAction)` reads them (the update variant *is* the patch shape). The new unit test pins that the annotation survives `Type.Optional` on both variants, in order, with its `store` metadata — that is the assumption this refactor rests on.
- **A persisted proposal is re-validated, not trusted.** `applyManageAgentsProposal` rebuilds the args from `runs.action_input` and runs them through the write-action union (`create | update | delete`, then `buildProposal`) before applying — so a stored row naming a non-write action is rejected instead of falling off the dispatch switch (the fixer's one finding; my first cut validated against the full five-variant schema). The one existing test that relied on a malformed proposal failing — a `delete` with no `agent_id` — still fails at the same point, now from the schema.
- Per-action access filtering applies for the first time: a read-scope listing shows `list`/`get` only; owner-admin `create`/`update`/`delete` appear at admin. The org-level read/write access check that used to sit in a pre-dispatch wrapper is now a small `orgGated` decorator per action.

### What the flat contract could not express (red → green)
The new `manage-agents-contract.test.ts` cases, run against the **old** flat schema via a scratch copy of `origin/main`'s contract:
```
(fail) OLD flat contract > requires agent_id for get/update/delete and name for create
(fail) OLD flat contract > rejects agent_id on list and name on delete
(pass) OLD flat contract > still rejects a key no action has (unchanged)
 1 pass / 2 fail
```
Same cases against the union: **6 pass / 0 fail**. (The third line matters: the flat validator already rejected keys that no action declares, so "unknown key → 400" is *not* new behaviour here — what is new is required-ness at the schema and cross-action fields being errors.)

### Prod payload census (60 days, `sdk_call_trace`; 0 of 192 reaction scripts call `client.agents.*`)
| SDK call | n | today | after |
|---|---|---|---|
| `agents.list` with no args / `{}` | 66 | ok | ok |
| `agents.list` `{org}` `{orgId}` `{include_models}` | 12 | already 400 (unknown key) | 400, same |
| `agents.get` / `agents.delete` (positional id or `{agent_id}`) | 45 | ok | ok |
| `agents.create` with `agent_id,name[,description,identity_md,default_model]` | 11 | ok | ok |
| `agents.create` with stray `model` / `sandbox_id`; one without `agent_id` | 5 | already 400 | 400, same |
| `agents.update` with `agent_id` + an editable field | 9 | ok | ok |
| `agents.update` with only `model`/`models`/`sandbox_id`/`nix_config`, or `id` | 7 | already 400 | 400, same (message now names the valid fields) |
| `agents.manage` / `agents.setSystemAgent` | 11 | mixed; none carries a cross-action field | unchanged |

No call that succeeds today fails after this change.

## Test plan
- [x] Staged by explicit path (`--pathspec-from-file`); `git diff --name-only origin/main...HEAD` equals the intended 7 files. `make pre-pr` clean (build, typecheck, knip, biome, naming, gateway-LLM + entity-write funnel gates).
- [x] `bun test packages/server/src/__tests__/unit/manage-agents-contract.test.ts` → **6 pass / 0 fail**; red proof above.
- [x] `bun test` wire-schema + `unit/sandbox/` + registry-split → **174 pass / 0 fail**.
- [x] Vitest `integration/tools/manage-agents-e2e.test.ts` (real tool path: immediate apply, queued approval, stale-approval skip, model config) + `operations-approval-transition-atomicity.test.ts` → **43 pass / 0 fail**. The atomicity test's expectation moved from the hand-check wording to the schema's `Invalid arguments for manage_agents: … agent_id`.
- [x] Client regenerated from the running server (`openapi.json` verified to carry the union, 5 variants, 0 occurrences of the old `[get/create/update/delete]` prefix): `ManageAgentsData.body` is now the five-variant discriminated union.
- [ ] No bot runtime change.

## Notes
**Wire behaviour for MCP clients** is unchanged in shape — the union is flattened into one object with the per-action `Required:` lines generated from the variants (pinned by the test), and editable fields keep their `[create/update]` prefix because a flattened property cannot say which actions accept it.

**One message changes:** an empty `name` on `create` now reads `name must not be blank for create action` (presence is the schema's job; blankness is still the handler's).

**Reviewer disclosure:** codex is at its usage limit until 2026-09-07, so `make review-fix` / `make review` ran as `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus` — same-model self-review, not the intended cross-harness check. `review-fix` made one edit (the write-union re-validation above) and independently re-ran the e2e suites (62/62) and the full unit job (1399 pass) on it; I re-ran the four coupled suites and `make pre-pr` after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated agent management to support clearly defined list, view, create, update, and delete actions.
  - Improved validation so each action accepts only its applicable fields.
  - Added stronger validation for queued agent-management changes before they are applied.

- **Bug Fixes**
  - Improved error messages when required agent identifiers are missing.
  - Preserved access controls and approval handling across agent-management actions.

- **Tests**
  - Added coverage for action-specific fields, validation, metadata, access filtering, and required-field descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->