### PR TITLE
refactor(connector-sdk): type ReactionClient inputs with the core contracts, not hand copies

### DIFF
--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -232,18 +232,32 @@ export type { ReactionContext } from './reaction-sdk.js';
 export type { ReactionClient } from './reaction-client-types.js';
 export type {
   CardElement,
-  EntityCreateInput,
-  EntityLinkInput,
-  EntityListFilter,
-  EntityUpdateInput,
   KnowledgeReadInput,
   KnowledgeSaveInput,
   KnowledgeSaveResult,
   KnowledgeSearchInput,
   NotificationsSendInput,
   NotificationsSendResult,
-  OperationsListRunsInput,
 } from './reaction-client-types.js';
+// Every object input a `ReactionClient` method takes is the server contract's
+// own per-action type, re-exported so a script can name the argument it builds.
+export type { ConnectionListInput } from '@lobu/core/contracts/tools/manage-connections';
+export type {
+  EntityCreateInput,
+  EntityDeleteInput,
+  EntityGetInput,
+  EntityLinkInput,
+  EntityListInput,
+  EntityListLinksInput,
+  EntityUnlinkInput,
+  EntityUpdateInput,
+  EntityUpdateLinkInput,
+} from '@lobu/core/contracts/tools/manage-entity';
+export type {
+  OperationExecuteInput,
+  OperationListAvailableInput,
+  OperationListRunsInput,
+} from '@lobu/core/contracts/tools/manage-operations';
 export type { Env } from './types.js';
 
 // =============================================================================

--- a/packages/connector-sdk/src/reaction-client-types.ts
+++ b/packages/connector-sdk/src/reaction-client-types.ts
@@ -15,6 +15,23 @@
 // Type-only imports: they erase at compile time, so nothing new enters the
 // isolate bundle. Core SUBPATH imports are permitted here; the root is not
 // (see AGENTS.md).
+import type { ConnectionListInput } from "@lobu/core/contracts/tools/manage-connections";
+import type {
+  EntityCreateInput,
+  EntityDeleteInput,
+  EntityGetInput,
+  EntityLinkInput,
+  EntityListInput,
+  EntityListLinksInput,
+  EntityUnlinkInput,
+  EntityUpdateInput,
+  EntityUpdateLinkInput,
+} from "@lobu/core/contracts/tools/manage-entity";
+import type {
+  OperationExecuteInput,
+  OperationListAvailableInput,
+  OperationListRunsInput,
+} from "@lobu/core/contracts/tools/manage-operations";
 import type { PublicGetContentArgs } from "@lobu/core/contracts/tools/read-knowledge";
 import type { PublicSearchArgs } from "@lobu/core/contracts/tools/search-memory";
 import type {} from "./reaction-client-types.typecheck";
@@ -76,41 +93,7 @@ export interface KnowledgeSaveResult {
   metadata: Record<string, unknown>;
 }
 
-// ── Entities ─────────────────────────────────────────────────────────────────
-
-export interface EntityCreateInput {
-  type: string;
-  name: string;
-  slug?: string;
-  content?: string;
-  parent_id?: number;
-  metadata?: Record<string, unknown>;
-}
-
-export interface EntityUpdateInput {
-  entity_id: number;
-  name?: string;
-  slug?: string;
-  content?: string;
-  metadata?: Record<string, unknown>;
-}
-
-export interface EntityLinkInput {
-  from_entity_id: number;
-  to_entity_id: number;
-  relationship_type_slug: string;
-  metadata?: Record<string, unknown>;
-}
-
-export interface EntityListFilter {
-  entity_type?: string;
-  parent_id?: number;
-  search?: string;
-  limit?: number;
-  offset?: number;
-  sort_by?: string;
-  sort_order?: "asc" | "desc";
-}
+// ── Notifications ────────────────────────────────────────────────────────────
 
 export interface NotificationsSendInput {
   /** Notification title (≤200 chars). */
@@ -175,25 +158,6 @@ export interface NotificationsSendResult {
   run_id?: number;
 }
 
-export interface OperationsListRunsInput {
-  connection_id?: number;
-  connection_ids?: number[];
-  feed_ids?: number[];
-  device_worker_id?: string;
-  connector_key?: string;
-  operation_key?: string;
-  status?: string;
-  approval_status?: string;
-  run_types?: string[];
-  created_after?: string;
-  created_before?: string;
-  automation_ids?: number[];
-  limit?: number;
-  offset?: number;
-  before_id?: number;
-  before_created_at?: string;
-}
-
 // ── Client ───────────────────────────────────────────────────────────────────
 
 /**
@@ -211,48 +175,26 @@ export interface ReactionClient {
     search(input: KnowledgeSearchInput): Promise<unknown>;
     save(input: KnowledgeSaveInput): Promise<KnowledgeSaveResult>;
     read(input: KnowledgeReadInput): Promise<unknown>;
-    delete(input: number | { event_id?: number; event_ids?: number[]; reason?: string }): Promise<unknown>;
+    /** Tombstone content by id. `delete_content` names the ids `content_id(s)`. */
+    delete(input: number | { content_id?: number; content_ids?: number[]; reason?: string }): Promise<unknown>;
   };
 
   entities: {
-    list(filter?: EntityListFilter): Promise<unknown>;
-    get(input: { entity_id: number; include_deleted?: boolean }): Promise<unknown>;
+    list(filter?: EntityListInput): Promise<unknown>;
+    get(input: EntityGetInput): Promise<unknown>;
     create(input: EntityCreateInput): Promise<{ id: number }>;
     update(input: EntityUpdateInput): Promise<unknown>;
-    delete(entity_id: number, options?: { force_delete_tree?: boolean }): Promise<unknown>;
+    delete(input: EntityDeleteInput): Promise<unknown>;
     link(input: EntityLinkInput): Promise<unknown>;
-    unlink(input: {
-      from_entity_id: number;
-      to_entity_id: number;
-      relationship_type_slug: string;
-    }): Promise<unknown>;
-    updateLink(input: {
-      from_entity_id: number;
-      to_entity_id: number;
-      relationship_type_slug: string;
-      metadata?: Record<string, unknown>;
-    }): Promise<unknown>;
-    listLinks(input: {
-      entity_id: number;
-      relationship_type_slug?: string;
-      limit?: number;
-      offset?: number;
-    }): Promise<unknown>;
+    unlink(input: EntityUnlinkInput): Promise<unknown>;
+    updateLink(input: EntityUpdateLinkInput): Promise<unknown>;
+    listLinks(input: EntityListLinksInput): Promise<unknown>;
     search(query: string, options?: { limit?: number }): Promise<unknown>;
   };
 
   connections: {
     /** List configured connections; `device_online` is computed server-side. */
-    list(input?: {
-      connector_key?: string;
-      status?: string;
-      entity_id?: number;
-      created_by?: string;
-      connection_ids?: number[];
-      setup_attempt_id?: string;
-      limit?: number;
-      offset?: number;
-    }): Promise<unknown>;
+    list(input?: ConnectionListInput): Promise<unknown>;
     get(connection_id: number): Promise<unknown>;
   };
 
@@ -274,12 +216,9 @@ export interface ReactionClient {
    */
   operations: {
     /** List the operations available on a connection (or the whole org). */
-    listAvailable(input?: {
-      connection_id?: number;
-      entity_id?: number;
-    }): Promise<unknown>;
+    listAvailable(input?: OperationListAvailableInput): Promise<unknown>;
     /** Read operational runs, including questions and staged connector actions. */
-    listRuns(input?: OperationsListRunsInput): Promise<{
+    listRuns(input?: OperationListRunsInput): Promise<{
       runs: Array<Record<string, unknown>>;
       total: number;
       limit: number;
@@ -289,19 +228,7 @@ export interface ReactionClient {
     /** Read one durable run and its completed answer/rejection state. */
     getRun(run_id: number): Promise<{ run: Record<string, unknown> }>;
     /** Execute one operation and wait for its result. */
-    execute(input: {
-      connection_id: number;
-      operation_key: string;
-      input?: Record<string, unknown>;
-      /** Durable key for at-most-once execution across reaction retries. */
-      idempotency_key?: string;
-      activation?: {
-        kind: "page_visit";
-        urls: string[];
-        expires_in_seconds?: number;
-      };
-      automation_source?: { automation_id: number; run_id: number };
-    }): Promise<{
+    execute(input: OperationExecuteInput): Promise<{
       status?:
         | "completed"
         | "failed"

--- a/packages/connector-sdk/src/reaction-client-types.typecheck.ts
+++ b/packages/connector-sdk/src/reaction-client-types.typecheck.ts
@@ -21,6 +21,7 @@ import type { PublicSearchArgs } from "@lobu/core/contracts/tools/search-memory"
 import type {
   KnowledgeReadInput,
   KnowledgeSearchInput,
+  ReactionClient,
 } from "./reaction-client-types";
 
 type Assert<T extends true> = T;
@@ -74,4 +75,31 @@ type ExactKeys<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : fals
 export type ReactionKnowledgeKeysExhaustive = [
   Assert<ExactKeys<keyof KnowledgeReadInput, keyof PublicGetContentArgs>>,
   Assert<ExactKeys<keyof KnowledgeSearchInput, keyof PublicSearchArgs>>,
+];
+
+/**
+ * The entity methods take the `manage_entity` contract's per-action inputs.
+ * These pin the three shapes the hand-written predecessors got wrong:
+ *  - `unlink`/`update_link` accept `relationship_id` alone. The triple the old
+ *    declaration required does work, so this was undiscoverability, not a
+ *    rejection.
+ *  - `delete` takes the object form. The positional number the old declaration
+ *    advertised was never accepted: the namespace spreads its single argument
+ *    into the action payload, so a number arrived as `{}` and failed the
+ *    validator on a missing `entity_id`.
+ *  - `create` names the field `entity_type`, as the contract does. The runtime
+ *    alias table still accepts `type` on the wire; the published type should
+ *    not be the place that teaches the alias.
+ */
+type EntityInput<M extends keyof ReactionClient["entities"]> = Parameters<
+  ReactionClient["entities"][M]
+>[0];
+
+export type ReactionEntityInputsContract = [
+  Assert<{ relationship_id: number } extends EntityInput<"unlink"> ? true : false>,
+  Assert<{ relationship_id: number; confidence: number } extends EntityInput<"updateLink"> ? true : false>,
+  Assert<{ entity_id: number; dry_run: true } extends EntityInput<"delete"> ? true : false>,
+  Assert<number extends EntityInput<"delete"> ? false : true>,
+  Assert<{ type: string; name: string } extends EntityInput<"create"> ? false : true>,
+  Assert<{ entity_type: string; name: string; domain: string } extends EntityInput<"create"> ? true : false>,
 ];


### PR DESCRIPTION
## Summary

`@lobu/connector-sdk`'s `ReactionClient` carried hand-written copies of the SDK inputs for `entities.*`, `connections.list` and `operations.*`. They had drifted from what the server accepts, and because the server's argument validator rejects unknown keys, a drifted published type is a hard error for the reaction author, not a warning. This PR deletes those copies and types the client with the server contracts' own per-action inputs from `@lobu/core` (the same pattern `knowledge.search` / `knowledge.read` already use via `PublicSearchArgs` / `PublicGetContentArgs`).

Net: 108 lines of duplicated type declarations removed, 77 added (imports, re-exports of every input type so a script can name it, compile-time pins).

### What the published types said vs. what the runtime accepts

| method | published before | runtime (now the type) |
|---|---|---|
| `entities.unlink` | required `{ from_entity_id, to_entity_id, relationship_type_slug }` | `relationship_id` alone, or the triple (`EntityUnlinkInput`); 3,922 of 3,926 live calls in 60d pass `relationship_id`, which the old type would not compile |
| `entities.updateLink` | the triple + `metadata` | `relationship_id` or the triple, plus `confidence` / `source` / `metadata` |
| `entities.delete` | positional `delete(entity_id, options?)` | object form `{ entity_id, force_delete_tree?, dry_run? }`; the positional form was never accepted (1,246 live calls fail on it today, unchanged by this PR) |
| `entities.create` | `{ type, name, slug?, content?, parent_id?, metadata? }` | `EntityCreateInput`: `entity_type` (the contract's name; the runtime keeps accepting `type` as an alias) plus `enabled_classifiers`, `domain`, `category`, `platform_type`, `main_market`, `market`, `link`, `automation_source` |
| `entities.update` | 5 fields | `EntityUpdateInput`: the create fields plus `field_note` / `affirm_fields` |
| `entities.list` | `EntityListFilter` (7 fields) | `EntityListInput`: adds `category`, `main_market`, `market`, `automation_source` |
| `entities.listLinks` | `{ entity_id, relationship_type_slug?, limit?, offset? }` | adds `direction`, `confidence_min`, `source`, `include_deleted` |
| `entities.get` | `{ entity_id, include_deleted? }` | same, as `EntityGetInput` |
| `connections.list` | 8 inline fields | `ConnectionListInput` — same fields |
| `operations.listAvailable` | `{ connection_id?, entity_id? }` | `OperationListAvailableInput`: adds `connector_key`, `kind`, `backend`, `query`, `include_*` |
| `operations.execute` | 6 inline fields | `OperationExecuteInput` — same fields |
| `operations.listRuns` | `OperationsListRunsInput` (16 fields) | `OperationListRunsInput` — same fields |
| `knowledge.delete` | `{ event_id?, event_ids?, reason? }` | `{ content_id?, content_ids?, reason? }` — the names `delete_content` actually reads (found by `make review-fix`; the old names were unknown-argument errors) |

### Evidence

Prod census, all 192 stored reaction scripts (`automations.reaction_script`):

```
uses client.entities.*           9
  entities.create                0   (0 with `type:`, 0 with `entity_type:`)
  entities.get/update/delete     1   (0 positional delete)
  entities.link/unlink/…         0
imports "@lobu/connector-sdk"    8   (ReactionClient / ReactionContext only)
names any removed type           0   (EntityListFilter, OperationsListRunsInput, …)
```

No stored script names a removed or renamed type, uses `type:` on create, or calls the positional delete. The ~5,000 agent `run_sdk` calls that pass `type` on `entities.create` go through the runtime alias table (`sdk-aliases.ts`), which this PR does not touch.

Compile-time pins (`reaction-client-types.typecheck.ts`, checked by `tsc`, not by `bun test`, since the package tsconfig excludes tests):

```
ReactionEntityInputsContract
  { relationship_id } extends unlink input                      ✓
  { relationship_id, confidence } extends updateLink input      ✓
  { entity_id, dry_run } extends delete input                   ✓
  number extends delete input                                   ✗ (asserted false)
  { type, name } extends create input                           ✗ (asserted false)
  { entity_type, name, domain } extends create input            ✓
```

Red proof that the pins are load-bearing — a scratch file asserting the positional delete compiles:

```
src/__pin-red.ts(3,27): error TS2344: Type 'false' does not satisfy the constraint 'true'.
```

## Test plan

- [x] `cd packages/connector-sdk && bun run typecheck` — 0 errors (before and after; the red-proof pin above fails it)
- [x] `bun test packages/connector-sdk/src/__tests__/reaction-client-types.test.ts` — 1 pass
- [x] `git grep` on `origin/main`: no consumer outside connector-sdk imports the removed names (`EntityListFilter`, `OperationsListRunsInput`); server imports only `NotificationsSendInput` / `NotificationsSendResult` / `EntityMetrics`, all unchanged
- [x] Prod census above (60d `sdk_call_trace` + all stored reaction scripts)
- [x] `make review-fix` on the settled diff, then `make pre-pr`

## Notes

**Published type surface changes (types only, runtime untouched).** `packages/connector-sdk/AGENTS.md` asks for additive changes to exported types unless a migration is planned; the two removals below are deliberate breaking changes to shapes the server rejected, kept out of a compat alias by the repo's no-shim rule. Flagging for the owner rather than hiding it:
- Renamed exports: `EntityListFilter` → `EntityListInput`, `OperationsListRunsInput` → `OperationListRunsInput` (core's names). No stored script and no repo consumer imports either.
- `EntityCreateInput.type` → `entity_type`. The runtime alias stays; the published type now names the contract field.
- `entities.delete` is the object form. The positional form the old type advertised has never been accepted.
- Every input widens to the full contract (fields listed in the table). These were all accepted at runtime already.

**Not in this PR:** `knowledge.save` / `knowledge.delete` are still hand-written in two places (this package and the server's `knowledge.ts`), because their schemas live in the server tools (`save_content.ts`, `delete_content.ts`) rather than in core. Moving those two schemas next to `read-knowledge.ts` / `search-memory.ts` and deriving both copies is the follow-up.

**Reviewer disclosure:** codex is at its usage limit until 2026-09-07, so `make review-fix` / `make review` ran as `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus` — same-model self-review, not the intended cross-harness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
