### PR TITLE
refactor(core,server): manage_entity as a union of per-action variants

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -852,191 +852,486 @@ export type RunSdkResponses = {
 export type RunSdkResponse = RunSdkResponses[keyof RunSdkResponses];
 
 export type ManageEntityData = {
-  body: {
-    /**
-     * Action to perform
-     */
-    action:
-      | "create"
-      | "update"
-      | "list"
-      | "get"
-      | "delete"
-      | "link"
-      | "unlink"
-      | "update_link"
-      | "list_links"
-      | "merge"
-      | "resolve_duplicates"
-      | "unmerge";
-    /**
-     * [merge] The surviving entity that absorbs `entity_id` (the duplicate).
-     */
-    winner_entity_id?: number;
-    /**
-     * [merge] All duplicate entities to fold into winner_entity_id. Use this for a duplicate group; entity_id remains supported for a single duplicate.
-     */
-    duplicate_entity_ids?: Array<number>;
-    /**
-     * [resolve_duplicates] Candidate entity IDs. The server re-reads their values and applies the entity type's resolution policy.
-     */
-    candidate_entity_ids?: Array<number>;
-    /**
-     * [merge] Optional structured evidence for human-initiated merge provenance. Agent and Automation evidence is always recomputed from the entity type's resolution policy.
-     */
-    merge_evidence?: Array<{
-      kind: string;
-      identifier: string;
-      identity_ids?: Array<number>;
-    }>;
-    /**
-     * [merge] Why you believe these are the same thing, in one sentence, for the human reviewing the approval card (e.g. 'Same phone digits; the shell is a WhatsApp handle for this contact.'). Shown as your claim, clearly separated from the workspace's own policy verdict — it never counts as proof and never affects whether the merge auto-applies.
-     */
-    merge_rationale?: string;
-    /**
-     * Entity type as defined in your workspace
-     */
-    entity_type?: string;
-    /**
-     * [get/update/delete/list_links/merge/unmerge] Entity ID to operate on
-     */
-    entity_id?: number;
-    /**
-     * [create/update] Entity name
-     */
-    name?: string;
-    /**
-     * [create/update] Free-text content body. Used by memory entities and any entity that carries rich text.
-     */
-    content?: string;
-    /**
-     * [create/update] URL-friendly slug (auto-generated from name if not provided)
-     */
-    slug?: string;
-    /**
-     * [create/update] Parent entity ID (for hierarchical entities)
-     */
-    parent_id?: number;
-    /**
-     * [create/update] Enabled classifier slugs
-     */
-    enabled_classifiers?: Array<string>;
-    /**
-     * [create/update] Primary domain (e.g., spotify.com)
-     */
-    domain?: string;
-    /**
-     * [create/update/list] Industry category
-     */
-    category?: string;
-    /**
-     * [create/update] Platform type (b2b, b2c, b2b2c)
-     */
-    platform_type?: string;
-    /**
-     * [create/update/list] Primary market (ISO 3166-1 alpha-2)
-     */
-    main_market?: string;
-    /**
-     * [create/update/list] Market/region (ISO 3166-1 alpha-2)
-     */
-    market?: string;
-    /**
-     * [create/update] Entity URL
-     */
-    link?: string;
-    /**
-     * [create/update/link/update_link] Custom metadata object. For entities: validated against the entity type's JSON schema. For links: relationship metadata. On update, fields a human owns are NOT overwritten — they are queued for the human's approval and reported in the result's `blocked_fields`/`approval_queued`; tell the user you PROPOSED those changes rather than claiming you set them. Unowned fields in the same call apply directly (`applied_fields`).
-     */
-    metadata?: {
-      [key: string]: unknown;
-    };
-    /**
-     * [update] Optional note explaining a human correction. Stored on the per-field ownership marker for every metadata field this update sets, so an Automation (and the UI) can see why the value was set.
-     */
-    field_note?: string;
-    /**
-     * [update] Metadata field names whose CURRENT value the human approves as-is. No value change, but each is marked human-owned so an Automation can't later overwrite it without an approval. The 'approve' half of the recap feedback loop.
-     */
-    affirm_fields?: Array<string>;
-    /**
-     * [list] Search by name
-     */
-    search?: string;
-    /**
-     * Page size (default: 100, max: 500)
-     */
-    limit?: number;
-    /**
-     * Pagination offset (default: 0, max: 1000000)
-     */
-    offset?: number;
-    /**
-     * [list] Sort by column (name, created_at, domain, total_content, active_connections, automations_count, children_count)
-     */
-    sort_by?: string;
-    /**
-     * [list] Sort order (asc or desc)
-     */
-    sort_order?: "asc" | "desc";
-    /**
-     * [delete] Hard delete entity and all descendants. Event history is never deleted (append-only) — event rows referencing the tree are detached instead.
-     */
-    force_delete_tree?: boolean;
-    /**
-     * [delete, merge] Preflight only. For delete: report what it would remove/detach. For merge: report whether the type's write rules would refuse it. Mutates nothing and never queues an approval.
-     */
-    dry_run?: boolean;
-    /**
-     * [link/unlink/update_link] Source entity ID. For unlink/update_link, supply this triple instead of relationship_id to address the edge by its endpoints.
-     */
-    from_entity_id?: number;
-    /**
-     * [link/unlink/update_link] Target entity ID
-     */
-    to_entity_id?: number;
-    /**
-     * [link/unlink/update_link/list_links] Relationship type slug
-     */
-    relationship_type_slug?: string;
-    /**
-     * [link/update_link] Confidence score 0-1. Defaults to 1.0 for ui/api source.
-     */
-    confidence?: number;
-    /**
-     * [link/update_link] Source of the relationship
-     */
-    source?: "ui" | "llm" | "feed" | "api";
-    /**
-     * [update_link/unlink] Relationship ID. Optional when from_entity_id + to_entity_id + relationship_type_slug identify the edge.
-     */
-    relationship_id?: number;
-    /**
-     * [list_links] Direction filter. Default both.
-     */
-    direction?: "outbound" | "inbound" | "both";
-    /**
-     * [list_links] Minimum confidence threshold
-     */
-    confidence_min?: number;
-    /**
-     * [get] Return the entity even if it is soft-deleted (deleted_at set). [list_links] Include soft-deleted relationships.
-     */
-    include_deleted?: boolean;
-    /**
-     * Attribution source when mutation is triggered by an Automation reaction
-     */
-    automation_source?: {
-      /**
-       * Automation that triggered this mutation
-       */
-      automation_id: number;
-      /**
-       * Automation run that triggered this mutation
-       */
-      run_id: number;
-    };
-  };
+  body:
+    | {
+        /**
+         * Create an entity of a given type.
+         */
+        action: "create";
+        /**
+         * Entity type as defined in your workspace
+         */
+        entity_type: string;
+        /**
+         * [create/update] Entity name
+         */
+        name: string;
+        /**
+         * [create/update] Free-text content body. Used by memory entities and any entity that carries rich text.
+         */
+        content?: string;
+        /**
+         * [create/update] URL-friendly slug (auto-generated from name if not provided)
+         */
+        slug?: string;
+        /**
+         * [create/update/list] Parent entity ID (for hierarchical entities). On list, only that parent's children.
+         */
+        parent_id?: number;
+        /**
+         * [create/update] Enabled classifier slugs
+         */
+        enabled_classifiers?: Array<string>;
+        /**
+         * [create/update] Primary domain (e.g., spotify.com)
+         */
+        domain?: string;
+        /**
+         * [create/update/list] Industry category
+         */
+        category?: string;
+        /**
+         * [create/update] Platform type (b2b, b2c, b2b2c)
+         */
+        platform_type?: string;
+        /**
+         * [create/update/list] Primary market (ISO 3166-1 alpha-2)
+         */
+        main_market?: string;
+        /**
+         * [create/update/list] Market/region (ISO 3166-1 alpha-2)
+         */
+        market?: string;
+        /**
+         * [create/update] Entity URL
+         */
+        link?: string;
+        /**
+         * [create/update/link/update_link] Custom metadata object. For entities: validated against the entity type's JSON schema. For links: relationship metadata. On update, fields a human owns are NOT overwritten — they are queued for the human's approval and reported in the result's `blocked_fields`/`approval_queued`; tell the user you PROPOSED those changes rather than claiming you set them. Unowned fields in the same call apply directly (`applied_fields`).
+         */
+        metadata?: {
+          [key: string]: unknown;
+        };
+        /**
+         * Attribution source when mutation is triggered by an Automation reaction
+         */
+        automation_source?: {
+          /**
+           * Automation that triggered this mutation
+           */
+          automation_id: number;
+          /**
+           * Automation run that triggered this mutation
+           */
+          run_id: number;
+        };
+      }
+    | {
+        /**
+         * Patch entity fields (human-owned fields queued for approval).
+         */
+        action: "update";
+        /**
+         * [get/update/delete/list_links/merge/unmerge] Entity ID to operate on
+         */
+        entity_id: number;
+        /**
+         * [create/update] Entity name
+         */
+        name?: string;
+        /**
+         * [create/update] Free-text content body. Used by memory entities and any entity that carries rich text.
+         */
+        content?: string;
+        /**
+         * [create/update] URL-friendly slug (auto-generated from name if not provided)
+         */
+        slug?: string;
+        /**
+         * [create/update/list] Parent entity ID (for hierarchical entities). On list, only that parent's children.
+         */
+        parent_id?: number;
+        /**
+         * [create/update] Enabled classifier slugs
+         */
+        enabled_classifiers?: Array<string>;
+        /**
+         * [create/update] Primary domain (e.g., spotify.com)
+         */
+        domain?: string;
+        /**
+         * [create/update/list] Industry category
+         */
+        category?: string;
+        /**
+         * [create/update] Platform type (b2b, b2c, b2b2c)
+         */
+        platform_type?: string;
+        /**
+         * [create/update/list] Primary market (ISO 3166-1 alpha-2)
+         */
+        main_market?: string;
+        /**
+         * [create/update/list] Market/region (ISO 3166-1 alpha-2)
+         */
+        market?: string;
+        /**
+         * [create/update] Entity URL
+         */
+        link?: string;
+        /**
+         * [create/update/link/update_link] Custom metadata object. For entities: validated against the entity type's JSON schema. For links: relationship metadata. On update, fields a human owns are NOT overwritten — they are queued for the human's approval and reported in the result's `blocked_fields`/`approval_queued`; tell the user you PROPOSED those changes rather than claiming you set them. Unowned fields in the same call apply directly (`applied_fields`).
+         */
+        metadata?: {
+          [key: string]: unknown;
+        };
+        /**
+         * [update] Optional note explaining a human correction. Stored on the per-field ownership marker for every metadata field this update sets, so an Automation (and the UI) can see why the value was set.
+         */
+        field_note?: string;
+        /**
+         * [update] Metadata field names whose CURRENT value the human approves as-is. No value change, but each is marked human-owned so an Automation can't later overwrite it without an approval. The 'approve' half of the recap feedback loop.
+         */
+        affirm_fields?: Array<string>;
+        /**
+         * Attribution source when mutation is triggered by an Automation reaction
+         */
+        automation_source?: {
+          /**
+           * Automation that triggered this mutation
+           */
+          automation_id: number;
+          /**
+           * Automation run that triggered this mutation
+           */
+          run_id: number;
+        };
+      }
+    | {
+        /**
+         * Paginated entity list with filters.
+         */
+        action: "list";
+        /**
+         * Entity type as defined in your workspace
+         */
+        entity_type?: string;
+        /**
+         * [create/update/list] Parent entity ID (for hierarchical entities). On list, only that parent's children.
+         */
+        parent_id?: number;
+        /**
+         * [list] Search by name
+         */
+        search?: string;
+        /**
+         * [create/update/list] Industry category
+         */
+        category?: string;
+        /**
+         * [create/update/list] Primary market (ISO 3166-1 alpha-2)
+         */
+        main_market?: string;
+        /**
+         * [create/update/list] Market/region (ISO 3166-1 alpha-2)
+         */
+        market?: string;
+        /**
+         * Page size (default: 100, max: 500)
+         */
+        limit?: number;
+        /**
+         * Pagination offset (default: 0, max: 1000000)
+         */
+        offset?: number;
+        /**
+         * [list] Sort by column (name, created_at, domain, total_content, active_connections, automations_count, children_count)
+         */
+        sort_by?: string;
+        /**
+         * [list] Sort order (asc or desc)
+         */
+        sort_order?: "asc" | "desc";
+        /**
+         * Attribution source when mutation is triggered by an Automation reaction
+         */
+        automation_source?: {
+          /**
+           * Automation that triggered this mutation
+           */
+          automation_id: number;
+          /**
+           * Automation run that triggered this mutation
+           */
+          run_id: number;
+        };
+      }
+    | {
+        /**
+         * Fetch one entity.
+         */
+        action: "get";
+        /**
+         * [get/update/delete/list_links/merge/unmerge] Entity ID to operate on
+         */
+        entity_id: number;
+        /**
+         * [get] Return the entity even if it is soft-deleted (deleted_at set). [list_links] Include soft-deleted relationships.
+         */
+        include_deleted?: boolean;
+      }
+    | {
+        /**
+         * Delete an entity (force_delete_tree for cascading).
+         */
+        action: "delete";
+        /**
+         * [get/update/delete/list_links/merge/unmerge] Entity ID to operate on
+         */
+        entity_id: number;
+        /**
+         * [delete] Hard delete entity and all descendants. Event history is never deleted (append-only) — event rows referencing the tree are detached instead.
+         */
+        force_delete_tree?: boolean;
+        /**
+         * [delete, merge] Preflight only. For delete: report what it would remove/detach. For merge: report whether the type's write rules would refuse it. Mutates nothing and never queues an approval.
+         */
+        dry_run?: boolean;
+        /**
+         * Attribution source when mutation is triggered by an Automation reaction
+         */
+        automation_source?: {
+          /**
+           * Automation that triggered this mutation
+           */
+          automation_id: number;
+          /**
+           * Automation run that triggered this mutation
+           */
+          run_id: number;
+        };
+      }
+    | {
+        /**
+         * Create a relationship edge between two entities.
+         */
+        action: "link";
+        /**
+         * [link/unlink/update_link] Source entity ID. For unlink/update_link, supply this triple instead of relationship_id to address the edge by its endpoints.
+         */
+        from_entity_id: number;
+        /**
+         * [link/unlink/update_link] Target entity ID
+         */
+        to_entity_id: number;
+        /**
+         * [link/unlink/update_link/list_links] Relationship type slug
+         */
+        relationship_type_slug: string;
+        /**
+         * [link/update_link] Confidence score 0-1. Defaults to 1.0 for ui/api source.
+         */
+        confidence?: number;
+        /**
+         * [link/update_link] Source of the relationship. [list_links] Only relationships from this source.
+         */
+        source?: "ui" | "llm" | "feed" | "api";
+        /**
+         * [create/update/link/update_link] Custom metadata object. For entities: validated against the entity type's JSON schema. For links: relationship metadata. On update, fields a human owns are NOT overwritten — they are queued for the human's approval and reported in the result's `blocked_fields`/`approval_queued`; tell the user you PROPOSED those changes rather than claiming you set them. Unowned fields in the same call apply directly (`applied_fields`).
+         */
+        metadata?: {
+          [key: string]: unknown;
+        };
+        /**
+         * Attribution source when mutation is triggered by an Automation reaction
+         */
+        automation_source?: {
+          /**
+           * Automation that triggered this mutation
+           */
+          automation_id: number;
+          /**
+           * Automation run that triggered this mutation
+           */
+          run_id: number;
+        };
+      }
+    | {
+        /**
+         * Soft-delete a relationship.
+         */
+        action: "unlink";
+        /**
+         * [update_link/unlink] Relationship ID. Optional when from_entity_id + to_entity_id + relationship_type_slug identify the edge.
+         */
+        relationship_id?: number;
+        /**
+         * [link/unlink/update_link] Source entity ID. For unlink/update_link, supply this triple instead of relationship_id to address the edge by its endpoints.
+         */
+        from_entity_id?: number;
+        /**
+         * [link/unlink/update_link] Target entity ID
+         */
+        to_entity_id?: number;
+        /**
+         * [link/unlink/update_link/list_links] Relationship type slug
+         */
+        relationship_type_slug?: string;
+      }
+    | {
+        /**
+         * Patch relationship metadata/confidence/source.
+         */
+        action: "update_link";
+        /**
+         * [update_link/unlink] Relationship ID. Optional when from_entity_id + to_entity_id + relationship_type_slug identify the edge.
+         */
+        relationship_id?: number;
+        /**
+         * [link/unlink/update_link] Source entity ID. For unlink/update_link, supply this triple instead of relationship_id to address the edge by its endpoints.
+         */
+        from_entity_id?: number;
+        /**
+         * [link/unlink/update_link] Target entity ID
+         */
+        to_entity_id?: number;
+        /**
+         * [link/unlink/update_link/list_links] Relationship type slug
+         */
+        relationship_type_slug?: string;
+        /**
+         * [link/update_link] Confidence score 0-1. Defaults to 1.0 for ui/api source.
+         */
+        confidence?: number;
+        /**
+         * [link/update_link] Source of the relationship. [list_links] Only relationships from this source.
+         */
+        source?: "ui" | "llm" | "feed" | "api";
+        /**
+         * [create/update/link/update_link] Custom metadata object. For entities: validated against the entity type's JSON schema. For links: relationship metadata. On update, fields a human owns are NOT overwritten — they are queued for the human's approval and reported in the result's `blocked_fields`/`approval_queued`; tell the user you PROPOSED those changes rather than claiming you set them. Unowned fields in the same call apply directly (`applied_fields`).
+         */
+        metadata?: {
+          [key: string]: unknown;
+        };
+      }
+    | {
+        /**
+         * List relationships for an entity with filters + counts.
+         */
+        action: "list_links";
+        /**
+         * [get/update/delete/list_links/merge/unmerge] Entity ID to operate on
+         */
+        entity_id: number;
+        /**
+         * [list_links] Direction filter. Default both.
+         */
+        direction?: "outbound" | "inbound" | "both";
+        /**
+         * [link/unlink/update_link/list_links] Relationship type slug
+         */
+        relationship_type_slug?: string;
+        /**
+         * [list_links] Minimum confidence threshold
+         */
+        confidence_min?: number;
+        /**
+         * [link/update_link] Source of the relationship. [list_links] Only relationships from this source.
+         */
+        source?: "ui" | "llm" | "feed" | "api";
+        /**
+         * [get] Return the entity even if it is soft-deleted (deleted_at set). [list_links] Include soft-deleted relationships.
+         */
+        include_deleted?: boolean;
+        /**
+         * Page size (default: 100, max: 500)
+         */
+        limit?: number;
+        /**
+         * Pagination offset (default: 0, max: 1000000)
+         */
+        offset?: number;
+        /**
+         * Attribution source when mutation is triggered by an Automation reaction
+         */
+        automation_source?: {
+          /**
+           * Automation that triggered this mutation
+           */
+          automation_id: number;
+          /**
+           * Automation run that triggered this mutation
+           */
+          run_id: number;
+        };
+      }
+    | {
+        /**
+         * Fold a duplicate entity (entity_id) into the one it really is (winner_entity_id). The loser is tombstoned + forwarded; its identities, aliases, edges, and events recall against the winner. Events are never rewritten. Use when two entities are confirmed the same real-world thing.
+         */
+        action: "merge";
+        /**
+         * [merge] The surviving entity that absorbs `entity_id` (the duplicate).
+         */
+        winner_entity_id: number;
+        /**
+         * [get/update/delete/list_links/merge/unmerge] Entity ID to operate on
+         */
+        entity_id?: number;
+        /**
+         * [merge] All duplicate entities to fold into winner_entity_id. Use this for a duplicate group; entity_id remains supported for a single duplicate.
+         */
+        duplicate_entity_ids?: Array<number>;
+        /**
+         * [merge] Optional structured evidence for human-initiated merge provenance. Agent and Automation evidence is always recomputed from the entity type's resolution policy.
+         */
+        merge_evidence?: Array<{
+          kind: string;
+          identifier: string;
+          identity_ids?: Array<number>;
+        }>;
+        /**
+         * [merge] Why you believe these are the same thing, in one sentence, for the human reviewing the approval card (e.g. 'Same phone digits; the shell is a WhatsApp handle for this contact.'). Shown as your claim, clearly separated from the workspace's own policy verdict — it never counts as proof and never affects whether the merge auto-applies.
+         */
+        merge_rationale?: string;
+        /**
+         * [delete, merge] Preflight only. For delete: report what it would remove/detach. For merge: report whether the type's write rules would refuse it. Mutates nothing and never queues an approval.
+         */
+        dry_run?: boolean;
+        /**
+         * Attribution source when mutation is triggered by an Automation reaction
+         */
+        automation_source?: {
+          /**
+           * Automation that triggered this mutation
+           */
+          automation_id: number;
+          /**
+           * Automation run that triggered this mutation
+           */
+          run_id: number;
+        };
+      }
+    | {
+        /**
+         * Discover duplicate components among candidate_entity_ids using the entity type's x-lobu-resolution policy, then auto-merge deterministic matches or queue review.
+         */
+        action: "resolve_duplicates";
+        /**
+         * [resolve_duplicates] Candidate entity IDs. The server re-reads their values and applies the entity type's resolution policy.
+         */
+        candidate_entity_ids: Array<number>;
+      }
+    | {
+        /**
+         * Reverse a merge from its durable ledger: restore the loser's identities, canonical attributes, and relationships, then un-tombstone it. Fails closed if later edits made exact reversal unsafe.
+         */
+        action: "unmerge";
+        /**
+         * [get/update/delete/list_links/merge/unmerge] Entity ID to operate on
+         */
+        entity_id: number;
+      };
   path: {
     /**
      * Organization slug (workspace identifier)

--- a/packages/core/src/contracts/tools/manage-entity.ts
+++ b/packages/core/src/contracts/tools/manage-entity.ts
@@ -1,5 +1,6 @@
 import { type Static, Type } from "@sinclair/typebox";
 import { ApprovalAttributionSchema } from "../interaction-envelope";
+import type { ActionInput } from "./action-input";
 import { paginationFields } from "./pagination";
 
 function SortOrderField(description: string) {
@@ -9,60 +10,310 @@ function SortOrderField(description: string) {
 }
 
 // ============================================
-// Typebox Schema
+// Typebox Schema (union of per-action variants)
 // ============================================
+//
+// The wire schema flattens this union into ONE MCP object and merges duplicate
+// properties first-occurrence-wins, so a property carried by more than one
+// variant must read true for every one of them.
 
-export const ManageEntitySchema = Type.Object({
-  action: Type.Union(
-    [
-      Type.Literal("create", {
-        description: "Create an entity of a given type.",
-      }),
-      Type.Literal("update", {
-        description:
-          "Patch entity fields (human-owned fields queued for approval).",
-      }),
-      Type.Literal("list", {
-        description: "Paginated entity list with filters.",
-      }),
-      Type.Literal("get", { description: "Fetch one entity." }),
-      Type.Literal("delete", {
-        description: "Delete an entity (force_delete_tree for cascading).",
-      }),
-      Type.Literal("link", {
-        description: "Create a relationship edge between two entities.",
-      }),
-      Type.Literal("unlink", { description: "Soft-delete a relationship." }),
-      Type.Literal("update_link", {
-        description: "Patch relationship metadata/confidence/source.",
-      }),
-      Type.Literal("list_links", {
-        description: "List relationships for an entity with filters + counts.",
-      }),
-      Type.Literal("merge", {
-        description:
-          "Fold a duplicate entity (entity_id) into the one it really is (winner_entity_id). The loser is tombstoned + forwarded; its identities, aliases, edges, and events recall against the winner. Events are never rewritten. Use when two entities are confirmed the same real-world thing.",
-      }),
-      Type.Literal("resolve_duplicates", {
-        description:
-          "Discover duplicate components among candidate_entity_ids using the entity type's x-lobu-resolution policy, then auto-merge deterministic matches or queue review.",
-      }),
-      Type.Literal("unmerge", {
-        description:
-          "Reverse a merge from its durable ledger: restore the loser's identities, canonical attributes, and relationships, then un-tombstone it. Fails closed if later edits made exact reversal unsafe.",
-      }),
-    ],
-    { description: "Action to perform" }
-  ),
+const EntityType = Type.String({
+  description: "Entity type as defined in your workspace",
+});
 
-  // Merge target (the survivor) — the loser is passed as `entity_id`.
-  winner_entity_id: Type.Optional(
-    Type.Number({
+const EntityId = Type.Number({
+  description:
+    "[get/update/delete/list_links/merge/unmerge] Entity ID to operate on",
+});
+
+// Attributes an entity carries. `create` and `update` share the set; `list`
+// filters on `parent_id`, `category`, `main_market` and `market`.
+const EntityFields = {
+  name: Type.String({
+    description: "[create/update] Entity name",
+    minLength: 1,
+  }),
+  content: Type.String({
+    description:
+      "[create/update] Free-text content body. Used by memory entities and any entity that carries rich text.",
+  }),
+  slug: Type.String({
+    description:
+      "[create/update] URL-friendly slug (auto-generated from name if not provided)",
+    pattern: "^[a-z0-9]+(-[a-z0-9]+)*$",
+  }),
+  parent_id: Type.Number({
+    description:
+      "[create/update/list] Parent entity ID (for hierarchical entities). On list, only that parent's children.",
+  }),
+  enabled_classifiers: Type.Array(Type.String(), {
+    description: "[create/update] Enabled classifier slugs",
+  }),
+  domain: Type.String({
+    description: "[create/update] Primary domain (e.g., spotify.com)",
+  }),
+  category: Type.String({
+    description: "[create/update/list] Industry category",
+  }),
+  platform_type: Type.String({
+    description: "[create/update] Platform type (b2b, b2c, b2b2c)",
+  }),
+  main_market: Type.String({
+    description: "[create/update/list] Primary market (ISO 3166-1 alpha-2)",
+  }),
+  market: Type.String({
+    description: "[create/update/list] Market/region (ISO 3166-1 alpha-2)",
+  }),
+  link: Type.String({ description: "[create/update] Entity URL" }),
+};
+
+// Custom metadata (validated against entity type's JSON schema)
+const Metadata = Type.Record(Type.String(), Type.Unknown(), {
+  description:
+    "[create/update/link/update_link] Custom metadata object. For entities: validated against the entity type's JSON schema. For links: relationship metadata. On update, fields a human owns are NOT overwritten — they are queued for the human's approval and reported in the result's `blocked_fields`/`approval_queued`; tell the user you PROPOSED those changes rather than claiming you set them. Unowned fields in the same call apply directly (`applied_fields`).",
+});
+
+// Carried by exactly the variants whose handler reads it: the principal seam
+// (`create`, `update`, `list`, `delete`, `merge`), the read gate that consults
+// it (`list_links`), and reaction tracking (`link`). `get` resolves its read
+// gate without one, and `unlink`/`update_link`/`resolve_duplicates`/`unmerge`
+// never consult it — declaring it there would advertise an inert field.
+const AutomationSource = Type.Object(
+  {
+    automation_id: Type.Number({
+      description: "Automation that triggered this mutation",
+    }),
+    run_id: Type.Number({
+      description: "Automation run that triggered this mutation",
+    }),
+  },
+  {
+    description:
+      "Attribution source when mutation is triggered by an Automation reaction",
+  }
+);
+
+const DryRun = Type.Boolean({
+  description:
+    "[delete, merge] Preflight only. For delete: report what it would remove/detach. For merge: report whether the type's write rules would refuse it. Mutates nothing and never queues an approval.",
+});
+
+const IncludeDeleted = Type.Boolean({
+  description:
+    "[get] Return the entity even if it is soft-deleted (deleted_at set). [list_links] Include soft-deleted relationships.",
+});
+
+// ---- Relationship (link) fields ----
+// `link` needs the endpoint triple; `unlink`/`update_link` address an edge by
+// `relationship_id` OR by the triple (the handler resolves whichever is given).
+const EdgeEndpoints = {
+  from_entity_id: Type.Number({
+    description:
+      "[link/unlink/update_link] Source entity ID. For unlink/update_link, supply this triple instead of relationship_id to address the edge by its endpoints.",
+  }),
+  to_entity_id: Type.Number({
+    description: "[link/unlink/update_link] Target entity ID",
+  }),
+  relationship_type_slug: Type.String({
+    description: "[link/unlink/update_link/list_links] Relationship type slug",
+    minLength: 1,
+  }),
+};
+
+const RelationshipId = Type.Number({
+  description:
+    "[update_link/unlink] Relationship ID. Optional when from_entity_id + to_entity_id + relationship_type_slug identify the edge.",
+});
+
+const Confidence = Type.Number({
+  description:
+    "[link/update_link] Confidence score 0-1. Defaults to 1.0 for ui/api source.",
+  minimum: 0,
+  maximum: 1,
+});
+
+const RelationshipSource = Type.Union(
+  [
+    Type.Literal("ui"),
+    Type.Literal("llm"),
+    Type.Literal("feed"),
+    Type.Literal("api"),
+  ],
+  {
+    description:
+      "[link/update_link] Source of the relationship. [list_links] Only relationships from this source.",
+  }
+);
+
+export const CreateEntityAction = Type.Object({
+  action: Type.Literal("create", {
+    description: "Create an entity of a given type.",
+  }),
+  entity_type: EntityType,
+  name: EntityFields.name,
+  content: Type.Optional(EntityFields.content),
+  slug: Type.Optional(EntityFields.slug),
+  parent_id: Type.Optional(EntityFields.parent_id),
+  enabled_classifiers: Type.Optional(EntityFields.enabled_classifiers),
+  domain: Type.Optional(EntityFields.domain),
+  category: Type.Optional(EntityFields.category),
+  platform_type: Type.Optional(EntityFields.platform_type),
+  main_market: Type.Optional(EntityFields.main_market),
+  market: Type.Optional(EntityFields.market),
+  link: Type.Optional(EntityFields.link),
+  metadata: Type.Optional(Metadata),
+  automation_source: Type.Optional(AutomationSource),
+});
+
+export const UpdateEntityAction = Type.Object({
+  action: Type.Literal("update", {
+    description:
+      "Patch entity fields (human-owned fields queued for approval).",
+  }),
+  entity_id: EntityId,
+  name: Type.Optional(EntityFields.name),
+  content: Type.Optional(EntityFields.content),
+  slug: Type.Optional(EntityFields.slug),
+  parent_id: Type.Optional(EntityFields.parent_id),
+  enabled_classifiers: Type.Optional(EntityFields.enabled_classifiers),
+  domain: Type.Optional(EntityFields.domain),
+  category: Type.Optional(EntityFields.category),
+  platform_type: Type.Optional(EntityFields.platform_type),
+  main_market: Type.Optional(EntityFields.main_market),
+  market: Type.Optional(EntityFields.market),
+  link: Type.Optional(EntityFields.link),
+  metadata: Type.Optional(Metadata),
+  // Human-correction annotation
+  field_note: Type.Optional(
+    Type.String({
       description:
-        "[merge] The surviving entity that absorbs `entity_id` (the duplicate).",
+        "[update] Optional note explaining a human correction. Stored on the per-field ownership marker for every metadata field this update sets, so an Automation (and the UI) can see why the value was set.",
     })
   ),
+  // Approve/affirm: claim ownership of a field's current value without changing it
+  affirm_fields: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        "[update] Metadata field names whose CURRENT value the human approves as-is. No value change, but each is marked human-owned so an Automation can't later overwrite it without an approval. The 'approve' half of the recap feedback loop.",
+    })
+  ),
+  automation_source: Type.Optional(AutomationSource),
+});
 
+export const ListEntitiesAction = Type.Object({
+  action: Type.Literal("list", {
+    description: "Paginated entity list with filters.",
+  }),
+  entity_type: Type.Optional(EntityType),
+  parent_id: Type.Optional(EntityFields.parent_id),
+  search: Type.Optional(Type.String({ description: "[list] Search by name" })),
+  category: Type.Optional(EntityFields.category),
+  main_market: Type.Optional(EntityFields.main_market),
+  market: Type.Optional(EntityFields.market),
+  ...paginationFields(100),
+  sort_by: Type.Optional(
+    Type.String({
+      description:
+        "[list] Sort by column (name, created_at, domain, total_content, active_connections, automations_count, children_count)",
+    })
+  ),
+  sort_order: SortOrderField("[list] Sort order (asc or desc)"),
+  automation_source: Type.Optional(AutomationSource),
+});
+
+export const GetEntityAction = Type.Object({
+  action: Type.Literal("get", { description: "Fetch one entity." }),
+  entity_id: EntityId,
+  include_deleted: Type.Optional(IncludeDeleted),
+});
+
+export const DeleteEntityAction = Type.Object({
+  action: Type.Literal("delete", {
+    description: "Delete an entity (force_delete_tree for cascading).",
+  }),
+  entity_id: EntityId,
+  force_delete_tree: Type.Optional(
+    Type.Boolean({
+      description:
+        "[delete] Hard delete entity and all descendants. Event history is never deleted (append-only) — event rows referencing the tree are detached instead.",
+    })
+  ),
+  dry_run: Type.Optional(DryRun),
+  automation_source: Type.Optional(AutomationSource),
+});
+
+export const LinkEntitiesAction = Type.Object({
+  action: Type.Literal("link", {
+    description: "Create a relationship edge between two entities.",
+  }),
+  from_entity_id: EdgeEndpoints.from_entity_id,
+  to_entity_id: EdgeEndpoints.to_entity_id,
+  relationship_type_slug: EdgeEndpoints.relationship_type_slug,
+  confidence: Type.Optional(Confidence),
+  source: Type.Optional(RelationshipSource),
+  metadata: Type.Optional(Metadata),
+  automation_source: Type.Optional(AutomationSource),
+});
+
+export const UnlinkEntitiesAction = Type.Object({
+  action: Type.Literal("unlink", {
+    description: "Soft-delete a relationship.",
+  }),
+  relationship_id: Type.Optional(RelationshipId),
+  from_entity_id: Type.Optional(EdgeEndpoints.from_entity_id),
+  to_entity_id: Type.Optional(EdgeEndpoints.to_entity_id),
+  relationship_type_slug: Type.Optional(EdgeEndpoints.relationship_type_slug),
+});
+
+export const UpdateLinkAction = Type.Object({
+  action: Type.Literal("update_link", {
+    description: "Patch relationship metadata/confidence/source.",
+  }),
+  relationship_id: Type.Optional(RelationshipId),
+  from_entity_id: Type.Optional(EdgeEndpoints.from_entity_id),
+  to_entity_id: Type.Optional(EdgeEndpoints.to_entity_id),
+  relationship_type_slug: Type.Optional(EdgeEndpoints.relationship_type_slug),
+  confidence: Type.Optional(Confidence),
+  source: Type.Optional(RelationshipSource),
+  metadata: Type.Optional(Metadata),
+});
+
+export const ListLinksAction = Type.Object({
+  action: Type.Literal("list_links", {
+    description: "List relationships for an entity with filters + counts.",
+  }),
+  entity_id: EntityId,
+  direction: Type.Optional(
+    Type.Union(
+      [Type.Literal("outbound"), Type.Literal("inbound"), Type.Literal("both")],
+      { description: "[list_links] Direction filter. Default both." }
+    )
+  ),
+  relationship_type_slug: Type.Optional(EdgeEndpoints.relationship_type_slug),
+  confidence_min: Type.Optional(
+    Type.Number({
+      description: "[list_links] Minimum confidence threshold",
+      minimum: 0,
+      maximum: 1,
+    })
+  ),
+  source: Type.Optional(RelationshipSource),
+  include_deleted: Type.Optional(IncludeDeleted),
+  ...paginationFields(100),
+  automation_source: Type.Optional(AutomationSource),
+});
+
+export const MergeEntitiesAction = Type.Object({
+  action: Type.Literal("merge", {
+    description:
+      "Fold a duplicate entity (entity_id) into the one it really is (winner_entity_id). The loser is tombstoned + forwarded; its identities, aliases, edges, and events recall against the winner. Events are never rewritten. Use when two entities are confirmed the same real-world thing.",
+  }),
+  // Merge target (the survivor) — the loser is passed as `entity_id`.
+  winner_entity_id: Type.Number({
+    description:
+      "[merge] The surviving entity that absorbs `entity_id` (the duplicate).",
+  }),
+  entity_id: Type.Optional(EntityId),
   duplicate_entity_ids: Type.Optional(
     Type.Array(Type.Number(), {
       minItems: 1,
@@ -72,17 +323,6 @@ export const ManageEntitySchema = Type.Object({
         "[merge] All duplicate entities to fold into winner_entity_id. Use this for a duplicate group; entity_id remains supported for a single duplicate.",
     })
   ),
-
-  candidate_entity_ids: Type.Optional(
-    Type.Array(Type.Integer({ minimum: 1 }), {
-      minItems: 2,
-      maxItems: 5000,
-      uniqueItems: true,
-      description:
-        "[resolve_duplicates] Candidate entity IDs. The server re-reads their values and applies the entity type's resolution policy.",
-    })
-  ),
-
   merge_evidence: Type.Optional(
     Type.Array(
       Type.Object({
@@ -99,7 +339,6 @@ export const ManageEntitySchema = Type.Object({
       }
     )
   ),
-
   merge_rationale: Type.Optional(
     Type.String({
       maxLength: 500,
@@ -107,210 +346,61 @@ export const ManageEntitySchema = Type.Object({
         "[merge] Why you believe these are the same thing, in one sentence, for the human reviewing the approval card (e.g. 'Same phone digits; the shell is a WhatsApp handle for this contact.'). Shown as your claim, clearly separated from the workspace's own policy verdict — it never counts as proof and never affects whether the merge auto-applies.",
     })
   ),
-
-  // Entity type (required for create, list)
-  entity_type: Type.Optional(
-    Type.String({
-      description: "Entity type as defined in your workspace",
-    })
-  ),
-
-  // Entity ID (for get, update, delete, list_links, merge, and unmerge)
-  entity_id: Type.Optional(
-    Type.Number({
-      description:
-        "[get/update/delete/list_links/merge/unmerge] Entity ID to operate on",
-    })
-  ),
-
-  // Common fields
-  name: Type.Optional(
-    Type.String({ description: "[create/update] Entity name", minLength: 1 })
-  ),
-  content: Type.Optional(
-    Type.String({
-      description:
-        "[create/update] Free-text content body. Used by memory entities and any entity that carries rich text.",
-    })
-  ),
-  slug: Type.Optional(
-    Type.String({
-      description:
-        "[create/update] URL-friendly slug (auto-generated from name if not provided)",
-      pattern: "^[a-z0-9]+(-[a-z0-9]+)*$",
-    })
-  ),
-  parent_id: Type.Optional(
-    Type.Number({
-      description:
-        "[create/update] Parent entity ID (for hierarchical entities)",
-    })
-  ),
-  enabled_classifiers: Type.Optional(
-    Type.Array(Type.String(), {
-      description: "[create/update] Enabled classifier slugs",
-    })
-  ),
-
-  // Optional fields (available on all entity types)
-  domain: Type.Optional(
-    Type.String({
-      description: "[create/update] Primary domain (e.g., spotify.com)",
-    })
-  ),
-  category: Type.Optional(
-    Type.String({ description: "[create/update/list] Industry category" })
-  ),
-  platform_type: Type.Optional(
-    Type.String({
-      description: "[create/update] Platform type (b2b, b2c, b2b2c)",
-    })
-  ),
-  main_market: Type.Optional(
-    Type.String({
-      description: "[create/update/list] Primary market (ISO 3166-1 alpha-2)",
-    })
-  ),
-  market: Type.Optional(
-    Type.String({
-      description: "[create/update/list] Market/region (ISO 3166-1 alpha-2)",
-    })
-  ),
-  link: Type.Optional(
-    Type.String({ description: "[create/update] Entity URL" })
-  ),
-
-  // Custom metadata (validated against entity type's JSON schema)
-  metadata: Type.Optional(
-    Type.Record(Type.String(), Type.Unknown(), {
-      description:
-        "[create/update/link/update_link] Custom metadata object. For entities: validated against the entity type's JSON schema. For links: relationship metadata. On update, fields a human owns are NOT overwritten — they are queued for the human's approval and reported in the result's `blocked_fields`/`approval_queued`; tell the user you PROPOSED those changes rather than claiming you set them. Unowned fields in the same call apply directly (`applied_fields`).",
-    })
-  ),
-
-  // Human-correction annotation
-  field_note: Type.Optional(
-    Type.String({
-      description:
-        "[update] Optional note explaining a human correction. Stored on the per-field ownership marker for every metadata field this update sets, so an Automation (and the UI) can see why the value was set.",
-    })
-  ),
-
-  // Approve/affirm: claim ownership of a field's current value without changing it
-  affirm_fields: Type.Optional(
-    Type.Array(Type.String(), {
-      description:
-        "[update] Metadata field names whose CURRENT value the human approves as-is. No value change, but each is marked human-owned so an Automation can't later overwrite it without an approval. The 'approve' half of the recap feedback loop.",
-    })
-  ),
-
-  // List/pagination
-  search: Type.Optional(Type.String({ description: "[list] Search by name" })),
-  ...paginationFields(100),
-  sort_by: Type.Optional(
-    Type.String({
-      description:
-        "[list] Sort by column (name, created_at, domain, total_content, active_connections, automations_count, children_count)",
-    })
-  ),
-  sort_order: SortOrderField("[list] Sort order (asc or desc)"),
-
-  // Delete options
-  force_delete_tree: Type.Optional(
-    Type.Boolean({
-      description:
-        "[delete] Hard delete entity and all descendants. Event history is never deleted (append-only) — event rows referencing the tree are detached instead.",
-    })
-  ),
-  dry_run: Type.Optional(
-    Type.Boolean({
-      description:
-        "[delete, merge] Preflight only. For delete: report what it would remove/detach. For merge: report whether the type's write rules would refuse it. Mutates nothing and never queues an approval.",
-    })
-  ),
-
-  // ---- Relationship (link) fields ----
-  from_entity_id: Type.Optional(
-    Type.Number({
-      description:
-        "[link/unlink/update_link] Source entity ID. For unlink/update_link, supply this triple instead of relationship_id to address the edge by its endpoints.",
-    })
-  ),
-  to_entity_id: Type.Optional(
-    Type.Number({ description: "[link/unlink/update_link] Target entity ID" })
-  ),
-  relationship_type_slug: Type.Optional(
-    Type.String({
-      description:
-        "[link/unlink/update_link/list_links] Relationship type slug",
-      minLength: 1,
-    })
-  ),
-  confidence: Type.Optional(
-    Type.Number({
-      description:
-        "[link/update_link] Confidence score 0-1. Defaults to 1.0 for ui/api source.",
-      minimum: 0,
-      maximum: 1,
-    })
-  ),
-  source: Type.Optional(
-    Type.Union(
-      [
-        Type.Literal("ui"),
-        Type.Literal("llm"),
-        Type.Literal("feed"),
-        Type.Literal("api"),
-      ],
-      { description: "[link/update_link] Source of the relationship" }
-    )
-  ),
-  relationship_id: Type.Optional(
-    Type.Number({
-      description:
-        "[update_link/unlink] Relationship ID. Optional when from_entity_id + to_entity_id + relationship_type_slug identify the edge.",
-    })
-  ),
-  direction: Type.Optional(
-    Type.Union(
-      [Type.Literal("outbound"), Type.Literal("inbound"), Type.Literal("both")],
-      {
-        description: "[list_links] Direction filter. Default both.",
-      }
-    )
-  ),
-  confidence_min: Type.Optional(
-    Type.Number({
-      description: "[list_links] Minimum confidence threshold",
-      minimum: 0,
-      maximum: 1,
-    })
-  ),
-  include_deleted: Type.Optional(
-    Type.Boolean({
-      description:
-        "[get] Return the entity even if it is soft-deleted (deleted_at set). [list_links] Include soft-deleted relationships.",
-    })
-  ),
-  automation_source: Type.Optional(
-    Type.Object(
-      {
-        automation_id: Type.Number({
-          description: "Automation that triggered this mutation",
-        }),
-        run_id: Type.Number({
-          description: "Automation run that triggered this mutation",
-        }),
-      },
-      {
-        description:
-          "Attribution source when mutation is triggered by an Automation reaction",
-      }
-    )
-  ),
+  dry_run: Type.Optional(DryRun),
+  automation_source: Type.Optional(AutomationSource),
 });
 
+export const ResolveDuplicatesAction = Type.Object({
+  action: Type.Literal("resolve_duplicates", {
+    description:
+      "Discover duplicate components among candidate_entity_ids using the entity type's x-lobu-resolution policy, then auto-merge deterministic matches or queue review.",
+  }),
+  candidate_entity_ids: Type.Array(Type.Integer({ minimum: 1 }), {
+    minItems: 2,
+    maxItems: 5000,
+    uniqueItems: true,
+    description:
+      "[resolve_duplicates] Candidate entity IDs. The server re-reads their values and applies the entity type's resolution policy.",
+  }),
+});
+
+export const UnmergeEntityAction = Type.Object({
+  action: Type.Literal("unmerge", {
+    description:
+      "Reverse a merge from its durable ledger: restore the loser's identities, canonical attributes, and relationships, then un-tombstone it. Fails closed if later edits made exact reversal unsafe.",
+  }),
+  entity_id: EntityId,
+});
+
+export const ManageEntitySchema = Type.Union([
+  CreateEntityAction,
+  UpdateEntityAction,
+  ListEntitiesAction,
+  GetEntityAction,
+  DeleteEntityAction,
+  LinkEntitiesAction,
+  UnlinkEntitiesAction,
+  UpdateLinkAction,
+  ListLinksAction,
+  MergeEntitiesAction,
+  ResolveDuplicatesAction,
+  UnmergeEntityAction,
+]);
+
 export type ManageEntityArgs = Static<typeof ManageEntitySchema>;
+
+export type EntityCreateInput = ActionInput<ManageEntityArgs, "create">;
+export type EntityUpdateInput = ActionInput<ManageEntityArgs, "update">;
+export type EntityListInput = ActionInput<ManageEntityArgs, "list">;
+export type EntityGetInput = ActionInput<ManageEntityArgs, "get">;
+export type EntityDeleteInput = ActionInput<ManageEntityArgs, "delete">;
+export type EntityLinkInput = ActionInput<ManageEntityArgs, "link">;
+export type EntityUnlinkInput = ActionInput<ManageEntityArgs, "unlink">;
+export type EntityUpdateLinkInput = ActionInput<
+  ManageEntityArgs,
+  "update_link"
+>;
+export type EntityListLinksInput = ActionInput<ManageEntityArgs, "list_links">;
 
 // ============================================
 // Result Types

--- a/packages/server/src/__tests__/integration/sandbox/entities-create-passthrough.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/entities-create-passthrough.test.ts
@@ -9,10 +9,10 @@
  * payload now passes straight through; `type` survives as a registered alias
  * for the callers that guess it.
  */
+import type { EntityCreateInput } from "@lobu/core/contracts/tools/manage-entity";
 import { beforeAll, describe, expect, it } from "vitest";
 import type { Env } from "../../../index";
 import { buildClientSDK, type ClientSDK } from "../../../sandbox/client-sdk";
-import type { EntityCreateInput } from "../../../sandbox/namespaces/entities";
 import type { ToolContext } from "../../../tools/registry";
 import { initWorkspaceProvider } from "../../../workspace";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";

--- a/packages/server/src/__tests__/unit/manage-entity-contract.test.ts
+++ b/packages/server/src/__tests__/unit/manage-entity-contract.test.ts
@@ -1,0 +1,271 @@
+/**
+ * `manage_entity` is a union of per-action variants, so the schema — not the
+ * handler — decides what each action requires and accepts. These pin what the
+ * flat contract could not express: `entity_type`+`name`, `entity_id`, the link
+ * endpoint triple, `winner_entity_id` and `candidate_entity_ids` are required
+ * where they matter rather than checked by hand; a field that belongs to
+ * another action is an error on this one instead of a silent no-op (the flat
+ * object accepted `entity_type` on `update` and `name` on `delete`); the two
+ * ways to address an edge stay a handler decision; and the registry's
+ * per-action access filtering — which only ever applied to union variants —
+ * now keeps owner-admin writes out of a read-scope client's listing.
+ */
+import { describe, expect, it } from "bun:test";
+import { ManageEntitySchema } from "@lobu/core/contracts/tools/manage-entity";
+import { getAllTools } from "../../tools/registry";
+import { validateToolArgs } from "../../tools/validate-args";
+import { ToolUserError } from "../../utils/errors";
+
+const validate = (args: unknown) =>
+	validateToolArgs("manage_entity", ManageEntitySchema, args);
+
+function messageOf(fn: () => unknown): string {
+	try {
+		fn();
+	} catch (err) {
+		expect(err).toBeInstanceOf(ToolUserError);
+		return (err as ToolUserError).message;
+	}
+	throw new Error("expected validation to throw");
+}
+
+describe("manage_entity union contract", () => {
+	it("requires each action's identifying fields at the schema", () => {
+		expect(messageOf(() => validate({ action: "create", name: "Acme" }))).toMatch(
+			/entity_type/,
+		);
+		expect(messageOf(() => validate({ action: "create", entity_type: "company" }))).toMatch(
+			/name/,
+		);
+		for (const action of ["update", "get", "delete", "list_links", "unmerge"]) {
+			expect(messageOf(() => validate({ action }))).toMatch(/entity_id/);
+		}
+		expect(
+			messageOf(() => validate({ action: "link", from_entity_id: 1, to_entity_id: 2 })),
+		).toMatch(/relationship_type_slug/);
+		expect(messageOf(() => validate({ action: "merge", entity_id: 7 }))).toMatch(
+			/winner_entity_id/,
+		);
+		expect(messageOf(() => validate({ action: "resolve_duplicates" }))).toMatch(
+			/candidate_entity_ids/,
+		);
+	});
+
+	it("rejects a field another action takes instead of ignoring it", () => {
+		const update = messageOf(() =>
+			validate({ action: "update", entity_id: 7, entity_type: "company", name: "Acme" }),
+		);
+		expect(update).toMatch(/unknown argument\(s\): entity_type/);
+		expect(update).toMatch(/valid arguments for action 'update' are: action, entity_id, name/);
+
+		const del = messageOf(() => validate({ action: "delete", entity_id: 7, name: "Acme" }));
+		expect(del).toMatch(/unknown argument\(s\): name/);
+		expect(del).toMatch(
+			/valid arguments for action 'delete' are: action, entity_id, force_delete_tree, dry_run, automation_source$/,
+		);
+
+		expect(
+			messageOf(() => validate({ action: "get", entity_id: 7, search: "acme" })),
+		).toMatch(/unknown argument\(s\): search/);
+	});
+
+	it("leaves the edge addressing choice (id or endpoint triple) to the handler", () => {
+		for (const action of ["unlink", "update_link"]) {
+			expect(validate({ action, relationship_id: 9 })).toEqual({ action, relationship_id: 9 });
+			expect(
+				validate({
+					action,
+					from_entity_id: 1,
+					to_entity_id: 2,
+					relationship_type_slug: "works_at",
+				}),
+			).toMatchObject({ action, relationship_type_slug: "works_at" });
+			// Neither given: the schema accepts it; resolveRelationshipId raises the
+			// "relationship_id, or from + to + slug" error with the action's name.
+			expect(validate({ action })).toEqual({ action });
+		}
+	});
+
+	it("bounds resolve_duplicates to at least two distinct candidates", () => {
+		expect(messageOf(() => validate({ action: "resolve_duplicates", candidate_entity_ids: [7] })))
+			.toMatch(/candidate_entity_ids/);
+		expect(
+			messageOf(() => validate({ action: "resolve_duplicates", candidate_entity_ids: [7, 7] })),
+		).toMatch(/candidate_entity_ids/);
+		expect(validate({ action: "resolve_duplicates", candidate_entity_ids: [7, 8] })).toEqual({
+			action: "resolve_duplicates",
+			candidate_entity_ids: [7, 8],
+		});
+	});
+
+	it("accepts each action's full field set", () => {
+		const source = { automation_id: 3, run_id: 44 };
+		expect(
+			validate({
+				action: "create",
+				entity_type: "company",
+				name: "Acme",
+				content: "body",
+				slug: "acme",
+				parent_id: 1,
+				enabled_classifiers: ["sentiment"],
+				domain: "acme.com",
+				category: "saas",
+				platform_type: "b2b",
+				main_market: "US",
+				market: "US",
+				link: "https://acme.com",
+				metadata: { team_size: 5 },
+				automation_source: source,
+			}),
+		).toMatchObject({ entity_type: "company", automation_source: source });
+		expect(
+			validate({
+				action: "update",
+				entity_id: 7,
+				metadata: { stage: "won" },
+				field_note: "closed by the AE",
+				affirm_fields: ["owner"],
+				automation_source: source,
+			}),
+		).toMatchObject({ entity_id: 7, affirm_fields: ["owner"] });
+		expect(
+			validate({
+				action: "list",
+				entity_type: "company",
+				parent_id: 1,
+				search: "acme",
+				category: "saas",
+				main_market: "US",
+				market: "US",
+				limit: 20,
+				offset: 40,
+				sort_by: "created_at",
+				sort_order: "desc",
+			}),
+		).toMatchObject({ parent_id: 1, limit: 20, sort_order: "desc" });
+		expect(validate({ action: "get", entity_id: 7, include_deleted: true })).toEqual({
+			action: "get",
+			entity_id: 7,
+			include_deleted: true,
+		});
+		expect(
+			validate({ action: "delete", entity_id: 7, force_delete_tree: true, dry_run: true }),
+		).toMatchObject({ force_delete_tree: true, dry_run: true });
+		expect(
+			validate({
+				action: "link",
+				from_entity_id: 1,
+				to_entity_id: 2,
+				relationship_type_slug: "works_at",
+				confidence: 0.9,
+				source: "llm",
+				metadata: { since: 2020 },
+				automation_source: source,
+			}),
+		).toMatchObject({ confidence: 0.9, source: "llm" });
+		expect(
+			validate({
+				action: "update_link",
+				relationship_id: 9,
+				confidence: 1,
+				source: "ui",
+				metadata: { since: 2021 },
+			}),
+		).toMatchObject({ relationship_id: 9, source: "ui" });
+		expect(
+			validate({
+				action: "list_links",
+				entity_id: 7,
+				direction: "inbound",
+				relationship_type_slug: "works_at",
+				source: "feed",
+				confidence_min: 0.5,
+				include_deleted: true,
+				limit: 200,
+				offset: 0,
+			}),
+		).toMatchObject({ direction: "inbound", source: "feed", limit: 200 });
+		expect(
+			validate({
+				action: "merge",
+				winner_entity_id: 1,
+				duplicate_entity_ids: [2, 3],
+				merge_evidence: [{ kind: "email", identifier: "a@acme.com" }],
+				merge_rationale: "Same email.",
+				dry_run: true,
+				automation_source: source,
+			}),
+		).toMatchObject({ winner_entity_id: 1, duplicate_entity_ids: [2, 3] });
+		expect(validate({ action: "merge", winner_entity_id: 1, entity_id: 2 })).toEqual({
+			action: "merge",
+			winner_entity_id: 1,
+			entity_id: 2,
+		});
+		expect(validate({ action: "unmerge", entity_id: 2 })).toEqual({
+			action: "unmerge",
+			entity_id: 2,
+		});
+	});
+});
+
+/**
+ * What an MCP client actually sees: the union is flattened to one object
+ * (hosts reject a top-level `anyOf`), so per-action requirements survive only
+ * as prose on the `action` enum.
+ */
+describe("manage_entity wire schema", () => {
+	const listedFor = (maxAccessLevel: "read" | "write" | "admin") =>
+		getAllTools({ publicOnly: false, maxAccessLevel }).find(
+			(tool) => tool.name === "manage_entity",
+		);
+
+	it("filters the action enum by the caller's access tier", () => {
+		expect(listedFor("read")?.inputSchema.properties.action.enum).toEqual([
+			"list",
+			"get",
+			"list_links",
+		]);
+		expect(listedFor("write")?.inputSchema.properties.action.enum).toEqual([
+			"create",
+			"update",
+			"list",
+			"get",
+			"link",
+			"unlink",
+			"update_link",
+			"list_links",
+		]);
+		expect(listedFor("admin")?.inputSchema.properties.action.enum).toEqual([
+			"create",
+			"update",
+			"list",
+			"get",
+			"delete",
+			"link",
+			"unlink",
+			"update_link",
+			"list_links",
+			"merge",
+			"resolve_duplicates",
+			"unmerge",
+		]);
+	});
+
+	it("names each action's required fields on the flattened enum", () => {
+		const description: string =
+			listedFor("admin")?.inputSchema.properties.action.description ?? "";
+		const lineFor = (action: string) =>
+			description.split("\n").find((line) => line.startsWith(`- ${action}:`));
+		expect(lineFor("create")).toContain("Required: entity_type, name.");
+		expect(lineFor("update")).toContain("Required: entity_id.");
+		expect(lineFor("list")).not.toContain("Required:");
+		expect(lineFor("link")).toContain(
+			"Required: from_entity_id, to_entity_id, relationship_type_slug.",
+		);
+		expect(lineFor("unlink")).not.toContain("Required:");
+		expect(lineFor("merge")).toContain("Required: winner_entity_id.");
+		expect(lineFor("resolve_duplicates")).toContain("Required: candidate_entity_ids.");
+		expect(lineFor("unmerge")).toContain("Required: entity_id.");
+	});
+});

--- a/packages/server/src/__tests__/unit/manage-wire-schema.test.ts
+++ b/packages/server/src/__tests__/unit/manage-wire-schema.test.ts
@@ -74,10 +74,10 @@ describe("manage_* wire schema: action discoverability", () => {
 		//    would render as a bare `- name` line — caught by asserting the
 		//    description line for each action contains a colon (prose follows).
 		//
-		//  - Flat tools (manage_entity, manage_automations, ...): `action.anyOf` of
-		//    `{const, description}` literals — the per-action prose lives on
-		//    each literal, not the field. Assert each anyOf entry has non-empty
-		//    description text.
+		//  - Flat tools (manage_entity_schema, manage_automations, ...):
+		//    `action.anyOf` of `{const, description}` literals — the per-action
+		//    prose lives on each literal, not the field. Assert each anyOf
+		//    entry has non-empty description text.
 		for (const tool of MANAGE_TOOLS) {
 			const action = (tool.inputSchema as any)?.properties?.action;
 			if (!action) continue;

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -70,7 +70,7 @@ export const METHOD_METADATA: Record<string, MethodMetadata> = {
 			"List entities in the current organization with optional filters. Returns `{ action, entities, metadata }` where `entities` is the page and `metadata` carries `total_count`, `has_more`, `limit`, `offset`.",
 		access: "read",
 		signature:
-			"entities.list(input?: { entity_type?: string; parent_id?: number; search?: string; limit?: number; offset?: number }): Promise<unknown>",
+			"entities.list(input?: { entity_type?: string; parent_id?: number; search?: string; category?: string; main_market?: string; market?: string; limit?: number; offset?: number; sort_by?: string; sort_order?: 'asc' | 'desc' }): Promise<unknown>",
 		example:
 			"const { entities } = await client.entities.list({ entity_type: 'company' });",
 		usageExample: `// All companies in the workspace, newest first.
@@ -181,7 +181,7 @@ export default async (_ctx, client) => {
 		summary: "List relationships for an entity.",
 		access: "read",
 		signature:
-			"entities.listLinks(input: { entity_id: number; direction?: 'outbound' | 'inbound' | 'both'; relationship_type_slug?: string; confidence_min?: number; include_deleted?: boolean }): Promise<unknown>",
+			"entities.listLinks(input: { entity_id: number; direction?: 'outbound' | 'inbound' | 'both'; relationship_type_slug?: string; source?: 'ui' | 'llm' | 'feed' | 'api'; confidence_min?: number; include_deleted?: boolean; limit?: number; offset?: number }): Promise<unknown>",
 	},
 	"entities.search": {
 		summary:

--- a/packages/server/src/sandbox/namespaces/entities.ts
+++ b/packages/server/src/sandbox/namespaces/entities.ts
@@ -5,106 +5,34 @@
  * checks fire inside the handler; this wrapper does not duplicate them.
  */
 
+import type {
+	EntityCreateInput,
+	EntityDeleteInput,
+	EntityGetInput,
+	EntityLinkInput,
+	EntityListInput,
+	EntityListLinksInput,
+	EntityUnlinkInput,
+	EntityUpdateInput,
+	EntityUpdateLinkInput,
+} from "@lobu/core/contracts/tools/manage-entity";
 import type { Env } from "../../index";
 import { manageEntity } from "../../tools/admin/manage_entity";
 import type { ToolContext } from "../../tools/registry";
 import { search } from "../../tools/search";
 import { createActionCaller } from "./action-call";
 
-export interface EntityListFilter {
-	entity_type?: string;
-	search?: string;
-	limit?: number;
-	offset?: number;
-	sort_by?: string;
-	sort_order?: "asc" | "desc";
-	category?: string;
-	main_market?: string;
-	market?: string;
-}
-
-export interface EntityCreateInput {
-	entity_type: string;
-	name: string;
-	slug?: string;
-	content?: string;
-	parent_id?: number;
-	metadata?: Record<string, unknown>;
-	enabled_classifiers?: string[];
-	domain?: string;
-	category?: string;
-	platform_type?: string;
-	main_market?: string;
-	market?: string;
-	link?: string;
-}
-
-export interface EntityUpdateInput {
-	entity_id: number;
-	name?: string;
-	slug?: string;
-	content?: string;
-	metadata?: Record<string, unknown>;
-	enabled_classifiers?: string[];
-	domain?: string;
-	category?: string;
-	platform_type?: string;
-	main_market?: string;
-	market?: string;
-	link?: string;
-	/** Optional note explaining a human correction; stored on the per-field
-	 *  ownership marker for the metadata fields this update sets. */
-	field_note?: string;
-	/** Metadata field names whose current value the human approves as-is:
-	 *  no value change, but each becomes human-owned. */
-	affirm_fields?: string[];
-}
-
-export interface EntityLinkInput {
-	from_entity_id: number;
-	to_entity_id: number;
-	relationship_type_slug: string;
-	source?: "ui" | "llm" | "feed" | "api";
-	confidence?: number;
-	metadata?: Record<string, unknown>;
-}
-
 export interface EntitiesNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	list(filter?: EntityListFilter): Promise<unknown>;
-	get(input: {
-		entity_id: number;
-		include_deleted?: boolean;
-	}): Promise<unknown>;
+	list(filter?: EntityListInput): Promise<unknown>;
+	get(input: EntityGetInput): Promise<unknown>;
 	create(input: EntityCreateInput): Promise<unknown>;
 	update(input: EntityUpdateInput): Promise<unknown>;
-	delete(input: {
-		entity_id: number;
-		force_delete_tree?: boolean;
-		/** Preflight only: report what would be removed/detached, mutate nothing. */
-		dry_run?: boolean;
-	}): Promise<unknown>;
+	delete(input: EntityDeleteInput): Promise<unknown>;
 	link(input: EntityLinkInput): Promise<unknown>;
-	unlink(input: {
-		from_entity_id: number;
-		to_entity_id: number;
-		relationship_type_slug: string;
-	}): Promise<unknown>;
-	updateLink(input: {
-		from_entity_id: number;
-		to_entity_id: number;
-		relationship_type_slug: string;
-		metadata?: Record<string, unknown>;
-	}): Promise<unknown>;
-	listLinks(input: {
-		entity_id: number;
-		direction?: "outbound" | "inbound" | "both";
-		relationship_type_slug?: string;
-		confidence_min?: number;
-		include_deleted?: boolean;
-		limit?: number;
-		offset?: number;
-	}): Promise<unknown>;
+	unlink(input: EntityUnlinkInput): Promise<unknown>;
+	updateLink(input: EntityUpdateLinkInput): Promise<unknown>;
+	listLinks(input: EntityListLinksInput): Promise<unknown>;
 	search(query: string, options?: { limit?: number }): Promise<unknown>;
 }
 

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -26,13 +26,25 @@ import {
 	type ApprovalAttribution as ApprovalAttributionType,
 } from "@lobu/core/contracts/interaction-envelope";
 import {
-	type ManageEntityArgs,
+	CreateEntityAction,
+	DeleteEntityAction,
+	GetEntityAction,
+	LinkEntitiesAction,
+	ListEntitiesAction,
+	ListLinksAction,
 	type ManageEntityResult,
 	ManageEntityResultSchema,
 	ManageEntitySchema,
+	MergeEntitiesAction,
 	type RelationshipCountByType,
 	type RelationshipRow,
+	ResolveDuplicatesAction,
+	UnlinkEntitiesAction,
+	UnmergeEntityAction,
+	UpdateEntityAction,
+	UpdateLinkAction,
 } from "@lobu/core/contracts/tools/manage-entity";
+import type { Static } from "@sinclair/typebox";
 import {
 	deferEntityCreate,
 	runMutationGate,
@@ -117,13 +129,12 @@ import { trackAutomationReaction } from "../../utils/automation-reactions";
 import { isAdminOrOwnerRole } from "../access-control";
 import { MEMBER_ENTITY_TYPE_SLUG } from "../constants";
 import type { ToolContext } from "../registry";
-import { withValidatedArgs } from "../validate-args";
 import {
 	buildEntityViewUrl,
 	getOrgUrlContext,
 	toEntityInfo,
 } from "../view-urls";
-import { defineFlatActionTool, flatAction } from "./action-tool";
+import { action, defineActionTool } from "./action-tool";
 import { proposeEntityDelete, proposeEntityMerge } from "./entity-field-approval";
 
 export { ManageEntityResultSchema, ManageEntitySchema };
@@ -145,7 +156,7 @@ function capitalize(value: string): string {
  * automation_source.
  */
 function actingPrincipalFor(
-	args: ManageEntityArgs | undefined,
+	args: Attributed | undefined,
 	ctx: ToolContext,
 ): Promise<ActingPrincipal> {
 	return resolveActingPrincipal(getDb(), {
@@ -204,7 +215,7 @@ function recordToolDenial(params: {
  * Default is auto (unrestricted within org); a policy can deny by type.
  */
 async function assertEntityReadAllowed(
-	args: ManageEntityArgs | undefined,
+	args: Attributed | undefined,
 	ctx: ToolContext,
 	entityTypeSlug: string | null | undefined,
 ): Promise<void> {
@@ -233,112 +244,132 @@ async function assertEntityReadAllowed(
 // Main Function (Action Router)
 // ============================================
 
-const runManageEntity = defineFlatActionTool<
-	ManageEntityArgs,
-	ManageEntityResult
->("manage_entity", {
-	create: flatAction((args, ctx, env) => handleCreate(args, env, ctx)),
-	update: flatAction(
-		(args, ctx, env) => handleUpdate(args.entity_id!, args, env, ctx),
-		{
-			requires: ["entity_id"],
-		},
+/** The one field the principal seam reads off any variant that carries it. */
+type Attributed = Pick<Static<typeof CreateEntityAction>, "automation_source">;
+
+/** How `unlink`/`update_link` address an edge: by id, by endpoint triple, or both. */
+type EdgeAddress = Pick<
+	Static<typeof UnlinkEntitiesAction>,
+	"relationship_id" | "from_entity_id" | "to_entity_id" | "relationship_type_slug"
+>;
+
+/**
+ * The mutations a reaction record is kept for, and the fields that record
+ * carries. Everything but `action` is optional because no single tracked
+ * variant declares all of them: `create` has no `entity_id`, `update` and
+ * `link` have no `entity_type`, and `link` has no `name`.
+ */
+interface TrackedMutationArgs extends Attributed {
+	action: "create" | "update" | "link";
+	entity_id?: number;
+	entity_type?: string;
+	name?: string;
+}
+
+type Handler<A> = (
+	args: A,
+	ctx: ToolContext,
+	env: Env,
+) => Promise<ManageEntityResult>;
+
+// Variants in the contract's order, so the derived union matches the exposed
+// `ManageEntitySchema`. Each handler receives its own variant's args; the
+// per-action access tiers are enforced by `routeAction` before dispatch.
+const manageEntityTool = defineActionTool("manage_entity", {
+	create: action(
+		CreateEntityAction,
+		trackedMutation((args, ctx, env) => handleCreate(args, env, ctx)),
 	),
-	list: flatAction((args, ctx, env) => handleList(args, env, ctx)),
-	get: flatAction(
-		(args, ctx, env) =>
-			handleGet(args.entity_id!, env, ctx, args.include_deleted ?? false),
-		{
-			requires: ["entity_id"],
-		},
+	update: action(
+		UpdateEntityAction,
+		trackedMutation((args, ctx, env) => handleUpdate(args, env, ctx)),
 	),
-	delete: flatAction(
-		(args, ctx, env) =>
-			handleDelete(
-				args.entity_id!,
-				args.force_delete_tree ?? false,
-				env,
-				ctx,
-				args,
-			),
-		{ requires: ["entity_id"] },
+	list: action(ListEntitiesAction, (args, ctx, env) =>
+		handleList(args, env, ctx),
 	),
-	link: flatAction((args, ctx, env) => handleLink(args, env, ctx)),
-	unlink: flatAction(handleUnlink),
-	update_link: flatAction(handleUpdateLink),
-	list_links: flatAction(handleListLinks),
-	merge: flatAction((args, ctx) => handleMerge(args, ctx), {
-		requires: ["winner_entity_id"],
-	}),
-	resolve_duplicates: flatAction((args, ctx) =>
-		handleResolveDuplicates(args, ctx),
+	get: action(GetEntityAction, (args, ctx, env) =>
+		handleGet(args.entity_id, env, ctx, args.include_deleted ?? false),
 	),
-	unmerge: flatAction((args, ctx) => handleUnmerge(args, ctx), {
-		requires: ["entity_id"],
-	}),
+	delete: action(DeleteEntityAction, (args, ctx, env) =>
+		handleDelete(args, env, ctx),
+	),
+	link: action(
+		LinkEntitiesAction,
+		trackedMutation((args, ctx, env) => handleLink(args, env, ctx)),
+	),
+	unlink: action(UnlinkEntitiesAction, handleUnlink),
+	update_link: action(UpdateLinkAction, handleUpdateLink),
+	list_links: action(ListLinksAction, handleListLinks),
+	merge: action(MergeEntitiesAction, handleMerge),
+	resolve_duplicates: action(ResolveDuplicatesAction, handleResolveDuplicates),
+	unmerge: action(UnmergeEntityAction, handleUnmerge),
 });
 
-export const manageEntity = withValidatedArgs(
-	"manage_entity",
-	ManageEntitySchema,
-	manageEntityImpl,
-);
+export const manageEntity = manageEntityTool.run;
 
-async function manageEntityImpl(
-	args: ManageEntityArgs,
-	env: Env,
+/**
+ * Record an Automation reaction for a mutating action once its handler
+ * returns. Reaction tracking took the declared source verbatim — no session
+ * precedence, no ownership check — so an unowned id credited another
+ * Automation's feedback record. Still gated on the caller HAVING declared a
+ * source: resolving one for every reaction session would start tracking
+ * mutations that were never tracked before, which is a product change, not
+ * this fix.
+ */
+function trackedMutation<A extends TrackedMutationArgs>(
+	handler: Handler<A>,
+): Handler<A> {
+	return async (args, ctx, env) => {
+		const result = await handler(args, ctx, env);
+		await trackEntityReaction(args, result, ctx);
+		return result;
+	};
+}
+
+async function trackEntityReaction(
+	args: TrackedMutationArgs,
+	result: ManageEntityResult,
 	ctx: ToolContext,
-): Promise<ManageEntityResult> {
-	const result = await runManageEntity(args, env, ctx);
-
-	// Track automation reaction for mutating actions.
-	// Reaction tracking took the declared source verbatim — no session
-	// precedence, no ownership check — so an unowned id credited another
-	// Automation's feedback record. Still gated on the caller HAVING declared a
-	// source: resolving one for every reaction session would start tracking
-	// mutations that were never tracked before, which is a product change, not
-	// this fix.
+): Promise<void> {
 	const reactionAttribution = args.automation_source
 		? await resolveAutomationAttribution(ctx, args.automation_source)
 		: null;
 	// A reaction record is keyed by the producing run.
 	if (
-		reactionAttribution?.automationId != null &&
-		reactionAttribution.runId != null &&
-		"action" in result
+		reactionAttribution?.automationId == null ||
+		reactionAttribution.runId == null ||
+		!("action" in result)
 	) {
-		const reactionType =
-			result.action === "create"
-				? "entity_created"
-				: result.action === "update"
-					? "entity_updated"
-					: result.action === "link"
-						? "entity_linked"
-						: null;
-		if (reactionType) {
-			const entityId =
-				result.action === "create" && "entity" in result
-					? result.entity?.id
-					: args.entity_id;
-			await trackAutomationReaction({
-				organizationId: ctx.organizationId,
-				automationId: reactionAttribution.automationId,
-				sourceRunId: reactionAttribution.runId,
-				reactionType,
-				toolName: "manage_entity",
-				toolArgs: {
-					action: args.action,
-					entity_type: args.entity_type,
-					name: args.name,
-					entity_id: args.entity_id,
-				},
-				toolResult: result as Record<string, unknown>,
-				entityId,
-			});
-		}
+		return;
 	}
-
-	return result;
+	const reactionType =
+		result.action === "create"
+			? "entity_created"
+			: result.action === "update"
+				? "entity_updated"
+				: result.action === "link"
+					? "entity_linked"
+					: null;
+	if (!reactionType) return;
+	const entityId =
+		result.action === "create" && "entity" in result
+			? result.entity?.id
+			: args.entity_id;
+	await trackAutomationReaction({
+		organizationId: ctx.organizationId,
+		automationId: reactionAttribution.automationId,
+		sourceRunId: reactionAttribution.runId,
+		reactionType,
+		toolName: "manage_entity",
+		toolArgs: {
+			action: args.action,
+			entity_type: args.entity_type,
+			name: args.name,
+			entity_id: args.entity_id,
+		},
+		toolResult: result as Record<string, unknown>,
+		entityId,
+	});
 }
 
 // ============================================
@@ -346,18 +377,10 @@ async function manageEntityImpl(
 // ============================================
 
 async function handleCreate(
-	args: ManageEntityArgs,
+	args: Static<typeof CreateEntityAction>,
 	env: Env,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
-	if (!args.entity_type) {
-		throw new ToolUserError("entity_type is required for create action", 400);
-	}
-
-	if (!args.name) {
-		throw new ToolUserError("name is required for create action", 400);
-	}
-
 	// (Derived-type rejection lives in createEntity — the single chokepoint that
 	// also resolves public-catalog types.)
 
@@ -573,11 +596,11 @@ async function handleCreate(
 }
 
 async function handleUpdate(
-	entityId: number,
-	args: ManageEntityArgs,
+	args: Static<typeof UpdateEntityAction>,
 	env: Env,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
+	const entityId = args.entity_id;
   const sql = getDb();
 
   // Fetch before state for change tracking and validation
@@ -839,7 +862,7 @@ function redactMemberEmail(
  * `applyMergeGroup`; this handler is the org-scoped gate + validation.
  */
 async function handleMerge(
-	args: ManageEntityArgs,
+	args: Static<typeof MergeEntitiesAction>,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
 	const actor = await actingPrincipalFor(args, ctx);
@@ -862,11 +885,6 @@ async function handleMerge(
 	if (loserIds.length === 0)
 		throw new ToolUserError(
 			"entity_id or duplicate_entity_ids is required for merge",
-			400,
-		);
-	if (!winnerId)
-		throw new ToolUserError(
-			"winner_entity_id (the survivor) is required for merge",
 			400,
 		);
 	if (loserIds.includes(winnerId))
@@ -947,7 +965,7 @@ async function handleMerge(
 	// Placed after the role gate (a principal who may not merge gets no preview)
 	// and before the review branch below — a dry run must never create an
 	// approval, exactly as on the delete path.
-	if (args?.dry_run) {
+	if (args.dry_run) {
 		const preview = await previewMerge({ loserIds, winnerId });
 		return {
 			action: "merge",
@@ -1137,18 +1155,11 @@ async function handleMerge(
 }
 
 async function handleResolveDuplicates(
-	args: ManageEntityArgs,
+	args: Static<typeof ResolveDuplicatesAction>,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
-	const candidateIds = [...new Set(args.candidate_entity_ids ?? [])].sort(
-		(a, b) => a - b,
-	);
-	if (candidateIds.length < 2) {
-		throw new ToolUserError(
-			"candidate_entity_ids must contain at least two entities",
-			400,
-		);
-	}
+	// The schema already requires >= 2 unique ids; sorted for a stable order.
+	const candidateIds = [...args.candidate_entity_ids].sort((a, b) => a - b);
 	let discovery: Awaited<ReturnType<typeof discoverWorkspaceResolutionGroups>>;
 	try {
 		discovery = await discoverWorkspaceResolutionGroups(getDb(), {
@@ -1209,7 +1220,7 @@ async function handleResolveDuplicates(
  * + validation.
  */
 async function handleUnmerge(
-	args: ManageEntityArgs,
+	args: Static<typeof UnmergeEntityAction>,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
 	if (!isAdminOrOwnerRole(ctx.memberRole)) {
@@ -1219,11 +1230,6 @@ async function handleUnmerge(
 		);
 	}
 	const loserId = args.entity_id;
-	if (!loserId)
-		throw new ToolUserError(
-			"entity_id (the merged loser to split out) is required for unmerge",
-			400,
-		);
 
 	const sql = getDb();
 	// The loser is a TOMBSTONE (deleted_at set by the merge), so we validate org
@@ -1270,7 +1276,7 @@ async function handleUnmerge(
 }
 
 async function handleList(
-	args: ManageEntityArgs,
+	args: Static<typeof ListEntitiesAction>,
 	env: Env,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
@@ -1604,12 +1610,12 @@ async function handleGet(
 }
 
 async function handleDelete(
-	entityId: number,
-	force: boolean,
+	args: Static<typeof DeleteEntityAction>,
 	env: Env,
 	ctx: ToolContext,
-	args?: ManageEntityArgs,
 ): Promise<ManageEntityResult> {
+	const entityId = args.entity_id;
+	const force = args.force_delete_tree ?? false;
 	// Get entity info before deletion
 	const entity = await getEntity(entityId, env, ctx);
 	if (!entity) {
@@ -1620,7 +1626,7 @@ async function handleDelete(
 	const denialAttemptId = randomUUID();
 	const deleteAttribution = await resolveAutomationAttribution(
 		ctx,
-		args?.automation_source
+		args.automation_source
 	);
 	const attribution = attributionFor(deleteActor);
 	const current = {
@@ -1668,7 +1674,7 @@ async function handleDelete(
 	// Preflight: report what the delete would remove/detach without mutating.
 	// Runs after the gate's deny check (a denied principal gets no preview) but
 	// before defer queues anything — a dry run must never create an approval.
-	if (args?.dry_run) {
+	if (args.dry_run) {
 		const preview = await deleteEntity(entityId, force, env, ctx, {
 			dryRun: true,
 		});
@@ -1744,7 +1750,7 @@ async function handleDelete(
 			force_delete_tree: force,
 			current,
 			automation_id:
-				ctx.actingAutomationId ?? args?.automation_source?.automation_id ?? null,
+				ctx.actingAutomationId ?? args.automation_source?.automation_id ?? null,
 			attribution,
 			reason: err.verdict.reason,
 		}, deleteAttribution.runId);
@@ -1921,17 +1927,10 @@ async function resolveRelationshipType(
 }
 
 async function handleLink(
-	args: ManageEntityArgs,
+	args: Static<typeof LinkEntitiesAction>,
 	env: Env,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
-	if (!args.from_entity_id)
-		throw new ToolUserError("from_entity_id is required for link", 400);
-	if (!args.to_entity_id)
-		throw new ToolUserError("to_entity_id is required for link", 400);
-	if (!args.relationship_type_slug)
-		throw new ToolUserError("relationship_type_slug is required for link", 400);
-
 	const sql = getDb();
 
 	validateNoSelfReference(args.from_entity_id, args.to_entity_id);
@@ -2051,7 +2050,7 @@ async function handleLink(
  * `retractManualRelationshipClaim`) still run downstream, unchanged.
  */
 async function resolveRelationshipId(
-	args: ManageEntityArgs,
+	args: EdgeAddress,
 	ctx: ToolContext,
 	action: "unlink" | "update_link",
 ): Promise<number> {
@@ -2111,7 +2110,7 @@ async function resolveRelationshipId(
 }
 
 async function handleUnlink(
-	args: ManageEntityArgs,
+	args: Static<typeof UnlinkEntitiesAction>,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
 	const relationshipId = await resolveRelationshipId(args, ctx, "unlink");
@@ -2160,7 +2159,7 @@ async function handleUnlink(
 }
 
 async function handleUpdateLink(
-	args: ManageEntityArgs,
+	args: Static<typeof UpdateLinkAction>,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
 	const relationshipId = await resolveRelationshipId(args, ctx, "update_link");
@@ -2251,12 +2250,9 @@ async function handleUpdateLink(
 }
 
 async function handleListLinks(
-	args: ManageEntityArgs,
+	args: Static<typeof ListLinksAction>,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
-	if (!args.entity_id)
-		throw new ToolUserError("entity_id is required for list_links", 400);
-
 	const sql = getDb();
 	const typeRows = await sql<{ entity_type: string }>`
 		SELECT et.slug AS entity_type


### PR DESCRIPTION
## Summary
- `manage_entity` moves from one flat object (an `action` enum, every field optional, and eight presence checks answered by hand in the handlers) to a `Type.Union` of twelve per-action variants in core, dispatched through `defineActionTool`. The schema now says what each action requires and accepts; the hand checks for `entity_type`/`name` (create), `entity_id` (update, get, delete, list_links, unmerge), the endpoint triple (link), `winner_entity_id` (merge) and `candidate_entity_ids` (resolve_duplicates) are gone, as are the `requires:` lists the flat router carried for the same purpose. Two rules stay in the handler because a schema cannot say "one of": merge's `entity_id` **or** `duplicate_entity_ids`, and unlink/update_link's `relationship_id` **or** endpoint triple.
- The reaction-tracking pass that wrapped the whole router (`manageEntityImpl`) becomes a `trackedMutation` decorator on the three actions it ever recorded (`create`, `update`, `link`); the tracking body is unchanged. Two fields the flat schema documented for other actions but the handlers already consumed are now declared where they are read: `parent_id` as a `list` filter and `source` as a `list_links` filter.
- **core owns the SDK input types.** Nine `Entity*Input` names are derived from the variants through `ActionInput<Args, Action>` (same idiom as #3359, #3361–#3364); the namespace's four hand-written interfaces and five inline object types are deleted. The hand copies had drifted: `unlink` was typed as requiring the endpoint triple although 3,922 of 3,926 prod calls address the edge by `relationship_id` (which the runtime has always accepted); `updateLink` omitted `relationship_id`/`confidence`/`source`; `listLinks` omitted `source`/`limit`/`offset`; `list` omitted `parent_id` and the `category`/`main_market`/`market` filters. The `entities.list` / `entities.listLinks` SDK signatures in `method-metadata.ts` are aligned to the same set.
- **Per-action access filtering applies for the first time:** a read-scope listing shows `list`/`get`/`list_links`; member-write adds `create`/`update`/`link`/`unlink`/`update_link`; the owner-admin actions (`delete`, `merge`, `resolve_duplicates`, `unmerge`) appear only at admin. The flat tool exposed all twelve to every scope.

### What the flat contract could not express (red → green)
The new `manage-entity-contract.test.ts` cases, run against the **old** flat schema via a scratch copy of `origin/main`'s contract:
```
(fail) requires each action's identifying fields at the schema
(fail) rejects a field another action takes instead of ignoring it
(pass) leaves the edge addressing choice (id or endpoint triple) to the handler     ← unchanged
(pass) bounds resolve_duplicates to at least two distinct candidates                ← unchanged
(pass) accepts each action's full field set                                          ← unchanged
 3 pass / 2 fail
```
Same cases against the union: **7 pass / 0 fail** (plus the two wire-schema cases).

### Prod payload census (60 days, `sdk_call_trace`, 106 distinct call shapes; 9 of 192 reaction scripts call `client.entities.*`)
| SDK call | n | today | after |
|---|---|---|---|
| `entities.create` `{type→entity_type, name, metadata[, slug, parent_id]}` | 5,006 | ok (alias) | ok |
| `entities.create` `{entity_type, name[, metadata, slug]}` | 32 | ok | ok |
| `entities.create` `{entity_type, metadata, name, source}` | 1 | ok — `source` (a link field) silently ignored | **400**: `unknown argument(s): source` |
| `entities.create` with `identities` / `entity` / `zzz_bogus` / bare string / `name` only | 10 | already 400 | 400, same |
| `entities.update` `{entity_id, metadata[, name, slug, field_note]}` | 788 | ok | ok |
| `entities.update` bare number, `{id,…}`, `{description,…}`, `{deleted_at,…}` | 932 | already 400 | 400, same |
| `entities.delete` `{entity_id[, force_delete_tree, dry_run]}` / `{id→entity_id}` | 2,651 / 57 | ok | ok |
| `entities.delete` bare number | 1,246 | already 400 | 400, same |
| `entities.get` `{entity_id[, include_deleted]}` / `{id→entity_id}` | 262 / 6 | ok | ok |
| `entities.get` bare number / `{id, include}` | 12 | already 400 | 400, same |
| `entities.link` `{from_entity_id, to_entity_id, relationship_type_slug[, confidence, source, metadata]}` | 9,623 | ok | ok |
| `entities.link` with `source_entity_id`/`target_entity_id`, `relationship_type`, `relationship_type_id`, partial triples | 82 | already 400 | 400, same |
| `entities.unlink` `{relationship_id}` / endpoint triple | 3,922 / 1 | ok | ok |
| `entities.unlink` `{link_id}` / `{id}` | 3 | already 400 | 400, same |
| `entities.updateLink` `{relationship_id, confidence[, metadata, source]}` | 8 | ok | ok |
| `entities.updateLink` `{confidence}` alone / `{link_id,…}` | 2 | already 400 (no edge address / unknown key) | 400, same |
| `entities.list` `{entity_type?, limit?, offset?, search?}` | 292 | ok | ok |
| `entities.list` with `type`, `organization_slug`, `org`, `organization_id`, `q`, `bogus_arg_zzz` | 13 | already 400 | 400, same |
| `entities.listLinks` `{entity_id[, direction, include_deleted, relationship_type_slug]}` | 36 | ok | ok |
| `entities.manage` merge / update / create / unmerge / resolve_duplicates with per-action fields | 585 | ok | ok |
| `entities.manage` `{action, entity_id, target_entity_id}` / `{action, id}` | 9 | already 400 | 400, same |

Reaction scripts: the one active automation calling `client.entities.*` does `entities.update({ entity_id, metadata })` (ok); the archived ones call `manage({ action: 'merge', winner_entity_id, duplicate_entity_ids, merge_evidence })` and `manage({ action: 'resolve_duplicates', candidate_entity_ids })` (ok). Owletto's seven `manage_entity` request bodies (`list`, `create`, `update`, `delete`, `unmerge`, `list_links`) and the CLI seeder's `list`/`create`/`link` payloads are all per-action valid; owletto's own `request-contract.test.ts` still passes against the union.

**One call that succeeds today fails after this change**: the single `entities.create` carrying a stray `source`.

**Failure class changes on the wire.** A call missing a required field used to get the handler's 400 (`entity_type is required for create action`); it now gets the validator's 400 naming the field (`/entity_type: Expected required property`). Cross-action fields (`entity_type` on `update`, `name` on `delete`, `search` on `get`, …) used to be silently accepted; they now 400 with the valid-argument list for the action given. Proven above against the old contract.

## Test plan
- [x] Staged by explicit path; `git diff --name-only origin/main...HEAD` equals the intended 8 files. `make pre-pr` clean.
- [x] `bun test unit/manage-entity-contract.test.ts unit/manage-wire-schema.test.ts` → **21 pass / 0 fail**; red proof above.
- [x] Vitest `integration/entities/` + `integration/relationships/` + `integration/sandbox/` (20 files) → **233 pass / 0 fail**.
- [x] Vitest, every other integration file that calls `manage_entity` or `client.entities.*` (33 files across `authz/`, `tools/`, `mcp/`, `api/`, …) → **390 pass / 0 fail** (2 skipped by their own guards).
- [x] Owletto `src/lib/api/request-contract.test.ts` (validates the SPA's request bodies against this contract) → **5 pass**.
- [x] Client regenerated from the running server (`types.gen.ts` 480+/185−): `ManageEntityData.body` is now the 12-variant discriminated union; `make review-fix` cross-checked every variant's property set and required-ness against the contract.
- [x] `make review-fix` (same-model, see below) found no defect; it tightened the `AutomationSource` comment, import ordering in two files, and the `TrackedMutationArgs` doc. Its residual note — the derived `manageEntityTool.schema` and the registered `ManageEntitySchema` have no equality guard — applies to every union tool in the series and is left for a series-wide follow-up.
- [ ] No bot runtime change.

## Notes
**SDK-visible type changes** (runtime unchanged — every field below was already accepted): `entities.unlink`'s input is now `{ relationship_id? } | endpoint triple?` instead of a required triple; `updateLink` gains `relationship_id`/`confidence`/`source`; `listLinks` gains `source`/`limit`/`offset`; `list` gains `parent_id`/`category`/`main_market`/`market`; the write inputs expose `automation_source`. The published connector SDK still carries its own hand-written entity inputs — switching it to these core types is PR B of the series and a surface decision on its own.

**`automation_source` is declared on the variants whose handler reads it** (create, update, delete, link, merge, and the type-gated reads list / list_links, where it resolves the acting principal). unlink, update_link, resolve_duplicates and unmerge never consumed it, so they do not accept it; no prod call passed it to any of them.

**Wire behaviour for MCP clients** is otherwise unchanged in shape: the union flattens to one object with per-action `Required:` lines generated from the variants (pinned by the test); the `[create/update]` / `[link/unlink/update_link]` prefixes stay because a flattened property cannot say which actions accept it.

**Reviewer disclosure:** codex is at its usage limit until 2026-09-07, so `make review-fix` / `make review` ran as `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus` — same-model self-review, not the intended cross-harness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved entity management validation with action-specific inputs and required fields.
  - Added clearer support for entity retrieval, linking, duplicate resolution, merging, and relationship operations.
  - Expanded entity listing options, including category, market, sorting, pagination, and link source filters.
  - Standardized entity operation inputs across the available entity management interfaces.
- **Bug Fixes**
  - Prevented invalid fields from being submitted to unrelated entity actions.
  - Improved validation for relationship endpoints and duplicate-resolution candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->