### PR TITLE
feat(connector-worker): stream fetch bodies to the isolate guest chunk by chunk

### DIFF
--- a/packages/connector-worker/AGENTS.md
+++ b/packages/connector-worker/AGENTS.md
@@ -44,8 +44,12 @@ also used by `@lobu/cli` and `@lobu/server`.
   limit, wall clock, named sync/async capabilities as `ivm.Reference`s),
   `prelude.ts` (the guest's globals — timers, console, URL, TextEncoder,
   AbortController, fetch — all over host capabilities; add one only with a
-  connector that needs it), `eligibility.ts` (rejects bundles that still
-  `require()` a Node builtin).
+  connector that needs it. `fetch` answers with headers as soon as they arrive
+  and `Response.body` is a pull `ReadableStream` over `fetchRead`, one host
+  chunk per read, so SSE and other long bodies are consumed as they stream;
+  `TextDecoder` with `{ stream: true }` holds its state on the host between
+  chunks), `eligibility.ts` (rejects bundles that still `require()` a Node
+  builtin).
 - `daemon/` — the poll loop (`worker.ts`, `executor.ts`) that claims and runs
   jobs from the worker API. `automation.ts` is the device-only Automation arm:
   it spawns the user's local agent CLI per its `AgentSpec` (from

--- a/packages/connector-worker/src/__tests__/isolate-prelude.test.ts
+++ b/packages/connector-worker/src/__tests__/isolate-prelude.test.ts
@@ -451,11 +451,55 @@ describe('guest ReadableStream reader', () => {
     expect(await reader.read()).toEqual({ value: undefined, done: true });
   });
 
+  it('an error the source reports after a cancel is dropped: a later read still reports done', async () => {
+    const guest = instantiateGuest();
+    let fail: ((error: Error) => void) | null = null;
+    const reader = new guest.ReadableStream({
+      pull: (controller: { error: (error: Error) => void }) => {
+        fail = (error: Error) => controller.error(error);
+      },
+    }).getReader();
+    const pending = reader.read();
+    await reader.cancel();
+    expect(await pending).toEqual({ value: undefined, done: true });
+    // The in-flight pull answers after the cancel, as a fetchRead killed by
+    // fetchAbort does with its AbortError.
+    fail?.(new Error('aborted after cancel'));
+    expect(await reader.read()).toEqual({ value: undefined, done: true });
+  });
+
   it('marks the stream disturbed on the first read, which is what Response.bodyUsed reports', async () => {
     const guest = instantiateGuest();
     const stream = new guest.ReadableStream(pullSource(['a']).source);
     expect(stream._disturbed).toBe(false);
     await stream.getReader().read();
     expect(stream._disturbed).toBe(true);
+  });
+});
+
+/**
+ * `Response.clone()` tees a streamed body on every other runtime; here it
+ * throws for one, since nothing bundled clones a network response and a tee
+ * nobody reads is surface for its own sake. A guest-constructed body still
+ * clones, so the narrowing is pinned exactly where it applies.
+ */
+describe('guest Response.clone', () => {
+  it('clones a guest-constructed body and refuses a streamed one', async () => {
+    const guest = instantiateGuest();
+    const built = new guest.Response('payload', { status: 201, headers: { 'x-a': '1' } });
+    const copy = built.clone();
+    expect(copy.status).toBe(201);
+    expect(copy.headers.get('x-a')).toBe('1');
+    expect(await copy.text()).toBe('payload');
+    expect(await built.text()).toBe('payload');
+
+    const streamed = new guest.Response(new guest.ReadableStream({ pull: (c: { close: () => void }) => c.close() }));
+    expect(streamed.body).not.toBeNull();
+    expect(() => streamed.clone()).toThrow(TypeError);
+    expect(() => streamed.clone()).toThrow(/streamed body cannot be cloned/);
+    // Refusing to clone did not consume the body.
+    expect(streamed.bodyUsed).toBe(false);
+    expect(await streamed.text()).toBe('');
+    expect(() => streamed.clone()).toThrow(/already been consumed/);
   });
 });

--- a/packages/connector-worker/src/__tests__/isolate-prelude.test.ts
+++ b/packages/connector-worker/src/__tests__/isolate-prelude.test.ts
@@ -5,7 +5,7 @@ import {
   IsolateLaneIneligibleError,
 } from '../isolate/eligibility.js';
 import { createHash, createHmac, pbkdf2Sync } from 'node:crypto';
-import { GUEST_PRELUDE, PRELUDE_GLOBALS, PRELUDE_HOST_SYNC } from '../isolate/prelude.js';
+import { createPreludeHostSync, GUEST_PRELUDE, PRELUDE_GLOBALS } from '../isolate/prelude.js';
 
 describe('guest prelude text', () => {
   it('installs every advertised global', () => {
@@ -86,11 +86,12 @@ describe('guest prelude text', () => {
  * assertions cover both sides of the bridge rather than a stub's idea of them.
  */
 function instantiateGuest(): any {
+  const hostSync = createPreludeHostSync();
   const guest: any = {
     __host_sync: {
       applySync: (_receiver: unknown, args: any[]) => {
         const [name, ...rest] = args;
-        const fn = PRELUDE_HOST_SYNC[String(name)];
+        const fn = hostSync[String(name)];
         if (!fn) return { __lobu: 1, ok: true, value: null };
         try {
           return { __lobu: 1, ok: true, value: fn(...rest) };
@@ -307,5 +308,154 @@ describe('guest Buffer shim — Node semantics connector code relies on', () => 
     expect(Array.from(guest.Buffer.alloc(3, 7))).toEqual([7, 7, 7]);
     expect(Array.from(guest.Buffer.alloc(2))).toEqual([0, 0]);
     expect(Array.from(guest.Buffer.alloc(3, new Uint8Array([5, 6])))).toEqual([5, 6, 5]);
+  });
+});
+
+/**
+ * `TextDecoder.decode(chunk, { stream: true })` is how every SSE consumer
+ * (pi-ai's Anthropic provider, the Stainless SDKs) reassembles a body that
+ * arrives in chunks. The guest shell has no decoder state of its own: the
+ * sequence of streaming decodes runs on one Node `TextDecoder` the host holds
+ * open until the flushing decode, so these pin that both halves agree with
+ * Node on a multi-byte sequence split across chunks.
+ */
+describe('guest TextDecoder streaming', () => {
+  // 'café €' = 63 61 66 | c3 a9 | 20 | e2 82 ac
+  const bytes = new TextEncoder().encode('café €');
+
+  it('holds a split multi-byte sequence across chunks and flushes on the final decode', () => {
+    const guest = instantiateGuest();
+    const decoder = new guest.TextDecoder();
+    expect(decoder.decode(bytes.subarray(0, 4), { stream: true })).toBe('caf');
+    expect(decoder.decode(bytes.subarray(4, 8), { stream: true })).toBe('é ');
+    expect(decoder.decode(bytes.subarray(8))).toBe('€');
+    // Reusable and stateless again after the flush, as the spec resets it.
+    expect(decoder.decode(bytes)).toBe('café €');
+  });
+
+  it('matches Node chunk for chunk over every split point', () => {
+    const guest = instantiateGuest();
+    for (let split = 0; split <= bytes.length; split++) {
+      const guestDecoder = new guest.TextDecoder();
+      const nodeDecoder = new TextDecoder();
+      const guestOut =
+        guestDecoder.decode(bytes.subarray(0, split), { stream: true }) + guestDecoder.decode(bytes.subarray(split));
+      const nodeOut = nodeDecoder.decode(bytes.subarray(0, split), { stream: true }) + nodeDecoder.decode(bytes.subarray(split));
+      expect(guestOut, `split at ${split}`).toBe(nodeOut);
+      expect(guestOut).toBe('café €');
+    }
+  });
+
+  it('without the stream flag a chunk boundary inside a sequence is a replacement character, as on Node', () => {
+    const guest = instantiateGuest();
+    const decoder = new guest.TextDecoder();
+    expect(decoder.decode(bytes.subarray(0, 4))).toBe(new TextDecoder().decode(bytes.subarray(0, 4)));
+    expect(decoder.decode(bytes.subarray(0, 4))).toBe('caf\uFFFD');
+  });
+
+  it('a fatal decoder throws at the flush for a sequence that never completed, and only then', () => {
+    const guest = instantiateGuest();
+    const decoder = new guest.TextDecoder('utf-8', { fatal: true });
+    expect(decoder.decode(bytes.subarray(0, 4), { stream: true })).toBe('caf');
+    expect(() => decoder.decode()).toThrow(TypeError);
+    // The failed flush released the host decoder: the next decode starts clean.
+    expect(decoder.decode(bytes)).toBe('café €');
+  });
+
+  it('a flush with no input ends the stream, the way an SSE reader finishes', () => {
+    const guest = instantiateGuest();
+    const decoder = new guest.TextDecoder();
+    expect(decoder.decode(bytes.subarray(0, 4), { stream: true })).toBe('caf');
+    expect(decoder.decode()).toBe('\uFFFD');
+    expect(decoder.decode(bytes.subarray(4, 6))).toBe('\uFFFD ');
+  });
+
+  it('bounds the streaming decoders one guest may leave open', () => {
+    const guest = instantiateGuest();
+    for (let i = 0; i < 1024; i++) new guest.TextDecoder().decode(bytes.subarray(0, 1), { stream: true });
+    expect(() => new guest.TextDecoder().decode(bytes.subarray(0, 1), { stream: true })).toThrow(RangeError);
+    // Each host is its own registry: a fresh guest is not affected.
+    expect(new (instantiateGuest().TextDecoder)().decode(bytes, { stream: true })).toBe('café €');
+  });
+});
+
+/**
+ * `Response.body` is a `ReadableStream` over the host's `fetchRead`, and a
+ * socket's `readable` is one over `socketRead`, so what a reader does after
+ * the consumer stops reading decides whether the guest reads from something
+ * the host already released. Both sources are pull-only, which these model
+ * directly rather than through a fetch.
+ */
+describe('guest ReadableStream reader', () => {
+  /**
+   * A source that hands out one chunk per pull and records the cancel. It
+   * answers on a later microtask, as `fetchRead` and `socketRead` do across
+   * the host boundary, so several reads really are waiting at once.
+   */
+  function pullSource(chunks: string[]): { source: Record<string, unknown>; pulls: () => number; cancelled: () => boolean } {
+    let pulls = 0;
+    let cancelled = false;
+    return {
+      source: {
+        pull: (controller: { enqueue: (chunk: string) => void; close: () => void }) => {
+          pulls += 1;
+          const index = pulls;
+          return Promise.resolve().then(() => {
+            if (index > chunks.length) controller.close();
+            else controller.enqueue(chunks[index - 1]);
+          });
+        },
+        cancel: () => {
+          cancelled = true;
+        },
+      },
+      pulls: () => pulls,
+      cancelled: () => cancelled,
+    };
+  }
+
+  it('answers concurrent reads in order, one pull each', async () => {
+    const guest = instantiateGuest();
+    const probe = pullSource(['a', 'b', 'c']);
+    const reader = new guest.ReadableStream(probe.source).getReader();
+    const results = await Promise.all([reader.read(), reader.read(), reader.read()]);
+    expect(results.map((r: { value: string }) => r.value)).toEqual(['a', 'b', 'c']);
+    expect(probe.pulls()).toBe(3);
+    expect((await reader.read()).done).toBe(true);
+  });
+
+  it('cancelling ends the stream: the source is cancelled once and no later read pulls it again', async () => {
+    const guest = instantiateGuest();
+    const probe = pullSource(['a', 'b', 'c']);
+    const reader = new guest.ReadableStream(probe.source).getReader();
+    expect((await reader.read()).value).toBe('a');
+    await reader.cancel();
+    expect(probe.cancelled()).toBe(true);
+    expect(await reader.read()).toEqual({ value: undefined, done: true });
+    expect(await reader.read()).toEqual({ value: undefined, done: true });
+    expect(probe.pulls()).toBe(1);
+  });
+
+  it('cancelling settles a read already waiting and drops a chunk the source still owed', async () => {
+    const guest = instantiateGuest();
+    let release: ((value: string) => void) | null = null;
+    const reader = new guest.ReadableStream({
+      pull: (controller: { enqueue: (chunk: string) => void }) => {
+        release = (value: string) => controller.enqueue(value);
+      },
+    }).getReader();
+    const pending = reader.read();
+    await reader.cancel();
+    expect(await pending).toEqual({ value: undefined, done: true });
+    release?.('late');
+    expect(await reader.read()).toEqual({ value: undefined, done: true });
+  });
+
+  it('marks the stream disturbed on the first read, which is what Response.bodyUsed reports', async () => {
+    const guest = instantiateGuest();
+    const stream = new guest.ReadableStream(pullSource(['a']).source);
+    expect(stream._disturbed).toBe(false);
+    await stream.getReader().read();
+    expect(stream._disturbed).toBe(true);
   });
 });

--- a/packages/connector-worker/src/executor/isolate.ts
+++ b/packages/connector-worker/src/executor/isolate.ts
@@ -9,7 +9,8 @@
  * boundary as a named host capability, so the host owns the network. Both
  * network capabilities dial through the one egress module: `fetch` (domain
  * allowlist from `@lobu/connector-sdk/egress-policy`, DNS pinning from
- * `@lobu/connector-worker/egress`, plus a body cap) and `socketOpen` (the
+ * `@lobu/connector-worker/egress`; the response body streams back to the
+ * guest one chunk per `fetchRead`, under a byte cap) and `socketOpen` (the
  * WinterCG `connect` the DB connectors need: a real TCP socket the HOST dials
  * at an address the same transport resolved and validated under the DB egress
  * policy).
@@ -57,7 +58,11 @@ export interface IsolateExecutorOptions {
   memoryMb: number;
   /** Cap on any single message crossing the boundary (default 16 MiB). */
   messageBytes: number;
-  /** Cap on a fetched response body (default 16 MiB). */
+  /**
+   * Cap on the bytes one fetched response body may deliver to the guest
+   * (default 16 MiB). Enforced as the guest pulls: the body stream errors
+   * with `FetchBodyLimitExceeded` at the chunk that crosses it.
+   */
   fetchBodyBytes: number;
   /** Cap on total console output forwarded per run (default 1 MiB). */
   logBytes: number;
@@ -106,6 +111,14 @@ const DEFAULT_OPTIONS: IsolateExecutorOptions = {
 
 const STREAM_TAIL_CAP_BYTES = 16 * 1024;
 const MAX_REDIRECTS = 20;
+/**
+ * Responses one run may hold open at once (headers delivered, body not yet
+ * drained or cancelled). Each pins an upstream socket and a reader on the
+ * host until the guest reads it to the end, cancels it, or the run ends, so
+ * the count is bounded here rather than by a guest that fetches and never
+ * reads; an honest connector drains or cancels every body it opens.
+ */
+const MAX_OPEN_FETCHES = 1024;
 
 /** Thrown when a job demands the isolate lane on a host that cannot run one. */
 export class IsolateRuntimeUnavailableError extends Error {
@@ -140,13 +153,32 @@ interface GuestFetchRequest {
   redirect: 'follow' | 'manual' | 'error';
 }
 
+/** What `fetchOpen` answers once the headers are in. */
 interface HostFetchReply {
   status: number;
   statusText: string;
   url: string;
   redirected: boolean;
   headers: [string, string][];
-  body: Uint8Array;
+  /** Whether a body follows: the guest pulls it through `fetchRead` under the request's own id. False for a body-less response (204, 304, HEAD). */
+  hasBody: boolean;
+}
+
+/** The upstream response as `hostFetch` hands it to the capability layer: headers now, body still on the wire. */
+interface HostFetchResponse extends Omit<HostFetchReply, 'hasBody'> {
+  body: ReadableStream<Uint8Array> | null;
+}
+
+/** One `fetchRead` answer: a chunk, the end of the body, or the error that ended it. */
+interface HostFetchChunk {
+  data: Uint8Array | null;
+  done: boolean;
+  error?: { name: string; message: string };
+}
+
+function describeBodyError(error: unknown): NonNullable<HostFetchChunk['error']> {
+  if (error instanceof Error) return { name: error.name || 'Error', message: error.message };
+  return { name: 'Error', message: String(error) };
 }
 
 /**
@@ -424,7 +456,24 @@ export class IsolateExecutor implements SyncExecutor {
     let processingChain: Promise<void> = Promise.resolve();
     const runAbort = new AbortController();
     const pendingSleeps = new Set<ReturnType<typeof setTimeout>>();
-    const inflightFetches = new Map<number, AbortController>();
+    interface ActiveFetch {
+      controller: AbortController;
+      /** The upstream body once the headers have arrived; null before that and for a body-less response. */
+      body: ReadableStreamDefaultReader<Uint8Array> | null;
+      /** Bytes handed to the guest so far, against `fetchBodyBytes`. */
+      received: number;
+      url: string;
+    }
+    /** Every request the guest has open, keyed by its own id, from `fetchOpen` until the body ends or is aborted. */
+    const activeFetches = new Map<number, ActiveFetch>();
+    const closeFetch = (active: ActiveFetch) => {
+      active.controller.abort();
+      void active.body?.cancel().catch(() => undefined);
+    };
+    const closeAllFetches = () => {
+      for (const active of activeFetches.values()) closeFetch(active);
+      activeFetches.clear();
+    };
     // The run's `fetch` transport: block-private, with the exact allowlist
     // entries lowered to the allow-private floor. One per run and destroyed
     // with it, so a worker that builds an executor per job never accumulates
@@ -489,8 +538,7 @@ export class IsolateExecutor implements SyncExecutor {
       runAbort.abort();
       for (const timer of pendingSleeps) clearTimeout(timer);
       pendingSleeps.clear();
-      for (const controller of inflightFetches.values()) controller.abort();
-      inflightFetches.clear();
+      closeAllFetches();
       closeAllSockets();
       host?.terminate(state);
     };
@@ -526,21 +574,73 @@ export class IsolateExecutor implements SyncExecutor {
       return undefined;
     };
 
-    const fetchCapability = async (request: unknown, body: unknown): Promise<HostFetchReply> => {
+    const fetchOpen = async (request: unknown, body: unknown): Promise<HostFetchReply> => {
       const req = request as GuestFetchRequest;
       if (!req || typeof req !== 'object' || typeof req.url !== 'string' || typeof req.id !== 'number') {
         throw new TypeError('fetch: malformed request from guest');
       }
-      const controller = new AbortController();
-      inflightFetches.set(req.id, controller);
-      const onRunAbort = () => controller.abort();
-      runAbort.signal.addEventListener('abort', onRunAbort, { once: true });
-      try {
-        return await this.hostFetch(req, body, controller.signal, egress, log);
-      } finally {
-        runAbort.signal.removeEventListener('abort', onRunAbort);
-        inflightFetches.delete(req.id);
+      if (activeFetches.has(req.id)) throw new TypeError(`fetch: request ${req.id} is already open`);
+      if (activeFetches.size >= MAX_OPEN_FETCHES) {
+        throw new TypeError(
+          `fetch: this run has ${MAX_OPEN_FETCHES} responses open; read or cancel a body before opening another`
+        );
       }
+      const active: ActiveFetch = { controller: new AbortController(), body: null, received: 0, url: req.url };
+      activeFetches.set(req.id, active);
+      let response: HostFetchResponse;
+      try {
+        response = await this.hostFetch(req, body, active.controller.signal, egress, log);
+      } catch (error) {
+        activeFetches.delete(req.id);
+        throw error;
+      }
+      if (activeFetches.get(req.id) !== active) {
+        // `fetchAbort` or teardown removed it while the headers were in flight.
+        await response.body?.cancel().catch(() => undefined);
+        const aborted = new Error('This operation was aborted');
+        aborted.name = 'AbortError';
+        throw aborted;
+      }
+      const { body: upstream, ...reply } = response;
+      if (!upstream) {
+        activeFetches.delete(req.id);
+        return { ...reply, hasBody: false };
+      }
+      active.body = upstream.getReader();
+      active.url = reply.url;
+      return { ...reply, hasBody: true };
+    };
+
+    // One upstream chunk per call, so the host never holds more of a body
+    // than the guest has asked for, and the cap is applied to what was handed
+    // over rather than to a buffer nobody has read yet.
+    const fetchRead = async (id: unknown): Promise<HostFetchChunk> => {
+      const key = typeof id === 'number' ? id : Number.NaN;
+      const active = activeFetches.get(key);
+      if (!active?.body) return { data: null, done: true };
+      const ended = (error?: HostFetchChunk['error']): HostFetchChunk => {
+        activeFetches.delete(key);
+        return error ? { data: null, done: true, error } : { data: null, done: true };
+      };
+      let chunk: Awaited<ReturnType<typeof active.body.read>>;
+      try {
+        chunk = await active.body.read();
+      } catch (error) {
+        // `fetchAbort` and teardown cancel the reader through the controller;
+        // undici reports that here as an AbortError the guest maps back onto
+        // its own signal. Anything else is the upstream failing mid-body.
+        return ended(describeBodyError(error));
+      }
+      if (chunk.done) return ended();
+      active.received += chunk.value.byteLength;
+      if (active.received > this.options.fetchBodyBytes) {
+        closeFetch(active);
+        return ended({
+          name: 'FetchBodyLimitExceeded',
+          message: `fetch response body exceeded the ${this.options.fetchBodyBytes}-byte cap for ${active.url}`,
+        });
+      }
+      return { data: chunk.value, done: false };
     };
 
     const mergedConfig = job.mode === 'authenticate' ? job.config : buildConnectorConfig(job);
@@ -558,8 +658,15 @@ export class IsolateExecutor implements SyncExecutor {
           terminate({ name: 'UncaughtException', message: desc.message ?? 'uncaught exception in the connector' });
           return undefined;
         },
+        // Before the headers: the request fails with the guest's abort reason.
+        // After them: the body stream errors with it, and the upstream socket
+        // is released either way.
         fetchAbort: (id: unknown) => {
-          if (typeof id === 'number') inflightFetches.get(id)?.abort();
+          const active = typeof id === 'number' ? activeFetches.get(id) : undefined;
+          if (active) {
+            activeFetches.delete(id as number);
+            closeFetch(active);
+          }
           return undefined;
         },
       },
@@ -632,7 +739,8 @@ export class IsolateExecutor implements SyncExecutor {
             if (timer) clearTimeout(timer);
           }
         },
-        fetch: fetchCapability,
+        fetchOpen,
+        fetchRead,
         socketOpen: async (hostParam: unknown, portParam: unknown, optionsJson: unknown) => {
           const rawHost = String(hostParam);
           const hostname = stripIpv6Brackets(rawHost);
@@ -896,6 +1004,7 @@ export class IsolateExecutor implements SyncExecutor {
       runAbort.abort();
       for (const timer of pendingSleeps) clearTimeout(timer);
       pendingSleeps.clear();
+      closeAllFetches();
       closeAllSockets();
       void egress.destroy().catch(() => undefined);
       host.dispose();
@@ -926,9 +1035,9 @@ export class IsolateExecutor implements SyncExecutor {
     signal: AbortSignal,
     egress: EgressDispatcher,
     log: RunLog
-  ): Promise<HostFetchReply> {
+  ): Promise<HostFetchResponse> {
     let url = new URL(request.url);
-    // The guest `fetch` rejects other schemes, but `__lobuHost.async('fetch')`
+    // The guest `fetch` rejects other schemes, but `__lobuHost.async('fetchOpen')`
     // is reachable from guest code directly, and a `data:` URL has no host for
     // the allowlist to judge: Node's fetch would resolve it locally.
     if (url.protocol !== 'http:' && url.protocol !== 'https:') {
@@ -1007,52 +1116,14 @@ export class IsolateExecutor implements SyncExecutor {
         await response.body?.cancel().catch(() => undefined);
         throw new TypeError('fetch failed: unexpected redirect');
       }
-      const bytes = await this.readBodyCapped(response, signal);
       return {
         status: response.status,
         statusText: response.statusText,
         url: url.href,
         redirected,
         headers: [...response.headers.entries()],
-        body: bytes,
+        body: response.body,
       };
     }
-  }
-
-  private async readBodyCapped(response: Response, signal: AbortSignal): Promise<Uint8Array> {
-    if (!response.body) return new Uint8Array(0);
-    const chunks: Uint8Array[] = [];
-    let total = 0;
-    const reader = response.body.getReader();
-    try {
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        if (!value) continue;
-        total += value.byteLength;
-        if (total > this.options.fetchBodyBytes) {
-          await reader.cancel().catch(() => undefined);
-          const capped = new Error(`fetch response body exceeded the ${this.options.fetchBodyBytes}-byte cap for ${response.url}`);
-          capped.name = 'FetchBodyLimitExceeded';
-          throw capped;
-        }
-        chunks.push(value);
-        if (signal.aborted) {
-          await reader.cancel().catch(() => undefined);
-          const aborted = new Error('This operation was aborted');
-          aborted.name = 'AbortError';
-          throw aborted;
-        }
-      }
-    } finally {
-      reader.releaseLock();
-    }
-    const out = new Uint8Array(total);
-    let offset = 0;
-    for (const chunk of chunks) {
-      out.set(chunk, offset);
-      offset += chunk.byteLength;
-    }
-    return out;
   }
 }

--- a/packages/connector-worker/src/isolate/bridge.ts
+++ b/packages/connector-worker/src/isolate/bridge.ts
@@ -24,7 +24,7 @@
  *  - `dispose()` on a disposed isolate throws; guard with `isDisposed`.
  */
 
-import { GUEST_PRELUDE, PRELUDE_HOST_SYNC } from './prelude.js';
+import { createPreludeHostSync, GUEST_PRELUDE } from './prelude.js';
 import type { IsolatedVm, IvmIsolate, IvmReference } from './ivm-types.js';
 
 export type HostSyncCapability = (...args: unknown[]) => unknown;
@@ -44,7 +44,7 @@ export interface IsolateHostOptions {
   messageBytes: number;
   /** `process.env` visible to the guest. */
   env: Record<string, string | undefined>;
-  /** The run's own sync capabilities; the prelude's host halves (`PRELUDE_HOST_SYNC`) are always installed too. */
+  /** The run's own sync capabilities; a fresh set of the prelude's host halves (`createPreludeHostSync`) is always installed too. */
   sync: Record<string, HostSyncCapability>;
   async: Record<string, HostAsyncCapability>;
 }
@@ -106,7 +106,7 @@ export class IsolateHost {
     this.isolate = isolate;
     this.context = context;
     this.options = options;
-    this.sync = { ...PRELUDE_HOST_SYNC, ...options.sync };
+    this.sync = { ...createPreludeHostSync(), ...options.sync };
   }
 
   static async create(options: IsolateHostOptions): Promise<IsolateHost> {

--- a/packages/connector-worker/src/isolate/prelude.ts
+++ b/packages/connector-worker/src/isolate/prelude.ts
@@ -18,15 +18,19 @@
  *    an uncaught exception ended the forked child this replaced.
  *  - `process = { env }` from the job env.
  *  - `TextEncoder`/`TextDecoder` and `atob`/`btoa`: object shells whose
- *    byte-level work the host does with Node's own codecs.
+ *    byte-level work the host does with Node's own codecs. A decode with
+ *    `{ stream: true }` opens a Node `TextDecoder` on the host that keeps the
+ *    partial sequence between chunks until the flushing decode releases it.
  *  - `URL` over the host `urlParse`/`urlSet` capabilities: the host runs Node's
  *    own URL, so both lanes agree on every input by construction.
  *    `URLSearchParams` keeps its list guest-side, parses and serializes through
  *    the host, and writes back through `search`.
  *  - `AbortController`/`AbortSignal`.
- *  - `Headers`, `Response` and `fetch` over the host `fetch` capability. The
- *    host performs the network call and returns status, headers and a bounded
- *    body; there are no streams on this lane (`Response.body` is null).
+ *  - `Headers`, `Response` and `fetch` over the host `fetchOpen` / `fetchRead`
+ *    capabilities. The host performs the network call and answers with status
+ *    and headers as soon as they arrive; the body is a pull `ReadableStream`
+ *    the guest drains one host chunk at a time, exactly as a socket's
+ *    `readable` is, so an SSE response is consumed as it streams.
  *  - `crypto`: `getRandomValues`/`randomUUID`, plus the `subtle` operations
  *    postgres.js needs to answer an md5 or SCRAM-SHA-256 challenge, all
  *    computed by Node on the host. `require('node:crypto')` additionally
@@ -146,12 +150,55 @@ function asPairs(value: unknown): [string, string][] {
 }
 
 /**
- * Host halves of prelude globals that delegate to Node. `IsolateHost` installs
- * them under every run, so they are part of the guest's standard library
- * rather than a capability a particular executor grants. Pure conversions
- * only: no network, no filesystem.
+ * Streaming `TextDecoder`s one guest may hold open at once. A decoder opened
+ * with `{ stream: true }` and never flushed (a stream that errored mid-way)
+ * stays on the host until the run ends, so the count is bounded here rather
+ * than by a hostile guest's loop; an honest guest holds one per open body.
  */
-export const PRELUDE_HOST_SYNC: Record<string, (...args: unknown[]) => unknown> = {
+const MAX_OPEN_TEXT_DECODERS = 1024;
+
+/**
+ * Host halves of prelude globals that delegate to Node. `IsolateHost` installs
+ * a fresh set under every run, so they are part of the guest's standard
+ * library rather than a capability a particular executor grants. Pure
+ * conversions only: no network, no filesystem. The one piece of state is the
+ * registry of streaming `TextDecoder`s, which is why this is a factory and not
+ * a table: a decoder's partial sequence belongs to one run.
+ */
+export function createPreludeHostSync(): Record<string, (...args: unknown[]) => unknown> {
+  const decoders = new Map<number, TextDecoder>();
+  let nextDecoderId = 1;
+  return {
+    ...STATELESS_HOST_SYNC,
+    /** Open a streaming decoder; the guest holds the id until its flushing decode. */
+    textDecoderOpen: (encoding: unknown, fatal: unknown, ignoreBOM: unknown): number => {
+      if (decoders.size >= MAX_OPEN_TEXT_DECODERS) {
+        throw new RangeError(`textDecoderOpen: more than ${MAX_OPEN_TEXT_DECODERS} streaming decoders are open`);
+      }
+      const id = nextDecoderId++;
+      decoders.set(id, new TextDecoder(String(encoding), { fatal: Boolean(fatal), ignoreBOM: Boolean(ignoreBOM) }));
+      return id;
+    },
+    /**
+     * Decode one chunk on an open streaming decoder. A decode without `stream`
+     * flushes and releases it, the point at which the spec resets a decoder's
+     * state; a fatal error mid-stream keeps it, as the spec does.
+     */
+    textDecoderDecode: (id: unknown, bytes: unknown, stream: unknown): string => {
+      const key = Number(id);
+      const decoder = decoders.get(key);
+      if (!decoder) throw new TypeError(`textDecoderDecode: no open streaming decoder ${String(id)}`);
+      const flush = !stream;
+      try {
+        return decoder.decode(asBytes(bytes, 'textDecoderDecode'), { stream: !flush });
+      } finally {
+        if (flush) decoders.delete(key);
+      }
+    },
+  };
+}
+
+const STATELESS_HOST_SYNC: Record<string, (...args: unknown[]) => unknown> = {
   urlParse: (input: unknown, base: unknown): GuestUrlRecord =>
     guestUrlRecord(base === undefined || base === null ? new URL(String(input)) : new URL(String(input), String(base))),
   urlSet: (href: unknown, name: unknown, value: unknown): GuestUrlRecord => {
@@ -485,12 +532,24 @@ var exports = module.exports;
     this._encoding = hostSync('textEncodingName', label === undefined ? 'utf-8' : String(label));
     this._fatal = !!(options && options.fatal);
     this._ignoreBOM = !!(options && options.ignoreBOM);
+    // The host decoder holding this decoder's partial sequence while a
+    // { stream: true } sequence of decodes is in progress; null between them.
+    this._streamId = null;
   }
   Object.defineProperty(TextDecoder.prototype, 'encoding', { get: function () { return this._encoding; }, enumerable: true });
   Object.defineProperty(TextDecoder.prototype, 'fatal', { get: function () { return this._fatal; }, enumerable: true });
   Object.defineProperty(TextDecoder.prototype, 'ignoreBOM', { get: function () { return this._ignoreBOM; }, enumerable: true });
-  TextDecoder.prototype.decode = function decode(input) {
-    return hostSync('textDecode', this._encoding, toBytes(input, 'TextDecoder.decode'), this._fatal, this._ignoreBOM);
+  TextDecoder.prototype.decode = function decode(input, options) {
+    var bytes = toBytes(input, 'TextDecoder.decode');
+    var stream = !!(options && options.stream);
+    if (this._streamId === null) {
+      if (!stream) return hostSync('textDecode', this._encoding, bytes, this._fatal, this._ignoreBOM);
+      this._streamId = hostSync('textDecoderOpen', this._encoding, this._fatal, this._ignoreBOM);
+    }
+    var id = this._streamId;
+    // The flushing decode releases the host decoder whether or not it throws.
+    if (!stream) this._streamId = null;
+    return hostSync('textDecoderDecode', id, bytes, stream);
   };
 
   global.TextEncoder = TextEncoder;
@@ -897,29 +956,88 @@ var exports = module.exports;
     throw new TypeError('Unsupported body type on the isolate lane: pass a string, URLSearchParams, ArrayBuffer or ArrayBufferView');
   }
 
+  // A guest-constructed body: its bytes handed over once, then end of stream.
+  function bytesStream(bytes) {
+    var sent = false;
+    return new ReadableStream({
+      pull: function (controller) {
+        if (sent) {
+          controller.close();
+          return;
+        }
+        sent = true;
+        controller.enqueue(bytes);
+      }
+    });
+  }
+
+  // Drain a body stream into one Uint8Array for text() / json() / arrayBuffer().
+  function readAllBytes(stream) {
+    var reader = stream.getReader();
+    var chunks = [];
+    var total = 0;
+    function step() {
+      return reader.read().then(function (result) {
+        if (result.done) {
+          reader.releaseLock();
+          var out = new Uint8Array(total);
+          var offset = 0;
+          for (var i = 0; i < chunks.length; i++) {
+            out.set(chunks[i], offset);
+            offset += chunks[i].length;
+          }
+          return out;
+        }
+        var chunk = toBytes(result.value, 'Response body');
+        chunks.push(chunk);
+        total += chunk.length;
+        return step();
+      });
+    }
+    return step();
+  }
+
   function Response(body, init) {
     if (!(this instanceof Response)) throw new TypeError("Class constructor Response cannot be invoked without 'new'");
     init = init || {};
     var status = init.status === undefined ? 200 : Number(init.status);
     if (!Number.isInteger(status) || status < 200 || status > 599) throw new RangeError('init["status"] must be in the range of 200 to 599, inclusive.');
-    var extracted = extractBody(body);
-    this._bytes = extracted.bytes;
-    this._bodyUsed = false;
     this.status = status;
     this.statusText = init.statusText === undefined ? (STATUS_TEXT[status] || '') : String(init.statusText);
     this.headers = new Headers(init.headers);
-    if (extracted.contentType && !this.headers.has('content-type')) this.headers.set('content-type', extracted.contentType);
     this.url = init.url === undefined ? '' : String(init.url);
     this.redirected = !!init.redirected;
     this.type = 'basic';
-    // Streams are not available on this lane; the body is always buffered.
-    this.body = null;
+    this._bodyUsed = false;
+    if (body instanceof ReadableStream) {
+      this._bytes = null;
+      this._stream = body;
+    } else {
+      var extracted = extractBody(body);
+      this._bytes = extracted.bytes;
+      this._stream = null;
+      if (extracted.contentType && !this.headers.has('content-type')) this.headers.set('content-type', extracted.contentType);
+    }
   }
   Object.defineProperty(Response.prototype, 'ok', { get: function () { return this.status >= 200 && this.status <= 299; }, enumerable: true });
-  Object.defineProperty(Response.prototype, 'bodyUsed', { get: function () { return this._bodyUsed; }, enumerable: true });
+  // A ReadableStream for every non-null body, as on every other runtime: a
+  // network response streams from the host, a guest-constructed one yields its
+  // bytes once. Null for a body-less response.
+  Object.defineProperty(Response.prototype, 'body', {
+    get: function () {
+      if (this._stream === null && this._bytes !== null) this._stream = bytesStream(this._bytes);
+      return this._stream;
+    },
+    enumerable: true
+  });
+  Object.defineProperty(Response.prototype, 'bodyUsed', {
+    get: function () { return this._bodyUsed || !!(this._stream && this._stream._disturbed); },
+    enumerable: true
+  });
   Response.prototype._consume = function () {
-    if (this._bodyUsed) return Promise.reject(new TypeError('Body is unusable: Body has already been read'));
+    if (this.bodyUsed) return Promise.reject(new TypeError('Body is unusable: Body has already been read'));
     this._bodyUsed = true;
+    if (this._stream) return readAllBytes(this._stream);
     return Promise.resolve(this._bytes || new Uint8Array(0));
   };
   Response.prototype.arrayBuffer = function () {
@@ -935,7 +1053,10 @@ var exports = module.exports;
     return this.text().then(function (text) { return JSON.parse(text); });
   };
   Response.prototype.clone = function () {
-    if (this._bodyUsed) throw new TypeError('Response.clone: Body has already been consumed.');
+    if (this.bodyUsed) throw new TypeError('Response.clone: Body has already been consumed.');
+    // Cloning a streamed body means teeing it, which nothing on this lane
+    // does; a guest-constructed body still has its bytes to copy.
+    if (this._bytes === null && this._stream !== null) throw new TypeError('Response.clone: a streamed body cannot be cloned on the isolate lane');
     return new Response(this._bytes ? new Uint8Array(this._bytes) : null, {
       status: this.status, statusText: this.statusText, headers: this.headers, url: this.url, redirected: this.redirected
     });
@@ -957,6 +1078,15 @@ var exports = module.exports;
   global.Response = Response;
 
   var fetchSeq = 0;
+
+  // The error a body stream ends with when the host reports one: an abort is
+  // the signal's own reason, anything else the host's description.
+  function bodyStreamError(desc, signal) {
+    if (desc && desc.name === 'AbortError') {
+      return signal && signal.aborted && signal.reason !== undefined ? signal.reason : abortError();
+    }
+    return makeError(desc);
+  }
 
   function fetch(input, init) {
     return new Promise(function (resolve) { resolve(); }).then(function () {
@@ -984,21 +1114,66 @@ var exports = module.exports;
       var redirect = init.redirect === undefined ? 'follow' : String(init.redirect);
       if (redirect !== 'follow' && redirect !== 'manual' && redirect !== 'error') throw new TypeError('Invalid redirect mode: ' + redirect);
       var id = ++fetchSeq;
+      // The abort listener lives as long as the response does, headers AND
+      // body: an abort after the headers arrived errors the body stream, as it
+      // does on every other runtime.
       var onAbort = null;
+      var finished = false;
+      function finish() {
+        if (finished) return;
+        finished = true;
+        if (onAbort) signal.removeEventListener('abort', onAbort);
+      }
       if (signal) {
         onAbort = function () { try { hostSync('fetchAbort', id); } catch (e) {} };
         signal.addEventListener('abort', onAbort, { once: true });
       }
       var request = { id: id, url: parsed.href, method: method, headers: headers._sortedEntries(), redirect: redirect };
-      return hostAsync('fetch', request, extracted.bytes === null ? undefined : extracted.bytes).then(
+      return hostAsync('fetchOpen', request, extracted.bytes === null ? undefined : extracted.bytes).then(
         function (reply) {
-          if (onAbort) signal.removeEventListener('abort', onAbort);
-          return new Response(reply.body, {
+          var body = null;
+          if (!reply.hasBody) {
+            finish();
+          } else {
+            // One host chunk per read, the way a socket's readable pulls: the
+            // host holds nothing the guest has not asked for yet.
+            body = new ReadableStream({
+              pull: function (controller) {
+                if (signal && signal.aborted) {
+                  finish();
+                  controller.error(bodyStreamError({ name: 'AbortError' }, signal));
+                  return;
+                }
+                return hostAsync('fetchRead', id).then(
+                  function (res) {
+                    if (res.error) {
+                      finish();
+                      controller.error(bodyStreamError(res.error, signal));
+                    } else if (res.done || res.data === null) {
+                      finish();
+                      controller.close();
+                    } else {
+                      controller.enqueue(toBytes(res.data, 'fetch body'));
+                    }
+                  },
+                  function (err) {
+                    finish();
+                    controller.error(err);
+                  }
+                );
+              },
+              cancel: function () {
+                finish();
+                try { hostSync('fetchAbort', id); } catch (e) {}
+              }
+            });
+          }
+          return new Response(body, {
             status: reply.status, statusText: reply.statusText, headers: reply.headers, url: reply.url, redirected: reply.redirected
           });
         },
         function (err) {
-          if (onAbort) signal.removeEventListener('abort', onAbort);
+          finish();
           if (signal && signal.aborted) throw signal.reason === undefined ? abortError() : signal.reason;
           throw err;
         }
@@ -1444,39 +1619,35 @@ var exports = module.exports;
   // ---------------------------------------------------------------------------
   function ReadableStream(underlyingSource) {
     this._source = underlyingSource || {};
+    // Set by the first read; Response.bodyUsed reports it.
+    this._disturbed = false;
   }
   ReadableStream.prototype.getReader = function () {
     var self = this;
     var queue = [];
-    var pendingRead = null;
+    var waiters = [];
     var isClosed = false;
     var streamError = null;
 
+    function settleWaiters(result) {
+      while (waiters.length > 0) waiters.shift()(result);
+    }
+
     var controller = {
       enqueue: function (chunk) {
-        if (pendingRead) {
-          var r = pendingRead;
-          pendingRead = null;
-          r({ value: chunk, done: false });
-        } else {
-          queue.push(chunk);
-        }
+        // A chunk the source still delivers after a close or a cancel is
+        // dropped: every read from that point on already reports done.
+        if (isClosed) return;
+        if (waiters.length > 0) waiters.shift()({ value: chunk, done: false });
+        else queue.push(chunk);
       },
       close: function () {
         isClosed = true;
-        if (pendingRead) {
-          var r = pendingRead;
-          pendingRead = null;
-          r({ value: undefined, done: true });
-        }
+        settleWaiters({ value: undefined, done: true });
       },
       error: function (err) {
         streamError = err;
-        if (pendingRead) {
-          var r = pendingRead;
-          pendingRead = null;
-          r(Promise.reject(err));
-        }
+        if (waiters.length > 0) settleWaiters(Promise.reject(err));
       }
     };
 
@@ -1486,6 +1657,7 @@ var exports = module.exports;
 
     return {
       read: function () {
+        self._disturbed = true;
         if (streamError) return Promise.reject(streamError);
         if (queue.length > 0) {
           return Promise.resolve({ value: queue.shift(), done: false });
@@ -1494,10 +1666,11 @@ var exports = module.exports;
           return Promise.resolve({ value: undefined, done: true });
         }
         // The waiter is registered BEFORE pull(), because a source that
-        // enqueues synchronously would otherwise push into the queue while
-        // pendingRead was still null and leave this read hanging forever.
+        // enqueues synchronously would otherwise push into the queue while no
+        // waiter was registered and leave this read hanging forever. Reads
+        // queue in order: each pull answers the oldest waiter.
         var waiter = new Promise(function (resolve) {
-          pendingRead = resolve;
+          waiters.push(resolve);
         });
         if (self._source && self._source.pull) {
           self._source.pull(controller);
@@ -1505,7 +1678,14 @@ var exports = module.exports;
         return waiter;
       },
       releaseLock: function () {},
+      // Cancelling ends the stream: the queue is dropped and every read from
+      // here on reports done. Without that a later read would pull the source
+      // again -- for a fetch body or a socket, a read on what the cancel just
+      // released.
       cancel: function (reason) {
+        isClosed = true;
+        queue.length = 0;
+        settleWaiters({ value: undefined, done: true });
         if (self._source && self._source.cancel) {
           return Promise.resolve(self._source.cancel(reason));
         }

--- a/packages/connector-worker/src/isolate/prelude.ts
+++ b/packages/connector-worker/src/isolate/prelude.ts
@@ -1646,6 +1646,11 @@ var exports = module.exports;
         settleWaiters({ value: undefined, done: true });
       },
       error: function (err) {
+        // Like enqueue: an error the source reports after a close or a cancel
+        // is dropped, so a read from then on still reports done. The fetch
+        // body reaches this when a cancel kills its in-flight pull, which
+        // answers with an AbortError only after the cancel has ended the stream.
+        if (isClosed) return;
         streamError = err;
         if (waiters.length > 0) settleWaiters(Promise.reject(err));
       }

--- a/packages/server/src/__tests__/integration/sandbox/fixtures/isolate-fixture-connector.ts
+++ b/packages/server/src/__tests__/integration/sandbox/fixtures/isolate-fixture-connector.ts
@@ -2,10 +2,10 @@
  * Fixture connector for `isolate-executor.test.ts`.
  *
  * Each `scenario` config value exercises one boundary of the connector isolate
- * lane: chunked emit and checkpoint hooks, host-mediated fetch, timers, console
- * redaction, runaway CPU and heap, thrown errors, a throwing timer callback,
- * an oversized bridge message, auth artifacts and chrome dispatch. The suite compiles it for BOTH lanes so what each lane observably does
- * can be compared. It is never registered as a real connector.
+ * lane: chunked emit and checkpoint hooks, host-mediated fetch with streamed
+ * bodies, timers, console redaction, runaway CPU and heap, thrown errors, a
+ * throwing timer callback, an oversized bridge message, auth artifacts and
+ * chrome dispatch. It is never registered as a real connector.
  */
 import {
 	type ActionContext,
@@ -23,6 +23,10 @@ interface FixtureConfig {
 	scenario?: string;
 	count?: number;
 	url?: string;
+	/** `stream`: POSTed after every chunk read, so the server can hold the next one back until the guest has seen this one. */
+	ackUrl?: string;
+	/** `stream_abort` / `stream_cancel`: fetched after the body was given up, to show the run carries on. */
+	afterUrl?: string;
 	method?: string;
 	body?: string;
 	secret?: string;
@@ -98,6 +102,7 @@ export default class IsolateFixtureConnector extends ConnectorRuntime<Record<str
 					init.headers = { ...(init.headers as Record<string, string>), "content-type": "application/json" };
 				}
 				const res = await fetch(String(ctx.config.url), init);
+				const hasBody = res.body !== null;
 				const text = await res.text();
 				return {
 					events: [],
@@ -107,10 +112,61 @@ export default class IsolateFixtureConnector extends ConnectorRuntime<Record<str
 						url: res.url,
 						redirected: res.redirected,
 						contentType: res.headers.get("content-type"),
+						hasBody,
 						bytes: text.length,
 						text: text.slice(0, 512),
 					},
 				};
+			}
+			case "stream": {
+				// Reads the body as it arrives and acknowledges every chunk to the
+				// server before it sends the next one. A lane that buffered the
+				// body would wait for an end the server only writes after the
+				// acknowledgement the guest cannot send until it has read a chunk.
+				const res = await fetch(String(ctx.config.url));
+				if (!res.body) throw new Error("streamed response has no body");
+				const usedBeforeRead = res.bodyUsed;
+				const reader = res.body.getReader();
+				const decoder = new TextDecoder();
+				const chunks: string[] = [];
+				for (;;) {
+					const { value, done } = await reader.read();
+					if (done) break;
+					chunks.push(decoder.decode(value, { stream: true }));
+					await fetch(String(ctx.config.ackUrl), { method: "POST", body: String(chunks.length) });
+				}
+				const tail = decoder.decode();
+				return {
+					events: [],
+					checkpoint: { chunks, tail, text: chunks.join("") + tail, usedBeforeRead, usedAfterRead: res.bodyUsed },
+				};
+			}
+			case "stream_abort": {
+				// Abort after the first chunk: the next read rejects with the
+				// signal's reason, and the run goes on to another fetch.
+				const controller = new AbortController();
+				const res = await fetch(String(ctx.config.url), { signal: controller.signal });
+				if (!res.body) throw new Error("streamed response has no body");
+				const reader = res.body.getReader();
+				const first = new TextDecoder().decode((await reader.read()).value);
+				controller.abort();
+				let rejection = "none";
+				try {
+					await reader.read();
+				} catch (error) {
+					rejection = String((error as Error).name);
+				}
+				const after = await (await fetch(String(ctx.config.afterUrl))).text();
+				return { events: [], checkpoint: { first, rejection, after } };
+			}
+			case "stream_cancel": {
+				const res = await fetch(String(ctx.config.url));
+				if (!res.body) throw new Error("streamed response has no body");
+				const reader = res.body.getReader();
+				const first = new TextDecoder().decode((await reader.read()).value);
+				await reader.cancel();
+				const after = await (await fetch(String(ctx.config.afterUrl))).text();
+				return { events: [], checkpoint: { first, after, bodyUsed: res.bodyUsed } };
 			}
 			case "raw_fetch": {
 				// Bypasses the guest fetch validator on purpose: the host must judge
@@ -118,7 +174,7 @@ export default class IsolateFixtureConnector extends ConnectorRuntime<Record<str
 				const host = (globalThis as unknown as { __lobuHost: { async(name: string, ...args: unknown[]): Promise<unknown> } })
 					.__lobuHost;
 				try {
-					await host.async("fetch", { id: 4242, url: String(ctx.config.url), method: "GET", headers: [], redirect: "follow" });
+					await host.async("fetchOpen", { id: 4242, url: String(ctx.config.url), method: "GET", headers: [], redirect: "follow" });
 					return { events: [], checkpoint: { outcome: "resolved" } };
 				} catch (error) {
 					const e = error as { name?: string; message?: string };

--- a/packages/server/src/__tests__/integration/sandbox/isolate-executor.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/isolate-executor.test.ts
@@ -13,7 +13,8 @@
  *     unchanged;
  *  3. a fixture connector exercises each boundary: chunked emit, checkpoint
  *     hooks, chrome dispatch, auth artifacts/signals, domain-restricted fetch,
- *     the body cap, wall-clock and heap limits, error shape parity, redaction;
+ *     bodies streamed chunk by chunk (with abort and cancel), the body cap,
+ *     wall-clock and heap limits, error shape parity, redaction;
  *  4. the guest's URL / URLSearchParams / TextEncoder / TextDecoder / atob /
  *     btoa are compared against Node's over 100+ inputs each. The host computes
  *     them for the guest, so this checks the bridge wiring (typed arrays, error
@@ -126,6 +127,26 @@ let baseUrl: string;
 let port: number;
 /** Requests the fixture server has answered: a denied fetch must not move it. */
 let hits = 0;
+/** `/sse` writes its next chunk only when `/ack` releases it; `acks` counts the releases. */
+let releaseSse: (() => void) | null = null;
+let acks = 0;
+/** `/drip` responses the client closed before the server ended them. */
+let dripClosed = 0;
+
+/** The `/sse` body: a multi-byte character split across the first two chunks, then a second event. */
+const SSE_CHUNKS = [
+	Buffer.concat([Buffer.from("data: caf", "utf8"), Buffer.from([0xc3])]),
+	Buffer.concat([Buffer.from([0xa9]), Buffer.from("\n\ndata: second\n\n", "utf8")]),
+];
+const SSE_TEXT = "data: café\n\ndata: second\n\n";
+
+async function until(check: () => boolean, ms = 5_000): Promise<void> {
+	const deadline = Date.now() + ms;
+	while (!check()) {
+		if (Date.now() > deadline) throw new Error("condition not met in time");
+		await new Promise((r) => setTimeout(r, 20));
+	}
+}
 
 async function runIsolate(
 	code: string,
@@ -216,6 +237,44 @@ beforeAll(async () => {
 					res.writeHead(200, { "content-type": "application/octet-stream" });
 					res.end("x".repeat(4096));
 					return;
+				case "/empty":
+					res.writeHead(204);
+					res.end();
+					return;
+				case "/sse": {
+					// Each chunk after the first waits for the client to acknowledge
+					// the previous one through /ack, so a client that has not READ a
+					// chunk can never be sent the next; the body ends after the last
+					// acknowledgement.
+					res.writeHead(200, { "content-type": "text/event-stream" });
+					let index = 0;
+					const step = () => {
+						if (index < SSE_CHUNKS.length) {
+							res.write(SSE_CHUNKS[index]);
+							index += 1;
+							releaseSse = step;
+						} else {
+							releaseSse = null;
+							res.end();
+						}
+					};
+					step();
+					return;
+				}
+				case "/ack":
+					acks += 1;
+					res.writeHead(200);
+					res.end("ok");
+					releaseSse?.();
+					return;
+				case "/drip":
+					// One chunk, then the body stays open until the client goes away.
+					res.writeHead(200, { "content-type": "text/event-stream" });
+					res.write("data: first\n\n");
+					res.on("close", () => {
+						dripClosed += 1;
+					});
+					return;
 				case "/redirect":
 					res.writeHead(302, { location: "/ok" });
 					res.end();
@@ -237,6 +296,7 @@ beforeAll(async () => {
 }, 120_000);
 
 afterAll(async () => {
+	server?.closeAllConnections();
 	await new Promise<void>((resolveClose) => server?.close(() => resolveClose()));
 });
 
@@ -572,6 +632,69 @@ describe("isolate lane: fixture connector", () => {
 		expect(hits).toBe(before);
 	});
 
+	it("streams a response body to the guest chunk by chunk, decoding a character split across chunks", async () => {
+		acks = 0;
+		const streamed = await runIsolate(
+			fixtureIsolateCode,
+			syncJob({ scenario: "stream", url: `${baseUrl}/sse`, ackUrl: `${baseUrl}/ack` }),
+			{ allowedDomains: ["127.0.0.1"], timeoutMs: 15_000 },
+		);
+		// Two chunks, each acknowledged before the server wrote the next: the
+		// guest saw the first while the body was still open. The split `é`
+		// (0xC3 in chunk one, 0xA9 in chunk two) comes out whole because the
+		// guest's TextDecoder kept the partial sequence across the two decodes.
+		expect(checkpointOf(streamed.result)).toEqual({
+			chunks: ["data: caf", "é\n\ndata: second\n\n"],
+			tail: "",
+			text: SSE_TEXT,
+			usedBeforeRead: false,
+			usedAfterRead: true,
+		});
+		expect(acks).toBe(2);
+	});
+
+	it("aborting the signal after the headers errors the body stream and releases the upstream socket", async () => {
+		const before = dripClosed;
+		const aborted = await runIsolate(
+			fixtureIsolateCode,
+			syncJob({ scenario: "stream_abort", url: `${baseUrl}/drip`, afterUrl: `${baseUrl}/ok` }),
+			{ allowedDomains: ["127.0.0.1"], timeoutMs: 15_000 },
+		);
+		expect(checkpointOf(aborted.result)).toEqual({
+			first: "data: first\n\n",
+			rejection: "AbortError",
+			after: "hello from the fixture server",
+		});
+		await until(() => dripClosed === before + 1);
+	});
+
+	it("cancelling the body releases the upstream socket and leaves the run running", async () => {
+		const before = dripClosed;
+		const cancelled = await runIsolate(
+			fixtureIsolateCode,
+			syncJob({ scenario: "stream_cancel", url: `${baseUrl}/drip`, afterUrl: `${baseUrl}/ok` }),
+			{ allowedDomains: ["127.0.0.1"], timeoutMs: 15_000 },
+		);
+		expect(checkpointOf(cancelled.result)).toEqual({
+			first: "data: first\n\n",
+			after: "hello from the fixture server",
+			bodyUsed: true,
+		});
+		await until(() => dripClosed === before + 1);
+	});
+
+	it("gives a body-less response a null body and an empty text, and every other response a stream", async () => {
+		const empty = await runIsolate(fixtureIsolateCode, syncJob({ scenario: "fetch", url: `${baseUrl}/empty` }), {
+			allowedDomains: ["127.0.0.1"],
+		});
+		expect(checkpointOf(empty.result)).toMatchObject({ status: 204, hasBody: false, bytes: 0, text: "" });
+
+		const full = await runIsolate(fixtureIsolateCode, syncJob({ scenario: "fetch", url: `${baseUrl}/ok` }), {
+			allowedDomains: ["127.0.0.1"],
+		});
+		expect(checkpointOf(full.result)).toMatchObject({ status: 200, hasBody: true });
+	});
+
 	it("caps the response body", async () => {
 		const failure = await failIsolate(fixtureIsolateCode, syncJob({ scenario: "fetch", url: `${baseUrl}/big` }), {
 			allowedDomains: ["127.0.0.1"],
@@ -586,6 +709,18 @@ describe("isolate lane: fixture connector", () => {
 			fetchBodyBytes: 8192,
 		});
 		expect(checkpointOf(fits.result).bytes).toBe(4096);
+
+		// The cap is charged as the guest pulls, never for what it did not take:
+		// `/drip` is unbounded, which no buffering lane could ever fit under a
+		// cap, yet reading its first chunk and cancelling is fine at the minimum.
+		const before = dripClosed;
+		const partial = await runIsolate(
+			fixtureIsolateCode,
+			syncJob({ scenario: "stream_cancel", url: `${baseUrl}/drip`, afterUrl: `${baseUrl}/ok` }),
+			{ allowedDomains: ["127.0.0.1"], fetchBodyBytes: 1024 },
+		);
+		expect(checkpointOf(partial.result)).toMatchObject({ first: "data: first\n\n" });
+		await until(() => dripClosed === before + 1);
 	});
 
 	it("kills a synchronous infinite loop at the wall-clock budget", async () => {


### PR DESCRIPTION
## Summary
- The connector isolate lane's `fetch` now streams. The host answers `fetchOpen` with status and headers as soon as they arrive (`hasBody` says whether a body follows); the guest's `Response.body` is a pull `ReadableStream` that takes one upstream chunk per `fetchRead` under the request's own id, the same shape as a socket's `readable` over `socketRead`. The host never holds more of a body than the guest has asked for, and the `fetchBodyBytes` cap is charged as chunks are handed over (the stream errors with `FetchBodyLimitExceeded` at the chunk that crosses it).
- `TextDecoder.decode(chunk, { stream: true })` works: the guest shell opens a Node `TextDecoder` on the host that keeps the partial sequence between chunks until the flushing decode releases it (`createPreludeHostSync()` replaces the constant table, since a decoder's state belongs to one run; at most 1024 may be left open). Every SSE consumer, pi-ai's Anthropic provider and the Stainless SDKs included, decodes this way.
- Aborting the request's signal after the headers arrived errors the body stream with the signal's reason and releases the upstream socket; `body.cancel()` does the same. `Response.body` is null for a body-less response (204, 304, HEAD) and a stream for everything else; `bodyUsed` follows the stream.
- Deleted: the buffered path (`readBodyCapped`, the `fetch` capability that returned a whole `Uint8Array`, the `Response.body = null` contract), and the constant `PRELUDE_HOST_SYNC`.

This is the third PR of the isolate-lane consolidation (after #3365 and #3369) and the prerequisite for running an LLM turn in the guest: the Anthropic SDK throws on a body-less response and reads SSE through `getReader()` plus a streaming `TextDecoder`.

Behaviour changes, all on the isolate lane:
- A connector that only ever called `res.text()` / `res.json()` sees the same bytes; the body is now drained chunk by chunk inside the guest instead of on the host, so a 16 MiB body costs guest heap (512 MB limit) rather than a host buffer.
- The body cap applies to what the guest pulls, not to the whole upstream body: an unbounded body the guest stops reading early is fine.
- `Response.clone()` on a network response throws (`a streamed body cannot be cloned on the isolate lane`); nothing bundled calls it (verified against `origin/main`: no `.clone()` in `connector-sdk`, `connectors` or `connector-worker`). A guest-constructed `Response` still clones.
- The guest `ReadableStream` now queues concurrent reads in order instead of overwriting the previous waiter, records whether it was read (for `bodyUsed`), ends on `cancel()` (a later read reports done instead of pulling the source again) and drops a chunk the source delivers after close. The socket lane shares the stream and its suites stay green, including the real-Postgres-over-isolate-socket run; no lock semantics were added because postgres.js's Cloudflare polyfill calls `getReader()` twice per socket, once after `startTls`.
- A run may hold at most 1024 responses open (headers delivered, body neither drained nor cancelled); `fetch` past that fails with a message saying so. Each open body pins an upstream socket and a host reader until the run ends, and a guest that fetches and never reads would otherwise pin them without bound. Not covered by a test: it would take 1025 live connections to the fixture server.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (local gates; full graph on CI)
- [x] Tests run:
  - `bun test ./packages/connector-worker/src/__tests__/` — 370 pass (adds 6 streaming `TextDecoder` cases over the real host halves: every split point of `café €` matches Node chunk for chunk, fatal flush, no-input flush, the 1024 cap, per-run registries; and 4 guest `ReadableStream` reader cases: FIFO waiters under a source that answers on a microtask, cancel ends the stream, a late chunk after close is dropped)
  - server vitest on a fresh `connector-worker` dist: `bun run test -- run src/__tests__/integration/sandbox/` — 9 files, 132 pass (`isolate-executor` 32 incl. the five below; `connector-isolate-lane` census unchanged; socket/TLS/pushdown suites green)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot runtime changed: n/a

Red (the new server tests against `origin/main`'s `connector-worker` dist, which still buffers):

```
× streams a response body to the guest chunk by chunk, decoding a character split across chunks 15060ms
    ConnectorExecutionError: Feed execution timed out after 15000ms
× aborting the signal after the headers errors the body stream and releases the upstream socket 15506ms
    ConnectorExecutionError: Feed execution timed out after 15000ms
× cancelling the body releases the upstream socket and leaves the run running 15021ms
    ConnectorExecutionError: Feed execution timed out after 15000ms
× gives a body-less response a null body and an empty text, and every other response a stream
    AssertionError: expected { status: 200, … } to match object { status: 200, hasBody: true }
```

The first is the deadlock by construction: the fixture server writes chunk two only after the guest acknowledges chunk one over a second request, which a guest that cannot see chunk one until the body ends never sends. The abort and cancel cases stream from an endpoint that never ends, which a buffering `fetch()` never returns from.

Green (this branch):

```
✓ streams a response body to the guest chunk by chunk, decoding a character split across chunks
✓ aborting the signal after the headers errors the body stream and releases the upstream socket
✓ cancelling the body releases the upstream socket and leaves the run running
✓ gives a body-less response a null body and an empty text, and every other response a stream
✓ caps the response body
```

Prototype gate (scratchpad, not committed): the pi-ai Anthropic provider (`@mariozechner/pi-ai` 0.73.1 over `@anthropic-ai/sdk` 0.91.1), bundled with the lane's build options and `fs` aliased to a stub, is isolate-eligible (no bare requires, 726 KB) and completes a mocked streamed completion inside `IsolateExecutor` with `allowedDomains: ['127.0.0.1']`:

```
server writes   : Hello@152ms  from@304  the@455  isolate@608  lane@760  " — café €"@911  !@1062  end@1214
guest text_delta: Hello@164ms  from@316  the@467  isolate@620  lane@773  " — café €"@925  !@1075  done@1276
text: "Hello from the isolate lane — café €!"  stopReason: stop  usage: 12 in / 9 out
```

Each delta reaches the guest about 12 ms after the server writes it, a second before the body ends. Request headers seen by the mock: `x-api-key`, `anthropic-version: 2023-06-01`, `content-type: application/json`, `user-agent: Anthropic/JS 0.91.1`, `stream: true`.

## Notes
- One gap surfaced by the prototype, deliberately NOT closed here: the Stainless request builder probes `body instanceof FormData` unguarded (`@anthropic-ai/sdk/client.js:499`), so the guest needs a `FormData` global before the SDK sends anything (the probe defined an empty class). The prelude adds a global only with the code that needs it, and that code is the agent guest of the `agent_turn` PR; noted there. `Blob` is guarded by the SDK and not needed.
- `fetchRead` carries chunks as `Uint8Array` across the bridge (the old `fetch` reply already did); the socket lane still base64-encodes its chunks. Consolidating the two onto one chunk shape is a candidate for the cutover PR, not this one.
- `Response.body` and `TextDecoder` `{ stream: true }` are the standard surface, so the guest code is unchanged for the planned Cloudflare Workers backend; `fetchOpen` / `fetchRead` / `textDecoderOpen` / `textDecoderDecode` are lane-internal host capabilities.
- `make review-fix` ran on the claude harness (codex is out of quota until Sep 7). It fixed two stream bugs in my first cut (`reader.cancel()` did not end the stream, so the next read pulled the source again; a chunk delivered after close resurfaced on a later read), each proved by mutation, replaced the `stream: id | null` handle with `hasBody` since the id was always the request's own, and added the reader tests. It also asked for the open-response bound above.
- Second commit, from the `make review` round (verdict bug_free 86 / simplicity 80 / slop 8 / 1 non-blocking bug): a stream error reported after `cancel()` no longer makes a later read reject (the in-flight `fetchRead` that `fetchAbort` kills answers after the cancel), pinned by a reader test; and `Response.clone()` behaviour is pinned (a guest-constructed body clones, a streamed one throws).
