### PR TITLE
refactor(core,server,connector-sdk): declare the knowledge save/delete contracts once, in core

### DIFF
--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -232,6 +232,7 @@ export type { ReactionContext } from './reaction-sdk.js';
 export type { ReactionClient } from './reaction-client-types.js';
 export type {
   CardElement,
+  KnowledgeDeleteInput,
   KnowledgeReadInput,
   KnowledgeSaveInput,
   KnowledgeSaveResult,

--- a/packages/connector-sdk/src/reaction-client-types.ts
+++ b/packages/connector-sdk/src/reaction-client-types.ts
@@ -15,6 +15,7 @@
 // Type-only imports: they erase at compile time, so nothing new enters the
 // isolate bundle. Core SUBPATH imports are permitted here; the root is not
 // (see AGENTS.md).
+import type { DeleteContentArgs } from "@lobu/core/contracts/tools/delete-knowledge";
 import type { ConnectionListInput } from "@lobu/core/contracts/tools/manage-connections";
 import type {
   EntityCreateInput,
@@ -33,6 +34,7 @@ import type {
   OperationListRunsInput,
 } from "@lobu/core/contracts/tools/manage-operations";
 import type { PublicGetContentArgs } from "@lobu/core/contracts/tools/read-knowledge";
+import type { SaveContentInput } from "@lobu/core/contracts/tools/save-memory";
 import type { PublicSearchArgs } from "@lobu/core/contracts/tools/search-memory";
 import type {} from "./reaction-client-types.typecheck";
 
@@ -56,25 +58,17 @@ export type CardElement = Record<string, unknown>;
  */
 export type KnowledgeSearchInput = PublicSearchArgs;
 
-export interface KnowledgeSaveInput {
-  entity_ids?: number[];
-  content: string;
-  semantic_type: string;
-  metadata?: Record<string, unknown>;
-  title?: string;
-  slug?: string;
-  author?: string;
-  payload_type?: "text" | "markdown" | "json_template" | "media" | "empty";
-  source_url?: string;
-  /** Event this content answers; stored as a durable thread edge. */
-  parent_event_id?: number;
-  /** Replace the current event while preserving its append-only row and lineage. */
-  supersedes_event_id?: number;
-  /** Stable producer key used to collapse reaction retries. */
-  idempotency_key?: string;
-  occurred_at?: string;
-  automation_source?: { automation_id: number; run_id: number };
-}
+/**
+ * The `save_memory` contract's own input, from core. The hand-written copy
+ * lacked `payload_data`, `payload_template` and `attachments`, required
+ * `content` for every payload type, and advertised a `slug` field the server
+ * rejects as an unknown argument. Pinned by `ReactionKnowledgeSaveContract`
+ * in `./reaction-client-types.typecheck`.
+ */
+export type KnowledgeSaveInput = SaveContentInput;
+
+/** Tombstone by id, or by the `delete_knowledge` contract's `content_id(s)` + `reason`. */
+export type KnowledgeDeleteInput = number | DeleteContentArgs;
 
 /**
  * Derived from the `read_knowledge` contract rather than re-declared. The
@@ -175,8 +169,7 @@ export interface ReactionClient {
     search(input: KnowledgeSearchInput): Promise<unknown>;
     save(input: KnowledgeSaveInput): Promise<KnowledgeSaveResult>;
     read(input: KnowledgeReadInput): Promise<unknown>;
-    /** Tombstone content by id. `delete_content` names the ids `content_id(s)`. */
-    delete(input: number | { content_id?: number; content_ids?: number[]; reason?: string }): Promise<unknown>;
+    delete(input: KnowledgeDeleteInput): Promise<unknown>;
   };
 
   entities: {

--- a/packages/connector-sdk/src/reaction-client-types.typecheck.ts
+++ b/packages/connector-sdk/src/reaction-client-types.typecheck.ts
@@ -2,24 +2,27 @@
  * @internal Compile-time fixtures pinning the published reaction-client input
  * types to the server schemas they forward to.
  *
- * These types must mirror the `read_knowledge` / `search_memory` schemas
- * exactly, and the server's `validate-args` rejects any unknown argument. So a
- * field declared here that the schema does not accept is a HARD error for the
- * reaction author, and a schema filter omitted here is a capability they
- * cannot discover.
+ * These types must mirror the `read_knowledge` / `save_memory` /
+ * `search_memory` schemas exactly, and the server's `validate-args` rejects
+ * any unknown argument. So a field declared here that the schema does not
+ * accept is a HARD error for the reaction author, and a schema filter omitted
+ * here is a capability they cannot discover.
  *
  * This lives in `src/` rather than beside the tests on purpose: `tsconfig.json`
  * excludes `**\/__tests__/**`, and `bun test` only transpiles, so a compile-time
  * assert written in a test file is never actually checked.
  *
- * Keyed on `keyof`, not assignability: every field is optional, so a stray
- * object structurally extends the type and an accepts/rejects pair passes no
- * matter what the interface declares.
+ * The read and search fixtures are keyed on `keyof`, not assignability: every
+ * field there is optional, so a stray object structurally extends the type and
+ * an accepts/rejects pair passes no matter what the interface declares. The
+ * save union does carry required fields, so it is pinned both ways.
  */
 import type { PublicGetContentArgs } from "@lobu/core/contracts/tools/read-knowledge";
+import type { SaveContentArgs } from "@lobu/core/contracts/tools/save-memory";
 import type { PublicSearchArgs } from "@lobu/core/contracts/tools/search-memory";
 import type {
   KnowledgeReadInput,
+  KnowledgeSaveInput,
   KnowledgeSearchInput,
   ReactionClient,
 } from "./reaction-client-types";
@@ -61,6 +64,16 @@ export type ReactionKnowledgeSearchContract = [
   Assert<HasSearchKey<"agent_id"> extends false ? true : false>,
 ];
 
+export type ReactionKnowledgeSaveContract = [
+  // Contract fields reach every variant; the phantom `slug` of the old hand copy does not.
+  Assert<"payload_data" extends keyof KnowledgeSaveInput ? true : false>,
+  Assert<"supersedes_event_id" extends keyof KnowledgeSaveInput ? true : false>,
+  Assert<"slug" extends keyof KnowledgeSaveInput ? false : true>,
+  // `content` is required only for text/markdown; the old copy demanded it for every payload type.
+  Assert<{ semantic_type: "note"; payload_type: "empty" } extends KnowledgeSaveInput ? true : false>,
+  Assert<{ semantic_type: "note" } extends KnowledgeSaveInput ? false : true>,
+];
+
 /**
  * Exhaustive counterpart to the sampled asserts above. Those name the fields
  * whose loss caused a real defect and say why each matters; this one catches
@@ -75,6 +88,9 @@ type ExactKeys<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : fals
 export type ReactionKnowledgeKeysExhaustive = [
   Assert<ExactKeys<keyof KnowledgeReadInput, keyof PublicGetContentArgs>>,
   Assert<ExactKeys<keyof KnowledgeSearchInput, keyof PublicSearchArgs>>,
+  // Every variant of the save union Picks the whole contract, so its `keyof`
+  // is the contract's — an omitted field in any one variant fails here.
+  Assert<ExactKeys<keyof KnowledgeSaveInput, keyof SaveContentArgs>>,
 ];
 
 /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -183,6 +183,18 @@
       "import": "./dist/refs.js",
       "require": "./dist/refs.js"
     },
+    "./contracts/tools/save-memory": {
+      "types": "./dist/contracts/tools/save-memory.d.ts",
+      "bun": "./src/contracts/tools/save-memory.ts",
+      "import": "./dist/contracts/tools/save-memory.js",
+      "require": "./dist/contracts/tools/save-memory.js"
+    },
+    "./contracts/tools/delete-knowledge": {
+      "types": "./dist/contracts/tools/delete-knowledge.d.ts",
+      "bun": "./src/contracts/tools/delete-knowledge.ts",
+      "import": "./dist/contracts/tools/delete-knowledge.js",
+      "require": "./dist/contracts/tools/delete-knowledge.js"
+    },
     "./contracts/tools/read-knowledge": {
       "types": "./dist/contracts/tools/read-knowledge.d.ts",
       "bun": "./src/contracts/tools/read-knowledge.ts",

--- a/packages/core/src/contracts/tools/delete-knowledge.ts
+++ b/packages/core/src/contracts/tools/delete-knowledge.ts
@@ -1,0 +1,36 @@
+/**
+ * Tool contract: `delete_knowledge`.
+ *
+ * Lives in core because it crosses package boundaries: the server validates
+ * against it, and `@lobu/connector-sdk` derives the `client.knowledge.delete`
+ * input it publishes to reaction authors. Both derive from this one
+ * declaration so neither can drift from the schema the handler enforces.
+ *
+ * Typebox only — no `node:` imports and nothing from core's root index, so the
+ * connector isolate lane can bundle it (`packages/connector-sdk/AGENTS.md`).
+ */
+
+import { type Static, Type } from "@sinclair/typebox";
+
+export const DeleteContentSchema = Type.Object({
+  content_id: Type.Optional(
+    Type.Number({
+      description:
+        "Single content id to delete. Provide either this or `content_ids`.",
+    })
+  ),
+  content_ids: Type.Optional(
+    Type.Array(Type.Number(), {
+      description:
+        "Batch of content ids to delete. Provide either this or `content_id`.",
+    })
+  ),
+  reason: Type.Optional(
+    Type.String({
+      description:
+        "Optional human-readable reason; persisted on the tombstone for audit trails.",
+    })
+  ),
+});
+
+export type DeleteContentArgs = Static<typeof DeleteContentSchema>;

--- a/packages/core/src/contracts/tools/save-memory.ts
+++ b/packages/core/src/contracts/tools/save-memory.ts
@@ -1,0 +1,142 @@
+/**
+ * Tool contract: `save_memory`.
+ *
+ * Lives in core because it crosses package boundaries: the server validates
+ * against it, and `@lobu/connector-sdk` derives the `client.knowledge.save`
+ * input it publishes to reaction authors. Both derive from this one
+ * declaration so neither can drift from the schema the handler enforces.
+ *
+ * Typebox only — no `node:` imports and nothing from core's root index, so the
+ * connector isolate lane can bundle it (`packages/connector-sdk/AGENTS.md`).
+ */
+
+import { type Static, Type } from "@sinclair/typebox";
+import type { FlatActionInput } from "./action-input";
+
+export const SaveContentSchema = Type.Object({
+  entity_ids: Type.Optional(
+    Type.Array(Type.Number(), {
+      description:
+        "Entity IDs to associate content with. Omit for org-scoped content.",
+    })
+  ),
+  content: Type.Optional(
+    Type.String({
+      description:
+        "The text content to save. Required for text/markdown payload types.",
+    })
+  ),
+  title: Type.Optional(Type.String({ description: "Short title or summary" })),
+  author: Type.Optional(
+    Type.String({ description: "Author name or identifier" })
+  ),
+  semantic_type: Type.Optional(
+    Type.String({
+      description:
+        "Semantic type (e.g. note, summary, decision, identity, observation). Preferred.",
+    })
+  ),
+  payload_type: Type.Optional(
+    Type.Union(
+      [
+        Type.Literal("text"),
+        Type.Literal("markdown"),
+        Type.Literal("json_template"),
+        Type.Literal("media"),
+        Type.Literal("empty"),
+      ],
+      {
+        description:
+          "Content format. 'text' (default): plain text. 'markdown': rendered as rich text. 'json_template': rendered via payload_template + payload_data. 'media': media-focused display. 'empty': metadata only.",
+      }
+    )
+  ),
+  payload_data: Type.Optional(
+    Type.Record(Type.String(), Type.Any(), {
+      description:
+        "Structured data object. Used as template data for json_template, or structured metadata for media.",
+    })
+  ),
+  payload_template: Type.Optional(
+    Type.Record(Type.String(), Type.Any(), {
+      description:
+        "JSON template for rendering. Required when payload_type is json_template. Must have a { root: ... } structure.",
+    })
+  ),
+  attachments: Type.Optional(
+    Type.Array(Type.Record(Type.String(), Type.Any()), {
+      description: "Array of attachment objects (e.g. files, images).",
+    })
+  ),
+  source_url: Type.Optional(
+    Type.String({ description: "URL of the original source for this content." })
+  ),
+  parent_event_id: Type.Optional(
+    Type.Integer({
+      minimum: 1,
+      description:
+        "Event this content answers. The saved event is threaded under the source and inherits its source_url when one is not supplied.",
+    })
+  ),
+  idempotency_key: Type.Optional(
+    Type.String({
+      minLength: 1,
+      maxLength: 300,
+      description:
+        "Stable producer key. Repeating a save with the same key returns the original event instead of appending a duplicate.",
+    })
+  ),
+  occurred_at: Type.Optional(
+    Type.String({
+      description:
+        "When the event actually happened (ISO 8601). Defaults to now if omitted.",
+    })
+  ),
+  metadata: Type.Optional(
+    Type.Record(Type.String(), Type.Any(), {
+      description:
+        "Structured metadata, validated against the metadata schema for the selected event kind when non-empty. Omit when no structured metadata is needed; an absent value is treated as {}.",
+    })
+  ),
+  supersedes_event_id: Type.Optional(
+    Type.Number({
+      description:
+        "ID of an existing event this content replaces (e.g. updated preference, corrected fact). The old event is marked as superseded and excluded from future searches.",
+    })
+  ),
+  automation_source: Type.Optional(
+    Type.Object(
+      {
+        automation_id: Type.Number({
+          description: "Automation that triggered this save",
+        }),
+        run_id: Type.Number({
+          description: "Automation run that triggered this save",
+        }),
+      },
+      {
+        description:
+          "Attribution source when save is triggered by an Automation reaction",
+      }
+    )
+  ),
+});
+
+export type SaveContentArgs = Static<typeof SaveContentSchema>;
+
+/**
+ * `client.knowledge.save` input. The schema leaves every field optional
+ * because `saveContent` resolves the requirement per `payload_type`:
+ * `semantic_type` always, `content` for text/markdown, `payload_template`
+ * for json_template. Stated here once, over the contract's own fields.
+ */
+type Save<R extends keyof SaveContentArgs = never> = FlatActionInput<
+  SaveContentArgs,
+  keyof SaveContentArgs,
+  "semantic_type" | R
+>;
+
+export type SaveContentInput =
+  | (Save<"content"> & { payload_type?: "text" | "markdown" })
+  | (Save<"payload_template"> & { payload_type: "json_template" })
+  | (Save & { payload_type: "media" | "empty" });

--- a/packages/server/src/sandbox/namespaces/knowledge.ts
+++ b/packages/server/src/sandbox/namespaces/knowledge.ts
@@ -6,6 +6,8 @@
  * than as a registered MCP tool.
  */
 
+import type { DeleteContentArgs } from "@lobu/core/contracts/tools/delete-knowledge";
+import type { SaveContentInput } from "@lobu/core/contracts/tools/save-memory";
 import type { Env } from "../../index";
 import { deleteContent } from "../../tools/delete_content";
 import { getContent, type PublicGetContentArgs } from "../../tools/get_content";
@@ -24,37 +26,14 @@ import type {} from "./knowledge.typecheck";
  */
 export type KnowledgeSearchInput = PublicSearchArgs;
 
-interface KnowledgeSaveBase {
-	entity_ids?: number[];
-	semantic_type: string;
-	metadata?: Record<string, unknown>;
-	title?: string;
-	slug?: string;
-	author?: string;
-	payload_data?: Record<string, unknown>;
-	payload_template?: Record<string, unknown>;
-	attachments?: Array<Record<string, unknown>>;
-	source_url?: string;
-	parent_event_id?: number;
-	idempotency_key?: string;
-	occurred_at?: string;
-	automation_source?: { automation_id: number; run_id: number };
-}
-
-export type KnowledgeSaveInput =
-	| (KnowledgeSaveBase & {
-			payload_type?: "text" | "markdown";
-			content: string;
-	  })
-	| (KnowledgeSaveBase & {
-			payload_type: "json_template";
-			payload_template: Record<string, unknown>;
-			content?: string;
-	  })
-	| (KnowledgeSaveBase & {
-			payload_type: "media" | "empty";
-			content?: string;
-	  });
+/**
+ * `client.knowledge.save` takes the `save_memory` contract's own input type,
+ * declared once in core and shared with `@lobu/connector-sdk`. The hand-written
+ * union here had drifted: it advertised a `slug` field the validator rejects
+ * and omitted `supersedes_event_id`. Pinned by `KnowledgeSaveInputContract`
+ * in `./knowledge.typecheck`.
+ */
+export type KnowledgeSaveInput = SaveContentInput;
 
 /**
  * `client.knowledge.read` forwards straight to `getContent`, so its input IS
@@ -67,9 +46,7 @@ export type KnowledgeSaveInput =
  */
 export type KnowledgeReadInput = PublicGetContentArgs;
 
-export type KnowledgeDeleteInput =
-	| number
-	| { content_id?: number; content_ids?: number[]; reason?: string };
+export type KnowledgeDeleteInput = number | DeleteContentArgs;
 
 export interface KnowledgeNamespace {
 	search(input: KnowledgeSearchInput): Promise<unknown>;

--- a/packages/server/src/sandbox/namespaces/knowledge.typecheck.ts
+++ b/packages/server/src/sandbox/namespaces/knowledge.typecheck.ts
@@ -1,3 +1,4 @@
+import type { SaveContentArgs } from "@lobu/core/contracts/tools/save-memory";
 import type { PublicGetContentArgs } from "../../tools/get_content";
 import type { PublicSearchArgs } from "../../tools/search";
 import type {
@@ -22,6 +23,9 @@ export type KnowledgeSaveInputContract = [
 	Assert<Accepts<{ semantic_type: "note"; content: string }>>,
 	Assert<Rejects<{ semantic_type: "note" }>>,
 	Assert<Rejects<{ semantic_type: "note"; payload_type: "text" }>>,
+	// Contract fields reach every variant; the phantom `slug` of the old hand copy does not.
+	Assert<"supersedes_event_id" extends keyof KnowledgeSaveInput ? true : false>,
+	Assert<"slug" extends keyof KnowledgeSaveInput ? false : true>,
 ];
 
 /**
@@ -85,4 +89,7 @@ type ExactKeys<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : fals
 export type KnowledgeInputKeysExhaustive = [
 	Assert<ExactKeys<keyof KnowledgeReadInput, keyof PublicGetContentArgs>>,
 	Assert<ExactKeys<keyof KnowledgeSearchInput, keyof PublicSearchArgs>>,
+	// Every variant of the save union Picks the whole contract, so its `keyof`
+	// is the contract's — an omitted field in any one variant fails here.
+	Assert<ExactKeys<keyof KnowledgeSaveInput, keyof SaveContentArgs>>,
 ];

--- a/packages/server/src/tools/delete_content.ts
+++ b/packages/server/src/tools/delete_content.ts
@@ -17,7 +17,7 @@
  * the same (insert an event with `supersedes_event_id`).
  */
 
-import { type Static, Type } from '@sinclair/typebox';
+import { type DeleteContentArgs, DeleteContentSchema } from '@lobu/core/contracts/tools/delete-knowledge';
 import { hasRequiredMcpScope } from '../auth/tool-access';
 import { getDb, pgBigintArray } from '../db/client';
 import type { Env } from '../index';
@@ -28,27 +28,6 @@ import { isSystemContext } from './access-control';
 import { TOMBSTONE_SEMANTIC_TYPE } from './constants';
 import type { ToolContext } from './registry';
 import { withValidatedArgs } from './validate-args';
-
-const DeleteContentSchema = Type.Object({
-  content_id: Type.Optional(
-    Type.Number({
-      description: 'Single content id to delete. Provide either this or `content_ids`.',
-    })
-  ),
-  content_ids: Type.Optional(
-    Type.Array(Type.Number(), {
-      description: 'Batch of content ids to delete. Provide either this or `content_id`.',
-    })
-  ),
-  reason: Type.Optional(
-    Type.String({
-      description:
-        'Optional human-readable reason; persisted on the tombstone for audit trails.',
-    })
-  ),
-});
-
-type DeleteContentArgs = Static<typeof DeleteContentSchema>;
 
 interface DeleteContentResult {
   deleted_ids: number[];

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -1,7 +1,9 @@
 /**
  * MCP Tool Registry
  *
- * This file defines all MCP tools and imports their Typebox schemas from tool files.
+ * This file defines all MCP tools and imports their Typebox schemas from the tool
+ * file that owns each one, or from `@lobu/core/contracts/tools/*` for the schemas
+ * shared with the connector SDK.
  * Typebox provides compile-time type safety and runtime JSON schema generation.
  *
  * Glossary — "namespace" in tool descriptions below means three different things,
@@ -17,6 +19,7 @@
  * `search_memory`'s top-level `agent_id` arg) — not any of the above.
  */
 
+import { SaveContentSchema } from '@lobu/core/contracts/tools/save-memory';
 import { getPublicReadableActions, getRequiredAccessLevel } from '../auth/tool-access';
 import type { Env } from '../index';
 import { LOBU_INTERACTION_RESOURCE_URI } from '../mcp-app-resource-uris';
@@ -39,7 +42,7 @@ import {
   invokeEventAction,
 } from './invoke_event_action';
 import { ResolvePathResultSchema, ResolvePathSchema, resolvePath } from './resolve_path';
-import { SaveContentResultSchema, SaveContentSchema, saveContent } from './save_content';
+import { SaveContentResultSchema, saveContent } from './save_content';
 import {
   QuerySchema,
   querySdkScript,

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -9,7 +9,8 @@
 
 import { Buffer } from 'node:buffer';
 import { normalizeAuthUserId, normalizeEmail } from '@lobu/connector-sdk/identity-normalize';
-import { type Static, Type } from '@sinclair/typebox';
+import { type SaveContentArgs, SaveContentSchema } from '@lobu/core/contracts/tools/save-memory';
+import { Type } from '@sinclair/typebox';
 import { resolveAutomationAttribution } from '../automations/automation-source';
 import { hasRequiredMcpScope } from '../auth/tool-access';
 import { resolveChannelEntityId } from '../authz/channel-entity';
@@ -113,109 +114,6 @@ async function findIdempotentEvent(
     metadata: (row.metadata ?? {}) as Record<string, unknown>,
   };
 }
-
-// ============================================
-// Typebox Schema
-// ============================================
-
-export const SaveContentSchema = Type.Object({
-  entity_ids: Type.Optional(
-    Type.Array(Type.Number(), {
-      description: 'Entity IDs to associate content with. Omit for org-scoped content.',
-    })
-  ),
-  content: Type.Optional(
-    Type.String({
-      description: 'The text content to save. Required for text/markdown payload types.',
-    })
-  ),
-  title: Type.Optional(Type.String({ description: 'Short title or summary' })),
-  author: Type.Optional(Type.String({ description: 'Author name or identifier' })),
-  semantic_type: Type.Optional(
-    Type.String({
-      description:
-        'Semantic type (e.g. note, summary, decision, identity, observation). Preferred.',
-    })
-  ),
-  payload_type: Type.Optional(
-    Type.Union(
-      [
-        Type.Literal('text'),
-        Type.Literal('markdown'),
-        Type.Literal('json_template'),
-        Type.Literal('media'),
-        Type.Literal('empty'),
-      ],
-      {
-        description:
-          "Content format. 'text' (default): plain text. 'markdown': rendered as rich text. 'json_template': rendered via payload_template + payload_data. 'media': media-focused display. 'empty': metadata only.",
-      }
-    )
-  ),
-  payload_data: Type.Optional(
-    Type.Record(Type.String(), Type.Any(), {
-      description:
-        'Structured data object. Used as template data for json_template, or structured metadata for media.',
-    })
-  ),
-  payload_template: Type.Optional(
-    Type.Record(Type.String(), Type.Any(), {
-      description:
-        'JSON template for rendering. Required when payload_type is json_template. Must have a { root: ... } structure.',
-    })
-  ),
-  attachments: Type.Optional(
-    Type.Array(Type.Record(Type.String(), Type.Any()), {
-      description: 'Array of attachment objects (e.g. files, images).',
-    })
-  ),
-  source_url: Type.Optional(
-    Type.String({ description: 'URL of the original source for this content.' })
-  ),
-  parent_event_id: Type.Optional(
-    Type.Integer({
-      minimum: 1,
-      description:
-        'Event this content answers. The saved event is threaded under the source and inherits its source_url when one is not supplied.',
-    })
-  ),
-  idempotency_key: Type.Optional(
-    Type.String({
-      minLength: 1,
-      maxLength: 300,
-      description:
-        'Stable producer key. Repeating a save with the same key returns the original event instead of appending a duplicate.',
-    })
-  ),
-  occurred_at: Type.Optional(
-    Type.String({
-      description: 'When the event actually happened (ISO 8601). Defaults to now if omitted.',
-    })
-  ),
-  metadata: Type.Optional(
-    Type.Record(Type.String(), Type.Any(), {
-      description:
-        'Structured metadata, validated against the metadata schema for the selected event kind when non-empty. Omit when no structured metadata is needed; an absent value is treated as {}.',
-    })
-  ),
-  supersedes_event_id: Type.Optional(
-    Type.Number({
-      description:
-        'ID of an existing event this content replaces (e.g. updated preference, corrected fact). The old event is marked as superseded and excluded from future searches.',
-    })
-  ),
-  automation_source: Type.Optional(
-    Type.Object(
-      {
-        automation_id: Type.Number({ description: 'Automation that triggered this save' }),
-        run_id: Type.Number({ description: 'Automation run that triggered this save' }),
-      },
-      { description: 'Attribution source when save is triggered by an Automation reaction' }
-    )
-  ),
-});
-
-type SaveContentArgs = Static<typeof SaveContentSchema>;
 
 // ============================================
 // Result Type


### PR DESCRIPTION
## Summary

`client.knowledge.save` and `client.knowledge.delete` were the last SDK inputs still typed by hand in two places — the server namespace (`sandbox/namespaces/knowledge.ts`) and the published `ReactionClient` in `@lobu/connector-sdk` — because their schemas lived in the server tool modules (`save_content.ts`, `delete_content.ts`) rather than in core. Neither copy was derived, and both had drifted from `SaveContentSchema`, the schema the argument validator actually enforces:

| | server namespace | published sdk | contract |
|---|---|---|---|
| `slug` | advertised | advertised | **not a field** — `unknown argument(s): slug` at runtime |
| `payload_data` / `payload_template` / `attachments` | present | missing | present |
| `supersedes_event_id` | missing | present | present |
| `content` | required only for text/markdown | required for every `payload_type` | optional; handler requires it per `payload_type` |
| `knowledge.delete` ids | `content_id(s)` | `content_id(s)` since #3368 (was `event_id(s)`) | `content_id(s)` |

This moves the two schemas to `@lobu/core/contracts/tools/{save-memory,delete-knowledge}` — the same file header, subpath export and placement as the existing `read-knowledge` / `search-memory` contracts — and declares the save input **once**, next to its schema, over the contract's own fields:

```ts
type Save<R extends keyof SaveContentArgs = never> =
  FlatActionInput<SaveContentArgs, keyof SaveContentArgs, "semantic_type" | R>;

export type SaveContentInput =
  | (Save<"content"> & { payload_type?: "text" | "markdown" })
  | (Save<"payload_template"> & { payload_type: "json_template" })
  | (Save & { payload_type: "media" | "empty" });
```

Server (`KnowledgeSaveInput`) and sdk (`KnowledgeSaveInput`) are now aliases of it; `KnowledgeDeleteInput = number | DeleteContentArgs` in both. The server tool modules import their schema from core; nothing else about the handlers changes.

Net: 255 added / 191 deleted. The schema move itself is line-neutral; the additions are the two contract-file headers, 12 lines of `package.json` subpath exports, and the compile-time pins below. Two hand copies deleted (53 lines), one derived declaration added (16).

### Proof

Scratch file compiled in `packages/connector-sdk` (`tsc --noEmit`), then deleted:

```
GREEN  { semantic_type, payload_type: "empty", metadata }                  (old sdk type: error, `content` required)
GREEN  { semantic_type, content, attachments, supersedes_event_id }        (old sdk type: error, no `attachments`)
RED    { semantic_type, content, slug: "s" }
         → TS2353 'slug' does not exist in type 'SaveContentInput'
RED    { semantic_type, payload_type: "json_template" }
         → TS2322 not assignable (payload_template required)
RED    { semantic_type: "note" }
         → TS2322 not assignable (content required for text)
```

Both typecheck files pin the drift classes: `ExactKeys<keyof KnowledgeSaveInput, keyof SaveContentArgs>` (every variant carries the whole contract, so a field dropped from any variant fails), `"slug" extends keyof KnowledgeSaveInput` (false), `{ semantic_type; payload_type: "empty" }` accepted, `{ semantic_type }` rejected (`knowledge.typecheck.ts`, `reaction-client-types.typecheck.ts`). `make review-fix` mutation-proved the `ExactKeys` pins: narrowing the picked keys by `attachments`, or dropping the per-variant `content` requirement, fails both files.

End to end, through the real SDK namespace against an embedded Postgres (scratch vitest, deleted): `knowledge.delete({ content_ids: [a, b] })` → `deleted_ids: [b, a]`, two tombstone rows; `knowledge.delete(c)` → `deleted_ids: [c]`; `knowledge.delete({ event_ids })` → `Invalid arguments for delete_knowledge: unknown argument(s): event_ids — valid arguments are: content_id, content_ids, reason`.

### Evidence

Prod, 60 days of `sdk_call_trace`:

```
knowledge.save     1,077 calls   0 pass `slug`
                     313 payload_type=empty without content   ← the old sdk type could not express these
                     575 no payload_type, content             (text default)
knowledge.delete      83 calls  65 content_ids · 1 positional · 6 event_id(s) · 11 no id
                                 (the 6 use the name the sdk published before #3368; they fail today)
```

Stored Automations with a reaction script: 20. 5 call `knowledge.save`; **1 passes `slug`**, which the validator rejects today and which this type now flags at compile time. 0 call `knowledge.delete`; 0 name `KnowledgeSaveInput`.

Client regen against the booted server: no diff in `packages/client` — the OpenAPI document is byte-identical, so the wire contract is untouched.

## Test plan

- [x] `packages/core` build, `packages/connector-sdk` build + `tsc --noEmit`, `packages/server` `tsc --noEmit` — 0 errors; red/green proof above
- [x] `bun test packages/connector-sdk/src/__tests__/reaction-client-types.test.ts` — 1 pass
- [x] `bun test packages/server/src/__tests__/unit/sandbox/` — 154 pass (sdk-signature-contract, method-metadata, sdk-search)
- [x] Vitest: `events/delete-content-tombstone`, `events/save-content-json-template`, `events/save-content-optional-metadata`, `automations/reaction-execute-typebox`, `sandbox/namespace-dispatch`, `sandbox/execute-wire` — 6 files, 40 tests pass
- [x] Scratch e2e above (`knowledge.delete` by ids, positional, and the rejected old name)
- [x] Client regen against the booted server: zero diff. CI's "Generated client must track the contract" step is a file-path heuristic (contract sources changed, generated client did not), so the commit carries its `[client-regen-not-needed]` sentinel with the reason
- [x] `make review-fix` on the settled diff, then `make pre-pr` — clean

## Notes

**Published type surface (types only; runtime and OpenAPI unchanged).** `packages/connector-sdk/AGENTS.md` asks for additive changes to exported types; flagging the non-additive parts rather than hiding them behind a compat alias (no-shim rule):
- `KnowledgeSaveInput` changes from an `interface` to a type alias of a union. A script that `extends`/`implements` it would break; 0 stored scripts name it.
- It loses `slug` (never accepted), gains `payload_data` / `payload_template` / `attachments`, and stops requiring `content` for `media` / `empty` / `json_template` payloads (`payload_template` is required for `json_template`).
- New export `KnowledgeDeleteInput`. `ReactionClient.knowledge.delete` is typed by it (same shape as before).
- Server-side `KnowledgeSaveInput` gains `supersedes_event_id` and loses `slug`; other namespaces untouched.
- `metadata` / `payload_data` / `payload_template` / `attachments` are typed from the contract's `Type.Any()` records, so they widen from `Record<string, unknown>` to `Record<string, any>` in the published type — faithful to the schema, and the same as the already-derived read/search inputs, but looser in an author's editor.
- `make review-fix` also evaluated main's `SaveContentSchema` / `DeleteContentSchema` against the moved ones: emitted JSON byte-identical, which the zero-diff client regen confirms from the outside.

Not in this PR: `KnowledgeSaveResult` in the sdk (`{ id, created, metadata }`) is a hand-written subset of the server's `SaveContentResultSchema`; the result schemas of `read_knowledge` also stay server-side today, so this follows that split.

**Reviewer disclosure:** codex is at its usage limit until 2026-09-07, so `make review-fix` / `make review` ran as `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus` — same-model self-review, not the intended cross-harness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
