### PR TITLE
refactor(core,server): manage_view_templates as a union of per-action variants

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -5726,42 +5726,111 @@ export type ManageClassifiersResponse =
   ManageClassifiersResponses[keyof ManageClassifiersResponses];
 
 export type ManageViewTemplatesData = {
-  body: {
-    /**
-     * Action to perform
-     */
-    action: "set" | "get" | "rollback" | "remove_tab" | "clear";
-    /**
-     * Type of resource: entity_type or entity
-     */
-    resource_type: "entity_type" | "entity";
-    /**
-     * Resource identifier: entity type slug (string) or entity id (number)
-     */
-    resource_id: string | number;
-    /**
-     * [set] The JSON template content. May include a data_sources key: { "data_sources": { "name": { "query": "SELECT ... FROM entities" } }, ...template }. Queries run against org-scoped virtual tables. Use {{entityId}} for current entity context.
-     */
-    json_template?: {
-      [key: string]: unknown;
-    };
-    /**
-     * Tab name. Omit for the default/overview tab.
-     */
-    tab_name?: string;
-    /**
-     * [set] Sort order for tabs (default 0)
-     */
-    tab_order?: number;
-    /**
-     * [set] Notes describing the change
-     */
-    change_notes?: string;
-    /**
-     * [rollback] Version number to rollback to
-     */
-    version?: number;
-  };
+  body:
+    | {
+        /**
+         * Create a new version of a view template / tab.
+         */
+        action: "set";
+        /**
+         * Type of resource: entity_type or entity
+         */
+        resource_type: "entity_type" | "entity";
+        /**
+         * Resource identifier: entity type slug (string) or entity id (number)
+         */
+        resource_id: string | number;
+        /**
+         * [set] The JSON template content. May include a data_sources key: { "data_sources": { "name": { "query": "SELECT ... FROM entities" } }, ...template }. Queries run against org-scoped virtual tables. Use {{entityId}} for current entity context.
+         */
+        json_template: {
+          [key: string]: unknown;
+        };
+        /**
+         * Tab name. Omit for the default/overview tab; required for `remove_tab`. `get` returns the default tab and every named tab whether or not it is given.
+         */
+        tab_name?: string;
+        /**
+         * [set] Sort order for tabs (default 0)
+         */
+        tab_order?: number;
+        /**
+         * [set] Notes describing the change
+         */
+        change_notes?: string;
+      }
+    | {
+        /**
+         * Fetch current default + tabs + history.
+         */
+        action: "get";
+        /**
+         * Type of resource: entity_type or entity
+         */
+        resource_type: "entity_type" | "entity";
+        /**
+         * Resource identifier: entity type slug (string) or entity id (number)
+         */
+        resource_id: string | number;
+        /**
+         * Tab name. Omit for the default/overview tab; required for `remove_tab`. `get` returns the default tab and every named tab whether or not it is given.
+         */
+        tab_name?: string;
+      }
+    | {
+        /**
+         * Roll back to a prior version.
+         */
+        action: "rollback";
+        /**
+         * Type of resource: entity_type or entity
+         */
+        resource_type: "entity_type" | "entity";
+        /**
+         * Resource identifier: entity type slug (string) or entity id (number)
+         */
+        resource_id: string | number;
+        /**
+         * [rollback] Version number to rollback to
+         */
+        version: number;
+        /**
+         * Tab name. Omit for the default/overview tab; required for `remove_tab`. `get` returns the default tab and every named tab whether or not it is given.
+         */
+        tab_name?: string;
+      }
+    | {
+        /**
+         * Delete a named tab.
+         */
+        action: "remove_tab";
+        /**
+         * Type of resource: entity_type or entity
+         */
+        resource_type: "entity_type" | "entity";
+        /**
+         * Resource identifier: entity type slug (string) or entity id (number)
+         */
+        resource_id: string | number;
+        /**
+         * Tab name. Omit for the default/overview tab; required for `remove_tab`. `get` returns the default tab and every named tab whether or not it is given.
+         */
+        tab_name: string;
+      }
+    | {
+        /**
+         * Null the default (non-tab) template.
+         */
+        action: "clear";
+        /**
+         * Type of resource: entity_type or entity
+         */
+        resource_type: "entity_type" | "entity";
+        /**
+         * Resource identifier: entity type slug (string) or entity id (number)
+         */
+        resource_id: string | number;
+      };
   path: {
     /**
      * Organization slug (workspace identifier)

--- a/packages/core/src/contracts/tools/manage-view-templates.ts
+++ b/packages/core/src/contracts/tools/manage-view-templates.ts
@@ -1,4 +1,5 @@
 import { type Static, Type } from "@sinclair/typebox";
+import type { ActionInput } from "./action-input";
 
 // ============================================
 // View template versioning types + helpers
@@ -28,63 +29,101 @@ export const ViewTemplateTabInfoSchema = Type.Object({
 });
 
 // ============================================
-// Schema
+// Input Schema (union of per-action variants)
 // ============================================
+//
+// The wire schema flattens this union into ONE MCP object and merges duplicate
+// properties first-occurrence-wins, so a property carried by more than one
+// variant must read true for every one of them.
 
-export const ManageViewTemplatesSchema = Type.Object({
-  action: Type.Union(
-    [
-      Type.Literal("set", {
-        description: "Create a new version of a view template / tab.",
-      }),
-      Type.Literal("get", {
-        description: "Fetch current default + tabs + history.",
-      }),
-      Type.Literal("rollback", {
-        description: "Roll back to a prior version.",
-      }),
-      Type.Literal("remove_tab", { description: "Delete a named tab." }),
-      Type.Literal("clear", {
-        description: "Null the default (non-tab) template.",
-      }),
-    ],
-    { description: "Action to perform" }
-  ),
+const ResourceType = Type.Union(
+  [Type.Literal("entity_type"), Type.Literal("entity")],
+  { description: "Type of resource: entity_type or entity" }
+);
+const ResourceId = Type.Union([Type.String(), Type.Number()], {
+  description:
+    "Resource identifier: entity type slug (string) or entity id (number)",
+});
+const TabName = Type.String({
+  description:
+    "Tab name. Omit for the default/overview tab; required for `remove_tab`. `get` returns the default tab and every named tab whether or not it is given.",
+});
 
-  resource_type: Type.Union(
-    [Type.Literal("entity_type"), Type.Literal("entity")],
-    {
-      description: "Type of resource: entity_type or entity",
-    }
-  ),
-  resource_id: Type.Union([Type.String(), Type.Number()], {
-    description:
-      "Resource identifier: entity type slug (string) or entity id (number)",
+export const SetViewTemplateAction = Type.Object({
+  action: Type.Literal("set", {
+    description: "Create a new version of a view template / tab.",
   }),
-
-  json_template: Type.Optional(
-    Type.Record(Type.String(), Type.Unknown(), {
-      description:
-        '[set] The JSON template content. May include a data_sources key: { "data_sources": { "name": { "query": "SELECT ... FROM entities" } }, ...template }. Queries run against org-scoped virtual tables. Use {{entityId}} for current entity context.',
-    })
-  ),
-  tab_name: Type.Optional(
-    Type.String({
-      description: "Tab name. Omit for the default/overview tab.",
-    })
-  ),
+  resource_type: ResourceType,
+  resource_id: ResourceId,
+  json_template: Type.Record(Type.String(), Type.Unknown(), {
+    description:
+      '[set] The JSON template content. May include a data_sources key: { "data_sources": { "name": { "query": "SELECT ... FROM entities" } }, ...template }. Queries run against org-scoped virtual tables. Use {{entityId}} for current entity context.',
+  }),
+  tab_name: Type.Optional(TabName),
   tab_order: Type.Optional(
     Type.Number({ description: "[set] Sort order for tabs (default 0)" })
   ),
   change_notes: Type.Optional(
     Type.String({ description: "[set] Notes describing the change" })
   ),
-  version: Type.Optional(
-    Type.Number({ description: "[rollback] Version number to rollback to" })
-  ),
 });
 
+export const GetViewTemplateAction = Type.Object({
+  action: Type.Literal("get", {
+    description: "Fetch current default + tabs + history.",
+  }),
+  resource_type: ResourceType,
+  resource_id: ResourceId,
+  tab_name: Type.Optional(TabName),
+});
+
+export const RollbackViewTemplateAction = Type.Object({
+  action: Type.Literal("rollback", {
+    description: "Roll back to a prior version.",
+  }),
+  resource_type: ResourceType,
+  resource_id: ResourceId,
+  version: Type.Number({
+    description: "[rollback] Version number to rollback to",
+  }),
+  tab_name: Type.Optional(TabName),
+});
+
+export const RemoveViewTemplateTabAction = Type.Object({
+  action: Type.Literal("remove_tab", { description: "Delete a named tab." }),
+  resource_type: ResourceType,
+  resource_id: ResourceId,
+  tab_name: TabName,
+});
+
+export const ClearViewTemplateAction = Type.Object({
+  action: Type.Literal("clear", {
+    description: "Null the default (non-tab) template.",
+  }),
+  resource_type: ResourceType,
+  resource_id: ResourceId,
+});
+
+export const ManageViewTemplatesSchema = Type.Union([
+  SetViewTemplateAction,
+  GetViewTemplateAction,
+  RollbackViewTemplateAction,
+  RemoveViewTemplateTabAction,
+  ClearViewTemplateAction,
+]);
+
 export type ManageViewTemplatesArgs = Static<typeof ManageViewTemplatesSchema>;
+
+export type ViewTemplateGetInput = ActionInput<ManageViewTemplatesArgs, "get">;
+export type ViewTemplateSetInput = ActionInput<ManageViewTemplatesArgs, "set">;
+export type ViewTemplateRollbackInput = ActionInput<
+  ManageViewTemplatesArgs,
+  "rollback"
+>;
+export type ViewTemplateRemoveTabInput = ActionInput<
+  ManageViewTemplatesArgs,
+  "remove_tab"
+>;
 
 // ============================================
 // Result Types

--- a/packages/server/src/__tests__/unit/manage-view-templates-contract.test.ts
+++ b/packages/server/src/__tests__/unit/manage-view-templates-contract.test.ts
@@ -1,0 +1,119 @@
+/**
+ * `manage_view_templates` is a union of per-action variants, so the schema —
+ * not the handler — decides what each action requires and accepts. These pin
+ * what the flat contract could not express: `json_template`, `version` and
+ * `tab_name` are required by the one action that needs each rather than
+ * checked by hand, a field that belongs to another action is an error on this
+ * one instead of a silent no-op (the flat object accepted `version` on `set`),
+ * and the registry's per-action access filtering — which only ever applied to
+ * union variants — now keeps the write actions out of a read-scope listing.
+ */
+import { describe, expect, it } from "bun:test";
+import { ManageViewTemplatesSchema } from "@lobu/core/contracts/tools/manage-view-templates";
+import { getAllTools } from "../../tools/registry";
+import { validateToolArgs } from "../../tools/validate-args";
+import { ToolUserError } from "../../utils/errors";
+
+const validate = (args: unknown) =>
+	validateToolArgs("manage_view_templates", ManageViewTemplatesSchema, args);
+
+function messageOf(fn: () => unknown): string {
+	try {
+		fn();
+	} catch (err) {
+		expect(err).toBeInstanceOf(ToolUserError);
+		return (err as ToolUserError).message;
+	}
+	throw new Error("expected validation to throw");
+}
+
+const ref = { resource_type: "entity_type", resource_id: "deal" } as const;
+
+describe("manage_view_templates union contract", () => {
+	it("requires json_template for set, version for rollback and tab_name for remove_tab, at the schema", () => {
+		expect(messageOf(() => validate({ action: "set", ...ref }))).toMatch(/json_template/);
+		expect(messageOf(() => validate({ action: "rollback", ...ref }))).toMatch(/version/);
+		expect(messageOf(() => validate({ action: "remove_tab", ...ref }))).toMatch(/tab_name/);
+	});
+
+	it("rejects a field another action takes instead of ignoring it", () => {
+		const set = messageOf(() =>
+			validate({ action: "set", ...ref, json_template: { type: "div" }, version: 3 }),
+		);
+		expect(set).toMatch(/unknown argument\(s\): version/);
+		expect(set).toMatch(
+			/valid arguments for action 'set' are: action, resource_type, resource_id, json_template, tab_name, tab_order, change_notes$/,
+		);
+
+		const clear = messageOf(() => validate({ action: "clear", ...ref, tab_name: "Pipeline" }));
+		expect(clear).toMatch(/unknown argument\(s\): tab_name/);
+		expect(clear).toMatch(
+			/valid arguments for action 'clear' are: action, resource_type, resource_id$/,
+		);
+	});
+
+	it("accepts each action's full field set, with a numeric or slug resource_id", () => {
+		expect(
+			validate({
+				action: "set",
+				resource_type: "entity",
+				resource_id: 42,
+				json_template: { type: "div" },
+				tab_name: "Pipeline",
+				tab_order: 2,
+				change_notes: "first cut",
+			}),
+		).toMatchObject({ resource_id: 42, tab_order: 2 });
+		expect(validate({ action: "get", ...ref, tab_name: "Pipeline" })).toEqual({
+			action: "get",
+			...ref,
+			tab_name: "Pipeline",
+		});
+		expect(validate({ action: "rollback", ...ref, version: 3 })).toEqual({
+			action: "rollback",
+			...ref,
+			version: 3,
+		});
+		expect(validate({ action: "remove_tab", ...ref, tab_name: "Pipeline" })).toEqual({
+			action: "remove_tab",
+			...ref,
+			tab_name: "Pipeline",
+		});
+		expect(validate({ action: "clear", ...ref })).toEqual({ action: "clear", ...ref });
+	});
+});
+
+/**
+ * What an MCP client actually sees: the union is flattened to one object
+ * (hosts reject a top-level `anyOf`), so per-action requirements survive only
+ * as prose on the `action` enum.
+ */
+describe("manage_view_templates wire schema", () => {
+	const listedFor = (maxAccessLevel: "read" | "admin") =>
+		getAllTools({ publicOnly: false, maxAccessLevel }).find(
+			(tool) => tool.name === "manage_view_templates",
+		);
+
+	it("hides the write actions from a read-scope listing", () => {
+		expect(listedFor("read")?.inputSchema.properties.action.enum).toEqual(["get"]);
+		expect(listedFor("admin")?.inputSchema.properties.action.enum).toEqual([
+			"set",
+			"get",
+			"rollback",
+			"remove_tab",
+			"clear",
+		]);
+	});
+
+	it("names each action's required fields on the flattened enum", () => {
+		const description: string =
+			listedFor("admin")?.inputSchema.properties.action.description ?? "";
+		const lineFor = (action: string) =>
+			description.split("\n").find((line) => line.startsWith(`- ${action}:`));
+		expect(lineFor("set")).toContain("Required: resource_type, resource_id, json_template.");
+		expect(lineFor("get")).toContain("Required: resource_type, resource_id.");
+		expect(lineFor("rollback")).toContain("Required: resource_type, resource_id, version.");
+		expect(lineFor("remove_tab")).toContain("Required: resource_type, resource_id, tab_name.");
+		expect(lineFor("clear")).toContain("Required: resource_type, resource_id.");
+	});
+});

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -1073,8 +1073,11 @@ export default async (_ctx, client) => {
 			"await client.viewTemplates.rollback({ resource_type: 'entity_type', resource_id: 'deal', version: 3 });",
 	},
 	"viewTemplates.removeTab": {
-		summary: "Remove a named tab from a template.",
+		summary:
+			"Remove a named tab from a template. `tab_name` is required; the default/overview tab has no name and is nulled with `viewTemplates.manage({ action: 'clear', ... })` instead.",
 		access: "admin",
+		signature:
+			"viewTemplates.removeTab(input: { resource_type: 'entity' | 'entity_type'; resource_id: string | number; tab_name: string }): Promise<unknown>",
 	},
 
 	// metrics — governed measures (prefer over client.query / query_sql)

--- a/packages/server/src/sandbox/namespaces/view-templates.ts
+++ b/packages/server/src/sandbox/namespaces/view-templates.ts
@@ -7,43 +7,23 @@
  * inside it when they want SQL-backed sources.
  */
 
+import type {
+	ViewTemplateGetInput,
+	ViewTemplateRemoveTabInput,
+	ViewTemplateRollbackInput,
+	ViewTemplateSetInput,
+} from "@lobu/core/contracts/tools/manage-view-templates";
 import type { Env } from "../../index";
 import { manageViewTemplates } from "../../tools/admin/manage_view_templates";
 import type { ToolContext } from "../../tools/registry";
 import { createActionCaller } from "./action-call";
 
-type ResourceType = "entity_type" | "entity";
-type ResourceId = string | number;
-
-export interface ViewTemplateSetInput {
-	resource_type: ResourceType;
-	resource_id: ResourceId;
-	json_template: Record<string, unknown>;
-	tab_name?: string;
-	tab_order?: number;
-	change_notes?: string;
-}
-
 export interface ViewTemplatesNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	get(input: {
-		resource_type: ResourceType;
-		resource_id: ResourceId;
-		tab_name?: string;
-	}): Promise<unknown>;
+	get(input: ViewTemplateGetInput): Promise<unknown>;
 	set(input: ViewTemplateSetInput): Promise<unknown>;
-	rollback(input: {
-		resource_type: ResourceType;
-		resource_id: ResourceId;
-		/** Version number (not the row id) to roll back to. */
-		version: number;
-		tab_name?: string;
-	}): Promise<unknown>;
-	removeTab(input: {
-		resource_type: ResourceType;
-		resource_id: ResourceId;
-		tab_name: string;
-	}): Promise<unknown>;
+	rollback(input: ViewTemplateRollbackInput): Promise<unknown>;
+	removeTab(input: ViewTemplateRemoveTabInput): Promise<unknown>;
 }
 
 export function buildViewTemplatesNamespace(

--- a/packages/server/src/tools/admin/manage_view_templates.ts
+++ b/packages/server/src/tools/admin/manage_view_templates.ts
@@ -2,18 +2,24 @@
  * Tool: manage_view_templates
  *
  * Unified view template versioning for entity types and individual entities.
- * Actions: set, get, rollback, remove_tab
+ * Actions: set, get, rollback, remove_tab, clear
  */
 
 
 import { validateEntityRowPatch } from "../../authz/entity-row-validation";
 import {
+  ClearViewTemplateAction,
+  GetViewTemplateAction,
   ManageViewTemplatesResultSchema,
   ManageViewTemplatesSchema,
+  RemoveViewTemplateTabAction,
+  RollbackViewTemplateAction,
+  SetViewTemplateAction,
   type ManageViewTemplatesArgs,
   type ManageViewTemplatesResult,
   type ViewTemplateVersionRow,
 } from '@lobu/core/contracts/tools/manage-view-templates';
+import type { Static } from '@sinclair/typebox';
 import { type DbClient, getDb } from '../../db/client';
 import { emit } from '../../events/emitter';
 import { recordToolConfigChange } from './helpers/config-audit';
@@ -23,8 +29,7 @@ import { validateDataSourceQuery } from '../../utils/execute-data-sources';
 import { resolveUsernames } from '../../utils/resolve-usernames';
 import { validateJsonTemplate } from '../../utils/validate-json-template';
 import type { ToolContext } from '../registry';
-import { withValidatedArgs } from '../validate-args';
-import { defineFlatActionTool, flatAction } from './action-tool';
+import { action, defineActionTool } from './action-tool';
 
 export { ManageViewTemplatesResultSchema, ManageViewTemplatesSchema };
 
@@ -50,20 +55,17 @@ function mapVersionRow(row: Record<string, unknown>): ViewTemplateVersionRow {
 // Main Function
 // ============================================
 
-export const manageViewTemplates = withValidatedArgs(
-  'manage_view_templates',
-  ManageViewTemplatesSchema,
-  defineFlatActionTool<ManageViewTemplatesArgs, ManageViewTemplatesResult>(
-    'manage_view_templates',
-    {
-      set: flatAction(handleSet),
-      get: flatAction(handleGet),
-      rollback: flatAction(handleRollback),
-      remove_tab: flatAction(handleRemoveTab),
-      clear: flatAction(handleClear),
-    }
-  )
-);
+// Variants in the contract's order, so the derived union matches the exposed
+// `ManageViewTemplatesSchema`. Each handler receives its own variant's args.
+const manageViewTemplatesTool = defineActionTool('manage_view_templates', {
+  set: action(SetViewTemplateAction, handleSet),
+  get: action(GetViewTemplateAction, handleGet),
+  rollback: action(RollbackViewTemplateAction, handleRollback),
+  remove_tab: action(RemoveViewTemplateTabAction, handleRemoveTab),
+  clear: action(ClearViewTemplateAction, handleClear),
+});
+
+export const manageViewTemplates = manageViewTemplatesTool.run;
 
 // ============================================
 // Helpers
@@ -231,11 +233,9 @@ function validateDataSources(dataSources: unknown): void {
 }
 
 async function handleSet(
-  args: ManageViewTemplatesArgs,
+  args: Static<typeof SetViewTemplateAction>,
   ctx: ToolContext
 ): Promise<ManageViewTemplatesResult> {
-  if (!args.json_template) throw new Error('json_template is required for set action');
-
   validateDataSources(args.json_template.data_sources);
   // Structural DSL validation: fail fast at authoring on a malformed node tree
   // (bad node shape / missing required field / unknown `format`) rather than
@@ -321,7 +321,7 @@ async function handleSet(
 }
 
 async function handleGet(
-  args: ManageViewTemplatesArgs,
+  args: Static<typeof GetViewTemplateAction>,
   ctx: ToolContext
 ): Promise<ManageViewTemplatesResult> {
   const sql = getDb();
@@ -400,7 +400,7 @@ async function handleGet(
  * template a pruning config no longer declares (named tabs use `remove_tab`).
  */
 async function handleClear(
-  args: ManageViewTemplatesArgs,
+  args: Static<typeof ClearViewTemplateAction>,
   ctx: ToolContext
 ): Promise<ManageViewTemplatesResult> {
   const sql = getDb();
@@ -427,11 +427,9 @@ async function handleClear(
 }
 
 async function handleRollback(
-  args: ManageViewTemplatesArgs,
+  args: Static<typeof RollbackViewTemplateAction>,
   ctx: ToolContext
 ): Promise<ManageViewTemplatesResult> {
-  if (args.version === undefined) throw new Error('version is required for rollback action');
-
   const sql = getDb();
   const rowId = await verifyAccess(sql, args, ctx, true);
   const resourceId = rid(args);
@@ -506,11 +504,9 @@ async function handleRollback(
 }
 
 async function handleRemoveTab(
-  args: ManageViewTemplatesArgs,
+  args: Static<typeof RemoveViewTemplateTabAction>,
   ctx: ToolContext
 ): Promise<ManageViewTemplatesResult> {
-  if (!args.tab_name) throw new Error('tab_name is required for remove_tab action');
-
   const sql = getDb();
   await verifyAccess(sql, args, ctx, true);
   const resourceId = rid(args);


### PR DESCRIPTION
## Summary
- `manage_view_templates` moves from one flat object (an `action` enum, every field optional, `json_template is required for set action` / `version is required for rollback action` / `tab_name is required for remove_tab action` thrown by hand as plain `Error`s) to a `Type.Union` of five per-action variants in core, dispatched through `defineActionTool`. The schema now says what each action requires and accepts; the three hand checks are gone.
- **core owns the SDK input types.** `ViewTemplateGetInput` / `SetInput` / `RollbackInput` / `RemoveTabInput` are derived from the variants through `ActionInput<Args, Action>` (same idiom as #3359, #3361, #3362); the namespace's hand-written `ViewTemplateSetInput` interface and three inline object types are deleted. The hand-written types were not wrong — but four of them existed, each a copy of the contract.
- **Per-action access filtering applies for the first time:** a read-scope listing shows `get` only; the four write actions appear at member-write. The flat tool exposed all five to every scope.
- Same series pattern as #3362 (agents), one tool per PR, each gated on a prod-payload census.

### What the flat contract could not express (red → green)
The new `manage-view-templates-contract.test.ts` cases, run against the **old** flat schema via a scratch copy of `origin/main`'s contract:
```
(fail) OLD flat contract > requires json_template for set, version for rollback, tab_name for remove_tab
(fail) OLD flat contract > rejects version on set and tab_name on clear
(pass) OLD flat contract > still rejects a key no action has (unchanged)
 1 pass / 2 fail
```
Same cases against the union: **5 pass / 0 fail**. (Third line: the flat validator already rejected keys no action declares, so "unknown key → 400" is not new here; required-ness at the schema and cross-action fields being errors are.)

### Prod payload census (60 days, `sdk_call_trace`; 0 of 192 reaction scripts call `client.viewTemplates.*`)
| SDK call | n | today | after |
|---|---|---|---|
| `viewTemplates.set` `{resource_type, resource_id, json_template, tab_name[, change_notes][, tab_order]}` | 9 | ok | ok |
| `viewTemplates.get` `{resource_type, resource_id[, tab_name]}` | 10 | ok | ok — `tab_name` stays optional on `get` (below) |
| `viewTemplates.get` `{entity_type}` | 1 | already 400 | 400, same |
| `viewTemplates.removeTab` `{resource_type, resource_id, tab_name}` | 4 | ok | ok |
| `viewTemplates.rollback` `{…, version}` / `{…, version_id}` | 2 / 1 | ok / already 400 | ok / 400, same |
| `viewTemplates.manage` with `template` (not `json_template`) | 2 | already 400 | 400, same |

No call that succeeds today fails after this change.

**`tab_name` on `get`.** The handler has never read it — `get` returns the default tab plus every named tab — yet the namespace, the SDK metadata (`Params: { …, tab_name? }`) and 8 of the 10 live `get` calls carry it. Dropping it from the variant would break those callers, so the variant keeps it optional and its description now says what `get` does with it (nothing). Whether `get` should *filter* by tab or the SDK should stop advertising it is a surface decision I have left for the owner; this PR changes no behaviour.

## Test plan
- [x] Staged by explicit path; `git diff --name-only origin/main...HEAD` equals the intended 6 files. `make pre-pr` clean.
- [x] `bun test …/manage-view-templates-contract.test.ts` → **5 pass / 0 fail**; red proof above. Existing `unit/tools/manage-view-templates-validation.test.ts` (the bad-shape guards) → **4 pass** — the missing-field cases now fail at the schema with the same `resource_type` / `resource_id` wording, before any DB query.
- [x] Vitest `entity-view-templates` + `entity-type-view-templates` + `view-template-clear` (real DB: set/get/rollback/remove_tab/clear round trips, malformed-template rejection) → **9 pass / 0 fail**.
- [x] Client regenerated from the running server (`openapi.json` verified to carry the union, 5 variants): `ManageViewTemplatesData.body` is now the discriminated union.
- [ ] No bot runtime change.

## Notes
**Failure class changes on the wire.** The three missing-field cases used to reach the handler and throw a bare `Error` (a 500-class failure); they now fail at validation as a 400 with the field named. The three cross-action cases (`set`+`version`, `clear`+`tab_name`, `get`+`json_template`) used to be silently accepted; they now 400. No successful call changes.

**Wire behaviour for MCP clients** is otherwise unchanged in shape: the union flattens to one object with the per-action `Required:` lines generated from the variants (pinned by the test); the `[set]` / `[rollback]` prefixes on the optional fields stay because a flattened property cannot say which actions accept it.

**Reviewer disclosure:** codex is at its usage limit until 2026-09-07, so `make review-fix` / `make review` ran as `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus` — same-model self-review, not the intended cross-harness check. `review-fix` made two edits: it collapsed a duplicated section banner in the contract, and gave `viewTemplates.removeTab` a `signature` in the SDK metadata — the validation error for a missing `tab_name` points callers at `search_sdk 'viewTemplates.removeTab'`, which previously listed no parameters. It also re-proved all six schema cases against the old contract and ran the full unit job (1425 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
