### PR TITLE
feat(connector-worker): run an agent turn as an isolate job, in shadow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -188,6 +188,8 @@
         "@lobu/connector-sdk": "workspace:*",
         "@lobu/core": "workspace:*",
         "@lobu/embeddings": "workspace:*",
+        "@mariozechner/pi-agent-core": "^0.73.1",
+        "@mariozechner/pi-ai": "^0.73.1",
         "@xenova/transformers": "^2.17.2",
         "esbuild": "^0.28.1",
         "jimp": "^1.6.0",

--- a/config/knip.ts
+++ b/config/knip.ts
@@ -31,6 +31,10 @@ const config: KnipConfig = {
         "src/mac-device-daemon.ts",
         "src/daemon/index.ts",
         "src/compile-connector.ts",
+        // The agent-session guest. esbuild resolves it by PATH at runtime
+        // (agent-turn/bundle.ts) so it can be compiled for the isolate, which
+        // is exactly the import knip cannot see.
+        "src/agent-turn/guest-entry.ts",
         "src/**/*.test.ts",
       ],
       ignoreDependencies: [

--- a/db/migrations/20260905220000_runs_agent_turn_run_type.sql
+++ b/db/migrations/20260905220000_runs_agent_turn_run_type.sql
@@ -1,10 +1,18 @@
+-- migrate:up
+
 -- An agent conversation turn executed as one isolate job on the connector
--- worker fleet. Distinct from 'chat_message', a lobu-queue row the gateway
--- drains to a subprocess worker: an 'agent_turn' row is only ever claimed by a
--- fleet worker that advertises the lane, and runs through IsolateExecutor.
+-- worker fleet. Distinct from 'chat_message', which carries the gateway's own
+-- MessagePayload: an 'agent_turn' row carries a self-contained execution
+-- envelope in action_input (model, prompt, transcript, proxy URL, allowlist)
+-- and is completed through /api/workers/complete-agent-turn.
 --
--- Its producer always has an organization, so 'agent_turn' joins
--- runs_legacy_org_required and every such row carries organization_id.
+-- organization_id is required for the new type, so it joins
+-- runs_legacy_org_required rather than being exempt from it.
+--
+-- Both lists below are the prior constraint definitions with 'agent_turn'
+-- added and nothing else changed. NOT VALID + VALIDATE keeps the rewrite off
+-- the table's write path: the ADD takes a brief lock, the VALIDATE scans
+-- without blocking writes.
 
 ALTER TABLE public.runs DROP CONSTRAINT IF EXISTS runs_run_type_check;
 ALTER TABLE public.runs
@@ -24,6 +32,35 @@ ALTER TABLE public.runs
     (run_type <> ALL (ARRAY[
       'sync'::text, 'action'::text, 'embed_backfill'::text,
       'automation'::text, 'auth'::text, 'agent_turn'::text
+    ])) OR organization_id IS NOT NULL
+  ) NOT VALID;
+ALTER TABLE public.runs VALIDATE CONSTRAINT runs_legacy_org_required;
+
+-- migrate:down
+
+-- Restores both constraints to their pre-'agent_turn' definitions. This is
+-- only reversible while no agent_turn rows exist: VALIDATE would reject them,
+-- which is the correct outcome — a down migration must not silently keep rows
+-- the schema no longer admits.
+
+ALTER TABLE public.runs DROP CONSTRAINT IF EXISTS runs_run_type_check;
+ALTER TABLE public.runs
+  ADD CONSTRAINT runs_run_type_check CHECK (
+    run_type = ANY (ARRAY[
+      'sync'::text, 'action'::text, 'embed_backfill'::text,
+      'automation'::text, 'automation_eval'::text,
+      'auth'::text, 'chat_message'::text,
+      'schedule'::text, 'agent_run'::text, 'internal'::text, 'task'::text
+    ])
+  ) NOT VALID;
+ALTER TABLE public.runs VALIDATE CONSTRAINT runs_run_type_check;
+
+ALTER TABLE public.runs DROP CONSTRAINT IF EXISTS runs_legacy_org_required;
+ALTER TABLE public.runs
+  ADD CONSTRAINT runs_legacy_org_required CHECK (
+    (run_type <> ALL (ARRAY[
+      'sync'::text, 'action'::text, 'embed_backfill'::text,
+      'automation'::text, 'auth'::text
     ])) OR organization_id IS NOT NULL
   ) NOT VALID;
 ALTER TABLE public.runs VALIDATE CONSTRAINT runs_legacy_org_required;

--- a/db/migrations/20260905220000_runs_agent_turn_run_type.sql
+++ b/db/migrations/20260905220000_runs_agent_turn_run_type.sql
@@ -1,0 +1,29 @@
+-- An agent conversation turn executed as one isolate job on the connector
+-- worker fleet. Distinct from 'chat_message', a lobu-queue row the gateway
+-- drains to a subprocess worker: an 'agent_turn' row is only ever claimed by a
+-- fleet worker that advertises the lane, and runs through IsolateExecutor.
+--
+-- Its producer always has an organization, so 'agent_turn' joins
+-- runs_legacy_org_required and every such row carries organization_id.
+
+ALTER TABLE public.runs DROP CONSTRAINT IF EXISTS runs_run_type_check;
+ALTER TABLE public.runs
+  ADD CONSTRAINT runs_run_type_check CHECK (
+    run_type = ANY (ARRAY[
+      'sync'::text, 'action'::text, 'embed_backfill'::text,
+      'automation'::text, 'automation_eval'::text,
+      'auth'::text, 'chat_message'::text, 'agent_turn'::text,
+      'schedule'::text, 'agent_run'::text, 'internal'::text, 'task'::text
+    ])
+  ) NOT VALID;
+ALTER TABLE public.runs VALIDATE CONSTRAINT runs_run_type_check;
+
+ALTER TABLE public.runs DROP CONSTRAINT IF EXISTS runs_legacy_org_required;
+ALTER TABLE public.runs
+  ADD CONSTRAINT runs_legacy_org_required CHECK (
+    (run_type <> ALL (ARRAY[
+      'sync'::text, 'action'::text, 'embed_backfill'::text,
+      'automation'::text, 'auth'::text, 'agent_turn'::text
+    ])) OR organization_id IS NOT NULL
+  ) NOT VALID;
+ALTER TABLE public.runs VALIDATE CONSTRAINT runs_legacy_org_required;

--- a/packages/connector-worker/package.json
+++ b/packages/connector-worker/package.json
@@ -39,6 +39,10 @@
       "import": "./dist/executor/isolate.js",
       "types": "./dist/executor/isolate.d.ts"
     },
+    "./agent-turn": {
+      "import": "./dist/agent-turn/index.js",
+      "types": "./dist/agent-turn/index.d.ts"
+    },
     "./compile": {
       "import": "./dist/compile/index.js",
       "types": "./dist/compile/index.d.ts"
@@ -74,6 +78,8 @@
     "@lobu/connector-sdk": "workspace:*",
     "@lobu/core": "workspace:*",
     "@lobu/embeddings": "workspace:*",
+    "@mariozechner/pi-agent-core": "^0.73.1",
+    "@mariozechner/pi-ai": "^0.73.1",
     "@xenova/transformers": "^2.17.2",
     "esbuild": "^0.28.1",
     "jimp": "^1.6.0",

--- a/packages/connector-worker/src/__tests__/agent-turn-arm.test.ts
+++ b/packages/connector-worker/src/__tests__/agent-turn-arm.test.ts
@@ -1,0 +1,262 @@
+/**
+ * The daemon arm for an agent turn.
+ *
+ * The run is ALREADY CLAIMED by the time this arm sees it, so the property
+ * under test everywhere here is the same one: every exit reports to
+ * `/complete-agent-turn`. An arm that returned an error locally instead would
+ * leave the turn `running` until the stale-run reaper writes it off minutes
+ * later — the failure looks like a hang rather than a failure.
+ */
+import { describe, expect, test } from "bun:test";
+import type { PollResponse } from "@lobu/core/contracts/worker/protocol";
+import { executeAgentTurnRun } from "../daemon/agent-turn.js";
+import type { ExecutorConfig } from "../daemon/executor.js";
+import type {
+  ExecutionHooks,
+  ExecutorJob,
+  ExecutorResult,
+  SyncExecutor,
+} from "../executor/interface.js";
+import type { CompleteAgentTurnRequest } from "../daemon/client.js";
+
+const WORKER_ID = "fleet-test-worker";
+
+interface Reported {
+  calls: CompleteAgentTurnRequest[];
+}
+
+/**
+ * The narrow slice of `ExecutorClient` this arm touches. Typed through
+ * `unknown` rather than stubbing the whole client: what matters is which
+ * endpoint gets called with what, not the transport.
+ */
+function fakeClient(reported: Reported) {
+  return {
+    id: WORKER_ID,
+    heartbeat: async () => {},
+    completeAgentTurn: async (req: CompleteAgentTurnRequest) => {
+      reported.calls.push(req);
+      return { ok: true as const, status: "completed" as const };
+    },
+  };
+}
+
+function turnJob(overrides: Record<string, unknown> = {}): PollResponse {
+  return {
+    run_id: 4242,
+    run_type: "agent_turn",
+    credentials: { provider: "anthropic", accessToken: "lobu_secret_placeholder" },
+    payload: {
+      turn: {
+        agent_id: "agent-under-test",
+        conversation_id: "conv-1",
+        message_id: "msg-1",
+        message_text: "hello",
+        system_prompt: "be brief",
+        messages: [],
+        provider: {
+          api: "anthropic-messages",
+          provider: "anthropic",
+          model_id: "claude-test",
+          base_url: "https://gateway.test.invalid/api/proxy/anthropic",
+        },
+        allowed_hosts: ["gateway.test.invalid"],
+        shadow: true,
+      },
+    },
+    ...overrides,
+  } as unknown as PollResponse;
+}
+
+function cfgWith(executor: SyncExecutor | undefined): ExecutorConfig {
+  return {
+    batchSize: 10,
+    // Long enough that no heartbeat fires inside a test.
+    heartbeatIntervalMs: 60_000,
+    generateEmbeddings: false,
+    timeoutMs: 30_000,
+    ...(executor ? { executor } : {}),
+  };
+}
+
+function executorReturning(result: ExecutorResult): SyncExecutor {
+  return {
+    execute: async (_code: string, _job: ExecutorJob, _hooks?: ExecutionHooks) => result,
+  };
+}
+
+describe("executeAgentTurnRun", () => {
+  test("reports the transcript the guest produced", async () => {
+    const reported: Reported = { calls: [] };
+    const transcript = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: [{ type: "text", text: "hi" }] },
+    ];
+    const executor = executorReturning({
+      mode: "agent_turn",
+      turn: {
+        text: "hi",
+        stopReason: "stop",
+        usage: { input: 3, output: 1 },
+        messages: transcript,
+      },
+    });
+
+    const outcome = await executeAgentTurnRun(
+      fakeClient(reported) as never,
+      turnJob(),
+      {},
+      cfgWith(executor)
+    );
+
+    expect(outcome.error).toBeUndefined();
+    expect(reported.calls).toHaveLength(1);
+    expect(reported.calls[0]).toMatchObject({
+      run_id: 4242,
+      worker_id: WORKER_ID,
+      status: "completed",
+      text: "hi",
+      stop_reason: "stop",
+      exit_reason: "ok",
+      transcript,
+    });
+  });
+
+  test("hands the guest the job the gateway described, and only its allowed hosts", async () => {
+    const reported: Reported = { calls: [] };
+    let seen: ExecutorJob | undefined;
+    const executor: SyncExecutor = {
+      execute: async (_code, job) => {
+        seen = job;
+        return {
+          mode: "agent_turn",
+          turn: { text: "", stopReason: "stop", usage: null, messages: [] },
+        };
+      },
+    };
+
+    await executeAgentTurnRun(fakeClient(reported) as never, turnJob(), {}, cfgWith(executor));
+
+    expect(seen?.mode).toBe("agent_turn");
+    if (seen?.mode !== "agent_turn") throw new Error("expected an agent_turn job");
+    expect(seen.turn.provider).toEqual({
+      api: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-test",
+      baseUrl: "https://gateway.test.invalid/api/proxy/anthropic",
+    });
+    expect(seen.turn.systemPrompt).toBe("be brief");
+    expect(seen.turn.userMessage).toBe("hello");
+    // The provider key never appears on the turn: it rides `credentials`, and
+    // the host swaps a vault placeholder over it before the guest sees it.
+    expect(seen.turn.provider.apiKey).toBeUndefined();
+    expect(seen.credentials?.accessToken).toBe("lobu_secret_placeholder");
+  });
+
+  test("reports a guest failure instead of returning it, because the run is claimed", async () => {
+    const reported: Reported = { calls: [] };
+    const executor: SyncExecutor = {
+      execute: async () => {
+        throw new Error("the isolate ran out of memory");
+      },
+    };
+
+    const outcome = await executeAgentTurnRun(
+      fakeClient(reported) as never,
+      turnJob(),
+      {},
+      cfgWith(executor)
+    );
+
+    expect(outcome.error).toBe("the isolate ran out of memory");
+    expect(reported.calls).toEqual([
+      {
+        run_id: 4242,
+        worker_id: WORKER_ID,
+        status: "failed",
+        error: "the isolate ran out of memory",
+        exit_reason: "error_message",
+      },
+    ]);
+  });
+
+  test("reports a turn that arrived without its provider credential", async () => {
+    const reported: Reported = { calls: [] };
+    const outcome = await executeAgentTurnRun(
+      fakeClient(reported) as never,
+      turnJob({ credentials: null }),
+      {},
+      cfgWith(executorReturning({ mode: "webhook_unregister" }))
+    );
+
+    expect(outcome.error).toBe("agent turn run arrived without its provider credential");
+    expect(reported.calls).toHaveLength(1);
+    expect(reported.calls[0]?.status).toBe("failed");
+  });
+
+  test("reports a payload that is not a turn", async () => {
+    const reported: Reported = { calls: [] };
+    const outcome = await executeAgentTurnRun(
+      fakeClient(reported) as never,
+      turnJob({ payload: { chat: {} } }),
+      {},
+      cfgWith(executorReturning({ mode: "webhook_unregister" }))
+    );
+
+    expect(outcome.error).toBe("agent turn run received a non-turn payload envelope");
+    expect(reported.calls).toHaveLength(1);
+    expect(reported.calls[0]?.status).toBe("failed");
+  });
+
+  test("reports a result of the wrong mode rather than completing the turn", async () => {
+    const reported: Reported = { calls: [] };
+    const outcome = await executeAgentTurnRun(
+      fakeClient(reported) as never,
+      turnJob(),
+      {},
+      cfgWith(executorReturning({ mode: "action", output: {} }))
+    );
+
+    expect(outcome.error).toBe("agent turn produced a action result");
+    expect(reported.calls[0]?.status).toBe("failed");
+  });
+
+  test("beats while the turn runs so the stale-run reaper leaves it alone", async () => {
+    const reported: Reported = { calls: [] };
+    const beats: number[] = [];
+    const client = {
+      ...fakeClient(reported),
+      heartbeat: async (runId: number) => {
+        beats.push(runId);
+      },
+    };
+    let release: (() => void) | undefined;
+    const executor: SyncExecutor = {
+      execute: async () => {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return {
+          mode: "agent_turn",
+          turn: { text: "", stopReason: "stop", usage: null, messages: [] },
+        };
+      },
+    };
+
+    const running = executeAgentTurnRun(client as never, turnJob(), {}, {
+      ...cfgWith(executor),
+      heartbeatIntervalMs: 5,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(beats.length).toBeGreaterThan(0);
+    expect(beats.every((id) => id === 4242)).toBe(true);
+
+    release?.();
+    await running;
+    // The interval is cleared on the way out, so a finished turn stops beating
+    // and a crashed worker's row really does go stale.
+    const settled = beats.length;
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(beats.length).toBe(settled);
+  });
+});

--- a/packages/connector-worker/src/__tests__/egress-credentials.test.ts
+++ b/packages/connector-worker/src/__tests__/egress-credentials.test.ts
@@ -67,6 +67,25 @@ describe("CredentialVault.swapHeaders", () => {
     expect(() => vault.swapHeaders(headers, HTTPS, { plaintextAllowed: false })).toThrow(TypeError);
   });
 
+  test("resolves a secret that is itself placeholder-shaped, because an agent turn's key is one", () => {
+    // The whole reason the malformed-prefix check reads what the GUEST sent
+    // rather than what the swap produced. An agent turn's provider credential
+    // is the gateway's own `lobu_secret_<uuid>`, which this vault conceals
+    // behind one of its own; checking after the swap would see the gateway's
+    // placeholder in the resolved value, fail to find it in this run's vault,
+    // and refuse a credential that is exactly right.
+    const vault = new CredentialVault();
+    const gatewayPlaceholder = `${CREDENTIAL_PLACEHOLDER_PREFIX}${randomUUID()}`;
+    const token = vault.mint(gatewayPlaceholder);
+    expect(token).not.toBe(gatewayPlaceholder);
+    const headers = new Headers({ "x-api-key": token });
+
+    const spends = vault.swapHeaders(headers, HTTPS, { plaintextAllowed: false });
+
+    expect(headers.get("x-api-key")).toBe(gatewayPlaceholder);
+    expect(spends).toEqual([{ placeholder: token, header: "x-api-key" }]);
+  });
+
   test("refuses a placeholder in the URL before touching the headers", () => {
     const vault = new CredentialVault();
     const token = vault.mint("tok_real");

--- a/packages/connector-worker/src/__tests__/isolate-prelude.test.ts
+++ b/packages/connector-worker/src/__tests__/isolate-prelude.test.ts
@@ -503,3 +503,148 @@ describe('guest Response.clone', () => {
     expect(() => streamed.clone()).toThrow(/already been consumed/);
   });
 });
+
+/**
+ * The Stainless HTTP clients every pi LLM provider is built on branch on
+ * `body instanceof FormData` with no `globalThis.FormData &&` guard, on the
+ * request path each provider call takes. A guest without the constructor
+ * therefore cannot reach any provider at all, which is why the lane carries
+ * one. It holds text fields only: `Blob` and `File` are not on this lane, so a
+ * non-primitive part is refused instead of stringified into "[object Object]".
+ */
+describe('guest FormData', () => {
+  function instantiateFetchGuest(): { guest: any; opened: Array<{ request: any; body: Uint8Array | undefined }> } {
+    const hostSync = createPreludeHostSync();
+    const opened: Array<{ request: any; body: Uint8Array | undefined }> = [];
+    const guest: any = {
+      __host_sync: {
+        applySync: (_receiver: unknown, args: any[]) => {
+          const [name, ...rest] = args;
+          const fn = hostSync[String(name)];
+          if (!fn) return { __lobu: 1, ok: true, value: null };
+          try {
+            return { __lobu: 1, ok: true, value: fn(...rest) };
+          } catch (error) {
+            const err = error as Error;
+            return { __lobu: 1, ok: false, error: { name: err.name, message: err.message } };
+          }
+        },
+      },
+      __host_async: {
+        apply: (_receiver: unknown, args: any[]) => {
+          const [name, ...rest] = args;
+          if (name === 'fetchOpen') {
+            opened.push({ request: rest[0], body: rest[1] as Uint8Array | undefined });
+            return Promise.resolve({
+              __lobu: 1,
+              ok: true,
+              value: { status: 204, statusText: 'No Content', url: rest[0].url, redirected: false, headers: [], hasBody: false },
+            });
+          }
+          return Promise.resolve({ __lobu: 1, ok: true, value: null });
+        },
+      },
+      __host_env_json: '{}',
+      atob: (x: string) => Buffer.from(x, 'base64').toString('binary'),
+      btoa: (x: string) => Buffer.from(x, 'binary').toString('base64'),
+      TextEncoder,
+      TextDecoder,
+    };
+    new Function('globalThis', GUEST_PRELUDE)(guest);
+    return { guest, opened };
+  }
+
+  it('answers the unguarded `body instanceof FormData` branch the provider SDKs take', () => {
+    const { guest } = instantiateFetchGuest();
+    expect(typeof guest.FormData).toBe('function');
+    expect(new guest.FormData() instanceof guest.FormData).toBe(true);
+    // The SDKs reach the check with a plain JSON object on the messages path.
+    expect({ model: 'claude' } instanceof guest.FormData).toBe(false);
+    expect(Object.prototype.toString.call(new guest.FormData())).toBe('[object FormData]');
+  });
+
+  it('keeps every appended value and replaces in place on set', () => {
+    const { guest } = instantiateFetchGuest();
+    const form = new guest.FormData();
+    form.append('a', '1');
+    form.append('b', '2');
+    form.append('a', '3');
+    expect(form.getAll('a')).toEqual(['1', '3']);
+    expect(form.get('a')).toBe('1');
+    expect(form.get('missing')).toBe(null);
+    expect(form.has('b')).toBe(true);
+    form.set('a', '9');
+    expect(Array.from(form)).toEqual([
+      ['a', '9'],
+      ['b', '2'],
+    ]);
+    form.delete('a');
+    expect(Array.from(form.keys())).toEqual(['b']);
+    expect(Array.from(form.values())).toEqual(['2']);
+  });
+
+  it('stringifies primitives and refuses the parts this lane cannot carry', () => {
+    const { guest } = instantiateFetchGuest();
+    const form = new guest.FormData();
+    form.append('n', 42);
+    form.append('t', true);
+    expect(form.getAll('n')).toEqual(['42']);
+    expect(form.getAll('t')).toEqual(['true']);
+    expect(() => form.append('f', { name: 'x' })).toThrow(
+      'FormData on the isolate lane holds text fields only; Blob and File parts are not available'
+    );
+    expect(form.has('f')).toBe(false);
+  });
+
+  it('sends a multipart body with a random boundary the field values cannot close', async () => {
+    const { guest, opened } = instantiateFetchGuest();
+    const form = new guest.FormData();
+    form.append('plain', 'hello');
+    // A value that spells out a terminator, and a name with the three
+    // characters the header line cannot carry raw.
+    form.append('sneaky\r\n"x"', '--boundary--');
+    await guest.fetch('https://api.example.test/upload', { method: 'POST', body: form });
+
+    expect(opened.length).toBe(1);
+    const contentType = opened[0].request.headers.find((h: string[]) => h[0] === 'content-type')?.[1] as string;
+    const boundary = /^multipart\/form-data; boundary=(----LobuFormBoundary[0-9a-f]{32})$/.exec(contentType)?.[1];
+    expect(boundary).toBeDefined();
+    const text = Buffer.from(opened[0].body as Uint8Array).toString('utf8');
+    expect(text).toBe(
+      `--${boundary}\r\n` +
+        'Content-Disposition: form-data; name="plain"\r\n\r\n' +
+        'hello\r\n' +
+        `--${boundary}\r\n` +
+        'Content-Disposition: form-data; name="sneaky%0D%0A%22x%22"\r\n\r\n' +
+        '--boundary--\r\n' +
+        `--${boundary}--\r\n`
+    );
+  });
+
+  it('gives every body its own boundary', async () => {
+    const { guest, opened } = instantiateFetchGuest();
+    for (let i = 0; i < 2; i++) {
+      const form = new guest.FormData();
+      form.append('i', String(i));
+      await guest.fetch('https://api.example.test/upload', { method: 'POST', body: form });
+    }
+    const boundaries = opened.map(
+      (o) => (o.request.headers.find((h: string[]) => h[0] === 'content-type')?.[1] as string)
+    );
+    expect(boundaries[0]).not.toBe(boundaries[1]);
+  });
+
+  it('does not overwrite a content-type the caller already set', async () => {
+    const { guest, opened } = instantiateFetchGuest();
+    const form = new guest.FormData();
+    form.append('a', '1');
+    await guest.fetch('https://api.example.test/upload', {
+      method: 'POST',
+      body: form,
+      headers: { 'content-type': 'multipart/form-data; boundary=caller' },
+    });
+    expect(opened[0].request.headers.find((h: string[]) => h[0] === 'content-type')?.[1]).toBe(
+      'multipart/form-data; boundary=caller'
+    );
+  });
+});

--- a/packages/connector-worker/src/agent-turn/bundle.ts
+++ b/packages/connector-worker/src/agent-turn/bundle.ts
@@ -1,0 +1,90 @@
+/**
+ * Builds the agent-session guest bundle.
+ *
+ * The guest is Lobu's own code, not organization-supplied source, so it is
+ * bundled once per worker process and reused for every turn. It goes through
+ * the SAME `ISOLATE_LANE_BUILD_OPTIONS` a connector does — one set of esbuild
+ * options, one eligibility rule — plus three alias rules that drop the provider
+ * SDKs this lane never selects.
+ *
+ * Why the aliases are exactly these three: `@google/genai` resolves to its Node
+ * build and drags google-auth-library, gaxios, ws, node-fetch, agent-base,
+ * https-proxy-agent, proxy-agent, debug and supports-color in with it, and
+ * `@aws-sdk/client-bedrock-runtime` drags the Bedrock path. Stubbing those two
+ * roots removes every Node builtin from the bundle but one: pi-ai reads
+ * `/proc/self/environ` through `node:fs` when it detects Bun with an empty
+ * `process.env`. That single importer loses `fs`; every other module keeps it,
+ * so a bare `require('fs')` anywhere else still survives into the bundle and
+ * `assertIsolateEligible` still rejects it.
+ */
+
+import { build } from 'esbuild';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ISOLATE_LANE_BUILD_OPTIONS } from '../compile/index.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** esbuild namespace for the aliased-away provider SDKs. */
+const STUB_NAMESPACE = 'lobu-agent-guest-stub';
+
+/**
+ * The compiled guest entry. `tsc` emits `guest-entry.js` next to this module;
+ * under `tsx` only the TypeScript source exists, and esbuild takes either.
+ */
+function guestEntryPath(): string {
+  const compiled = join(HERE, 'guest-entry.js');
+  return existsSync(compiled) ? compiled : join(HERE, 'guest-entry.ts');
+}
+
+let cached: Promise<string> | null = null;
+
+async function buildAgentGuest(): Promise<string> {
+  const result = await build({
+    ...ISOLATE_LANE_BUILD_OPTIONS,
+    entryPoints: [guestEntryPath()],
+    bundle: true,
+    write: false,
+    minify: false,
+    sourcemap: false,
+    logLevel: 'silent',
+    plugins: [
+      {
+        name: 'agent-guest-alias',
+        setup(pluginBuild) {
+          pluginBuild.onResolve({ filter: /^(@google\/genai|@aws-sdk\/client-bedrock-runtime)(\/.*)?$/ }, (args) => ({
+            path: args.path,
+            namespace: STUB_NAMESPACE,
+          }));
+          pluginBuild.onResolve({ filter: /^(node:)?fs$/ }, (args) =>
+            /pi-ai[/\\]dist[/\\]env-api-keys\.js$/.test(args.importer)
+              ? { path: args.path, namespace: STUB_NAMESPACE }
+              : undefined
+          );
+          pluginBuild.onLoad({ filter: /.*/, namespace: STUB_NAMESPACE }, () => ({
+            contents: 'module.exports = {};',
+            loader: 'js',
+          }));
+        },
+      },
+    ],
+  });
+  const code = result.outputFiles?.[0]?.text;
+  if (!code) throw new Error('the agent guest bundle built to nothing');
+  return code;
+}
+
+/**
+ * The guest bundle for this process. Built on the first turn and kept: it is
+ * the same bytes for every agent, and rebuilding it per turn would cost about a
+ * second of the turn's own budget.
+ */
+export function agentGuestBundle(): Promise<string> {
+  cached ??= buildAgentGuest().catch((error) => {
+    // A failed build must not poison every later turn with the same rejection.
+    cached = null;
+    throw error;
+  });
+  return cached;
+}

--- a/packages/connector-worker/src/agent-turn/guest-entry.ts
+++ b/packages/connector-worker/src/agent-turn/guest-entry.ts
@@ -41,7 +41,6 @@ function buildModel(input: AgentTurnInput): Record<string, unknown> {
     // turn, one request, and the gateway owns the history it sends.
     contextWindow: 200_000,
     maxTokens: input.provider.maxTokens ?? 8192,
-    ...(input.provider.headers ? { headers: input.provider.headers } : {}),
   };
 }
 

--- a/packages/connector-worker/src/agent-turn/guest-entry.ts
+++ b/packages/connector-worker/src/agent-turn/guest-entry.ts
@@ -1,0 +1,123 @@
+/**
+ * The agent-session GUEST. This module is bundled by `bundle.ts` with the
+ * lane's own esbuild options and executed inside the isolate, so it must stay
+ * portable: no `node:` import, no host module, nothing the guest prelude does
+ * not provide.
+ *
+ * It runs one turn of pi's agent loop. The loop itself (`pi-agent-core`) has no
+ * Node dependency; the provider call is pi-ai's fetch-native Anthropic or
+ * OpenAI path, which reaches the network through the prelude's streaming
+ * `fetch` and therefore through the host's one egress module.
+ *
+ * The turn never sees a real provider key. `provider.apiKey` is the gateway's
+ * own `lobu_secret_` placeholder and `provider.baseUrl` is its agent-scoped
+ * secret-proxy, so the swap happens at the gateway, where it already happens
+ * for the subprocess lane.
+ */
+
+import { Agent } from '@mariozechner/pi-agent-core';
+import { streamAnthropic } from '@mariozechner/pi-ai/anthropic';
+import { streamOpenAICompletions } from '@mariozechner/pi-ai/openai-completions';
+import type { AgentTurnEvent, AgentTurnInput, AgentTurnOutput } from './types.js';
+
+/**
+ * The model object pi-ai reads. The gateway resolves which model a turn runs,
+ * not its price list or its window, so the fields pi only uses for bookkeeping
+ * are zeroed rather than guessed. `cost` carries all FOUR keys: pi divides by
+ * each one to price a turn, so a missing `cacheRead`/`cacheWrite` puts NaN in
+ * the transcript entry the next turn resumes from.
+ */
+function buildModel(input: AgentTurnInput): Record<string, unknown> {
+  return {
+    id: input.provider.modelId,
+    name: input.provider.modelId,
+    api: input.provider.api,
+    provider: input.provider.provider,
+    baseUrl: input.provider.baseUrl,
+    reasoning: false,
+    input: ['text'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    // Only read to decide when to compact, which this lane never does: one
+    // turn, one request, and the gateway owns the history it sends.
+    contextWindow: 200_000,
+    maxTokens: input.provider.maxTokens ?? 8192,
+    ...(input.provider.headers ? { headers: input.provider.headers } : {}),
+  };
+}
+
+/**
+ * Run one turn and resolve with the transcript it produced.
+ *
+ * `emit` is the host bridge: every call crosses into the worker while the
+ * stream is still open, which is what makes a delta on this lane arrive at the
+ * same point in the turn as a delta on the subprocess lane.
+ */
+export async function runAgentTurn(
+  input: AgentTurnInput,
+  emit: (event: AgentTurnEvent) => void
+): Promise<AgentTurnOutput> {
+  if (!input.provider.apiKey) throw new Error('the agent turn reached the guest with no provider credential');
+  const model = buildModel(input);
+  const stream = input.provider.api === 'anthropic-messages' ? streamAnthropic : streamOpenAICompletions;
+
+  const agent = new Agent({
+    initialState: {
+      systemPrompt: input.systemPrompt,
+      model: model as never,
+      messages: input.messages as never,
+    },
+    // pi hands the loop's own options through; the key rides here rather than
+    // in the model so it never lands in a transcript entry.
+    streamFn: ((m: unknown, context: unknown, options: Record<string, unknown> | undefined) =>
+      (stream as (a: unknown, b: unknown, c: unknown) => unknown)(m, context, {
+        ...(options ?? {}),
+        apiKey: input.provider.apiKey,
+      })) as never,
+  });
+
+  let text = '';
+  let stopReason: string | null = null;
+  let usage: AgentTurnOutput['usage'] = null;
+  // pi does not throw a failed provider call: it ends the turn with an
+  // assistant message whose stopReason is 'error'. On this lane a failed turn
+  // must be a failed RUN, or the job completes 'successfully' with no text.
+  let failure: string | null = null;
+
+  agent.subscribe((event) => {
+    if (event.type === 'message_update') {
+      const partial = event.assistantMessageEvent as { type?: string; delta?: string };
+      if (partial.type === 'text_delta' && typeof partial.delta === 'string') {
+        text += partial.delta;
+        emit({ type: 'text_delta', delta: partial.delta });
+      } else if (partial.type === 'thinking_delta' && typeof partial.delta === 'string') {
+        emit({ type: 'thinking_delta', delta: partial.delta });
+      }
+      return;
+    }
+    if (event.type === 'message_end') {
+      const message = event.message as unknown as {
+        stopReason?: string;
+        errorMessage?: string;
+        usage?: { input?: number; output?: number };
+      };
+      if (typeof message.stopReason === 'string') stopReason = message.stopReason;
+      if (typeof message.errorMessage === 'string' && message.errorMessage) failure = message.errorMessage;
+      if (message.usage) usage = { input: message.usage.input ?? 0, output: message.usage.output ?? 0 };
+      emit({ type: 'message_end' });
+    }
+  });
+
+  await agent.prompt(input.userMessage);
+  await agent.waitForIdle();
+
+  const stateError = (agent.state as { errorMessage?: string }).errorMessage;
+  const ended = failure ?? (typeof stateError === 'string' && stateError ? stateError : null);
+  if (ended) throw new Error(ended);
+
+  return {
+    text,
+    stopReason,
+    usage,
+    messages: agent.state.messages as unknown as AgentTurnOutput['messages'],
+  };
+}

--- a/packages/connector-worker/src/agent-turn/index.ts
+++ b/packages/connector-worker/src/agent-turn/index.ts
@@ -1,0 +1,11 @@
+/**
+ * The agent-turn lane: one conversation turn executed as one isolate job.
+ *
+ * The turn reuses the connector lane wholesale — `IsolateExecutor` runs it
+ * under the same egress dispatcher, credential vault, streaming fetch, wall
+ * clock, memory limit and log budget a connector gets. What lives here is only
+ * what a turn adds: the wire shapes and the guest bundle.
+ */
+
+export { agentGuestBundle } from './bundle.js';
+export type { AgentTurnEvent, AgentTurnInput, AgentTurnOutput } from './types.js';

--- a/packages/connector-worker/src/agent-turn/types.ts
+++ b/packages/connector-worker/src/agent-turn/types.ts
@@ -25,7 +25,6 @@ export interface AgentTurnProvider {
    * the guest a credential the vault never minted, and the vault refuses those.
    */
   apiKey?: string;
-  headers?: Record<string, string>;
   maxTokens?: number;
 }
 

--- a/packages/connector-worker/src/agent-turn/types.ts
+++ b/packages/connector-worker/src/agent-turn/types.ts
@@ -1,0 +1,62 @@
+/**
+ * The agent-turn wire shapes, shared by the host executor, the guest bundle and
+ * the daemon lane. Kept in one module with no imports so the guest entry can
+ * pull the types without dragging any host code into the isolate bundle.
+ */
+
+/** Which provider the turn talks to, and how it authenticates. */
+export interface AgentTurnProvider {
+  /** pi-ai's api id. Only the two fetch-native families run on this lane. */
+  api: 'anthropic-messages' | 'openai-completions';
+  /** Provider slug pi-ai reports on the model (`anthropic`, `openai`, ...). */
+  provider: string;
+  modelId: string;
+  /**
+   * The gateway's agent-scoped secret-proxy URL. The guest never learns a real
+   * provider key: the proxy swaps the placeholder it sends for the real key.
+   */
+  baseUrl: string;
+  /**
+   * HOST-INJECTED, never set by the producer. The provider key travels on
+   * `job.credentials.accessToken` so it goes through the lane's one credential
+   * path: the host mints a per-run vault placeholder over the gateway's own
+   * placeholder, the guest only ever sees the vault's, and the host swaps it
+   * back into the outbound header. A producer that set this itself would hand
+   * the guest a credential the vault never minted, and the vault refuses those.
+   */
+  apiKey?: string;
+  headers?: Record<string, string>;
+  maxTokens?: number;
+}
+
+/**
+ * One transcript entry, in pi's own `AgentMessage` shape. The host does not
+ * interpret it; it round-trips whatever the guest returns back into the run row
+ * so the next turn resumes from it.
+ */
+export type AgentTurnMessage = Record<string, unknown>;
+
+/** Everything a single turn needs. */
+export interface AgentTurnInput {
+  provider: AgentTurnProvider;
+  systemPrompt: string;
+  /** The transcript this turn continues, oldest first. */
+  messages: AgentTurnMessage[];
+  /** What the human just said. */
+  userMessage: string;
+}
+
+/** What the guest streams out while the turn runs. */
+export type AgentTurnEvent =
+  | { type: 'text_delta'; delta: string }
+  | { type: 'thinking_delta'; delta: string }
+  | { type: 'message_end' };
+
+/** What the turn produced. */
+export interface AgentTurnOutput {
+  text: string;
+  stopReason: string | null;
+  usage: { input: number; output: number } | null;
+  /** The transcript after the turn, to persist and resume from. */
+  messages: AgentTurnMessage[];
+}

--- a/packages/connector-worker/src/daemon/agent-turn.ts
+++ b/packages/connector-worker/src/daemon/agent-turn.ts
@@ -1,0 +1,124 @@
+/**
+ * The daemon arm for an agent turn: one conversation turn as one isolate job.
+ *
+ * There is no separate executor. The turn is an `ExecutorJob` mode, so it runs
+ * through `selectExecutor` exactly as a connector does and inherits that lane's
+ * egress dispatcher, credential vault, wall clock, memory limit and log budget.
+ * What this module adds is only the envelope: the guest bundle, the allowlist,
+ * and reporting the result.
+ */
+
+import type { AgentTurnPollPayload, PollResponse } from '@lobu/core/contracts/worker/protocol';
+import { agentGuestBundle } from '../agent-turn/bundle.js';
+import type { AgentTurnEvent } from '../agent-turn/types.js';
+import { selectExecutor } from '../executor/select.js';
+import type { ExecutorConfig } from './executor.js';
+import type { ExecutorClient } from './client.js';
+import { log } from './log.js';
+
+function isAgentTurnPayload(value: unknown): value is AgentTurnPollPayload {
+  return !!value && typeof value === 'object' && 'turn' in value;
+}
+
+export async function executeAgentTurnRun(
+  client: ExecutorClient,
+  job: PollResponse,
+  env: Record<string, string | undefined>,
+  cfg: ExecutorConfig
+): Promise<{ itemsCollected: number; error?: string }> {
+  const runId = job.run_id;
+  if (!runId) return { itemsCollected: 0, error: 'agent turn run missing its run id' };
+
+  const fail = async (error: string) => {
+    await client.completeAgentTurn({
+      run_id: runId,
+      worker_id: client.id,
+      status: 'failed',
+      error,
+      exit_reason: 'error_message',
+    });
+    return { itemsCollected: 0, error };
+  };
+
+  // The run is already claimed, so a rejected envelope must be REPORTED, not
+  // returned: a local return leaves the turn parked until the stale sweep.
+  const payload = job.payload;
+  if (!isAgentTurnPayload(payload)) {
+    return fail('agent turn run received a non-turn payload envelope');
+  }
+  const turn = payload.turn;
+  if (!job.credentials?.accessToken) {
+    return fail('agent turn run arrived without its provider credential');
+  }
+
+  let deltas = 0;
+  // The connector-lane reaper writes a claimed run off once its heartbeat goes
+  // stale, and a turn's wall clock is far longer than that threshold. Beat on
+  // the same interval every other lane does, so a live turn is never reaped and
+  // a crashed worker's turn still is.
+  const heartbeat = setInterval(() => {
+    void client
+      .heartbeat(runId, { items_collected_so_far: deltas })
+      .catch((err) => log.debug('[agent-turn] heartbeat failed:', err));
+  }, cfg.heartbeatIntervalMs);
+  try {
+    const guestCode = await agentGuestBundle();
+    // Same executor seam every other lane uses (`resolveJobExecution`): an
+    // injected one owns its own limits, otherwise build the isolate here.
+    const executor =
+      cfg.executor ??
+      (await selectExecutor({
+        timeoutMs: cfg.timeoutMs,
+        // Deny-all but the hosts the gateway named — normally just itself. A
+        // connector's open default would let a prompt-injected turn reach the
+        // whole internet.
+        allowedDomains: turn.allowed_hosts,
+      }));
+    const result = await executor.execute(
+      guestCode,
+      {
+        mode: 'agent_turn',
+        turn: {
+          provider: {
+            api: turn.provider.api,
+            provider: turn.provider.provider,
+            modelId: turn.provider.model_id,
+            baseUrl: turn.provider.base_url,
+            ...(turn.provider.max_tokens !== undefined ? { maxTokens: turn.provider.max_tokens } : {}),
+          },
+          systemPrompt: turn.system_prompt,
+          messages: turn.messages,
+          userMessage: turn.message_text,
+        },
+        config: {},
+        credentials: job.credentials,
+        sessionState: null,
+        env,
+      },
+      {
+        onTurnEvent: (event: AgentTurnEvent) => {
+          if (event.type === 'text_delta') deltas += 1;
+        },
+      }
+    );
+    if (result.mode !== 'agent_turn') {
+      return fail(`agent turn produced a ${result.mode} result`);
+    }
+    await client.completeAgentTurn({
+      run_id: runId,
+      worker_id: client.id,
+      status: 'completed',
+      text: result.turn.text,
+      stop_reason: result.turn.stopReason,
+      usage: result.turn.usage,
+      transcript: result.turn.messages,
+      exit_reason: 'ok',
+    });
+    log.info(`[agent-turn] run ${runId} completed after ${deltas} deltas`);
+    return { itemsCollected: 0 };
+  } catch (error) {
+    return fail(error instanceof Error ? error.message : String(error));
+  } finally {
+    clearInterval(heartbeat);
+  }
+}

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -60,6 +60,11 @@ export interface ExecutorClient {
     runId: number,
     req: CompleteDeviceChatRequest
   ): Promise<CompleteDeviceChatResponse>;
+  /**
+   * Report an agent turn. Fleet-only, so it posts to the shared worker route
+   * rather than the device-scoped `/me/runs/...` family.
+   */
+  completeAgentTurn(req: CompleteAgentTurnRequest): Promise<CompleteAgentTurnResponse>;
   /** MCP endpoint + bearer the automation arm wires into the spawned CLI. */
   readonly mcpWiring?: { url: string; bearer?: string };
   /** Terminal ACP transcript upload authenticated by the per-run agent token. */
@@ -83,6 +88,8 @@ export interface ExecutorClient {
  */
 export type {
   CompleteActionRequest,
+  CompleteAgentTurnRequest,
+  CompleteAgentTurnResponse,
   CompleteAuthRequest,
   CompleteAutomationRequest,
   CompleteAutomationResponse,
@@ -104,6 +111,8 @@ export type {
 } from "@lobu/core/contracts/worker/protocol";
 import type {
   CompleteActionRequest,
+  CompleteAgentTurnRequest,
+  CompleteAgentTurnResponse,
   CompleteAuthRequest,
   CompleteAutomationRequest,
   CompleteAutomationResponse,
@@ -546,6 +555,10 @@ export class WorkerClient implements ExecutorClient {
       );
     }
     return interpretCompleteAutomationResponse(body);
+  }
+
+  async completeAgentTurn(req: CompleteAgentTurnRequest): Promise<CompleteAgentTurnResponse> {
+    return this.requestJson<CompleteAgentTurnResponse>('/api/workers/complete-agent-turn', req);
   }
 
   async completeDeviceChat(

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -13,6 +13,7 @@ import {
   hasDaemonBuiltin,
   hasDaemonBuiltinConnector,
 } from './builtins/index.js';
+import { executeAgentTurnRun } from './agent-turn.js';
 import { executeDeviceChatRun } from './device-chat.js';
 import type { ContentItem, ExecutorClient, PollResponse } from './client.js';
 import { attachedInteractiveSession, attachInteractiveSession } from './interactive-session.js';
@@ -249,6 +250,8 @@ export async function executeRun(
         return await executeAutomationRun(client, job, cfg);
       case 'chat_message':
         return await executeDeviceChatRun(client, job, cfg);
+      case 'agent_turn':
+        return await executeAgentTurnRun(client, job, env, cfg);
       case 'embed_backfill':
         return await executeEmbedBackfillRun(client, job, env, cfg);
       case 'auth':

--- a/packages/connector-worker/src/daemon/start.ts
+++ b/packages/connector-worker/src/daemon/start.ts
@@ -145,11 +145,15 @@ export async function startDaemonCommand(
     );
   }
 
-  // Fleet workers advertise the DB-egress contract by default. Device workers
-  // advertise only their declared, server-authorized capabilities.
+  // Fleet workers advertise the DB-egress contract and the agent-turn lane by
+  // default; device workers advertise only their declared, server-authorized
+  // capabilities. `agent_turn` is what stops a gateway that already emits the
+  // new run type from handing one to a worker binary that predates the lane:
+  // the two sides agree by string equality, so an old worker never matches and
+  // its dispatch default (a connector sync) is never reached.
   const workerCapabilities: Record<string, boolean> = platform
     ? Object.fromEntries(capabilities.map((name) => [name, true]))
-    : { db_egress_hardening: true };
+    : { db_egress_hardening: true, agent_turn: true };
   // Auto-discover device identity from the host when not passed: a device
   // worker defaults to `<platform>:<short-hostname>` and a hostname label. An
   // interactive daemon instead derives its id from the exact inherited

--- a/packages/connector-worker/src/daemon/terminal-failure.ts
+++ b/packages/connector-worker/src/daemon/terminal-failure.ts
@@ -37,6 +37,18 @@ export async function reportTerminalFailure(
     });
     return;
   }
+  if (job.run_type === 'agent_turn') {
+    // The generic route refuses an agent turn with a 409, so a failure that
+    // fell through to it would leave the run parked until the stale sweep.
+    await client.completeAgentTurn({
+      run_id: job.run_id,
+      worker_id: client.id,
+      status: 'failed',
+      error: message,
+      exit_reason: exitReason,
+    });
+    return;
+  }
   if (job.run_type === 'automation') {
     await client.completeAutomation(job.run_id, {
       worker_id: client.id,

--- a/packages/connector-worker/src/egress/credentials.ts
+++ b/packages/connector-worker/src/egress/credentials.ts
@@ -88,6 +88,14 @@ export class CredentialVault {
     for (const [name, value] of headers) {
       if (!containsCredentialPlaceholder(value)) continue;
       if (!options.plaintextAllowed) parseCredentialedHttpsUrl(url);
+      if (containsCredentialPlaceholder(value.replace(PLACEHOLDER_PATTERN, ''))) {
+        // The prefix without a well-formed id behind it: not something this lane
+        // minted. Checked on what the GUEST sent, before the swap, because a
+        // resolved value is allowed to be placeholder-shaped itself -- an agent
+        // turn's provider key is the gateway's own `lobu_secret_` placeholder,
+        // which this vault conceals behind one of its own.
+        throw new TypeError(`the credential placeholder in header ${name} is not valid for this run`);
+      }
       const swapped = value.replace(PLACEHOLDER_PATTERN, (placeholder) => {
         const real = this.values.get(placeholder);
         if (real === undefined) {
@@ -96,10 +104,6 @@ export class CredentialVault {
         spends.push({ placeholder, header: name });
         return real;
       });
-      if (containsCredentialPlaceholder(swapped)) {
-        // The prefix without a well-formed id behind it: not something this lane minted.
-        throw new TypeError(`the credential placeholder in header ${name} is not valid for this run`);
-      }
       resolved.push([name, swapped]);
     }
     for (const [name, value] of resolved) headers.set(name, value);

--- a/packages/connector-worker/src/executor/interface.ts
+++ b/packages/connector-worker/src/executor/interface.ts
@@ -1,3 +1,4 @@
+import type { AgentTurnEvent, AgentTurnInput, AgentTurnOutput } from '../agent-turn/types.js';
 import type {
   AuthResult,
   ConnectorWebhookSchema,
@@ -78,6 +79,19 @@ export type ExecutorJob =
       env: Record<string, string | undefined>;
     }
   | {
+      // One turn of an agent conversation. Not connector code: `compiledCode`
+      // is Lobu's own agent-session guest bundle. `credentials.accessToken` is
+      // the gateway's own `lobu_secret_` placeholder for this agent, so the
+      // worker never holds a real provider key either — it rides the lane's
+      // ordinary credential path and the guest sees the vault's placeholder.
+      mode: 'agent_turn';
+      turn: AgentTurnInput;
+      config: Record<string, unknown>;
+      credentials: SyncCredentials | null;
+      sessionState: Record<string, unknown> | null;
+      env: Record<string, string | undefined>;
+    }
+  | {
       // Tear down the provider subscription created by `webhook_register` when
       // the connection is removed.
       mode: 'webhook_unregister';
@@ -138,10 +152,16 @@ export type ExecutorResult =
       webhookScheme: ConnectorWebhookSchema | null;
     }
   | {
+      mode: 'agent_turn';
+      turn: AgentTurnOutput;
+    }
+  | {
       mode: 'webhook_unregister';
     };
 
 export interface ExecutionHooks {
+  /** Agent turns: the guest emitted a token or ended a message, mid-stream. */
+  onTurnEvent?: (event: AgentTurnEvent) => Promise<void> | void;
   /** Sync runs: connector streamed a chunk of events (and we should persist them). */
   onEventChunk?: (events: EventEnvelope[]) => Promise<void> | void;
   /** Sync runs: connector pushed an incremental checkpoint update. */

--- a/packages/connector-worker/src/executor/isolate.ts
+++ b/packages/connector-worker/src/executor/isolate.ts
@@ -44,6 +44,7 @@ import { IsolateHost, IsolateHostError, type IsolateTerminalState } from '../iso
 import { assertIsolateEligible } from '../isolate/eligibility.js';
 import type { IsolatedVm } from '../isolate/ivm-types.js';
 import { isolatedVmUnavailableReason, loadIsolatedVm } from '../isolate/load.js';
+import type { AgentTurnEvent } from '../agent-turn/types.js';
 import { buildConnectorConfig } from './connector-config.js';
 import type {
   ExecutionHooks,
@@ -330,7 +331,33 @@ const GUEST_RUNNER = String.raw`
     };
   }
 
+  // An agent turn does not duck-type a connector class: the bundle is Lobu's
+  // own agent-session guest and exports one entry point.
+  async function executeAgentTurn(mod) {
+    if (!mod || typeof mod.runAgentTurn !== 'function') {
+      throw new Error('the agent guest bundle does not export runAgentTurn()');
+    }
+    // The provider key reaches the guest here and nowhere else: the host has
+    // already replaced it with this run's vault placeholder.
+    var turnInput = Object.assign({}, job.turn, {
+      provider: Object.assign({}, job.turn.provider, {
+        apiKey: job.credentials ? job.credentials.accessToken : undefined
+      })
+    });
+    var output = await mod.runAgentTurn(turnInput, function (event) {
+      // Fire-and-forget on purpose: a delta must not stall the token stream
+      // waiting for the host, and the host reports its own hook failures by
+      // terminating the run.
+      H.async('emitTurnEvent', JSON.stringify(event));
+    });
+    return { mode: 'agent_turn', turn: output };
+  }
+
   try {
+    if (job.mode === 'agent_turn') {
+      var turnResult = await executeAgentTurn(module.exports);
+      return JSON.stringify({ ok: true, result: turnResult });
+    }
     var RuntimeClass = findRuntimeClass(module.exports);
     if (!RuntimeClass) throw new Error('No ConnectorRuntime class found. Expected a class with sync() and execute() methods.');
     var instance = new RuntimeClass();
@@ -727,6 +754,13 @@ export class IsolateExecutor implements SyncExecutor {
           const events: EventEnvelope[] = Array.isArray(parsed) ? (parsed as EventEnvelope[]) : [];
           await queueHook(async () => {
             await hooks?.onEventChunk?.(events);
+          });
+          return undefined;
+        },
+        emitTurnEvent: async (json: unknown) => {
+          const event = parseGuestJson(json, 'emitTurnEvent') as AgentTurnEvent;
+          await queueHook(async () => {
+            await hooks?.onTurnEvent?.(event);
           });
           return undefined;
         },

--- a/packages/connector-worker/src/isolate/prelude.ts
+++ b/packages/connector-worker/src/isolate/prelude.ts
@@ -46,9 +46,14 @@
  * boundary because an async rejection also surfaces as an unhandled rejection
  * in the host process.
  *
- * Deliberately absent (no bundled isolate-eligible connector or SDK root path
- * uses them): `Request`, `structuredClone`, `FormData`, `Blob`. Add one only
- * with a real connector that needs it.
+ * `FormData` carries text fields only and serialises itself to a multipart
+ * body; the Stainless clients pi's LLM providers are built on test
+ * `body instanceof FormData` unguarded on every request, so the guest
+ * cannot reach a provider without it.
+ *
+ * Deliberately absent (no isolate-eligible connector or SDK root path uses
+ * them): `Request`, `structuredClone`, `Blob`. Add one only with a real
+ * caller that needs it.
  *
  * Written as sloppy-mode ES2020 with no template literals so the string can
  * live in this module verbatim. `String.raw` keeps the regex escapes intact.
@@ -79,6 +84,7 @@ export const PRELUDE_GLOBALS = [
   'AbortController',
   'AbortSignal',
   'Headers',
+  'FormData',
   'Response',
   'fetch',
   'crypto',
@@ -941,6 +947,111 @@ var exports = module.exports;
   global.Headers = Headers;
 
   // ---------------------------------------------------------------------------
+  // FormData
+  // ---------------------------------------------------------------------------
+
+  // Text fields only. Blob and File are not on this lane, so every part is a
+  // string; a non-primitive value is refused rather than stringified into
+  // "[object Object]". Present because the Stainless clients pi's providers use
+  // evaluate "body instanceof FormData" UNGUARDED on every request they send
+  // (@anthropic-ai/sdk client.mjs, openai client.mjs), so a guest without the
+  // constructor cannot reach any LLM at all.
+
+  function formDataValue(value) {
+    if (value !== null && typeof value === 'object') {
+      throw new TypeError('FormData on the isolate lane holds text fields only; Blob and File parts are not available');
+    }
+    return String(value);
+  }
+
+  // WHATWG "escape a form field name": normalise the line breaks, then
+  // percent-encode the three characters that would break the header line.
+  function escapeFormName(name) {
+    return String(name)
+      .replace(/\r\n|\r|\n/g, '\r\n')
+      .replace(/"/g, '%22')
+      .replace(/\r/g, '%0D')
+      .replace(/\n/g, '%0A');
+  }
+
+  function FormData(form) {
+    if (!(this instanceof FormData)) throw new TypeError("Class constructor FormData cannot be invoked without 'new'");
+    if (form !== undefined && form !== null) throw new TypeError('FormData constructor: no HTMLFormElement on the isolate lane');
+    this._entries = [];
+  }
+  FormData.prototype.append = function (name, value) {
+    this._entries.push([String(name), formDataValue(value)]);
+  };
+  FormData.prototype.set = function (name, value) {
+    var key = String(name);
+    var v = formDataValue(value);
+    var replaced = false;
+    var kept = [];
+    for (var i = 0; i < this._entries.length; i++) {
+      if (this._entries[i][0] !== key) {
+        kept.push(this._entries[i]);
+      } else if (!replaced) {
+        replaced = true;
+        kept.push([key, v]);
+      }
+    }
+    if (!replaced) kept.push([key, v]);
+    this._entries = kept;
+  };
+  FormData.prototype.get = function (name) {
+    var key = String(name);
+    for (var i = 0; i < this._entries.length; i++) if (this._entries[i][0] === key) return this._entries[i][1];
+    return null;
+  };
+  FormData.prototype.getAll = function (name) {
+    var key = String(name);
+    var out = [];
+    for (var i = 0; i < this._entries.length; i++) if (this._entries[i][0] === key) out.push(this._entries[i][1]);
+    return out;
+  };
+  FormData.prototype.has = function (name) {
+    var key = String(name);
+    for (var i = 0; i < this._entries.length; i++) if (this._entries[i][0] === key) return true;
+    return false;
+  };
+  FormData.prototype.delete = function (name) {
+    var key = String(name);
+    var kept = [];
+    for (var i = 0; i < this._entries.length; i++) if (this._entries[i][0] !== key) kept.push(this._entries[i]);
+    this._entries = kept;
+  };
+  FormData.prototype.forEach = function (callback, thisArg) {
+    if (typeof callback !== 'function') throw new TypeError('The "callback" argument must be of type function');
+    for (var i = 0; i < this._entries.length; i++) callback.call(thisArg, this._entries[i][1], this._entries[i][0], this);
+  };
+  FormData.prototype.entries = function () {
+    return this._entries.map(function (e) { return [e[0], e[1]]; })[Symbol.iterator]();
+  };
+  FormData.prototype.keys = function () {
+    return this._entries.map(function (e) { return e[0]; })[Symbol.iterator]();
+  };
+  FormData.prototype.values = function () {
+    return this._entries.map(function (e) { return e[1]; })[Symbol.iterator]();
+  };
+  FormData.prototype[Symbol.iterator] = FormData.prototype.entries;
+  Object.defineProperty(FormData.prototype, Symbol.toStringTag, { value: 'FormData', configurable: true });
+  global.FormData = FormData;
+
+  // Serialise to a multipart/form-data body. The boundary is random per body so
+  // a field value can never close the envelope early.
+  function encodeFormData(form) {
+    var boundary = '----LobuFormBoundary' + crypto.randomUUID().replace(/-/g, '');
+    var text = '';
+    for (var i = 0; i < form._entries.length; i++) {
+      text += '--' + boundary + '\r\n';
+      text += 'Content-Disposition: form-data; name="' + escapeFormName(form._entries[i][0]) + '"\r\n\r\n';
+      text += form._entries[i][1] + '\r\n';
+    }
+    text += '--' + boundary + '--\r\n';
+    return { bytes: utf8Encode(text), contentType: 'multipart/form-data; boundary=' + boundary };
+  }
+
+  // ---------------------------------------------------------------------------
   // Response / fetch
   // ---------------------------------------------------------------------------
 
@@ -953,7 +1064,8 @@ var exports = module.exports;
     if (body instanceof URLSearchParams) return { bytes: utf8Encode(body.toString()), contentType: 'application/x-www-form-urlencoded;charset=UTF-8' };
     if (body instanceof ArrayBuffer) return { bytes: new Uint8Array(body.slice(0)), contentType: null };
     if (ArrayBuffer.isView(body)) return { bytes: new Uint8Array(body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength)), contentType: null };
-    throw new TypeError('Unsupported body type on the isolate lane: pass a string, URLSearchParams, ArrayBuffer or ArrayBufferView');
+    if (body instanceof FormData) return encodeFormData(body);
+    throw new TypeError('Unsupported body type on the isolate lane: pass a string, URLSearchParams, FormData, ArrayBuffer or ArrayBufferView');
   }
 
   // A guest-constructed body: its bytes handed over once, then end of stream.

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -65,6 +65,15 @@ export const RunTypeSchema = Type.Union([
   Type.Literal("chat_message"),
   Type.Literal("embed_backfill"),
   Type.Literal("auth"),
+  /**
+   * One conversation turn executed as one isolate job, claimed only by a fleet
+   * worker that advertises the lane and run through `IsolateExecutor`. Distinct
+   * from `chat_message`, a lobu-queue row the gateway drains to a subprocess
+   * worker — or, when the agent is device-pinned, hands to that device through
+   * this same poll. A daemon that predates this lane must never claim an
+   * `agent_turn`: its dispatch would fall through to a connector sync.
+   */
+  Type.Literal("agent_turn"),
 ]);
 
 /** Categorized run exit reason on the failed-run path. */
@@ -276,6 +285,47 @@ export const DeviceChatPollPayloadSchema = Type.Object({
   context: AutomationPollContextSchema,
 });
 
+/**
+ * `payload` of an agent-turn poll response.
+ *
+ * The provider credential is deliberately NOT here: it rides the response's
+ * ordinary `credentials.accessToken`, so the worker host conceals it behind a
+ * per-run placeholder exactly as it does a connector's OAuth token. Its value
+ * is the gateway's own `lobu_secret_` placeholder for the agent, which only the
+ * gateway's secret proxy at `base_url` can resolve — the worker never holds a
+ * real provider key at either hop.
+ */
+export const AgentTurnPollPayloadSchema = Type.Object({
+  turn: Type.Object({
+    agent_id: Type.String({ minLength: 1 }),
+    conversation_id: Type.String({ minLength: 1 }),
+    message_id: Type.String({ minLength: 1 }),
+    /** What the human said, verbatim. */
+    message_text: Type.String({ maxLength: 32_000 }),
+    system_prompt: Type.String(),
+    /** The transcript this turn continues, oldest first, in pi's message shape. */
+    messages: Type.Array(Type.Record(Type.String(), Type.Unknown())),
+    provider: Type.Object({
+      api: Type.Union([
+        Type.Literal("anthropic-messages"),
+        Type.Literal("openai-completions"),
+      ]),
+      provider: Type.String({ minLength: 1 }),
+      model_id: Type.String({ minLength: 1 }),
+      /** The gateway's agent-scoped secret-proxy base URL. */
+      base_url: Type.String({ minLength: 1 }),
+      max_tokens: Type.Optional(Type.Integer({ minimum: 1 })),
+    }),
+    /**
+     * Hosts the turn may reach. An agent turn is deny-all by default, unlike a
+     * connector's open one, so this is normally just the gateway.
+     */
+    allowed_hosts: Type.Array(Type.String({ minLength: 1 })),
+    /** Shadow runs report their result and never reach the conversation. */
+    shadow: Type.Boolean(),
+  }),
+});
+
 /** `POST /api/workers/poll` response body (a claimed run, or a poll-again). */
 export const PollResponseSchema = Type.Object({
   next_poll_seconds: Type.Optional(Type.Number()),
@@ -342,7 +392,11 @@ export const PollResponseSchema = Type.Object({
    * matching completion endpoint. No connector code or credentials are shipped.
    */
   payload: Type.Optional(
-    Type.Union([AutomationPollPayloadSchema, DeviceChatPollPayloadSchema])
+    Type.Union([
+      AutomationPollPayloadSchema,
+      DeviceChatPollPayloadSchema,
+      AgentTurnPollPayloadSchema,
+    ])
   ),
 });
 
@@ -528,6 +582,38 @@ export const CompleteDeviceChatResponseSchema = Type.Object({
   idempotent: Type.Optional(Type.Boolean()),
 });
 
+/**
+ * `POST /api/workers/complete-agent-turn`.
+ *
+ * `transcript` is what the turn produced, to resume the next one from. A shadow
+ * run reports it and nothing else happens; when the lane becomes authoritative
+ * the same body carries the reply.
+ */
+export const CompleteAgentTurnRequestSchema = Type.Object({
+  run_id: Type.Integer(),
+  worker_id: Type.String(),
+  status: Type.Union([Type.Literal("completed"), Type.Literal("failed")]),
+  text: Type.Optional(Type.String()),
+  stop_reason: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  usage: Type.Optional(
+    Type.Union([
+      Type.Object({ input: Type.Integer(), output: Type.Integer() }),
+      Type.Null(),
+    ])
+  ),
+  transcript: Type.Optional(
+    Type.Array(Type.Record(Type.String(), Type.Unknown()))
+  ),
+  error: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  exit_reason: Type.Optional(WorkerExitReasonSchema),
+});
+
+export const CompleteAgentTurnResponseSchema = Type.Object({
+  ok: Type.Boolean(),
+  status: Type.Union([Type.Literal("completed"), Type.Literal("failed")]),
+  idempotent: Type.Optional(Type.Boolean()),
+});
+
 // ── auth signalling ─────────────────────────────────────────────────────────
 
 /** `POST /api/workers/emit-auth-artifact`. */
@@ -625,6 +711,13 @@ export type CompleteDeviceChatRequest = Static<
 >;
 export type CompleteDeviceChatResponse = Static<
   typeof CompleteDeviceChatResponseSchema
+>;
+export type AgentTurnPollPayload = Static<typeof AgentTurnPollPayloadSchema>;
+export type CompleteAgentTurnRequest = Static<
+  typeof CompleteAgentTurnRequestSchema
+>;
+export type CompleteAgentTurnResponse = Static<
+  typeof CompleteAgentTurnResponseSchema
 >;
 export type ActivatePageRequest = Static<typeof ActivatePageRequestSchema>;
 export type ActivatePageResponse = Static<typeof ActivatePageResponseSchema>;

--- a/packages/server/src/__tests__/integration/agent-turn-shadow.test.ts
+++ b/packages/server/src/__tests__/integration/agent-turn-shadow.test.ts
@@ -1,0 +1,501 @@
+/**
+ * The shadow producer end to end: a selected agent's message produces an
+ * `agent_turn` run, only a fleet worker that advertises the lane can claim it,
+ * and the turn is reported back on the lane's own completion route. This is the
+ * seam that makes the isolate turn lane REACHABLE — the executor suite proves
+ * the turn runs, this proves a real message reaches it and comes back.
+ */
+import {
+  AgentTurnPollPayloadSchema,
+  PollResponseSchema,
+} from '@lobu/core/contracts/worker/protocol';
+import type { MessagePayload } from '@lobu/core';
+import { Value } from '@sinclair/typebox/value';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { enqueueAgentTurnShadow } from '../../gateway/orchestration/agent-turn-shadow';
+import type { AgentSettingsStore } from '../../gateway/auth/settings/agent-settings-store';
+import type { ProviderCatalogService } from '../../gateway/auth/provider-catalog';
+import type { ModelProviderModule } from '../../gateway/modules/module-system';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestPAT,
+  createTestUser,
+} from '../setup/test-fixtures';
+import { post } from '../setup/test-helpers';
+
+const SHADOW_ENV = 'LOBU_ISOLATE_TURN_SHADOW_AGENTS';
+const PUBLIC_ORIGIN = 'https://gateway.test.invalid';
+const AGENT_ID = 'shadow-agent';
+
+/**
+ * A provider module shaped like the real Claude one: a Lobu id that differs
+ * from its upstream slug, so the model-prefix strip is actually exercised.
+ */
+function claudeModule(overrides: Partial<ModelProviderModule> = {}): ModelProviderModule {
+  return {
+    providerId: 'claude',
+    sdkCompat: 'anthropic',
+    getUpstreamConfig: () => ({
+      slug: 'anthropic',
+      upstreamBaseUrl: 'https://api.anthropic.com',
+      apiKeyHeader: 'x-api-key' as const,
+    }),
+    getProxyBaseUrlMappings: (
+      proxyUrl: string,
+      agentId?: string,
+      context?: { organizationId?: string; userId?: string }
+    ) => ({
+      ANTHROPIC_BASE_URL: `${proxyUrl}/anthropic/a/${agentId}/o/${context?.organizationId}/u/${context?.userId}`,
+    }),
+    buildCredentialPlaceholder: () => 'lobu_secret_11111111-2222-3333-4444-555555555555',
+    ...overrides,
+  } as unknown as ModelProviderModule;
+}
+
+function catalogFor(module: ModelProviderModule | undefined): ProviderCatalogService {
+  return {
+    getInstalledModules: async () => (module ? [module] : []),
+    findProviderForModel: async () => module,
+  } as unknown as ProviderCatalogService;
+}
+
+const settingsStore = {
+  getSettings: async () => ({
+    identityMd: 'I am the shadow agent.',
+    soulMd: 'Answer briefly.',
+    userMd: '',
+  }),
+} as unknown as AgentSettingsStore;
+
+function messageFor(organizationId: string): MessagePayload {
+  return {
+    userId: 'user-shadow',
+    conversationId: 'conv-shadow',
+    messageId: 'msg-shadow',
+    channelId: 'api_user-shadow',
+    agentId: AGENT_ID,
+    organizationId,
+    botId: 'bot-shadow',
+    platform: 'api',
+    messageText: 'what is the shadow lane?',
+    platformMetadata: {},
+    agentOptions: { model: 'claude/claude-opus-4-8' },
+  } as MessagePayload;
+}
+
+async function shadowRuns() {
+  const sql = getTestDb();
+  return (await sql`
+    SELECT id, run_type, status, approval_status, organization_id, action_input
+    FROM runs
+    WHERE run_type = 'agent_turn'
+    ORDER BY id
+  `) as unknown as Array<{
+    id: number;
+    run_type: string;
+    status: string;
+    approval_status: string;
+    organization_id: string;
+    action_input: Record<string, unknown>;
+  }>;
+}
+
+async function pollFleet(workerId: string, capabilities: Record<string, boolean>) {
+  return post('/api/workers/poll', {
+    body: { worker_id: workerId, capabilities },
+    token: 'test-fleet-token',
+    env: { WORKER_API_TOKEN: 'test-fleet-token' },
+  });
+}
+
+async function postAsFleet(path: string, body: Record<string, unknown>) {
+  return post(path, {
+    body,
+    token: 'test-fleet-token',
+    env: { WORKER_API_TOKEN: 'test-fleet-token' },
+  });
+}
+
+/** Enqueue a shadow turn and claim it, as the fleet worker would. */
+async function claimedShadowRun(workerId: string): Promise<number> {
+  const org = await createTestOrganization();
+  await enqueueAgentTurnShadow(messageFor(org.id), {
+    agentSettings: settingsStore,
+    catalog: catalogFor(claudeModule()),
+    publicOrigin: PUBLIC_ORIGIN,
+  });
+  const response = await pollFleet(workerId, { agent_turn: true });
+  const body = await response.json();
+  return body.run_id as number;
+}
+
+async function runRow(runId: number) {
+  const sql = getTestDb();
+  const [row] = (await sql`
+    SELECT status, error_message, exit_reason, output_tail, action_input
+    FROM runs WHERE id = ${runId}
+  `) as unknown as Array<{
+    status: string;
+    error_message: string | null;
+    exit_reason: string | null;
+    output_tail: string | null;
+    action_input: { turn?: unknown; result?: Record<string, unknown> };
+  }>;
+  return row;
+}
+
+describe('agent turn shadow producer', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    delete process.env.WORKER_API_TOKEN;
+    process.env[SHADOW_ENV] = AGENT_ID;
+  });
+
+  afterEach(() => {
+    delete process.env[SHADOW_ENV];
+  });
+
+  it('produces a claimable, schema-valid envelope with the credential lifted off the turn', async () => {
+    const org = await createTestOrganization();
+    await enqueueAgentTurnShadow(messageFor(org.id), {
+      agentSettings: settingsStore,
+      catalog: catalogFor(claudeModule()),
+      publicOrigin: PUBLIC_ORIGIN,
+    });
+
+    const rows = await shadowRuns();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      run_type: 'agent_turn',
+      status: 'pending',
+      approval_status: 'auto',
+      organization_id: org.id,
+    });
+
+    const envelope = rows[0].action_input as {
+      turn: Record<string, unknown>;
+      credential: string;
+    };
+    // The poll response is built straight off this, so it must satisfy the
+    // payload contract before any worker ever sees it.
+    expect(Value.Check(AgentTurnPollPayloadSchema, { turn: envelope.turn })).toBe(true);
+
+    expect(envelope.turn).toMatchObject({
+      agent_id: AGENT_ID,
+      conversation_id: 'conv-shadow',
+      message_id: 'msg-shadow',
+      message_text: 'what is the shadow lane?',
+      shadow: true,
+      provider: {
+        api: 'anthropic-messages',
+        provider: 'anthropic',
+        // Lobu stores "claude/…"; the upstream only knows the bare id.
+        model_id: 'claude-opus-4-8',
+        base_url: `${PUBLIC_ORIGIN}/api/proxy/anthropic/a/${AGENT_ID}/o/${org.id}/u/user-shadow`,
+      },
+      // Deny-all: the gateway proxy and nothing else.
+      allowed_hosts: ['gateway.test.invalid'],
+    });
+    expect(envelope.turn.system_prompt).toBe(
+      '## Agent Identity\n\nI am the shadow agent.\n\n## Agent Instructions\n\nAnswer briefly.'
+    );
+    expect(envelope.turn.messages).toEqual([]);
+
+    // The credential rides OUTSIDE the turn so the poll can lift it onto the
+    // response's `credentials` and the worker can conceal it before the guest
+    // ever sees a provider key.
+    expect(envelope.credential).toBe('lobu_secret_11111111-2222-3333-4444-555555555555');
+    expect(JSON.stringify(envelope.turn)).not.toContain('lobu_secret_');
+  });
+
+  it('arms no turn marker and journals no run input', async () => {
+    const org = await createTestOrganization();
+    await enqueueAgentTurnShadow(messageFor(org.id), {
+      agentSettings: settingsStore,
+      catalog: catalogFor(claudeModule()),
+      publicOrigin: PUBLIC_ORIGIN,
+    });
+
+    const sql = getTestDb();
+    // Both are keyed (deploymentName, messageId) and both are first-writer-wins,
+    // so a shadow that wrote either would let the observational lane terminate
+    // or replay the real turn.
+    const [markers] = (await sql`
+      SELECT count(*)::int AS n FROM runs WHERE queue_name = 'internal:turn_timeout'
+    `) as unknown as Array<{ n: number }>;
+    expect(markers.n).toBe(0);
+    const [journal] = (await sql`
+      SELECT count(*)::int AS n FROM agent_run_input WHERE message_id = 'msg-shadow'
+    `) as unknown as Array<{ n: number }>;
+    expect(journal.n).toBe(0);
+  });
+
+  it('a fleet worker that advertises the lane claims it and receives the turn plus the credential', async () => {
+    const org = await createTestOrganization();
+    await enqueueAgentTurnShadow(messageFor(org.id), {
+      agentSettings: settingsStore,
+      catalog: catalogFor(claudeModule()),
+      publicOrigin: PUBLIC_ORIGIN,
+    });
+    const [run] = await shadowRuns();
+
+    const response = await pollFleet('fleet-agent-turn', { agent_turn: true });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(Value.Check(PollResponseSchema, body)).toBe(true);
+    expect(body.run_id).toBe(run.id);
+    expect(body.run_type).toBe('agent_turn');
+    expect(body.organization_id).toBe(org.id);
+    expect(body.payload.turn.provider.model_id).toBe('claude-opus-4-8');
+    expect(body.credentials).toEqual({
+      provider: 'anthropic',
+      accessToken: 'lobu_secret_11111111-2222-3333-4444-555555555555',
+    });
+
+    const sql = getTestDb();
+    const [claimed] = (await sql`
+      SELECT status, claimed_by FROM runs WHERE id = ${run.id}
+    `) as unknown as Array<{ status: string; claimed_by: string }>;
+    expect(claimed).toEqual({ status: 'running', claimed_by: 'fleet-agent-turn' });
+  });
+
+  it('a fleet worker without the capability leaves the run pending', async () => {
+    const org = await createTestOrganization();
+    await enqueueAgentTurnShadow(messageFor(org.id), {
+      agentSettings: settingsStore,
+      catalog: catalogFor(claudeModule()),
+      publicOrigin: PUBLIC_ORIGIN,
+    });
+    const [run] = await shadowRuns();
+
+    // An older daemon advertises no `agent_turn`. If it could claim the row it
+    // would fall through `executeRun`'s default arm into `executeSyncRun`.
+    const response = await pollFleet('fleet-old-daemon', { db_egress_hardening: true });
+    const body = await response.json();
+    expect(body.run_id).toBeUndefined();
+
+    const sql = getTestDb();
+    const [still] = (await sql`
+      SELECT status FROM runs WHERE id = ${run.id}
+    `) as unknown as Array<{ status: string }>;
+    expect(still.status).toBe('pending');
+  });
+
+  it('a user-scoped device worker cannot claim an agent turn', async () => {
+    const org = await createTestOrganization();
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, org.id, 'owner');
+    await enqueueAgentTurnShadow(messageFor(org.id), {
+      agentSettings: settingsStore,
+      catalog: catalogFor(claudeModule()),
+      publicOrigin: PUBLIC_ORIGIN,
+    });
+    const [run] = await shadowRuns();
+
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO device_workers (user_id, worker_id, platform, capabilities, organization_id)
+      VALUES (${user.id}, 'device-agent-turn', 'macos', ${sql.json([])}, ${org.id})
+    `;
+    const pat = await createTestPAT(user.id, org.id, { scope: 'device_worker:run' });
+    const response = await post('/api/workers/poll', {
+      token: pat.token,
+      body: {
+        worker_id: 'device-agent-turn',
+        platform: 'macos',
+        capabilities: { agent_turn: true },
+      },
+    });
+    const body = await response.json();
+    expect(body.run_id).toBeUndefined();
+
+    const [still] = (await sql`
+      SELECT status FROM runs WHERE id = ${run.id}
+    `) as unknown as Array<{ status: string }>;
+    expect(still.status).toBe('pending');
+  });
+
+  it('produces nothing when the agent is not selected, has no model, or runs an unsupported protocol', async () => {
+    const org = await createTestOrganization();
+    const deps = {
+      agentSettings: settingsStore,
+      catalog: catalogFor(claudeModule()),
+      publicOrigin: PUBLIC_ORIGIN,
+    };
+
+    process.env[SHADOW_ENV] = 'some-other-agent';
+    await enqueueAgentTurnShadow(messageFor(org.id), deps);
+    expect(await shadowRuns()).toHaveLength(0);
+
+    process.env[SHADOW_ENV] = AGENT_ID;
+    const noModel = messageFor(org.id);
+    noModel.agentOptions = {};
+    await enqueueAgentTurnShadow(noModel, deps);
+    expect(await shadowRuns()).toHaveLength(0);
+
+    // An attachment-only message: both providers reject an empty user turn, so
+    // enqueueing one would only ever produce a failed run.
+    const noText = messageFor(org.id);
+    noText.messageText = '   ';
+    await enqueueAgentTurnShadow(noText, deps);
+    expect(await shadowRuns()).toHaveLength(0);
+
+    // Google speaks a protocol whose pi-ai adapter is not fetch-native, so it
+    // cannot be bundled for the isolate and must not produce a shadow.
+    await enqueueAgentTurnShadow(messageFor(org.id), {
+      ...deps,
+      catalog: catalogFor(claudeModule({ sdkCompat: 'google' })),
+    });
+    expect(await shadowRuns()).toHaveLength(0);
+
+    // No public origin means no URL a fleet worker could reach the proxy on.
+    await enqueueAgentTurnShadow(messageFor(org.id), { ...deps, publicOrigin: undefined });
+    expect(await shadowRuns()).toHaveLength(0);
+
+    // `*` selects every agent — the operator's blanket switch.
+    process.env[SHADOW_ENV] = '*';
+    await enqueueAgentTurnShadow(messageFor(org.id), deps);
+    expect(await shadowRuns()).toHaveLength(1);
+  });
+});
+
+
+describe('agent turn completion', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    delete process.env.WORKER_API_TOKEN;
+    process.env[SHADOW_ENV] = AGENT_ID;
+  });
+
+  afterEach(() => {
+    delete process.env[SHADOW_ENV];
+  });
+
+  it('records the transcript on the run row and is idempotent on a retry', async () => {
+    const workerId = 'fleet-complete';
+    const runId = await claimedShadowRun(workerId);
+
+    const transcript = [
+      { role: 'user', content: 'what is the shadow lane?' },
+      { role: 'assistant', content: [{ type: 'text', text: 'an observational copy' }] },
+    ];
+    const response = await postAsFleet('/api/workers/complete-agent-turn', {
+      run_id: runId,
+      worker_id: workerId,
+      status: 'completed',
+      text: 'an observational copy',
+      stop_reason: 'stop',
+      usage: { input: 11, output: 7 },
+      transcript,
+      exit_reason: 'ok',
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, status: 'completed' });
+
+    const row = await runRow(runId);
+    expect(row.status).toBe('completed');
+    expect(row.exit_reason).toBe('ok');
+    expect(row.output_tail).toBe('an observational copy');
+    expect(row.error_message).toBe(null);
+    // The turn envelope survives alongside the result, so the shadow stays
+    // diffable against what the subprocess lane answered.
+    expect(row.action_input.turn).toBeDefined();
+    expect(row.action_input.result).toEqual({
+      text: 'an observational copy',
+      stop_reason: 'stop',
+      usage: { input: 11, output: 7 },
+      transcript,
+    });
+
+    // A retry (worker reconnect, at-least-once delivery) must not re-transition.
+    const retry = await postAsFleet('/api/workers/complete-agent-turn', {
+      run_id: runId,
+      worker_id: workerId,
+      status: 'failed',
+      error: 'a late duplicate report',
+    });
+    expect(await retry.json()).toEqual({
+      ok: true,
+      status: 'completed',
+      idempotent: true,
+    });
+    expect((await runRow(runId)).status).toBe('completed');
+  });
+
+  it('fails the run when the worker reports a failed turn', async () => {
+    const workerId = 'fleet-fail';
+    const runId = await claimedShadowRun(workerId);
+
+    const response = await postAsFleet('/api/workers/complete-agent-turn', {
+      run_id: runId,
+      worker_id: workerId,
+      status: 'failed',
+      error: 'the provider refused the request',
+      exit_reason: 'error_message',
+    });
+    expect(await response.json()).toEqual({ ok: true, status: 'failed' });
+
+    const row = await runRow(runId);
+    expect(row.status).toBe('failed');
+    expect(row.error_message).toBe('the provider refused the request');
+    expect(row.exit_reason).toBe('error_message');
+  });
+
+  it('refuses a worker that did not claim the run', async () => {
+    const runId = await claimedShadowRun('fleet-claimant');
+
+    const response = await postAsFleet('/api/workers/complete-agent-turn', {
+      run_id: runId,
+      worker_id: 'fleet-impostor',
+      status: 'completed',
+      text: 'not mine to report',
+    });
+    // Not this worker's run: reported as already-settled rather than applied.
+    expect(await response.json()).toMatchObject({ idempotent: true });
+    expect((await runRow(runId)).status).toBe('running');
+  });
+
+  it('refuses to record a reply for a turn that did not declare itself observational', async () => {
+    const workerId = 'fleet-authoritative';
+    const runId = await claimedShadowRun(workerId);
+    // Strip the flag the producer sets. This is the deploy-skew shape the guard
+    // exists for: a producer that starts marking turns authoritative before the
+    // reply path exists would otherwise have every reply recorded and dropped.
+    const sql = getTestDb();
+    await sql`
+      UPDATE runs
+      SET action_input = jsonb_set(action_input, '{turn,shadow}', 'false'::jsonb)
+      WHERE id = ${runId}
+    `;
+
+    const response = await postAsFleet('/api/workers/complete-agent-turn', {
+      run_id: runId,
+      worker_id: workerId,
+      status: 'completed',
+      text: 'a reply nobody would deliver',
+    });
+    expect(response.status).toBe(409);
+    const row = await runRow(runId);
+    expect(row.status).toBe('running');
+    expect(row.action_input.result).toBeUndefined();
+  });
+
+  it('the generic complete route refuses an agent turn and leaves it running', async () => {
+    const workerId = 'fleet-generic';
+    const runId = await claimedShadowRun(workerId);
+
+    // A daemon that predates the lane would finalize the turn with sync
+    // semantics, dropping the transcript and the reply. The reaper terminalizes
+    // it instead.
+    const response = await postAsFleet('/api/workers/complete', {
+      run_id: runId,
+      worker_id: workerId,
+      status: 'completed',
+      items_collected: 0,
+    });
+    expect(response.status).toBe(409);
+    expect((await runRow(runId)).status).toBe('running');
+  });
+});

--- a/packages/server/src/__tests__/integration/sandbox/isolate-agent-turn.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/isolate-agent-turn.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Agent turn on the connector isolate lane, end to end.
+ *
+ * One conversation turn is one isolate job: `IsolateExecutor` runs Lobu's own
+ * agent-session guest bundle exactly the way it runs a connector, so the turn
+ * inherits the lane's egress dispatcher, wall clock, memory limit, log budget
+ * and terminal-state machine rather than growing a second copy of any of them.
+ *
+ * What is pinned here:
+ *  1. the guest bundle is isolate-eligible — no Node builtin survives the
+ *     aliasing, which is the only cheap proof the artifact can load at all;
+ *  2. a turn against a provider that streams Server-Sent Events produces the
+ *     tokens ON THE HOST WHILE THE STREAM IS OPEN, not in one lump at the end
+ *     (what the subprocess lane visibly does, and the reason PR 3 taught
+ *     the lane to stream);
+ *  3. the transcript comes back with the turn appended, so the next turn can
+ *     resume from it;
+ *  4. the guest reaches the gateway host it was given and NOTHING else — an
+ *     agent turn runs deny-all, unlike a connector's open default.
+ *
+ * Runs under Node (vitest); like the other lane suites it FAILS rather than
+ * skips when `isolated-vm` cannot load.
+ */
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { agentGuestBundle } from "@lobu/connector-worker/agent-turn";
+import type { AgentTurnEvent, AgentTurnInput, AgentTurnOutput } from "@lobu/connector-worker/agent-turn";
+import type { ExecutorJob } from "@lobu/connector-worker/executor/interface";
+import { IsolateExecutor, type IsolateLogLevel } from "@lobu/connector-worker/executor/isolate";
+import { assertIsolateEligible } from "@lobu/connector-worker/isolate";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/** Requests the fake provider has answered. */
+interface ProviderHit {
+	url: string;
+	authorization: string | null;
+	apiKeyHeader: string | null;
+	body: string;
+}
+
+let guestCode: string;
+let server: Server;
+let port: number;
+let hits: ProviderHit[] = [];
+
+/** The gateway's own placeholder for the agent's provider key. */
+const GATEWAY_PLACEHOLDER = "lobu_secret_00000000-0000-4000-8000-000000000000";
+
+/**
+ * Resolved by the test when the HOST has seen its first token. The fake
+ * provider will not finish its response until then, so a lane that buffered the
+ * body and only handed the tokens over at the end would deadlock here rather
+ * than pass — which is the whole point of streaming the body.
+ */
+let sawFirstDelta: Promise<void> = Promise.resolve();
+let markFirstDelta: () => void = () => undefined;
+
+function armFirstDeltaGate(): void {
+	sawFirstDelta = new Promise<void>((resolve) => {
+		markFirstDelta = resolve;
+	});
+}
+
+/** One SSE frame per write, so the guest has to pull the body more than once. */
+async function writeAnthropicStream(res: Parameters<Parameters<typeof createServer>[0]>[1], pieces: string[]): Promise<void> {
+	res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+	const send = (type: string, data: unknown) => res.write(`event: ${type}\ndata: ${JSON.stringify(data)}\n\n`);
+	send("message_start", {
+		type: "message_start",
+		message: {
+			id: "msg_isolate",
+			type: "message",
+			role: "assistant",
+			model: "claude-test",
+			content: [],
+			stop_reason: null,
+			stop_sequence: null,
+			usage: { input_tokens: 11, output_tokens: 0 },
+		},
+	});
+	send("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } });
+	for (const piece of pieces) {
+		send("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: piece } });
+	}
+	await sawFirstDelta;
+	send("content_block_stop", { type: "content_block_stop", index: 0 });
+	send("message_delta", {
+		type: "message_delta",
+		delta: { stop_reason: "end_turn", stop_sequence: null },
+		usage: { output_tokens: 7 },
+	});
+	send("message_stop", { type: "message_stop" });
+	res.end();
+}
+
+beforeAll(async () => {
+	guestCode = await agentGuestBundle();
+	server = createServer((req, res) => {
+		const chunks: Buffer[] = [];
+		req.on("data", (c: Buffer) => chunks.push(c));
+		req.on("end", () => {
+			hits.push({
+				url: req.url ?? "",
+				authorization: (req.headers.authorization as string | undefined) ?? null,
+				apiKeyHeader: (req.headers["x-api-key"] as string | undefined) ?? null,
+				body: Buffer.concat(chunks).toString("utf8"),
+			});
+			void writeAnthropicStream(res, ["Hello", " from", " the", " isolate"]);
+		});
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	port = (server.address() as AddressInfo).port;
+}, 120_000);
+
+afterAll(async () => {
+	await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+function turnJob(input: Partial<AgentTurnInput> = {}, baseUrl?: string): ExecutorJob {
+	return {
+		mode: "agent_turn",
+		turn: {
+			provider: {
+				api: "anthropic-messages",
+				provider: "anthropic",
+				modelId: "claude-test",
+				baseUrl: baseUrl ?? `http://127.0.0.1:${port}`,
+				maxTokens: 64,
+			},
+			systemPrompt: "You are a test agent.",
+			messages: [],
+			userMessage: "hi",
+			...input,
+		},
+		config: {},
+		// What the gateway hands the subprocess lane today: its own placeholder,
+		// resolved by the secret-proxy, never a real key. The host mints a vault
+		// placeholder over it, so this exact string must still arrive upstream.
+		credentials: { provider: "anthropic", accessToken: GATEWAY_PLACEHOLDER },
+		sessionState: null,
+		env: {},
+	};
+}
+
+interface TurnRun {
+	events: AgentTurnEvent[];
+	logs: { level: IsolateLogLevel; line: string }[];
+	output: AgentTurnOutput;
+}
+
+async function runTurn(job: ExecutorJob, allowedDomains: readonly string[] = ["127.0.0.1"]): Promise<TurnRun> {
+	const events: AgentTurnEvent[] = [];
+	const logs: { level: IsolateLogLevel; line: string }[] = [];
+	const executor = new IsolateExecutor({
+		timeoutMs: 60_000,
+		allowedDomains,
+		logSink: (level, line) => logs.push({ level, line }),
+	});
+	const result = await executor.execute(guestCode, job, {
+		onTurnEvent: (event) => {
+			events.push(event);
+			if (event.type === "text_delta") markFirstDelta();
+		},
+	});
+	if (result.mode !== "agent_turn") throw new Error(`expected an agent_turn result, got ${result.mode}`);
+	return { events, logs, output: result.turn };
+}
+
+/** A turn the lane refused, with the run log that says why. */
+async function failTurn(
+	job: ExecutorJob,
+	allowedDomains: readonly string[],
+): Promise<{ error: Error; logs: { level: IsolateLogLevel; line: string }[] }> {
+	const logs: { level: IsolateLogLevel; line: string }[] = [];
+	const executor = new IsolateExecutor({
+		timeoutMs: 60_000,
+		allowedDomains,
+		logSink: (level, line) => logs.push({ level, line }),
+	});
+	const error = await executor.execute(guestCode, job, {}).then(
+		() => null,
+		(caught: unknown) => caught as Error,
+	);
+	if (!error) throw new Error("expected the agent turn to fail");
+	return { error, logs };
+}
+
+describe("agent turn on the isolate lane", () => {
+	it("bundles the agent guest with no Node builtin left in it", () => {
+		expect(guestCode.length).toBeGreaterThan(1_000_000);
+		expect(() => assertIsolateEligible(guestCode)).not.toThrow();
+	});
+
+	it("streams a turn: deltas reach the host while the response is still open", async () => {
+		hits = [];
+		armFirstDeltaGate();
+		const run = await runTurn(turnJob());
+
+		expect(run.output.text).toBe("Hello from the isolate");
+		expect(run.output.stopReason).toBe("stop");
+		expect(run.output.usage).toEqual({ input: 11, output: 7 });
+
+		const deltas = run.events.filter((e) => e.type === "text_delta");
+		expect(deltas.map((e) => (e as { delta: string }).delta)).toEqual(["Hello", " from", " the", " isolate"]);
+		expect(run.events.at(-1)).toEqual({ type: "message_end" });
+
+		// The response the deltas came from is the only request made, and the
+		// guest never saw a real key: it sent the gateway's placeholder.
+		expect(hits.length).toBe(1);
+		expect(hits[0]?.url).toBe("/v1/messages");
+		expect(hits[0]?.apiKeyHeader).toBe(GATEWAY_PLACEHOLDER);
+		expect(JSON.parse(hits[0]?.body ?? "{}")).toMatchObject({ model: "claude-test", system: expect.anything() });
+	}, 120_000);
+
+	it("returns the transcript with the turn appended so the next turn resumes from it", async () => {
+		hits = [];
+		armFirstDeltaGate();
+		const first = await runTurn(turnJob());
+		armFirstDeltaGate();
+		expect(first.output.messages.length).toBeGreaterThanOrEqual(2);
+		expect(first.output.messages[0]).toMatchObject({ role: "user" });
+		expect(first.output.messages.at(-1)).toMatchObject({ role: "assistant" });
+
+		// pi prices every assistant entry off the model's four cost keys. A model
+		// missing one puts NaN there, which JSON turns to null on the way to the
+		// run row — so the entry must be finite before it is ever persisted.
+		const priced = first.output.messages.at(-1) as {
+			usage?: { cost?: Record<string, number> };
+		};
+		expect(Object.values(priced.usage?.cost ?? {}).every(Number.isFinite)).toBe(true);
+
+		const second = await runTurn(turnJob({ messages: first.output.messages, userMessage: "and again" }));
+		expect(second.output.messages.length).toBe(first.output.messages.length + 2);
+		const sent = JSON.parse(hits.at(-1)?.body ?? "{}") as { messages: unknown[] };
+		expect(sent.messages.length).toBe(3);
+	}, 120_000);
+
+	it("runs deny-all: a turn cannot reach a host outside its allowlist", async () => {
+		hits = [];
+		const { error, logs } = await failTurn(turnJob(), ["gateway.invalid"]);
+
+		// The provider SDK reports every transport failure as one masked
+		// message, so the refusal is only legible in the run log — which is
+		// exactly where an operator looks, and why the lane logs it there.
+		expect(error.message).toBe("Connection error.");
+		expect(logs).toContainEqual({
+			level: "warn",
+			line: "egress denied: fetch to 127.0.0.1 is not permitted (this run may reach: gateway.invalid)",
+		});
+		expect(hits.length).toBe(0);
+	}, 120_000);
+
+	it("conceals the gateway's own credential from the guest and audits the spend", async () => {
+		hits = [];
+		armFirstDeltaGate();
+		const run = await runTurn(turnJob());
+
+		// Upstream got the gateway's placeholder, so the secret-proxy can still
+		// resolve it...
+		expect(hits[0]?.apiKeyHeader).toBe(GATEWAY_PLACEHOLDER);
+		// ...but what the guest held was a different, per-run placeholder, and the
+		// host recorded spending it. Same audit line a connector's OAuth token gets.
+		const spends = run.logs.filter((l) => l.line.startsWith("credential "));
+		expect(spends).toHaveLength(1);
+		expect(spends[0]?.line).toMatch(/^credential [0-9a-f]{12} spent on 127\.0\.0\.1 in header x-api-key$/);
+		expect(spends[0]?.line).not.toContain(GATEWAY_PLACEHOLDER.slice(-12));
+	}, 120_000);
+});

--- a/packages/server/src/__tests__/setup/test-db.ts
+++ b/packages/server/src/__tests__/setup/test-db.ts
@@ -557,7 +557,7 @@ async function fixSchemaConstraints(db: postgres.Sql): Promise<void> {
   try {
     // runs.run_type needs the connector lanes plus the lobu-queue lanes. Keep
     // this in sync with the latest constraint definition in
-    // db/migrations/20260816000010_automation_vocabulary.sql.
+    // db/migrations/20260905220000_runs_agent_turn_run_type.sql.
     //
     // This runs on every cleanupTestDatabase(), so a lane missing here is
     // re-narrowed away between tests: the migration applies at setup, the first
@@ -568,7 +568,7 @@ async function fixSchemaConstraints(db: postgres.Sql): Promise<void> {
       ALTER TABLE IF EXISTS runs ADD CONSTRAINT runs_run_type_check
         CHECK (run_type IN (
           'sync','action','automation','automation_eval','embed_backfill','auth',
-          'chat_message','schedule','agent_run','internal','task'
+          'chat_message','agent_turn','schedule','agent_run','internal','task'
         ));
     `);
     // connections.status needs 'pending_auth'

--- a/packages/server/src/gateway/orchestration/agent-turn-shadow.ts
+++ b/packages/server/src/gateway/orchestration/agent-turn-shadow.ts
@@ -1,0 +1,430 @@
+/**
+ * Shadow producer for the agent-turn isolate lane.
+ *
+ * A selected agent's turn is enqueued TWICE: once the ordinary way, to the
+ * subprocess worker that answers the conversation, and once as an `agent_turn`
+ * row the connector-worker fleet claims and runs inside an isolate. The shadow
+ * copy is observational — its reply is written to its own run row by
+ * `/api/workers/complete-agent-turn` and never reaches the client — so the two
+ * lanes can be compared on live traffic before the isolate lane becomes
+ * authoritative.
+ *
+ * Three things this producer must NOT do, each of which would corrupt the real
+ * turn rather than merely observe it:
+ *
+ *  - Arm a turn-timeout marker. The marker is keyed
+ *    `(deploymentName, messageId)` and discharged first-writer-wins, so a
+ *    second marker for the same turn would let the shadow's outcome terminate
+ *    the client's stream.
+ *  - Write an `agent_run_input` journal row. Same key, same collision: a
+ *    replay would resume the wrong lane.
+ *  - Use a run type inside `LOBU_RUN_TYPES`. `agent_turn` is deliberately
+ *    outside it, so `RunsQueue` never claims or completes these rows.
+ *
+ * Everything here is best-effort. `enqueueAgentTurnShadow` never throws into
+ * the enqueue path, and the caller runs it AFTER the real message is on the
+ * worker queue, so a shadow that cannot be produced costs the turn nothing.
+ *
+ * Selection is the operator env var `LOBU_ISOLATE_TURN_SHADOW_AGENTS`
+ * (comma-separated agent ids, or `*`). It is an operator switch for a
+ * short-lived overlap, not a product surface, so it is deliberately not an
+ * agent column.
+ */
+
+import {
+  createLogger,
+  entryToMessage,
+  getErrorMessage,
+  type MessagePayload,
+  parseSessionEntries,
+  resolveSdkCompat,
+} from "@lobu/core";
+import { getDb } from "../../db/client.js";
+import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
+import type { ProviderCatalogService } from "../auth/provider-catalog.js";
+import type { ModelProviderModule } from "../modules/module-system.js";
+import {
+  readSnapshotJsonl,
+  transcriptText,
+} from "../services/transcript-snapshot.js";
+
+const logger = createLogger("agent-turn-shadow");
+
+const SHADOW_AGENTS_ENV = "LOBU_ISOLATE_TURN_SHADOW_AGENTS";
+
+/**
+ * pi-ai's two fetch-native adapters. Every other protocol in
+ * `SDK_COMPAT_PROTOCOLS` reaches its upstream through a Node-bound SDK, which
+ * cannot be bundled for the isolate — so those agents simply produce no shadow.
+ */
+const LANE_APIS = new Set(["anthropic-messages", "openai-completions"]);
+
+/** Snapshot suffix read for history. Twelve 16 KB messages fit comfortably. */
+const HISTORY_TAIL_CHARS = 256 * 1024;
+const HISTORY_MESSAGE_LIMIT = 12;
+const HISTORY_MESSAGE_CHARS = 16_000;
+const TURN_MESSAGE_CHARS = 32_000;
+
+export interface AgentTurnShadowDeps {
+  /** Reads the agent's identity/soul/user layers. Absent → no shadow. */
+  agentSettings?: AgentSettingsStore;
+  /** Resolves the agent's provider modules. Absent → no shadow. */
+  catalog?: ProviderCatalogService;
+  /**
+   * Externally reachable gateway origin the fleet worker resolves the secret
+   * proxy on. Injected rather than read here so the caller owns the lookup: the
+   * canonical accessor memoizes `PUBLIC_GATEWAY_URL` for the life of the
+   * process, which a caller under test cannot vary without reaching into that
+   * cache. Absent → no shadow, because there is no URL to hand the worker.
+   */
+  publicOrigin?: string;
+}
+
+function shadowSelects(agentId: string): boolean {
+  const raw = process.env[SHADOW_AGENTS_ENV]?.trim();
+  if (!raw) return false;
+  if (raw === "*") return true;
+  return raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .includes(agentId);
+}
+
+/**
+ * The system prompt for the shadow turn.
+ *
+ * DELIBERATELY REDUCED: the subprocess lane's prompt also carries platform,
+ * network, skills and MCP instruction blocks, none of which the isolate lane
+ * can act on yet (it has no tools). Composing only the three agent layers keeps
+ * the comparison honest about what the lane can currently do, and matches the
+ * worker's own section headings (`composeAgentInstructions`) so the identity
+ * text itself is byte-identical.
+ */
+function composeShadowSystemPrompt(layers: {
+  identityMd?: string | null;
+  soulMd?: string | null;
+  userMd?: string | null;
+}): string {
+  const sections: string[] = [];
+  const identity = layers.identityMd?.trim();
+  const soul = layers.soulMd?.trim();
+  const user = layers.userMd?.trim();
+  if (identity) sections.push(`## Agent Identity\n\n${identity}`);
+  if (soul) sections.push(`## Agent Instructions\n\n${soul}`);
+  if (user) sections.push(`## User Context\n\n${user}`);
+  return sections.join("\n\n");
+}
+
+/**
+ * Rebuild the conversation so far as pi messages.
+ *
+ * The snapshot stores pi's own entries, but a stored assistant entry carries
+ * provider bookkeeping (usage, stop reason, tool calls) that this lane cannot
+ * replay faithfully, so history is flattened to text and re-wrapped in the
+ * minimal shapes pi's provider adapters read: `role` plus `content`. Tool
+ * calls and their results are dropped with the rest — the shadow lane has no
+ * tools, so replaying a tool call would produce a transcript the turn could
+ * never have made.
+ */
+function historyMessages(snapshot: string, model: {
+  api: string;
+  provider: string;
+  modelId: string;
+}): Record<string, unknown>[] {
+  const timestamp = 0;
+  return parseSessionEntries(snapshot)
+    .entries.flatMap((entry): Record<string, unknown>[] => {
+      const message = entryToMessage(entry);
+      if (
+        message?.type !== "message" ||
+        (message.role !== "user" && message.role !== "assistant")
+      ) {
+        return [];
+      }
+      const text = transcriptText(message.content).slice(
+        0,
+        HISTORY_MESSAGE_CHARS
+      );
+      if (!text) return [];
+      if (message.role === "user") {
+        return [{ role: "user", content: text, timestamp }];
+      }
+      return [
+        {
+          role: "assistant",
+          content: [{ type: "text", text }],
+          api: model.api,
+          provider: model.provider,
+          model: model.modelId,
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "stop",
+          timestamp,
+        },
+      ];
+    })
+    .slice(-HISTORY_MESSAGE_LIMIT);
+}
+
+/**
+ * Strip the provider prefix Lobu stores model refs under, so the upstream sees
+ * its own bare model id.
+ *
+ * Exactly one prefix comes off, and only the resolved provider's own — its Lobu
+ * id (`claude`) or its upstream slug (`anthropic`). A foreign inner namespace
+ * (OpenRouter's `anthropic/claude-sonnet-4`) is left intact, the same rule the
+ * worker's `resolveModelRef` applies.
+ */
+function bareModelId(
+  ref: string,
+  providerId: string,
+  upstreamSlug: string | undefined
+): string {
+  for (const prefix of [providerId, upstreamSlug]) {
+    if (prefix && ref.startsWith(`${prefix}/`)) {
+      return ref.slice(prefix.length + 1);
+    }
+  }
+  return ref;
+}
+
+interface ShadowProvider {
+  api: string;
+  provider: string;
+  modelId: string;
+  baseUrl: string;
+  credential: string;
+  host: string;
+}
+
+/**
+ * Resolve the provider exactly the way the subprocess lane's session context
+ * does: the agent's installed modules, the module that owns the requested
+ * model, its agent-scoped secret-proxy URL and its credential placeholder.
+ *
+ * Returns null (with one log line) whenever the turn is not shadowable, which
+ * is a normal outcome, not a failure: an agent on Google or Bedrock, a provider
+ * with no proxy route, a credential the gateway cannot placeholder.
+ */
+async function resolveShadowProvider(
+  module: ModelProviderModule,
+  args: {
+    agentId: string;
+    organizationId: string;
+    userId: string;
+    modelRef: string;
+    publicOrigin: string;
+  }
+): Promise<ShadowProvider | null> {
+  const protocol = resolveSdkCompat(module.sdkCompat);
+  if (!protocol || !LANE_APIS.has(protocol.api)) {
+    logger.info(
+      { agentId: args.agentId, provider: module.providerId, api: protocol?.api ?? null },
+      "Agent turn shadow skipped: the provider's protocol has no fetch-native adapter on the isolate lane"
+    );
+    return null;
+  }
+
+  const context = {
+    organizationId: args.organizationId,
+    userId: args.userId,
+  };
+  const mappings = module.getProxyBaseUrlMappings(
+    `${args.publicOrigin}/api/proxy`,
+    args.agentId,
+    context
+  );
+  // Every module maps its base URL under one or more env-var names that all
+  // carry the SAME URL (openai publishes a second alias). More than one
+  // DISTINCT URL would mean the module routes by key, which this producer
+  // cannot express in a single `base_url`.
+  const routes = [...new Set(Object.values(mappings))];
+  if (routes.length !== 1) {
+    logger.info(
+      { agentId: args.agentId, provider: module.providerId, routes: routes.length },
+      "Agent turn shadow skipped: the provider does not publish exactly one proxy base URL"
+    );
+    return null;
+  }
+  const baseUrl = routes[0];
+
+  const credential = module.buildCredentialPlaceholder
+    ? await module.buildCredentialPlaceholder(args.agentId, context)
+    : "lobu-proxy";
+  if (!credential) {
+    logger.info(
+      { agentId: args.agentId, provider: module.providerId },
+      "Agent turn shadow skipped: the provider produced no credential placeholder"
+    );
+    return null;
+  }
+
+  let host: string;
+  try {
+    host = new URL(baseUrl).hostname;
+  } catch {
+    logger.warn(
+      { agentId: args.agentId, provider: module.providerId },
+      "Agent turn shadow skipped: the provider's proxy base URL does not parse"
+    );
+    return null;
+  }
+
+  return {
+    api: protocol.api,
+    provider: protocol.registryAlias,
+    modelId: bareModelId(
+      args.modelRef,
+      module.providerId,
+      module.getUpstreamConfig?.()?.slug
+    ),
+    baseUrl,
+    credential,
+    host,
+  };
+}
+
+/**
+ * Produce the shadow `agent_turn` run for this message, when one is selected
+ * and resolvable. Never throws: the caller has already delivered the real turn.
+ */
+export async function enqueueAgentTurnShadow(
+  data: MessagePayload,
+  deps: AgentTurnShadowDeps
+): Promise<void> {
+  try {
+    if (!data.agentId || !shadowSelects(data.agentId)) return;
+    if (!data.organizationId) return;
+
+    // An attachment-only message has no text for this lane to send, and both
+    // providers reject an empty user turn — so it would enqueue a run that can
+    // only fail. The isolate lane carries no attachments yet.
+    if (!data.messageText?.trim()) {
+      logger.info(
+        { agentId: data.agentId, messageId: data.messageId },
+        "Agent turn shadow skipped: the message carries no text for the turn to send"
+      );
+      return;
+    }
+
+    const modelRef = data.agentOptions?.model?.trim();
+    if (!modelRef) {
+      logger.info(
+        { agentId: data.agentId },
+        "Agent turn shadow skipped: this turn carries no resolved model, and the shadow does not re-run the worker's default resolution"
+      );
+      return;
+    }
+
+    const catalog = deps.catalog;
+    const agentSettings = deps.agentSettings;
+    if (!catalog || !agentSettings) {
+      logger.info(
+        { agentId: data.agentId },
+        "Agent turn shadow skipped: the provider catalog or the agent settings store is not wired yet"
+      );
+      return;
+    }
+
+    const publicOrigin = deps.publicOrigin;
+    if (!publicOrigin) {
+      logger.info(
+        { agentId: data.agentId },
+        "Agent turn shadow skipped: PUBLIC_GATEWAY_URL is not configured, so there is no URL the fleet worker can reach the proxy on"
+      );
+      return;
+    }
+
+    const modules = await catalog.getInstalledModules(
+      data.agentId,
+      data.organizationId
+    );
+    const module = await catalog.findProviderForModel(modelRef, modules);
+    if (!module) {
+      logger.info(
+        { agentId: data.agentId, model: modelRef },
+        "Agent turn shadow skipped: no installed provider owns this model"
+      );
+      return;
+    }
+
+    const provider = await resolveShadowProvider(module, {
+      agentId: data.agentId,
+      organizationId: data.organizationId,
+      userId: data.userId,
+      modelRef,
+      publicOrigin,
+    });
+    if (!provider) return;
+
+    const settings = await agentSettings.getSettings(data.agentId, {
+      organizationId: data.organizationId,
+    });
+    const snapshot = await readSnapshotJsonl({
+      organizationId: data.organizationId,
+      agentId: data.agentId,
+      conversationId: data.conversationId,
+      suffixChars: HISTORY_TAIL_CHARS,
+    });
+
+    const turn = {
+      agent_id: data.agentId,
+      conversation_id: data.conversationId,
+      message_id: data.messageId,
+      message_text: data.messageText.slice(0, TURN_MESSAGE_CHARS),
+      system_prompt: composeShadowSystemPrompt(settings ?? {}),
+      messages: snapshot ? historyMessages(snapshot, provider) : [],
+      provider: {
+        api: provider.api,
+        provider: provider.provider,
+        model_id: provider.modelId,
+        base_url: provider.baseUrl,
+      },
+      // DENY-ALL. A connector's allowlist defaults open; an agent turn's does
+      // not. The gateway proxy is the only host this turn has any business
+      // reaching, and the provider is behind it.
+      allowed_hosts: [provider.host],
+      shadow: true,
+    };
+
+    const sql = getDb();
+    const rows = await sql<{ id: number }>`
+      INSERT INTO runs (
+        organization_id, run_type, status,
+        approval_status, action_input, created_at
+      ) VALUES (
+        ${data.organizationId}, 'agent_turn', 'pending',
+        'auto', ${sql.json({ turn, credential: provider.credential })},
+        current_timestamp
+      )
+      RETURNING id
+    `;
+
+    logger.info(
+      {
+        runId: rows[0]?.id,
+        agentId: data.agentId,
+        messageId: data.messageId,
+        provider: provider.provider,
+        model: provider.modelId,
+        history: turn.messages.length,
+      },
+      "Enqueued a shadow agent turn on the isolate lane"
+    );
+  } catch (err) {
+    // A shadow is never worth a real turn. The message is already on the
+    // worker queue by the time this runs, so the only correct response to any
+    // failure here is a log line.
+    logger.warn(
+      { agentId: data.agentId, messageId: data.messageId, err: getErrorMessage(err) },
+      "Agent turn shadow could not be produced"
+    );
+  }
+}

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -34,6 +34,7 @@ import {
 } from "../infrastructure/queue/index.js";
 import { armTurnTimeout, failTurnIfPending } from "./turn-liveness.js";
 import { recordAgentRunInput } from "./agent-run-input.js";
+import { enqueueAgentTurnShadow } from "./agent-turn-shadow.js";
 import {
   buildCanonicalConversationKey,
   type DeploymentManager,
@@ -41,6 +42,7 @@ import {
   type OrchestratorConfig,
 } from "./deployment-manager.js";
 import { buildWorkerTokenClaims } from "./worker-token-claims.js";
+import { getConfiguredPublicOrigin } from "../../utils/public-origin.js";
 import { resolvePinnedSelection } from "../../lobu/stores/sandbox-store.js";
 import { threadIdFromApiConversationId } from "../services/api-conversation-id.js";
 import {
@@ -598,6 +600,18 @@ export class MessageConsumer {
         { traceId, traceparent: childTraceparent, deploymentName },
         "Enqueued message to thread queue"
       );
+
+      // 1b) Shadow the same turn onto the isolate lane when the operator has
+      // selected this agent. Deliberately AFTER the real send: the message is
+      // already on the worker queue, so nothing here can delay or fail the turn
+      // it observes. `enqueueAgentTurnShadow` never throws, and for an agent the
+      // operator has not selected it returns on an env-var read before touching
+      // the database — the unselected path costs the enqueue nothing.
+      await enqueueAgentTurnShadow(data, {
+        agentSettings: this.agentSettingsStore,
+        catalog: this.deploymentManager.getProviderCatalogService?.(),
+        publicOrigin: getConfiguredPublicOrigin(),
+      });
 
       // 2) Ensure worker exists in the background (don't block queue send)
       // Pass traceparent for propagation to worker deployment

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -601,18 +601,6 @@ export class MessageConsumer {
         "Enqueued message to thread queue"
       );
 
-      // 1b) Shadow the same turn onto the isolate lane when the operator has
-      // selected this agent. Deliberately AFTER the real send: the message is
-      // already on the worker queue, so nothing here can delay or fail the turn
-      // it observes. `enqueueAgentTurnShadow` never throws, and for an agent the
-      // operator has not selected it returns on an env-var read before touching
-      // the database — the unselected path costs the enqueue nothing.
-      await enqueueAgentTurnShadow(data, {
-        agentSettings: this.agentSettingsStore,
-        catalog: this.deploymentManager.getProviderCatalogService?.(),
-        publicOrigin: getConfiguredPublicOrigin(),
-      });
-
       // 2) Ensure worker exists in the background (don't block queue send)
       // Pass traceparent for propagation to worker deployment
       this.ensureWorkerExists(
@@ -671,6 +659,22 @@ export class MessageConsumer {
             logger.error("Failed to track deployment failure:", trackError);
           }
         );
+      });
+
+      // 3) Shadow the same turn onto the isolate lane when the operator has
+      // selected this agent. It observes the turn queued above and never
+      // reaches the conversation, so it goes last: `ensureWorkerExists` is
+      // fired-and-forgotten precisely so a cold worker starts booting without
+      // waiting on anything, and the shadow's own work (catalog, provider
+      // resolution, agent settings, snapshot read, INSERT) is several round
+      // trips that must not sit in front of that boot.
+      // `enqueueAgentTurnShadow` never throws, and for an agent the operator
+      // has not selected it returns on an env-var read before touching the
+      // database — the unselected path costs the enqueue nothing.
+      await enqueueAgentTurnShadow(data, {
+        agentSettings: this.agentSettingsStore,
+        catalog: this.deploymentManager.getProviderCatalogService?.(),
+        publicOrigin: getConfiguredPublicOrigin(),
       });
 
       queueSpan?.setStatus({ code: SpanStatusCode.OK });

--- a/packages/server/src/gateway/services/transcript-snapshot.ts
+++ b/packages/server/src/gateway/services/transcript-snapshot.ts
@@ -44,3 +44,27 @@ export async function readSnapshotJsonl(args: {
   `;
 	return rows[0]?.snapshot_jsonl ?? null;
 }
+
+/**
+ * Flatten one transcript entry's `content` to plain text.
+ *
+ * A snapshot entry carries either a bare string or pi's block array, and every
+ * consumer that rebuilds a conversation from a snapshot (the device-chat poll
+ * envelope, the isolate turn's history) needs the same reduction: text blocks
+ * joined, everything else dropped. Kept here with the reader so the two do not
+ * drift.
+ */
+export function transcriptText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.map((part) =>
+			part &&
+			typeof part === "object" &&
+			(part as Record<string, unknown>).type === "text"
+				? String((part as Record<string, unknown>).text ?? "")
+				: ""
+		)
+		.filter(Boolean)
+		.join("\n");
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -731,6 +731,7 @@ app.route("/api", createSkillRoutes());
 import {
 	activatePageRun,
 	completeActionRun,
+	completeAgentTurnRun,
 	completeAuthRun,
 	completeEmbeddings,
 	completeAutomationRun,
@@ -926,6 +927,9 @@ app.post("/api/workers/heartbeat", heartbeat);
 app.post("/api/workers/stream", streamContent);
 app.post("/api/workers/complete", completeWorkerJob);
 app.post("/api/workers/complete-action", completeActionRun);
+// Fleet-only, deliberately absent from `allowedPathsForUserWorker`: an agent
+// turn carries the organization's provider proxy and never runs on a device.
+app.post("/api/workers/complete-agent-turn", completeAgentTurnRun);
 
 // Bridge that lets connector-worker fleets dispatch chrome connector actions
 // against a paired Owletto extension. See dispatch-chrome-action.ts.

--- a/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
+++ b/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
@@ -52,7 +52,13 @@ interface SeedRunOpts {
 	status: "pending" | "claimed" | "running" | "completed";
 	lastHeartbeatAgoSeconds: number | null;
 	claimedAtAgoSeconds?: number | null;
-	runType?: "sync" | "action" | "embed_backfill" | "auth" | "automation";
+	runType?:
+		| "sync"
+		| "action"
+		| "embed_backfill"
+		| "auth"
+		| "automation"
+		| "agent_turn";
 	feedId?: number | null;
 	createdAtAgoSeconds?: number;
 	/** Defaults to 'auto' (worker-claimable). Set 'pending' for a human-approval run. */
@@ -1139,5 +1145,34 @@ describe("reapStaleRuns — dry runs are reaped but never resurrected", () => {
       FROM feeds WHERE id = ${feedId}
     `) as unknown as Array<Record<string, unknown>>;
 		expect(after).toEqual(before);
+	});
+});
+
+describe("agent turn lane", () => {
+	test("reaps a stale agent turn and leaves a heartbeating one running", async () => {
+		// The isolate turn lane runs on the SAME worker with the same claim and
+		// heartbeat contract, so it belongs to this sweep. Without it a crashed
+		// fleet worker leaves the turn `running` for good.
+		const stale = await seedRun({
+			status: "running",
+			runType: "agent_turn",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 2,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+		});
+		const live = await seedRun({
+			status: "running",
+			runType: "agent_turn",
+			lastHeartbeatAgoSeconds: 1,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+		});
+
+		const result = await reapStaleRuns();
+
+		expect(result.reaped).toBe(1);
+		expect(await statusOf(stale)).toBe("timeout");
+		expect(await statusOf(live)).toBe("running");
+		// The retry arm is sync-only: a turn is never re-run behind the user's
+		// back, it just ends.
+		expect(result.retriesCreated).toBe(0);
 	});
 });

--- a/packages/server/src/scheduled/check-stalled-executions.ts
+++ b/packages/server/src/scheduled/check-stalled-executions.ts
@@ -212,7 +212,10 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
   // the executor beat at least once; rows with none are judged on
   // COALESCE(claimed_at, created_at). One threshold covers both paths.
   const staleWhereSql = buildStaleRunWhereSql({
-    runTypes: ['sync', 'action', 'embed_backfill', 'auth'],
+    // `agent_turn` joins the connector lanes because it runs on the SAME
+    // worker with the same claim + heartbeat contract; without it a crashed
+    // fleet worker leaves the turn `running` forever.
+    runTypes: ['sync', 'action', 'embed_backfill', 'auth', 'agent_turn'],
     heartbeatSemantics: 'any-heartbeat',
     heartbeatStaleInterval: `${thresholdSeconds} seconds`,
     coarseStaleInterval: `${thresholdSeconds} seconds`,

--- a/packages/server/src/scheduled/embedded-connector-worker.ts
+++ b/packages/server/src/scheduled/embedded-connector-worker.ts
@@ -65,7 +65,10 @@ export function startEmbeddedConnectorWorker(
       // dispatch db-egress-hardened connector runs (e.g. postgres) here. This
       // in-process worker ships the same code as the gateway, so it always
       // folds in the gateway's authoritative db_egress_policy.
-      capabilities: { db_egress_hardening: true },
+      // ...and the agent-turn lane, which runs Lobu's own guest bundle through
+      // the same isolate executor. Advertising it is what lets the gateway
+      // hand this process an `agent_turn` row at all.
+      capabilities: { db_egress_hardening: true, agent_turn: true },
       pollIntervalMs: intervals.embeddedWorkerPollIntervalMs,
       maxConcurrentJobs: 1,
     },

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -10,8 +10,11 @@
 
 // Polling (device registration + run claiming)
 export { pollWorkerJob } from './worker-api/poll';
-export { completeDeviceChatRun } from './worker-api/device-chat';
 export { activatePageRun } from './worker-api/page-activation';
+
+// Lanes that own their completion route instead of /api/workers/complete
+export { completeAgentTurnRun } from './worker-api/agent-turn';
+export { completeDeviceChatRun } from './worker-api/device-chat';
 
 // Run lifecycle (heartbeat, stream, complete, Automation/auth/action/embedding)
 export {

--- a/packages/server/src/worker-api/agent-turn.ts
+++ b/packages/server/src/worker-api/agent-turn.ts
@@ -1,0 +1,114 @@
+/**
+ * Completion for an agent turn run.
+ *
+ * A shadow turn reports what the isolate produced and stops there: the
+ * conversation's reply still comes from the subprocess lane, so nothing here
+ * writes a thread response, a transcript snapshot or a turn marker. What it
+ * does write is the transcript the turn produced, onto the run row, which is
+ * how the two lanes are compared while the shadow runs.
+ *
+ * When the lane becomes authoritative this is where the reply and the snapshot
+ * join, on the same fenced terminal transition.
+ */
+import {
+	type CompleteAgentTurnRequest,
+	CompleteAgentTurnRequestSchema,
+} from "@lobu/core/contracts/worker/protocol";
+import { Value } from "@sinclair/typebox/value";
+import type { Context } from "hono";
+import { getDb } from "../db/client";
+import type { Env } from "../index";
+import { runLeaseFence } from "../runs/run-lease";
+import { stripNul } from "../utils/strip-nul";
+import { authorizeRunForWorker } from "./shared";
+
+/** What of the turn's own text is kept on the run row for the shadow diff. */
+const MAX_OUTPUT_TAIL = 2_000;
+
+export async function completeAgentTurnRun(c: Context<{ Bindings: Env }>) {
+	let rawBody: unknown;
+	try {
+		rawBody = await c.req.json();
+	} catch {
+		return c.json({ error: "Invalid or missing JSON body" }, 400);
+	}
+	if (!Value.Check(CompleteAgentTurnRequestSchema, rawBody)) {
+		return c.json({ error: "Invalid agent turn completion body" }, 400);
+	}
+	const body = rawBody as CompleteAgentTurnRequest;
+	// Fleet-only lane, so this waves the token through and the run's own
+	// claimed_by/status read below is what enforces ownership and idempotency.
+	const denied = await authorizeRunForWorker(c, body.run_id, body.worker_id);
+	if (denied) return denied;
+
+	const sql = getDb();
+	const rows = await sql<{
+		status: string;
+		claimed_by: string | null;
+		action_input: Record<string, unknown> | null;
+	}>`
+    SELECT status, claimed_by, action_input
+    FROM public.runs
+    WHERE id = ${body.run_id}
+      AND run_type = 'agent_turn'
+    LIMIT 1
+  `;
+	const run = rows[0];
+	if (!run) return c.json({ error: "Agent turn run not found" }, 404);
+	if (run.claimed_by !== body.worker_id || run.status !== "running") {
+		return c.json({
+			ok: true,
+			status: run.status === "completed" ? "completed" : "failed",
+			idempotent: true,
+		});
+	}
+
+	// `turn.shadow` is the run's own statement about what its reply is FOR, and
+	// this is the gate that gives it force. Today every producer sets it, and
+	// the only thing this endpoint does with a reply is record it. A turn that
+	// declared itself authoritative would therefore have its reply silently
+	// dropped, so refuse it instead: whichever PR wires the reply path lands
+	// that publish and this branch together.
+	const envelope = (run.action_input ?? {}) as { turn?: { shadow?: unknown } };
+	if (envelope.turn?.shadow !== true) {
+		return c.json(
+			{
+				error:
+					"Agent turn runs are observational: this endpoint records a reply, it does not deliver one",
+			},
+			409
+		);
+	}
+
+	const failed = body.status === "failed";
+	const error = typeof body.error === "string" ? stripNul(body.error).trim() : "";
+	const text = typeof body.text === "string" ? stripNul(body.text) : "";
+	// The turn's own output goes back on the row it came from, so a shadow run
+	// is diffable against the subprocess reply without a second table.
+	const result = {
+		...(run.action_input ?? {}),
+		result: {
+			text,
+			stop_reason: body.stop_reason ?? null,
+			usage: body.usage ?? null,
+			transcript: body.transcript ?? [],
+		},
+	};
+
+	const transitioned = await sql`
+    UPDATE public.runs
+    SET status = ${failed ? "failed" : "completed"},
+        completed_at = current_timestamp,
+        error_message = ${failed ? error || "agent turn failed" : null},
+        output_tail = ${text ? text.slice(-MAX_OUTPUT_TAIL) : null},
+        exit_reason = ${body.exit_reason ?? (failed ? "error_message" : "ok")},
+        action_input = ${sql.json(result)}
+    WHERE id = ${body.run_id}
+      ${runLeaseFence(sql, body.worker_id)}
+    RETURNING id
+  `;
+	if (transitioned.length === 0) {
+		return c.json({ ok: true, status: failed ? "failed" : "completed", idempotent: true });
+	}
+	return c.json({ ok: true, status: failed ? "failed" : "completed" });
+}

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -31,7 +31,10 @@ import {
   buildAutomationRunWorkerAccess,
   buildDeviceChatRunWorkerAccess,
 } from '../gateway/services/run-worker-access';
-import { readSnapshotJsonl } from '../gateway/services/transcript-snapshot';
+import {
+  readSnapshotJsonl,
+  transcriptText,
+} from '../gateway/services/transcript-snapshot';
 import { resolvePublicOrigin } from '../utils/public-origin';
 import { getDb, parsePgTextArray, pgTextArray } from '../db/client';
 import type { Outputs } from '../types/automations';
@@ -89,21 +92,6 @@ const DEVICE_CHAT_DISPATCH_ERROR =
   'The selected device could not start this message.';
 
 const DUE_FEEDS_LOCK_KEY = 71001;
-
-function transcriptText(content: unknown): string {
-  if (typeof content === 'string') return content;
-  if (!Array.isArray(content)) return '';
-  return content
-    .map((part) =>
-      part &&
-      typeof part === 'object' &&
-      (part as Record<string, unknown>).type === 'text'
-        ? String((part as Record<string, unknown>).text ?? '')
-        : ''
-    )
-    .filter(Boolean)
-    .join('\n');
-}
 
 /**
  * Fail a run that this worker already claimed. Approval-gated actions also
@@ -457,6 +445,15 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // apply. Gated in the shared fleet claim lane; only active in cloud mode.
   const workerHardensDbEgress = capabilities.db_egress_hardening === true;
 
+  // An agent turn runs Lobu's own agent-session guest bundle through
+  // IsolateExecutor. `executeRun`'s default arm is a connector sync, so a
+  // daemon that predates this lane would claim the row and then fail it as a
+  // malformed connector run. Gate the claim on the worker SAYING it can run
+  // one: the two sides agree by string equality, so an old worker simply never
+  // matches. Fleet only — an agent turn carries the org's provider proxy and
+  // has no business on a user's device.
+  const workerRunsAgentTurns = capabilities.agent_turn === true;
+
   // Device-worker registry: upsert device_workers row for user-scoped workers
   // so /api/me/devices can enumerate them. Also ensure advertised capability
   // connectors are fully wired. Best-effort — never fail the poll.
@@ -779,6 +776,12 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
                 runManifestHash: tx`run_cv.artifact_hash`,
                 runRuntime: tx`cd.run_runtime`,
               })}
+            )
+            -- (1a) Agent turns: one conversation turn as one isolate job.
+            --      Fleet-only, and only for a worker that advertises the lane.
+            OR (
+              ${!isUserScopedWorker && workerRunsAgentTurns}
+              AND r.run_type = 'agent_turn'
             )
             -- (1b) Embedding backfills have no connector identity. They are
             -- server-side work and may only be claimed by the trusted fleet.
@@ -1165,6 +1168,47 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // therefore into the hash, so one contract could not be served by two
   // endpoints.
   const isDeviceOwnedRun = isUserScopedWorker && row.connector_manifest_backed;
+
+  // An agent turn ships its whole envelope in `action_input`: the producer
+  // already resolved the model, the prompt, the transcript and the gateway
+  // proxy, so there is nothing for the poll to look up. The provider
+  // credential is lifted OUT of the payload and onto the response's
+  // `credentials`, so the worker host conceals it behind a per-run placeholder
+  // the way it does a connector's OAuth token — the guest never sees either.
+  if (row.run_type === 'agent_turn') {
+    const envelope = (row.action_input ?? {}) as {
+      turn?: Record<string, unknown>;
+      credential?: unknown;
+    };
+    const turn = envelope.turn;
+    const credential = envelope.credential;
+    if (!turn || typeof credential !== 'string' || credential.length === 0) {
+      const failure = 'agent turn run has an incomplete execution envelope';
+      await failClaimedWorkerRun({
+        runId: row.run_id,
+        workerId: worker_id,
+        errorMessage: failure,
+      });
+      logger.error({ run_id: row.run_id }, failure);
+      return c.json({
+        next_poll_seconds: 1,
+        skipped_run_id: row.run_id,
+        error: failure,
+        ...pollMetadata,
+      });
+    }
+    return c.json({
+      ...pollMetadata,
+      run_id: row.run_id,
+      run_type: 'agent_turn',
+      organization_id: row.organization_id,
+      payload: { turn },
+      credentials: {
+        provider: String((turn.provider as { provider?: unknown } | undefined)?.provider ?? 'unknown'),
+        accessToken: credential,
+      },
+    });
+  }
 
   // Device chat reuses the ordinary messages/chat_message row. The poll
   // response is only an execution envelope: ownership/routing remain on the

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -928,15 +928,33 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 		if (denied) return denied;
 
 		const sql = getDb();
-		const deviceChat = await sql<{ id: number }>`
-      SELECT id FROM runs
+		// The two lanes that own their own completion route, resolved in ONE
+		// primary-key read: this runs on every generic completion, so each extra
+		// round trip is paid by every connector run.
+		const [dedicatedLane] = await sql<{
+			agent_turn: boolean;
+			device_chat: boolean;
+		}>`
+      SELECT
+        run_type = 'agent_turn' AS agent_turn,
+        (run_type = 'chat_message'
+          AND queue_name = 'messages'
+          AND action_input->'executionTarget'->>'kind' = 'device') AS device_chat
+      FROM runs
       WHERE id = ${req.run_id}
-        AND run_type = 'chat_message'
-        AND queue_name = 'messages'
-        AND action_input->'executionTarget'->>'kind' = 'device'
       LIMIT 1
     `;
-		if (deviceChat.length > 0) {
+		if (dedicatedLane?.agent_turn) {
+			// An agent turn carries a transcript and a reply; finalizing it with
+			// sync semantics would drop both and mark the turn done. Same shape as
+			// the device-chat guard below: refuse, leave the run in progress, and
+			// let the lane's own endpoint (or the stale-run reaper) terminalize it.
+			return c.json(
+				{ error: "Agent turn runs must use the complete-agent-turn endpoint" },
+				409
+			);
+		}
+		if (dedicatedLane?.device_chat) {
 			// Device chat has a dedicated completion adapter that persists the
 			// transcript and publishes the thread_response awaited by Activity. Keep
 			// the run in progress when an older daemon calls the generic sync route;


### PR DESCRIPTION
## Summary

- Runs one pi agent conversation turn as an **isolate job on the connector worker**, reusing the lane the connectors already use: the same egress dispatcher, credential vault, streaming fetch, wall clock, memory limit, log budget and terminal machine. There is no second executor — the turn is a new `agent_turn` mode on `ExecutorJob`.
- Ships the lane in **shadow mode**. A selected agent's message is enqueued twice: once the ordinary way to the subprocess worker that answers the conversation, and once as an `agent_turn` run the fleet claims. The shadow's reply lands on its own run row and never reaches the client, so the two lanes can be compared on live traffic.
- Selection is the operator env var `LOBU_ISOLATE_TURN_SHADOW_AGENTS` (comma-separated agent ids, or `*`). Nothing is produced when it is unset.

### What the guest needed

`prelude.ts` gains a `FormData` global. The Anthropic and OpenAI SDKs evaluate `body instanceof FormData` **unguarded on every request**, so without the constructor a guest cannot reach any provider at all. It holds text fields only and encodes to multipart at `extractBody`.

### The bug this found

`concealCredentials` ran its "this placeholder was not minted by this run" guard on the value **after** the swap. That is wrong whenever the resolved secret is itself placeholder-shaped — which is exactly an agent turn, whose provider key is the gateway's own `lobu_secret_` placeholder. The guard now runs on what the guest sent, with well-formed matches stripped, before the swap. Mutation-proved: the old guard fails 3 agent-turn tests while all 8 credential unit tests stay green.

### Safety

- **Deny-all egress.** A connector's allowlist defaults open; an agent turn's does not. `allowed_hosts` is the gateway proxy host and nothing else, so a prompt-injected turn cannot reach the internet.
- **No real credential.** The worker receives the gateway's own placeholder on `credentials.accessToken`; the host mints a per-run vault placeholder over it, and the guest only ever sees the vault's. One audit line per spend.
- **Fleet-only, capability-gated claim.** `executeRun`'s default arm is `executeSyncRun`, so an older daemon that could claim an `agent_turn` would try to run it as a connector sync. The claim requires `capabilities.agent_turn`.
- **The shadow arms no turn-timeout marker and writes no `agent_run_input`.** Both are keyed `(deploymentName, messageId)` and first-writer-wins, so a second writer would let the observational lane terminate or replay the real turn.
- `agent_turn` joins the connector-lane stale-run reaper, and the daemon heartbeats through the turn, so a crashed worker's turn ends instead of sitting `running` forever.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run:
  - `packages/server` vitest `src/__tests__/integration/sandbox/isolate-agent-turn.test.ts` — 5/5. Real `IsolateExecutor`, real guest bundle, fake Anthropic SSE server. Covers bundle eligibility, deltas reaching the host **while the response is still open** (causally enforced: the server awaits the first delta before closing), transcript resume, the deny-all refusal, and the credential audit line.
  - `packages/server` vitest `src/__tests__/integration/agent-turn-shadow.test.ts` — 11/11. Produce → poll → claim → complete, plus the capability gate, the device-worker refusal, the "no marker, no journal" guard, completion idempotency, the non-claimant refusal, and both 409 guards.
  - `packages/connector-worker` bun `agent-turn-arm.test.ts` — 7/7. Every exit of the daemon arm reports to `/complete-agent-turn`, because the run is already claimed and a local return would look like a hang.
  - `packages/server` bun `src/scheduled/__tests__/stale-run-reaper.test.ts` — 34/34.
  - `packages/connector-worker` bun `isolate-prelude.test.ts` + `egress-credentials.test.ts` — 46/46.
  - `packages/server` vitest `device-chat-lane.test.ts` 2/2 and `embed-backfill-poll-claim.test.ts` 4/4, the two neighbouring claim lanes this branch touches.
- [x] Mutation proofs, all re-run after `make review-fix` edited the tests, each restored:
  - drop `workerRunsAgentTurns` from the claim → 1 shadow test fails.
  - stop stripping the provider prefix from the model ref → 2 shadow tests fail.
  - remove `agent_turn` from the reaper's run types → the reaper test fails.
  - restore the old post-swap credential guard → 3 executor tests fail, 8/8 credential units stay green.
  - give the guest model a two-key `cost` → the finite-cost assertion fails.
  - disable the `turn.shadow` completion guard → 1 shadow test fails.
  - return the daemon arm's failure locally instead of reporting it → 1 arm test fails.
  - drop the heartbeat's `clearInterval` → 1 arm test fails.

## Notes

- `db/migrations/20260905220000_runs_agent_turn_run_type.sql` widens `runs_run_type_check` and `runs_legacy_org_required`. `fixSchemaConstraints` in the test harness re-narrows that constraint on every cleanup, so it is updated in lockstep — otherwise the migration applies at setup and the first cleanup silently reverts it.
- `transcriptText` moves from `poll.ts` into `transcript-snapshot.ts` next to the reader, now shared by the device-chat envelope and the shadow turn.
- The shadow's system prompt is deliberately reduced to the agent's identity/soul/user layers. The subprocess lane also carries platform, network, skills and MCP blocks, none of which this lane can act on yet — it has no tools. Tool parity, steer and cancel are the next PR; the cutover and deletion of the subprocess lane the one after.
- Per-turn wall clock is the daemon's existing `timeoutMs` (600s). Flagging rather than adding a knob: a tighter agent-specific budget belongs with the cutover, when the turn is user-visible.
- `LOBU_ISOLATE_TURN_SHADOW_AGENTS` is not in `.env.example`, consistent with the repo (16 of 177 server env vars are listed). The module docstring is where it is documented.
- **Not yet observed**: the lane has never run against a real provider through a real gateway secret-proxy. The sandbox test uses a loopback SSE server, so the `base_url` plus `lobu_secret_` resolution at the proxy hop is the thing shadow traffic in production is there to prove.
