### PR TITLE
refactor(core,server): manage_classifiers as a union of per-action variants

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -5643,123 +5643,168 @@ export type ReadKnowledgeResponse =
   ReadKnowledgeResponses[keyof ReadKnowledgeResponses];
 
 export type ManageClassifiersData = {
-  body: {
-    /**
-     * Action to perform
-     */
-    action:
-      | "create"
-      | "list"
-      | "generate_embeddings"
-      | "delete"
-      | "classify"
-      | "apply";
-    /**
-     * [create/list] Entity ID to scope classifiers (global if omitted)
-     */
-    entity_id?: number;
-    /**
-     * [create] Persisted Automation ID returned by manage_automations (numeric string). OMIT for an org-level classifier — only those are matched by `apply` and the reconciliation job. Pass it only to scope the classifier to a single Automation.
-     */
-    automation_id?: string;
-    /**
-     * [generate_embeddings/delete] Classifier ID
-     */
-    classifier_id?: number;
-    /**
-     * [create] Unique identifier (e.g., "sentiment", "quality")
-     */
-    slug?: string;
-    /**
-     * [create] Display name
-     */
-    name?: string;
-    /**
-     * [create] Classifier description
-     */
-    description?: string;
-    /**
-     * [create] Key in content classifications (e.g., "sentiment")
-     */
-    attribute_key?: string;
-    /**
-     * [create] Map of attribute values to descriptions, examples, and optional embeddings.
-     */
-    attribute_values?: {
-      [key: string]:
-        | unknown
-        | {
-            description: string;
-            examples: Array<string>;
-            embedding?: Array<number> | null;
-          };
-    };
-    /**
-     * [create] Minimum similarity threshold (default: 0.7)
-     */
-    min_similarity?: number;
-    /**
-     * [create] Fallback value if no match (default: null)
-     */
-    fallback_value?: unknown;
-    /**
-     * [create] Creator identifier
-     */
-    created_by?: string;
-    /**
-     * [list] Filter by status. Defaults to 'active' (deprecated classifiers are excluded). Pass 'deprecated' to see archived ones, or 'all' to list every classifier regardless of status.
-     */
-    status?: string;
-    /**
-     * [generate_embeddings] Force regenerate existing embeddings (default: false)
-     */
-    force_regenerate?: boolean;
-    /**
-     * [create/generate_embeddings/apply] Embedding model to use. Defaults to this deployment's configured model; only set it to work in a different vector space. Label vectors and event vectors must share a model — a classifier embedded under one model matches nothing when applied under another, and `apply` will report every id as not_embedded until the events are embedded under the same model.
-     */
-    embedding_model?: string;
-    /**
-     * [classify] Content ID to update (single mode)
-     */
-    content_id?: number;
-    /**
-     * [classify] Array of classifications to update (batch mode)
-     */
-    classifications?: Array<{
-      /**
-       * Content ID
-       */
-      content_id: number;
-      /**
-       * Classification value, or null to unset
-       */
-      value: string | null;
-      /**
-       * Reasoning/justification for this classification
-       */
-      reasoning?: string;
-    }>;
-    /**
-     * [apply] Content ids to classify. Get them with a read-only SQL query first, then pass them here. Ids outside your organization, or without an embedding, are skipped and reported — never silently dropped.
-     */
-    content_ids?: Array<number>;
-    /**
-     * [classify/apply] Classifier slug (e.g., "sentiment", "bug-severity")
-     */
-    classifier_slug?: string;
-    /**
-     * [classify] Classification value for single update, or null to unset
-     */
-    value?: string | null;
-    /**
-     * [classify] Classification source: "llm" (AI-generated) or "user" (manual). Defaults to "user".
-     */
-    source?: "llm" | "user";
-    /**
-     * [classify] Reasoning/justification for the classification(s)
-     */
-    reasoning?: string;
-  };
+  body:
+    | {
+        /**
+         * Create a classifier. Org-level by default; pass automation_id to scope it to one Automation.
+         */
+        action: "create";
+        /**
+         * [create/list] Entity ID to scope classifiers (global if omitted)
+         */
+        entity_id?: number;
+        /**
+         * [create] Persisted Automation ID returned by manage_automations (numeric string). OMIT for an org-level classifier — only those are matched by `apply` and the reconciliation job. Pass it only to scope the classifier to a single Automation.
+         */
+        automation_id?: string;
+        /**
+         * [create] Unique identifier (e.g., "sentiment", "quality")
+         */
+        slug: string;
+        /**
+         * [create] Display name
+         */
+        name: string;
+        /**
+         * [create] Classifier description
+         */
+        description?: string;
+        /**
+         * [create] Key in content classifications (e.g., "sentiment")
+         */
+        attribute_key: string;
+        /**
+         * [create] Map of attribute values to descriptions, examples, and optional embeddings.
+         */
+        attribute_values: {
+          [key: string]:
+            | unknown
+            | {
+                description: string;
+                examples: Array<string>;
+                embedding?: Array<number> | null;
+              };
+        };
+        /**
+         * [create] Minimum similarity threshold (default: 0.7)
+         */
+        min_similarity?: number;
+        /**
+         * [create] Fallback value if no match (default: null)
+         */
+        fallback_value?: unknown;
+        /**
+         * [create] Creator identifier
+         */
+        created_by?: string;
+        /**
+         * [create/generate_embeddings/apply] Embedding model to use. Defaults to this deployment's configured model; only set it to work in a different vector space. Label vectors and event vectors must share a model — a classifier embedded under one model matches nothing when applied under another, and `apply` will report every id as not_embedded until the events are embedded under the same model.
+         */
+        embedding_model?: string;
+      }
+    | {
+        /**
+         * List classifiers with filters.
+         */
+        action: "list";
+        /**
+         * [create/list] Entity ID to scope classifiers (global if omitted)
+         */
+        entity_id?: number;
+        /**
+         * [list] Filter by status. Defaults to 'active' (deprecated classifiers are excluded). Pass 'deprecated' to see archived ones, or 'all' to list every classifier regardless of status.
+         */
+        status?: string;
+      }
+    | {
+        /**
+         * Generate/regenerate attribute-value embeddings.
+         */
+        action: "generate_embeddings";
+        /**
+         * [generate_embeddings/delete] Classifier ID
+         */
+        classifier_id: number;
+        /**
+         * [generate_embeddings] Force regenerate existing embeddings (default: false)
+         */
+        force_regenerate?: boolean;
+        /**
+         * [create/generate_embeddings/apply] Embedding model to use. Defaults to this deployment's configured model; only set it to work in a different vector space. Label vectors and event vectors must share a model — a classifier embedded under one model matches nothing when applied under another, and `apply` will report every id as not_embedded until the events are embedded under the same model.
+         */
+        embedding_model?: string;
+      }
+    | {
+        /**
+         * Archive a classifier (status -> deprecated).
+         */
+        action: "delete";
+        /**
+         * [generate_embeddings/delete] Classifier ID
+         */
+        classifier_id: number;
+      }
+    | {
+        /**
+         * Manual single/batch classification.
+         */
+        action: "classify";
+        /**
+         * [classify/apply] Classifier slug (e.g., "sentiment", "bug-severity")
+         */
+        classifier_slug: string;
+        /**
+         * [classify] Content ID to update (single mode)
+         */
+        content_id?: number;
+        /**
+         * [classify] Classification value for single update, or null to unset
+         */
+        value?: string | null;
+        /**
+         * [classify] Array of classifications to update (batch mode)
+         */
+        classifications?: Array<{
+          /**
+           * Content ID
+           */
+          content_id: number;
+          /**
+           * Classification value, or null to unset
+           */
+          value: string | null;
+          /**
+           * Reasoning/justification for this classification
+           */
+          reasoning?: string;
+        }>;
+        /**
+         * [classify] Classification source: "llm" (AI-generated) or "user" (manual). Defaults to "user".
+         */
+        source?: "llm" | "user";
+        /**
+         * [classify] Reasoning/justification for the classification(s)
+         */
+        reasoning?: string;
+      }
+    | {
+        /**
+         * Run a classifier over specific content ids (embedding match, no LLM). Re-running re-labels: it replaces prior embedding results and never touches manual/LLM ones. Use after editing a classifier — run generate_embeddings first.
+         */
+        action: "apply";
+        /**
+         * [classify/apply] Classifier slug (e.g., "sentiment", "bug-severity")
+         */
+        classifier_slug: string;
+        /**
+         * [apply] Content ids to classify. Get them with a read-only SQL query first, then pass them here. Ids outside your organization, or without an embedding, are skipped and reported — never silently dropped.
+         */
+        content_ids: Array<number>;
+        /**
+         * [create/generate_embeddings/apply] Embedding model to use. Defaults to this deployment's configured model; only set it to work in a different vector space. Label vectors and event vectors must share a model — a classifier embedded under one model matches nothing when applied under another, and `apply` will report every id as not_embedded until the events are embedded under the same model.
+         */
+        embedding_model?: string;
+      };
   path: {
     /**
      * Organization slug (workspace identifier)

--- a/packages/core/src/contracts/tools/manage-classifiers.ts
+++ b/packages/core/src/contracts/tools/manage-classifiers.ts
@@ -1,91 +1,69 @@
 import { type Static, Type } from "@sinclair/typebox";
+import type { ActionInput } from "./action-input";
 
 // ============================================
-// Typebox Schema
+// Typebox Schema (union of per-action variants)
 // ============================================
+//
+// The wire schema flattens this union into ONE MCP object and merges duplicate
+// properties first-occurrence-wins, so a property carried by more than one
+// variant must read true for every one of them.
 
-export const ManageClassifiersSchema = Type.Object({
-  action: Type.Union(
-    [
-      // Template CRUD
-      Type.Literal("create", {
-        description:
-          "Create a classifier. Org-level by default; pass automation_id to scope it to one Automation.",
-      }),
-      Type.Literal("list", { description: "List classifiers with filters." }),
-      Type.Literal("generate_embeddings", {
-        description: "Generate/regenerate attribute-value embeddings.",
-      }),
-      Type.Literal("delete", {
-        description: "Archive a classifier (status -> deprecated).",
-      }),
-      // Manual classification
-      Type.Literal("classify", {
-        description: "Manual single/batch classification.",
-      }),
-      Type.Literal("apply", {
-        description:
-          "Run a classifier over specific content ids (embedding match, no LLM). Re-running re-labels: it replaces prior embedding results and never touches manual/LLM ones. Use after editing a classifier — run generate_embeddings first.",
-      }),
-    ],
-    { description: "Action to perform" }
-  ),
+const EntityId = Type.Number({
+  description:
+    "[create/list] Entity ID to scope classifiers (global if omitted)",
+});
+const ClassifierId = Type.Number({
+  description: "[generate_embeddings/delete] Classifier ID",
+});
+const ClassifierSlug = Type.String({
+  description:
+    '[classify/apply] Classifier slug (e.g., "sentiment", "bug-severity")',
+});
+const EmbeddingModel = Type.String({
+  description:
+    "[create/generate_embeddings/apply] Embedding model to use. Defaults to this deployment's configured model; only set it to work in a different vector space. Label vectors and event vectors must share a model — a classifier embedded under one model matches nothing when applied under another, and `apply` will report every id as not_embedded until the events are embedded under the same model.",
+});
 
-  // Template fields
-  entity_id: Type.Optional(
-    Type.Number({
-      description:
-        "[create/list] Entity ID to scope classifiers (global if omitted)",
-    })
-  ),
+export const CreateClassifierAction = Type.Object({
+  action: Type.Literal("create", {
+    description:
+      "Create a classifier. Org-level by default; pass automation_id to scope it to one Automation.",
+  }),
+  entity_id: Type.Optional(EntityId),
   automation_id: Type.Optional(
     Type.String({
       description:
         "[create] Persisted Automation ID returned by manage_automations (numeric string). OMIT for an org-level classifier — only those are matched by `apply` and the reconciliation job. Pass it only to scope the classifier to a single Automation.",
     })
   ),
-  classifier_id: Type.Optional(
-    Type.Number({
-      description: "[generate_embeddings/delete] Classifier ID",
-    })
-  ),
-  slug: Type.Optional(
-    Type.String({
-      description: '[create] Unique identifier (e.g., "sentiment", "quality")',
-    })
-  ),
-  name: Type.Optional(Type.String({ description: "[create] Display name" })),
+  slug: Type.String({
+    description: '[create] Unique identifier (e.g., "sentiment", "quality")',
+  }),
+  name: Type.String({ description: "[create] Display name" }),
   description: Type.Optional(
     Type.String({ description: "[create] Classifier description" })
   ),
-  attribute_key: Type.Optional(
-    Type.String({
-      description:
-        '[create] Key in content classifications (e.g., "sentiment")',
-    })
-  ),
-  attribute_values: Type.Optional(
-    Type.Record(
-      Type.String({ minLength: 1 }),
-      Type.Object(
-        {
-          description: Type.String(),
-          examples: Type.Array(Type.String()),
-          embedding: Type.Optional(
-            Type.Union([
-              Type.Array(Type.Number(), { minItems: 1 }),
-              Type.Null(),
-            ])
-          ),
-        },
-        { additionalProperties: false }
-      ),
+  attribute_key: Type.String({
+    description: '[create] Key in content classifications (e.g., "sentiment")',
+  }),
+  attribute_values: Type.Record(
+    Type.String({ minLength: 1 }),
+    Type.Object(
       {
-        minProperties: 1,
-        description:
-          "[create] Map of attribute values to descriptions, examples, and optional embeddings.",
-      }
-    )
+        description: Type.String(),
+        examples: Type.Array(Type.String()),
+        embedding: Type.Optional(
+          Type.Union([Type.Array(Type.Number(), { minItems: 1 }), Type.Null()])
+        ),
+      },
+      { additionalProperties: false }
+    ),
+    {
+      minProperties: 1,
+      description:
+        "[create] Map of attribute values to descriptions, examples, and optional embeddings.",
+    }
   ),
   min_similarity: Type.Optional(
     Type.Number({
@@ -100,29 +78,57 @@ export const ManageClassifiersSchema = Type.Object({
   created_by: Type.Optional(
     Type.String({ description: "[create] Creator identifier" })
   ),
+  embedding_model: Type.Optional(EmbeddingModel),
+});
+
+export const ListClassifiersAction = Type.Object({
+  action: Type.Literal("list", {
+    description: "List classifiers with filters.",
+  }),
+  entity_id: Type.Optional(EntityId),
   status: Type.Optional(
     Type.String({
       description:
         "[list] Filter by status. Defaults to 'active' (deprecated classifiers are excluded). Pass 'deprecated' to see archived ones, or 'all' to list every classifier regardless of status.",
     })
   ),
+});
+
+export const GenerateClassifierEmbeddingsAction = Type.Object({
+  action: Type.Literal("generate_embeddings", {
+    description: "Generate/regenerate attribute-value embeddings.",
+  }),
+  classifier_id: ClassifierId,
   force_regenerate: Type.Optional(
     Type.Boolean({
       description:
         "[generate_embeddings] Force regenerate existing embeddings (default: false)",
     })
   ),
-  embedding_model: Type.Optional(
-    Type.String({
-      description:
-        "[create/generate_embeddings/apply] Embedding model to use. Defaults to this deployment's configured model; only set it to work in a different vector space. Label vectors and event vectors must share a model — a classifier embedded under one model matches nothing when applied under another, and `apply` will report every id as not_embedded until the events are embedded under the same model.",
-    })
-  ),
+  embedding_model: Type.Optional(EmbeddingModel),
+});
 
-  // Manual classification fields
+export const DeleteClassifierAction = Type.Object({
+  action: Type.Literal("delete", {
+    description: "Archive a classifier (status -> deprecated).",
+  }),
+  classifier_id: ClassifierId,
+});
+
+export const ClassifyContentAction = Type.Object({
+  action: Type.Literal("classify", {
+    description: "Manual single/batch classification.",
+  }),
+  classifier_slug: ClassifierSlug,
   content_id: Type.Optional(
     Type.Number({
       description: "[classify] Content ID to update (single mode)",
+    })
+  ),
+  value: Type.Optional(
+    Type.Union([Type.String(), Type.Null()], {
+      description:
+        "[classify] Classification value for single update, or null to unset",
     })
   ),
   classifications: Type.Optional(
@@ -144,26 +150,6 @@ export const ManageClassifiersSchema = Type.Object({
       }
     )
   ),
-  content_ids: Type.Optional(
-    Type.Array(Type.Number(), {
-      minItems: 1,
-      maxItems: 2000,
-      description:
-        "[apply] Content ids to classify. Get them with a read-only SQL query first, then pass them here. Ids outside your organization, or without an embedding, are skipped and reported — never silently dropped.",
-    })
-  ),
-  classifier_slug: Type.Optional(
-    Type.String({
-      description:
-        '[classify/apply] Classifier slug (e.g., "sentiment", "bug-severity")',
-    })
-  ),
-  value: Type.Optional(
-    Type.Union([Type.String(), Type.Null()], {
-      description:
-        "[classify] Classification value for single update, or null to unset",
-    })
-  ),
   source: Type.Optional(
     Type.Union([Type.Literal("llm"), Type.Literal("user")], {
       description:
@@ -178,7 +164,50 @@ export const ManageClassifiersSchema = Type.Object({
   ),
 });
 
+export const ApplyClassifierAction = Type.Object({
+  action: Type.Literal("apply", {
+    description:
+      "Run a classifier over specific content ids (embedding match, no LLM). Re-running re-labels: it replaces prior embedding results and never touches manual/LLM ones. Use after editing a classifier — run generate_embeddings first.",
+  }),
+  classifier_slug: ClassifierSlug,
+  content_ids: Type.Array(Type.Number(), {
+    minItems: 1,
+    maxItems: 2000,
+    description:
+      "[apply] Content ids to classify. Get them with a read-only SQL query first, then pass them here. Ids outside your organization, or without an embedding, are skipped and reported — never silently dropped.",
+  }),
+  embedding_model: Type.Optional(EmbeddingModel),
+});
+
+export const ManageClassifiersSchema = Type.Union([
+  CreateClassifierAction,
+  ListClassifiersAction,
+  GenerateClassifierEmbeddingsAction,
+  DeleteClassifierAction,
+  ClassifyContentAction,
+  ApplyClassifierAction,
+]);
+
 export type ManageClassifiersArgs = Static<typeof ManageClassifiersSchema>;
+
+export type ClassifierCreateInput = ActionInput<
+  ManageClassifiersArgs,
+  "create"
+>;
+export type ClassifierListInput = ActionInput<ManageClassifiersArgs, "list">;
+export type ClassifierGenerateEmbeddingsInput = ActionInput<
+  ManageClassifiersArgs,
+  "generate_embeddings"
+>;
+export type ClassifierDeleteInput = ActionInput<
+  ManageClassifiersArgs,
+  "delete"
+>;
+export type ClassifierClassifyInput = ActionInput<
+  ManageClassifiersArgs,
+  "classify"
+>;
+export type ClassifierApplyInput = ActionInput<ManageClassifiersArgs, "apply">;
 
 /**
  * Result of `manage_classifiers`. TypeBox-first: `Static<>` derives the TS type

--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -651,9 +651,12 @@ describe('tool invocation audit coverage', () => {
   });
 
   it('records resolved tool failures as failed', async () => {
+    // A failure the HANDLER resolves, not one the arg validator throws:
+    // manage_classifiers' per-action schema now supplies `classifier_id`'s
+    // required-ness, so an omitted id raises instead of returning a result.
     const result = (await executeTool(
       'manage_classifiers',
-      { action: 'delete' },
+      { action: 'delete', classifier_id: 999999 },
       {} as Env,
       authCtxFor('pat')
     )) as { success: boolean };

--- a/packages/server/src/__tests__/unit/manage-classifiers-contract.test.ts
+++ b/packages/server/src/__tests__/unit/manage-classifiers-contract.test.ts
@@ -1,0 +1,145 @@
+/**
+ * `manage_classifiers` is a union of per-action variants, so the schema — not
+ * the handler — decides what each action requires and accepts. These pin what
+ * the flat contract could not express: `create`'s four required fields,
+ * `classifier_id` for `generate_embeddings`/`delete`, `classifier_slug` for
+ * `classify`/`apply` and `content_ids` for `apply` are required at the schema
+ * rather than answered with a `success: false` result; a field that belongs to
+ * another action is an error on this one instead of a silent no-op (the flat
+ * object accepted `slug` on `list`); and the registry's per-action access
+ * filtering — which only ever applied to union variants — now keeps the five
+ * write actions out of a read-scope listing.
+ */
+import { describe, expect, it } from "bun:test";
+import { ManageClassifiersSchema } from "@lobu/core/contracts/tools/manage-classifiers";
+import { getAllTools } from "../../tools/registry";
+import { validateToolArgs } from "../../tools/validate-args";
+import { ToolUserError } from "../../utils/errors";
+
+const validate = (args: unknown) =>
+	validateToolArgs("manage_classifiers", ManageClassifiersSchema, args);
+
+function messageOf(fn: () => unknown): string {
+	try {
+		fn();
+	} catch (err) {
+		expect(err).toBeInstanceOf(ToolUserError);
+		return (err as ToolUserError).message;
+	}
+	throw new Error("expected validation to throw");
+}
+
+const values = { positive: { description: "Positive", examples: ["great"] } };
+
+describe("manage_classifiers union contract", () => {
+	it("requires each action's fields at the schema", () => {
+		expect(messageOf(() => validate({ action: "create", slug: "sentiment", name: "S" }))).toMatch(
+			/attribute_key|attribute_values/,
+		);
+		expect(messageOf(() => validate({ action: "generate_embeddings" }))).toMatch(/classifier_id/);
+		expect(messageOf(() => validate({ action: "delete" }))).toMatch(/classifier_id/);
+		expect(messageOf(() => validate({ action: "classify", content_id: 1, value: "x" }))).toMatch(
+			/classifier_slug/,
+		);
+		expect(messageOf(() => validate({ action: "apply", classifier_slug: "sentiment" }))).toMatch(
+			/content_ids/,
+		);
+		expect(
+			messageOf(() => validate({ action: "apply", classifier_slug: "sentiment", content_ids: [] })),
+		).toMatch(/content_ids/);
+	});
+
+	it("rejects a field another action takes instead of ignoring it", () => {
+		const list = messageOf(() => validate({ action: "list", slug: "sentiment" }));
+		expect(list).toMatch(/unknown argument\(s\): slug/);
+		expect(list).toMatch(/valid arguments for action 'list' are: action, entity_id, status$/);
+
+		const del = messageOf(() =>
+			validate({ action: "delete", classifier_id: 7, force_regenerate: true }),
+		);
+		expect(del).toMatch(/unknown argument\(s\): force_regenerate/);
+		expect(del).toMatch(/valid arguments for action 'delete' are: action, classifier_id$/);
+	});
+
+	it("accepts each action's full field set", () => {
+		expect(
+			validate({
+				action: "create",
+				slug: "sentiment",
+				name: "Sentiment",
+				attribute_key: "sentiment",
+				attribute_values: values,
+				description: "tone",
+				entity_id: 12,
+				automation_id: "42",
+				min_similarity: 0.6,
+				fallback_value: null,
+				created_by: "agent",
+				embedding_model: "text-embedding-3-small",
+			}),
+		).toMatchObject({ slug: "sentiment", attribute_values: values });
+		expect(validate({ action: "list" })).toEqual({ action: "list" });
+		expect(validate({ action: "list", entity_id: 12, status: "all" })).toMatchObject({ status: "all" });
+		expect(
+			validate({
+				action: "generate_embeddings",
+				classifier_id: 7,
+				force_regenerate: true,
+				embedding_model: "text-embedding-3-small",
+			}),
+		).toMatchObject({ classifier_id: 7 });
+		expect(validate({ action: "delete", classifier_id: 7 })).toEqual({
+			action: "delete",
+			classifier_id: 7,
+		});
+		expect(
+			validate({
+				action: "classify",
+				classifier_slug: "sentiment",
+				classifications: [{ content_id: 1, value: null, reasoning: "unset" }],
+				source: "llm",
+				reasoning: "batch",
+			}),
+		).toMatchObject({ source: "llm" });
+		expect(
+			validate({ action: "apply", classifier_slug: "sentiment", content_ids: [1, 2], embedding_model: "m" }),
+		).toMatchObject({ content_ids: [1, 2] });
+	});
+});
+
+/**
+ * What an MCP client actually sees: the union is flattened to one object
+ * (hosts reject a top-level `anyOf`), so per-action requirements survive only
+ * as prose on the `action` enum.
+ */
+describe("manage_classifiers wire schema", () => {
+	const listedFor = (maxAccessLevel: "read" | "admin") =>
+		getAllTools({ publicOnly: false, maxAccessLevel }).find(
+			(tool) => tool.name === "manage_classifiers",
+		);
+
+	it("hides the write actions from a read-scope listing", () => {
+		expect(listedFor("read")?.inputSchema.properties.action.enum).toEqual(["list"]);
+		expect(listedFor("admin")?.inputSchema.properties.action.enum).toEqual([
+			"create",
+			"list",
+			"generate_embeddings",
+			"delete",
+			"classify",
+			"apply",
+		]);
+	});
+
+	it("names each action's required fields on the flattened enum", () => {
+		const description: string =
+			listedFor("admin")?.inputSchema.properties.action.description ?? "";
+		const lineFor = (action: string) =>
+			description.split("\n").find((line) => line.startsWith(`- ${action}:`));
+		expect(lineFor("create")).toContain("Required: slug, name, attribute_key, attribute_values.");
+		expect(lineFor("list")).not.toContain("Required:");
+		expect(lineFor("generate_embeddings")).toContain("Required: classifier_id.");
+		expect(lineFor("delete")).toContain("Required: classifier_id.");
+		expect(lineFor("classify")).toContain("Required: classifier_slug.");
+		expect(lineFor("apply")).toContain("Required: classifier_slug, content_ids.");
+	});
+});

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -1004,10 +1004,10 @@ export default async (_ctx, client) => {
 	},
 	"classifiers.create": {
 		summary:
-			"Create a classifier template. Requires `slug`, `name`, and `attribute_key`. `attribute_values` is an OBJECT keyed by value slug — each entry needs a `description` and `examples` (string array), not a flat list. OMIT `automation_id` for an org-level classifier, which is the only kind `apply` and the reconciliation job can match; pass it only to scope the classifier to one Automation.",
+			"Create a classifier template. Requires `slug`, `name`, `attribute_key`, and `attribute_values`. `attribute_values` is an OBJECT keyed by value slug — each entry needs a `description` and `examples` (string array), not a flat list. OMIT `automation_id` for an org-level classifier, which is the only kind `apply` and the reconciliation job can match; pass it only to scope the classifier to one Automation.",
 		access: "admin",
 		signature:
-			"classifiers.create(input: { slug: string; name: string; attribute_key: string; automation_id?: string; attribute_values?: Record<string, { description: string; examples: string[] }>; entity_id?: number; min_similarity?: number; fallback_value?: unknown; description?: string }): Promise<unknown>",
+			"classifiers.create(input: { slug: string; name: string; attribute_key: string; attribute_values: Record<string, { description: string; examples: string[]; embedding?: number[] | null }>; automation_id?: string; entity_id?: number; description?: string; min_similarity?: number; fallback_value?: unknown; created_by?: string; embedding_model?: string }): Promise<unknown>",
 		example:
 			"await client.classifiers.create({ slug: 'sentiment', name: 'Sentiment', attribute_key: 'sentiment', attribute_values: { positive: { description: 'Positive tone', examples: ['Great work!'] } } });",
 	},

--- a/packages/server/src/sandbox/namespaces/classifiers.ts
+++ b/packages/server/src/sandbox/namespaces/classifiers.ts
@@ -1,84 +1,29 @@
 /**
  * ClientSDK `classifiers` namespace. Thin wrapper over `manageClassifiers`.
  *
- * Most CRUD actions use `classifier_id: number`; `classify` uses
- * `classifier_slug: string`. The namespace keeps those distinct.
+ * `generateEmbeddings`/`delete` address a classifier by `classifier_id:
+ * number`; `classify`/`apply` address it by `classifier_slug: string`.
  */
 
+import type {
+	ClassifierApplyInput,
+	ClassifierClassifyInput,
+	ClassifierCreateInput,
+	ClassifierDeleteInput,
+	ClassifierGenerateEmbeddingsInput,
+	ClassifierListInput,
+} from "@lobu/core/contracts/tools/manage-classifiers";
 import type { Env } from "../../index";
 import { manageClassifiers } from "../../tools/admin/manage_classifiers";
 import type { ToolContext } from "../../tools/registry";
 import { createActionCaller } from "./action-call";
 
-export interface ClassifierCreateInput {
-	/** Model to embed the label vectors under; defaults to the configured one. */
-	embedding_model?: string;
-	slug: string;
-	name: string;
-	description?: string;
-	attribute_key: string;
-	attribute_values?: Record<
-		string,
-		{
-			description: string;
-			examples: string[];
-			embedding?: number[] | null;
-		}
-	>;
-	entity_id?: number;
-	/** Omit for an org-level classifier (the only kind `apply` and the
-	 *  reconciliation job match); set to scope to a single Automation. */
-	automation_id?: string;
-	min_similarity?: number;
-	fallback_value?: unknown;
-	created_by?: string;
-}
-
-export interface ClassifierClassifyInput {
-	classifier_slug: string;
-	/** Single-mode update. */
-	content_id?: number;
-	value?: string | null;
-	/** Batch mode. */
-	classifications?: Array<{
-		content_id: number;
-		value: string | null;
-		reasoning?: string;
-	}>;
-	source?: "llm" | "user";
-	reasoning?: string;
-}
-
-/**
- * `apply` runs the classifier's embedding match over content ids you supply.
- * Unlike the reconciliation cron it needs no entity link, so it is the only way
- * to classify org-scoped feed content. Ids that produce no classification come
- * back with a reason (`not_in_organization` | `superseded` | `not_embedded` |
- * `below_threshold`) rather than as a silent shortfall.
- */
-export interface ClassifierApplyInput {
-	classifier_slug: string;
-	content_ids: number[];
-	/**
-	 * Vector space to match in; defaults to the deployment's configured model.
-	 * The classifier's label vectors must already live in this model too (embed
-	 * them with `generateEmbeddings({ embedding_model })`), and so must the
-	 * events — ids without a vector in this model come back `not_embedded`.
-	 */
-	embedding_model?: string;
-}
-
 export interface ClassifiersNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	list(input?: { entity_id?: number; status?: string }): Promise<unknown>;
+	list(input?: ClassifierListInput): Promise<unknown>;
 	create(input: ClassifierCreateInput): Promise<unknown>;
-	generateEmbeddings(input: {
-		classifier_id: number;
-		force_regenerate?: boolean;
-		/** Model to embed the label vectors under; defaults to the configured one. */
-		embedding_model?: string;
-	}): Promise<unknown>;
-	delete(input: { classifier_id: number }): Promise<unknown>;
+	generateEmbeddings(input: ClassifierGenerateEmbeddingsInput): Promise<unknown>;
+	delete(input: ClassifierDeleteInput): Promise<unknown>;
 	classify(input: ClassifierClassifyInput): Promise<unknown>;
 	apply(input: ClassifierApplyInput): Promise<unknown>;
 }

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -5,7 +5,7 @@
  *
  * Template actions:
  * - create: Create new classifier (v1)
- * - list: List all classifiers (optionally filter by slug/status)
+ * - list: List all classifiers (optionally filter by entity_id/status)
  * - generate_embeddings: Generate embeddings for attribute values
  * - delete: Archive classifier (soft delete)
  *
@@ -17,11 +17,17 @@
  */
 
 import {
+  ApplyClassifierAction,
+  ClassifyContentAction,
+  CreateClassifierAction,
+  DeleteClassifierAction,
+  GenerateClassifierEmbeddingsAction,
+  ListClassifiersAction,
   ManageClassifiersSchema,
-  type ManageClassifiersArgs,
   ManageClassifiersResultSchema,
   type ManageClassifiersResult,
 } from '@lobu/core/contracts/tools/manage-classifiers';
+import type { Static } from '@sinclair/typebox';
 import type { DbClient } from '../../db/client';
 import { getDb, pgBigintArray } from '../../db/client';
 import type { Env } from '../../index';
@@ -33,8 +39,7 @@ import {
 } from '../../utils/embeddings';
 import logger from '../../utils/logger';
 import type { ToolContext } from '../registry';
-import { withValidatedArgs } from '../validate-args';
-import { defineFlatActionTool, flatAction } from './action-tool';
+import { action, defineActionTool } from './action-tool';
 
 export { ManageClassifiersResultSchema, ManageClassifiersSchema };
 
@@ -196,37 +201,31 @@ function stripEmbeddingsFromAttributeValues(
 // Main Function (Action Router)
 // ============================================
 
-export const manageClassifiers = withValidatedArgs(
-  'manage_classifiers',
-  ManageClassifiersSchema,
-  defineFlatActionTool<ManageClassifiersArgs, ManageClassifiersResult>('manage_classifiers', {
-    create: flatAction((args, ctx, env) => handleCreate(args, env, ctx)),
-    list: flatAction(handleList),
-    generate_embeddings: flatAction((args, ctx, env) => handleGenerateEmbeddings(args, env, ctx)),
-    delete: flatAction(handleDelete),
-    classify: flatAction(handleClassify),
-    apply: flatAction(handleApply),
-  })
-);
+// Variants in the contract's order, so the derived union matches the exposed
+// `ManageClassifiersSchema`. Each handler receives its own variant's args.
+const manageClassifiersTool = defineActionTool('manage_classifiers', {
+  create: action(CreateClassifierAction, (args, ctx, env) => handleCreate(args, env, ctx)),
+  list: action(ListClassifiersAction, handleList),
+  generate_embeddings: action(GenerateClassifierEmbeddingsAction, (args, ctx, env) =>
+    handleGenerateEmbeddings(args, env, ctx)
+  ),
+  delete: action(DeleteClassifierAction, handleDelete),
+  classify: action(ClassifyContentAction, handleClassify),
+  apply: action(ApplyClassifierAction, handleApply),
+});
+
+export const manageClassifiers = manageClassifiersTool.run;
 
 // ============================================
 // Template CRUD Handlers
 // ============================================
 
 async function handleCreate(
-  args: ManageClassifiersArgs,
+  args: Static<typeof CreateClassifierAction>,
   env: Env,
   ctx: ToolContext
 ): Promise<ManageClassifiersResult> {
   const sql = getDb();
-
-  if (!args.slug || !args.name || !args.attribute_key || !args.attribute_values) {
-    return {
-      success: false,
-      action: 'create',
-      message: 'Missing required fields: slug, name, attribute_key, attribute_values',
-    };
-  }
 
   const entityId = args.entity_id ?? null;
   // Optional on purpose. `automation_id` becomes `classify_facet.automation_id`, and
@@ -330,7 +329,7 @@ async function handleCreate(
 }
 
 async function handleList(
-  args: ManageClassifiersArgs,
+  args: Static<typeof ListClassifiersAction>,
   ctx: ToolContext
 ): Promise<ManageClassifiersResult> {
   const sql = getDb();
@@ -400,18 +399,11 @@ async function handleList(
 }
 
 async function handleGenerateEmbeddings(
-  args: ManageClassifiersArgs,
+  args: Static<typeof GenerateClassifierEmbeddingsAction>,
   env: Env,
   ctx: ToolContext
 ): Promise<ManageClassifiersResult> {
   const sql = getDb();
-  if (!args.classifier_id) {
-    return {
-      success: false,
-      action: 'generate_embeddings',
-      message: 'Missing required field: classifier_id',
-    };
-  }
 
   const facet = await sql`
     SELECT cf.attribute_values
@@ -457,13 +449,10 @@ async function handleGenerateEmbeddings(
 }
 
 async function handleDelete(
-  args: ManageClassifiersArgs,
+  args: Static<typeof DeleteClassifierAction>,
   ctx: ToolContext
 ): Promise<ManageClassifiersResult> {
   const sql = getDb();
-  if (!args.classifier_id) {
-    return { success: false, action: 'delete', message: 'Missing required field: classifier_id' };
-  }
 
   const result = await sql`
     UPDATE classify_facet
@@ -492,7 +481,7 @@ async function handleDelete(
 // ============================================
 
 async function handleClassify(
-  args: ManageClassifiersArgs,
+  args: Static<typeof ClassifyContentAction>,
   ctx: ToolContext
 ): Promise<ManageClassifiersResult> {
   const sql = getDb();
@@ -508,10 +497,6 @@ async function handleClassify(
         message:
           'Must provide either content_id (single mode) or classifications array (batch mode), not both',
       };
-    }
-
-    if (!args.classifier_slug) {
-      return { success: false, action: 'classify', message: 'classifier_slug is required' };
     }
 
     const classifierResult = (await sql`
@@ -653,17 +638,10 @@ const SKIP_REASON_TEXT: Record<SkipReason, string> = {
  * looking like a successful no-op.
  */
 async function runApply(
-  args: ManageClassifiersArgs,
+  args: Static<typeof ApplyClassifierAction>,
   ctx: ToolContext
 ): Promise<ManageClassifiersResult> {
   const sql = getDb();
-
-  if (!args.classifier_slug) {
-    return { success: false, action: 'apply', message: 'classifier_slug is required' };
-  }
-  if (!args.content_ids || args.content_ids.length === 0) {
-    return { success: false, action: 'apply', message: 'content_ids is required and must be non-empty' };
-  }
 
   // Dedupe so the counts below describe distinct events, not request repeats.
   const requestedIds = [...new Set(args.content_ids)];
@@ -800,14 +778,14 @@ async function runApply(
  * `routeAction`.
  */
 async function handleApply(
-  args: ManageClassifiersArgs,
+  args: Static<typeof ApplyClassifierAction>,
   ctx: ToolContext
 ): Promise<ManageClassifiersResult> {
   try {
     return await runApply(args, ctx);
   } catch (error) {
     logger.error(
-      { error, classifier_slug: args.classifier_slug, requested: args.content_ids?.length ?? 0 },
+      { error, classifier_slug: args.classifier_slug, requested: args.content_ids.length },
       'Failed to apply classifier over content ids'
     );
     return {


### PR DESCRIPTION
## Summary
- `manage_classifiers` moves from one flat object (an `action` enum, every field optional, and five missing-field cases answered by hand with a `success: false` result) to a `Type.Union` of six per-action variants in core, dispatched through `defineActionTool`. The schema now says what each action requires and accepts; the hand checks for `slug`/`name`/`attribute_key`/`attribute_values` (create), `classifier_id` (generate_embeddings, delete), `classifier_slug` (classify, apply) and `content_ids` (apply) are gone. The single-vs-batch mode rule in `classify` stays in the handler — a schema cannot say "exactly one of".
- **core owns the SDK input types.** Six `Classifier*Input` names are derived from the variants through `ActionInput<Args, Action>` (same idiom as #3359, #3361, #3362, #3363); the namespace's three hand-written interfaces and three inline object types are deleted. The hand copies had drifted: `ClassifierCreateInput.attribute_values` was optional although the handler has always refused a create without it, and the SDK metadata's `classifiers.create` signature said the same — both now match the contract.
- **Per-action access filtering applies for the first time:** a read-scope listing shows `list` only; the five write actions appear at admin. The flat tool exposed all six to every scope.

### What the flat contract could not express (red → green)
The new `manage-classifiers-contract.test.ts` cases, run against the **old** flat schema via a scratch copy of `origin/main`'s contract:
```
(fail) OLD flat contract > requires create fields, classifier_id, classifier_slug, content_ids
(fail) OLD flat contract > rejects slug on list and force_regenerate on delete
(pass) OLD flat contract > still rejects a key no action has (unchanged)
 1 pass / 2 fail
```
Same cases against the union: **5 pass / 0 fail**. (Third line: the flat validator already rejected keys no action declares, so "unknown key → 400" is not new here; required-ness at the schema and cross-action fields being errors are.)

### Prod payload census (60 days, `sdk_call_trace`; 0 of 192 reaction scripts call `client.classifiers.*`)
| SDK call | n | today | after |
|---|---|---|---|
| `classifiers.create` with `slug, name, attribute_key, attribute_values[, description, min_similarity, fallback_value]` | 5 | ok | ok |
| `classifiers.create` carrying `behavior_id` / `watcher_id` / `scope` | 6 | already 400 (unknown key) | 400, same |
| `classifiers.list` no args / `{}` | 4 | ok | ok |
| `classifiers.list` `{watcher_id}` / `{behavior_id}` | 2 | already 400 | 400, same |
| `classifiers.generateEmbeddings` `{classifier_id, force_regenerate}` | 1 | ok | ok |
| `classifiers.delete` `{classifier_id}` / bare number | 6 / 1 | ok / already 400 | ok / 400, same |
| `classifiers.classify` `{classifier_slug, content_id, value, source, reasoning}` | 4 | ok | ok |
| `classifiers.classify` with `classifier_id` instead of `classifier_slug`; with `content_ids` | 2 / 1 | already 400 (unknown key) | 400, same |
| `classifiers.apply` `{classifier_slug, content_ids}` | 3 | ok | ok |
| `classifiers.apply` with `classifier_id` | 1 | already 400 | 400, same |

No call that succeeds today fails after this change.

**Failure class changes on the wire.** A call that reaches the tool with a required field missing used to get a 200 carrying `{ success: false, message: 'Missing required field: …' }`; it now gets a 400 naming the field at validation, before the handler runs. Cross-action fields (`slug` on `list`, `force_regenerate` on `delete`, …) used to be silently accepted; they now 400. Proven above against the old contract; the census shows no live call in either class.

## Test plan
- [x] Staged by explicit path; `git diff --name-only origin/main...HEAD` equals the intended 7 files. `make pre-pr` clean.
- [x] `make review-fix` found one real red: `integration/mcp/tool-invocation-audit.test.ts` ("records resolved tool failures as failed") relied on the handler's `success: false` for a `delete` with no `classifier_id`; that is now a validation 400, so the case passes a nonexistent id and measures a handler-resolved failure as intended. It also tightened three stale doc claims (tool header `list` filters, `classifiers.create` summary, namespace header).
- [x] `bun test …/manage-classifiers-contract.test.ts` + `unit/sandbox/` → **159 pass / 0 fail**; red proof above. Existing Vitest `unit/manage-classifiers-validation.test.ts` (the `attribute_values` shape guards) → **6 pass**.
- [x] Vitest `integration/classifiers/` — all 17 files (CRUD, tenancy, isolation, read scope, embedding-model stamping, apply skip reasons, agent reachability, automation-created classifiers) → **52 pass / 0 fail**.
- [x] Client regenerated from the running server after rebasing onto main: a second `bun run generate` against the booted worktree produced **no diff**, so `types.gen.ts` is byte-identical to what the live `openapi.json` emits; `ManageClassifiersData.body` is now the discriminated union.
- [ ] No bot runtime change.

## Notes
**Wire behaviour for MCP clients** is otherwise unchanged in shape: the union flattens to one object with the per-action `Required:` lines generated from the variants (pinned by the test); the `[create]` / `[classify]` / `[apply]` prefixes stay because a flattened property cannot say which actions accept it.

**Reviewer disclosure:** codex is at its usage limit until 2026-09-07, so `make review-fix` / `make review` ran as `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus` — same-model self-review, not the intended cross-harness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated classifier management actions with action-specific inputs and required fields.
  - Invalid or misplaced arguments are now rejected earlier with clearer validation messages.
  - Classifier operations consistently use the appropriate identifier format for each action.
  - Classifier creation documentation now includes required attributes and optional embedding details.

- **Bug Fixes**
  - Improved handling of invalid classifier-management requests so failures are reported consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->