### PR TITLE
fix(ci): clear the pending label from a released PR so the next release opens

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -269,3 +269,60 @@ jobs:
           tag: ${{ steps.bump.outputs.tag }}
           expected-sha: ${{ needs.attest.outputs.sha }}
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      # release-please marks its own merged release PR `autorelease: tagged`
+      # from inside the release step, and this workflow skips that step
+      # (`skip-github-release: true`) so the release can be bound to the
+      # attested commit rather than to whatever the action considered HEAD.
+      # Nothing else moves the label, so it stays `autorelease: pending`
+      # forever -- and release-please refuses to open the NEXT release PR
+      # while any merged one still reads pending ("There are untagged, merged
+      # release PRs outstanding - aborting"). One release therefore blocks
+      # every release after it: 18.0.0 was tagged on 2026-09-03 and no
+      # version-bump PR opened again until its label was corrected by hand.
+      #
+      # Matching is by ancestry, not by title: `assert-newer` above guarantees
+      # the release just cut is the newest, so any release PR merged at or
+      # before the attested commit has had its version superseded and its
+      # pending label is stale by construction. A title comparison would go
+      # silently stale the moment `pull-request-title-pattern` changed, which
+      # is the same silence this step exists to remove.
+      #
+      # Merged-ness is read from the list payload, so an unmerged PR costs no
+      # extra call -- and it has to be read, because release-please closes
+      # every release PR it supersedes without clearing the label. Those
+      # closed-unmerged ones are harmless to the abort above, which counts
+      # merged PRs only, but their `merge_commit_sha` is the
+      # `refs/pull/N/merge` test merge: GitHub garbage-collects it, and
+      # comparing against a collected one 404s and, under `set -e`, fails this
+      # job after the release was already created.
+      - name: Clear the pending label from released PRs
+        if: steps.bump.outputs.bumped == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          ATTESTED_SHA: ${{ needs.attest.outputs.sha }}
+        run: |
+          set -euo pipefail
+          pending=$(gh api --paginate --slurp \
+            "repos/${REPOSITORY}/issues?state=closed&labels=autorelease:%20pending&per_page=100" \
+            | jq -r '.[][] | select(.pull_request.merged_at) | .number')
+          for pr in $pending; do
+            merged_sha=$(gh api "repos/${REPOSITORY}/pulls/${pr}" --jq '.merge_commit_sha')
+            compare_status=$(gh api "repos/${REPOSITORY}/compare/${merged_sha}...${ATTESTED_SHA}" --jq '.status')
+            case "$compare_status" in
+              ahead | identical) ;;
+              *) continue ;;
+            esac
+            # Add then remove, so the PR is never momentarily unlabelled. The
+            # DELETE is tolerated because two main pushes can both reach this
+            # step for one release -- the create step above is written for that
+            # same race -- and the second finds the label already gone. It
+            # cannot swallow a permission fault: the POST shares the token and
+            # is not tolerated.
+            gh api --method POST "repos/${REPOSITORY}/issues/${pr}/labels" \
+              --input <(jq -n '{labels: ["autorelease: tagged"]}') >/dev/null
+            gh api --method DELETE \
+              "repos/${REPOSITORY}/issues/${pr}/labels/autorelease:%20pending" >/dev/null || true
+            echo "cleared the pending label from #${pr}"
+          done

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -304,8 +304,7 @@ jobs:
           ATTESTED_SHA: ${{ needs.attest.outputs.sha }}
         run: |
           set -euo pipefail
-          pending=$(gh api --paginate --slurp \
-            "repos/${REPOSITORY}/issues?state=closed&labels=autorelease:%20pending&per_page=100" \
+          pending=$(gh api --paginate --slurp "repos/${REPOSITORY}/issues?state=closed&labels=autorelease:%20pending&per_page=100" \
             | jq -r '.[][] | select(.pull_request.merged_at) | .number')
           for pr in $pending; do
             merged_sha=$(gh api "repos/${REPOSITORY}/pulls/${pr}" --jq '.merge_commit_sha')

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -742,3 +742,63 @@ describe("paginated API payloads are piped into jq, never passed as arguments", 
     expect(piped).toHaveLength(slurped.length);
   });
 });
+
+// release-please marks its own merged release PR `autorelease: tagged` from
+// inside the release step, which this workflow skips so the release can bind
+// to the attested commit. The replacement step below is therefore the ONLY
+// thing that clears the label, and release-please aborts opening the next
+// release PR while a merged one still reads pending -- while still reporting
+// the job green. Deleting the step re-freezes the whole npm train with no red
+// anywhere, which is how lobu-v18.0.0 went unnoticed for three days.
+describe("a cut release clears the pending label off the PR that produced it", () => {
+  const jobId = "release-please-write";
+  const stepName = "Clear the pending label from released PRs";
+  const step = () => {
+    const found = steps("release-please.yml", jobId).find(
+      (candidate) => candidate.name === stepName
+    );
+    if (!found)
+      throw new Error(`release-please.yml/${jobId} lost "${stepName}"`);
+    return found;
+  };
+
+  it("still has the step, after the release is verified", () => {
+    expect(step().run ?? "").not.toEqual("");
+    expect(
+      stepAt("release-please.yml", jobId, "Verify the release")
+    ).toBeLessThan(stepAt("release-please.yml", jobId, stepName));
+  });
+
+  it("only runs when this workflow actually cut a release", () => {
+    // Without the gate an ordinary main push clears the label off a release PR
+    // whose release has not been created yet, and that release is then never
+    // cut at all.
+    expect(step().if).toBe("steps.bump.outputs.bumped == 'true'");
+  });
+
+  it("excludes closed-unmerged PRs before it compares anything", () => {
+    // A closed-unmerged PR still reports a `refs/pull/N/merge` test-merge sha,
+    // so an emptiness check does not filter it. GitHub collects those commits,
+    // and `compare` against a collected one 404s -- under `set -e` that fails
+    // the job after the release already exists.
+    const body = step().run ?? "";
+    const filter = body.indexOf("select(.pull_request.merged_at)");
+    expect(filter).toBeGreaterThan(-1);
+    expect(filter).toBeLessThan(body.indexOf("/compare/"));
+  });
+
+  it("tolerates a losing DELETE but never a failing POST", () => {
+    // Two main pushes can both reach this step for one release, and the second
+    // finds the label already gone. Tolerating the POST as well would swallow a
+    // token-permission fault and silently leave the label in place.
+    const body = step().run ?? "";
+    const post = body.slice(
+      body.indexOf("--method POST"),
+      body.indexOf("--method DELETE")
+    );
+    const del = body.slice(body.indexOf("--method DELETE"));
+    expect(post).toContain(">/dev/null");
+    expect(post).not.toContain("|| true");
+    expect(del).toContain("|| true");
+  });
+});


### PR DESCRIPTION
## Summary

The release train has been stuck since 2026-09-03. `lobu-v18.0.0` exists, is not a draft, and points at the merge commit of #3241 — but #3241 is still labelled `autorelease: pending`, and release-please refuses to open a new release PR while any merged one reads pending:

```
❯ Found pull request #3241: 'chore(main): release lobu 18.0.0'
⚠ There are untagged, merged release PRs outstanding - aborting
```

That line is in every `release-please.yml` run since. No version-bump PR has opened, so nothing merged after 18.0.0 has reached the registry — `@lobu/cli` is still 18.0.0 from 2026-09-03 while main is nine PRs ahead.

The cause is structural, not a one-off. release-please sets `autorelease: tagged` from inside its own release step, and this workflow passes `skip-github-release: true` so the release can be bound to the attested commit rather than to whatever the action considered HEAD. Nothing else moves the label. 18.0.0 was the first release cut after `skip-github-release` landed (#3247, 2026-09-02), which is why it is the first one to have stranded its successor.

A new step clears the label after the release is verified.

## Design notes

**Ancestry, not title.** `assert-newer` above already guarantees the release just cut is the newest, so any release PR merged at or before the attested commit has had its version superseded and its pending label is stale by construction. Matching on `pull-request-title-pattern` instead would go stale silently the first time that pattern changed — the same silence this step exists to remove.

**Merged-ness comes from the list payload.** release-please closes the release PRs it supersedes without clearing the label; there are 18 such closed-unmerged PRs in this repo today. They are harmless to the abort above, which counts merged PRs only, but a closed-unmerged PR still reports a `refs/pull/N/merge` test-merge sha. GitHub garbage-collects those, and comparing against a collected one 404s — under `set -e` that would fail the job *after* the release was already created. Filtering on `.pull_request.merged_at` costs no extra call.

**Add before remove**, so the PR is never momentarily unlabelled. The DELETE is tolerated because two main pushes can both reach this step for one release — the create step above is written for that same race — and the second finds the label gone. It cannot swallow a permission fault: the POST shares the token and is not tolerated.

## Validation

The step has no local harness, so it was exercised read-only against the live API with the mutations stubbed.

Positive path, `ATTESTED_SHA` = the commit 18.0.0 was bound to — it selects exactly the PR that caused the outage:

```
WOULD clear the pending label from #3241 (merged da6397db, ahead)
WOULD clear the pending label from #3171 (merged 4b20a3a1, ahead)
```

Negative path, an older attested commit — a release PR merged after it is skipped rather than relabelled:

```
SKIP #3241 (behind)
SKIP #3171 (behind)
WOULD clear #3146 (identical)
```

The merged filter, run against both labels:

```
autorelease: pending  ->  0 selected of 18   (all closed-unmerged)
autorelease: tagged   ->  103 selected of 103
```

and the field it reads is present in the list payload (`#292 merged_at: null`, `#3241 merged_at: 2026-09-03T05:14:30Z`).

`actionlint` clean on the new step; YAML parses; `bash -n` clean. `make pre-pr` clean.

## Rollout

#3241's label was corrected by hand so the train could move again — this PR is what keeps the next release from stranding the one after it. The step only runs when this workflow actually cuts a release (`bumped == 'true'`), so it is inert on an ordinary main push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation by updating status labels for merged pull requests included in a completed release.
  * Prevented stale pending-release labels from remaining after successful releases.
  * Made label updates resilient when another process has already changed or removed a label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->