### PR TITLE
refactor(server,core): derive the flat-contract namespace inputs instead of restating them

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -5001,7 +5001,7 @@ export type ManageAutomationsData = {
       finalize_nudges?: number;
     };
     /**
-     * [create] Tags for filtering
+     * [create/update] Tags for filtering
      */
     tags?: Array<string>;
     /**

--- a/packages/core/src/contracts/tools/action-input.ts
+++ b/packages/core/src/contracts/tools/action-input.ts
@@ -19,9 +19,23 @@
  * Only for contracts whose input schema is a `Type.Union` of per-action
  * variants, each carrying a single-literal `action`. A flat `Type.Object`
  * contract has nothing to `Extract` — its `action` is a union-typed field, not
- * a discriminator.
+ * a discriminator — so it uses `FlatActionInput` below.
  */
 export type ActionInput<
   Args extends { action: string },
   Action extends Args["action"],
 > = Omit<Extract<Args, { action: Action }>, "action">;
+
+/**
+ * For a FLAT contract — one `Type.Object` whose non-discriminator fields are
+ * all optional because they span every action — the fields one action reads,
+ * with `R` naming the ones that action requires. A key not on the contract
+ * fails to compile, so an SDK method's shape cannot drift from the schema's
+ * fields; `R` still has to be checked against the handler, since a flat schema
+ * cannot express per-action required-ness.
+ */
+export type FlatActionInput<
+  Args extends object,
+  K extends keyof Args,
+  R extends K = never,
+> = Pick<Args, Exclude<K, R>> & Required<Pick<Args, R>>;

--- a/packages/core/src/contracts/tools/manage-automations.ts
+++ b/packages/core/src/contracts/tools/manage-automations.ts
@@ -754,7 +754,9 @@ export const ManageAutomationsSchema = Type.Object(
       Type.Union([Type.Null(), AutomationExecutionConfigSchema])
     ),
     tags: Type.Optional(
-      Type.Array(Type.String(), { description: "[create] Tags for filtering" })
+      Type.Array(Type.String(), {
+        description: "[create/update] Tags for filtering",
+      })
     ),
 
     // Version management

--- a/packages/server/src/__tests__/integration/automations/device-agent-kinds-gate.test.ts
+++ b/packages/server/src/__tests__/integration/automations/device-agent-kinds-gate.test.ts
@@ -107,8 +107,8 @@ async function setup(opts: {
   })) as { automation_id: string };
   const automationId = Number(automation.automation_id);
 
-  // AutomationCreateInput doesn't expose device_worker_id / agent_kind; set
-  // them directly, as manual-trigger.test.ts does.
+  // Pin the automation to the device directly rather than through
+  // automations.create, as manual-trigger.test.ts does.
   await sql`
     UPDATE automations
     SET device_worker_id = ${deviceWorkerId}::uuid,

--- a/packages/server/src/__tests__/integration/automations/manual-trigger.test.ts
+++ b/packages/server/src/__tests__/integration/automations/manual-trigger.test.ts
@@ -112,9 +112,9 @@ async function setupDevicePinnedAutomation(opts: { workerId: string }): Promise<
   })) as { automation_id: string };
   const automationId = Number(automation.automation_id);
 
-  // Pin the automation to the device. `AutomationCreateInput` doesn't expose
-  // device_worker_id / agent_kind, so set them directly — matches how
-  // automation-contract.test.ts pins automations for the #802 dispatcher tests.
+  // Pin the automation to the device directly rather than through
+  // automations.create — matches how automation-contract.test.ts pins
+  // automations for the #802 dispatcher tests.
   await sql`
     UPDATE automations
     SET device_worker_id = ${deviceWorkerId}::uuid,

--- a/packages/server/src/sandbox/namespaces/automations.ts
+++ b/packages/server/src/sandbox/namespaces/automations.ts
@@ -7,17 +7,14 @@
  * reachable via `automations.manage({ action, ... })`.
  */
 
-import type { Env } from "../../index";
+import type { FlatActionInput } from "@lobu/core/contracts/tools/action-input";
 import type {
 	AutomationClaimNextWindowResult,
-	AutomationExecutionConfig,
-	AutomationSource,
-	AutomationTrigger,
 	AutomationTriggerResult,
 	ListAutomationsArgs,
 	ManageAutomationsResult,
 } from "@lobu/core/contracts/tools/manage-automations";
-import type { AgentKind } from "@lobu/core/contracts/worker/device-automation";
+import type { Env } from "../../index";
 import {
 	type ManageAutomationsArgs,
 	manageAutomations,
@@ -30,6 +27,11 @@ type AutomationId = string;
 type AutomationActionInput = Omit<ManageAutomationsArgs, "action" | "automation_id"> & {
 	automation_id?: AutomationId;
 };
+/** The contract's fields one action reads; `R` names the ones it requires. */
+type Input<
+	K extends keyof ManageAutomationsArgs,
+	R extends K = never,
+> = FlatActionInput<ManageAutomationsArgs, K, R>;
 
 export type AutomationListFilter = ListAutomationsArgs;
 
@@ -43,94 +45,102 @@ export type AutomationCreateResult =
 	| Extract<ManageAutomationsResult, { action: "create" }>
 	| (Omit<AutomationPendingApprovalResult, "action"> & { action: "create" });
 
-export interface AutomationCreateInput {
-	/** Attach the Automation to an entity. Omit for an org-scoped/global Automation. */
-	entity_id?: number;
-	prompt: string;
-	sources?: AutomationSource[];
-	triggers?: AutomationTrigger[];
-	slug?: string;
-	name?: string;
-	description?: string;
-	outputs?: Record<string, unknown>;
-	classifiers?: Record<string, unknown>;
-	reactions_guidance?: string;
-	reaction_script?: string;
-	managed_agent_id?: string | null;
-	device_worker_id?: string;
-	agent_kind?: AgentKind;
-	model_config?: Record<string, unknown>;
-	execution_config?: AutomationExecutionConfig;
-	tags?: string[];
-}
+/**
+ * `slug` is the only hard requirement (`handleCreate`). The instruction
+ * requirement is satisfied by `prompt`, `skills`, OR `reaction_script`, and an
+ * event trigger with execution 'turn' may omit all three
+ * (`assertAutomationInstructions`) — so none of them is required here.
+ */
+export type AutomationCreateInput = Input<
+	| "entity_id"
+	| "prompt"
+	| "skills"
+	| "sources"
+	| "triggers"
+	| "slug"
+	| "name"
+	| "description"
+	| "outputs"
+	| "classifiers"
+	| "reactions_guidance"
+	| "reaction_script"
+	| "managed_agent_id"
+	| "device_worker_id"
+	| "agent_kind"
+	| "delivery_target"
+	| "min_cooldown_seconds"
+	| "model_config"
+	| "execution_config"
+	| "tags",
+	"slug"
+>;
 
-export interface AutomationUpdateInput {
-	automation_id: AutomationId;
-	triggers?: AutomationTrigger[];
-	managed_agent_id?: string | null;
-	device_worker_id?: string | null;
-	agent_kind?: AgentKind | null;
-	model_config?: Record<string, unknown>;
-	/** `null` clears a previously-saved config back to NULL/defaults. */
-	execution_config?: AutomationExecutionConfig | null;
-}
+/**
+ * `tags` is patchable here even though the schema annotates it `[create]` —
+ * `handleUpdate` lists it in `updatedFields` and writes it. Omitting it is the
+ * drift `FlatActionInput` exists to prevent: a field the schema accepts that no
+ * typed caller can reach.
+ */
+export type AutomationUpdateInput = Input<
+	| "automation_id"
+	| "triggers"
+	| "managed_agent_id"
+	| "device_worker_id"
+	| "agent_kind"
+	| "delivery_target"
+	| "min_cooldown_seconds"
+	| "model_config"
+	| "execution_config"
+	| "tags",
+	"automation_id"
+>;
 
-export interface AutomationCompleteWindowInput {
-	automation_id: AutomationId;
-	/** JWT obtained from knowledge.read for this Automation run/window. */
-	window_token?: string;
-	/** Multiple page JWTs obtained from knowledge.read for the same Automation run/window. */
-	window_tokens?: string[];
-	extracted_data: Record<string, unknown>;
-	client_id?: string;
-	model?: string;
-	/** Automation run id from the dispatch prompt or Automation list. */
-	run_id: number;
-	run_metadata?: Record<string, unknown>;
-	template_version_id?: number;
-}
+export type AutomationCompleteWindowInput = Input<
+	| "automation_id"
+	| "window_token"
+	| "window_tokens"
+	| "extracted_data"
+	| "client_id"
+	| "model"
+	| "run_id"
+	| "run_metadata"
+	| "template_version_id",
+	"automation_id" | "extracted_data" | "run_id"
+>;
 
-export interface AutomationClaimNextWindowInput {
-	automation_id: AutomationId;
-	lease_seconds?: number;
-	limit?: number;
-	/** Existing lease run id when fetching the next source page. */
-	run_id?: number;
-	before_occurred_at?: string;
-	before_id?: number;
-}
+export type AutomationClaimNextWindowInput = Input<
+	| "automation_id"
+	| "lease_seconds"
+	| "limit"
+	| "run_id"
+	| "before_occurred_at"
+	| "before_id",
+	"automation_id"
+>;
 
 export interface AutomationCreateVersionInput extends AutomationActionInput {
 	automation_id: AutomationId;
 }
 
-export interface AutomationVersionDetailsInput {
-	automation_id: AutomationId;
-	version?: number;
-}
+export type AutomationVersionDetailsInput = Input<
+	"automation_id" | "version",
+	"automation_id"
+>;
 
-export interface AutomationSubmitFeedbackInput {
-	automation_id: AutomationId;
-	run_id: number;
-	corrections: Array<{
-		field_path: string;
-		mutation?: "set" | "remove" | "add";
-		value?: unknown;
-		note?: string;
-	}>;
-}
+export type AutomationSubmitFeedbackInput = Input<
+	"automation_id" | "run_id" | "corrections",
+	"automation_id" | "run_id" | "corrections"
+>;
 
-export interface AutomationGetFeedbackInput {
-	automation_id: AutomationId;
-	run_id?: number;
-	limit?: number;
-}
+export type AutomationGetFeedbackInput = Input<
+	"automation_id" | "run_id" | "limit",
+	"automation_id"
+>;
 
-export interface AutomationCreateFromVersionInput {
-	version_id: number;
-	entity_ids: number[];
-	name_pattern?: string;
-}
+export type AutomationCreateFromVersionInput = Input<
+	"version_id" | "entity_ids" | "name_pattern",
+	"version_id" | "entity_ids"
+>;
 
 export interface AutomationsNamespace {
 	/** Raw escape hatch for any manage_automations action. Prefer named methods. */

--- a/packages/server/src/sandbox/namespaces/entity-schema.ts
+++ b/packages/server/src/sandbox/namespaces/entity-schema.ts
@@ -4,80 +4,60 @@
  * and `action`.
  *
  * Field names mirror the handler: plain `slug` for the type identifier,
- * `source_entity_type_slug` / `target_entity_type_slug` / `relationship_type_slug`
- * for add_rule.
+ * `source_entity_type_slug` / `target_entity_type_slug` for add_rule.
  */
 
+import type { FlatActionInput } from "@lobu/core/contracts/tools/action-input";
+import type { ManageEntitySchemaArgs } from "@lobu/core/contracts/tools/manage-entity-schema";
 import type { Env } from "../../index";
 import { manageEntitySchema } from "../../tools/admin/manage_entity_schema";
 import type { ToolContext } from "../../tools/registry";
 import { createActionCaller, idArg } from "./action-call";
 
-export interface EntitySchemaAddRuleInput {
-	slug: string;
-	source_entity_type_slug: string;
-	target_entity_type_slug: string;
-	relationship_type_slug?: string;
-	description?: string;
-}
+/**
+ * The contract's fields one action reads; `R` names the ones it requires.
+ * `schema_type` and `action` are not inputs — each method fills them in.
+ */
+type Input<
+	K extends keyof ManageEntitySchemaArgs,
+	R extends K = never,
+> = FlatActionInput<ManageEntitySchemaArgs, K, R>;
+type TypeFields = "slug" | "name" | "description" | "metadata_schema";
+type EntityTypeFields =
+	| TypeFields
+	| "icon"
+	| "color"
+	| "event_kinds"
+	| "backing"
+	| "metrics_config"
+	| "rules_source";
+type RelationshipTypeFields = TypeFields | "inverse_type_slug" | "status";
 
 export interface EntitySchemaNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	listTypes(input?: { list_scope?: "accessible" | "organization" }): Promise<unknown>;
+	listTypes(input?: Input<"list_scope">): Promise<unknown>;
 	getType(slug: string): Promise<unknown>;
-	createType(input: {
-		slug: string;
-		name: string;
-		description?: string;
-		icon?: string;
-		color?: string;
-		metadata_schema?: Record<string, unknown>;
-		event_kinds?: Record<string, unknown> | null;
-		/**
-		 * Make the type derived (a SQL view); `null`/omit ⇒ a stored type. With
-		 * `connection`, the view runs LIVE against that connection's external DB
-		 * (read-only pushdown) instead of the org's internal tables.
-		 */
-		backing?: { sql: string; connection?: string } | null;
-		/** Declared metric contract (eventSets/measures/dimensions/segments); `null` clears it. */
-		metrics_config?: Record<string, unknown> | null;
-	}): Promise<unknown>;
-	updateType(input: {
-		slug: string;
-		name?: string;
-		description?: string;
-		icon?: string;
-		color?: string;
-		metadata_schema?: Record<string, unknown>;
-		event_kinds?: Record<string, unknown> | null;
-		/** Set/clear the derived view; omit to leave backing unchanged. With
-		 *  `connection`, the view reads live from that external connection (pushdown). */
-		backing?: { sql: string; connection?: string } | null;
-		/** Set/clear declared metrics; `null` clears, omit to leave unchanged. */
-		metrics_config?: Record<string, unknown> | null;
-	}): Promise<unknown>;
-	deleteType(input: { slug: string }): Promise<unknown>;
+	createType(input: Input<EntityTypeFields, "slug" | "name">): Promise<unknown>;
+	updateType(input: Input<EntityTypeFields, "slug">): Promise<unknown>;
+	deleteType(input: Input<"slug", "slug">): Promise<unknown>;
 	auditType(slug: string): Promise<unknown>;
 
-	listRelTypes(input?: { list_scope?: "accessible" | "organization" }): Promise<unknown>;
+	listRelTypes(input?: Input<"list_scope" | "include_deleted">): Promise<unknown>;
 	getRelType(slug: string): Promise<unknown>;
-	createRelType(input: {
-		slug: string;
-		name: string;
-		description?: string;
-		inverse_type_slug?: string | null;
-	}): Promise<unknown>;
-	updateRelType(input: {
-		slug: string;
-		name?: string;
-		description?: string;
-		inverse_type_slug?: string | null;
-	}): Promise<unknown>;
-	deleteRelType(input: { slug: string }): Promise<unknown>;
+	createRelType(
+		input: Input<RelationshipTypeFields | "is_symmetric", "slug" | "name">,
+	): Promise<unknown>;
+	updateRelType(input: Input<RelationshipTypeFields, "slug">): Promise<unknown>;
+	deleteRelType(input: Input<"slug", "slug">): Promise<unknown>;
 
-	addRule(input: EntitySchemaAddRuleInput): Promise<unknown>;
-	removeRule(input: { slug: string; rule_id: number }): Promise<unknown>;
-	listRules(input: { slug: string }): Promise<unknown>;
+	addRule(
+		input: Input<
+			"slug" | "source_entity_type_slug" | "target_entity_type_slug",
+			"slug" | "source_entity_type_slug" | "target_entity_type_slug"
+		>,
+	): Promise<unknown>;
+	removeRule(input: Input<"slug" | "rule_id", "rule_id">): Promise<unknown>;
+	listRules(input: Input<"slug", "slug">): Promise<unknown>;
 }
 
 export function buildEntitySchemaNamespace(


### PR DESCRIPTION
## Summary

The two SDK namespaces still backed by a flat contract (`automations`, `entitySchema`) declared their method inputs by hand: 8 interfaces in `automations.ts` and 11 inline object types in `entity-schema.ts`, restating fields the `@lobu/core` contract already defines. They had drifted: `automations.create` was missing `skills`, `delivery_target` and `min_cooldown_seconds`; `automations.update` was missing `delivery_target` and `min_cooldown_seconds`; `entitySchema.createType` lacked `rules_source`; `createRelType` lacked `metadata_schema` / `is_symmetric` / `status`; `addRule` advertised `relationship_type_slug` and `description`, which the server rejects as unknown arguments.

This derives every one of them from the contract instead. One 4-line helper in core, `FlatActionInput<Args, K, R>`, picks the fields an action reads and marks the ones it requires; a key that is not on the contract is a compile error, and a field's type is the contract's. Union-backed namespaces already do this through `ActionInput`; this is the flat-contract counterpart, so the last two namespaces stop being a second source of truth without converting 16-action and 14-variant contracts to unions.

Net across the two namespaces and the helper: 142 lines removed, 146 added — the additions are key lists plus the comments that record which handler each required-field choice was checked against. Not a size win; a source-of-truth win.

### Proof

Scratch file compiled against the server (`tsc --noEmit`), then deleted:

```
GREEN  AutomationCreateInput  { slug, skills, delivery_target, min_cooldown_seconds }
GREEN  AutomationUpdateInput  { automation_id, tags, delivery_target, min_cooldown_seconds }
GREEN  createRelType input     { slug, name, metadata_schema, is_symmetric, status }
RED    FlatActionInput<ManageAutomationsArgs, "prompt" | "not_a_field">
         → TS2344 "not_a_field" does not satisfy keyof ManageAutomationsArgs
RED    AutomationCreateInput = { name: "x" }        → TS2322 property 'slug' is missing
RED    updateRelType input = { slug, is_symmetric } → TS2353 'is_symmetric' does not exist
```

The three RED lines are exactly the drift classes the hand-written interfaces could not catch: a phantom key, a lost required field, and a field of a different action.

### SDK-visible type changes (types only; the runtime validator accepted all of these before)

- `automations.create`: gains `skills`, `delivery_target`, `min_cooldown_seconds`; `device_worker_id` / `agent_kind` become `… | null` as the contract says (the hand type omitted `null`). `prompt` is no longer marked required and `slug` is: `handleCreate` hard-requires only `slug`, and the instruction requirement is met by `prompt` OR `skills` OR `reaction_script` (`assertAutomationInstructions`). The old type refused a valid skills-only Automation.
- `automations.update`: gains `delivery_target`, `min_cooldown_seconds`, `tags`. `handleUpdate` already writes `tags` (`crud.ts:633`, `:688`) but no typed caller could reach it; the contract's field description is corrected from `[create]` to `[create/update]` to match, which is the one wire-visible string change in this PR.
- `entitySchema.createType` / `updateType`: gain `rules_source`; `event_kinds` narrows from `Record<string, unknown> | null` to the contract's keyed record of `{ description?, metadataSchema?, jsonTemplate?, interactions? }`.
- `entitySchema.createRelType`: gains `metadata_schema`, `is_symmetric`, `status`; `inverse_type_slug` is `string` (the hand type's `| null` was never accepted).
- `entitySchema.updateRelType`: gains `metadata_schema`, `status`; does not offer `is_symmetric` (create-only per the contract; the handler rejects it on update).
- `entitySchema.addRule`: loses `relationship_type_slug` and `description` (both were unknown-argument errors). `EntitySchemaAddRuleInput` export removed; nothing imported it.
- `entitySchema.removeRule`: `slug` becomes optional, matching the contract and the handler (the rule id identifies the rule).
- `entitySchema.listRelTypes`: gains `include_deleted`.

Prod census (60d `sdk_call_trace`, all stored reaction scripts): no live call is affected — these are compile-time shapes for script authors; the wire validator is unchanged.

## Test plan

- [x] `packages/server`: `tsc --noEmit` 0 errors; scratch GREEN/RED proof above
- [x] `bun test src/__tests__/unit/sandbox/` — 154 pass (sdk-signature-contract, method-metadata, sdk-search)
- [x] Vitest: `integration/sandbox/namespace-dispatch`, `execute-wire`, `automations/automations-crud`, `entity-schema/entity-types` — 4 files, 79 tests pass (runtime is untouched; these prove the builders still dispatch)
- [x] `make review-fix` on the settled diff (it audited every key list and `R` against its handler; its two field corrections — `slug` not `prompt` required on create, `tags` patchable on update — are folded in above), then client regen and `make pre-pr`
- [x] Two test comments that claimed `AutomationCreateInput` hides `device_worker_id` / `agent_kind` reworded; they were already wrong on main

## Notes

`AutomationCompleteWindowInput` keeps `automation_id` required although `handleCompleteWindow` identifies the window by token, unchanged from main. `AutomationCreateVersionInput` already derived (`Omit<ManageAutomationsArgs, …>`) and stays as is. The parked alternative for `manage_entity_schema` (a 14-variant two-discriminator union with validator and flattener support) is not pursued: it costs ~200 source lines of validator and flattener machinery for one tool; this PR's only machinery is the 4-line helper.

**Reviewer disclosure:** codex is at its usage limit until 2026-09-07, so `make review-fix` / `make review` ran as `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus` — same-model self-review, not the intended cross-harness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
