### PR TITLE
fix(ci): build the release body from a file, not a 490KB jq argument

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -247,10 +247,21 @@ jobs:
           fi
 
           # This version's changelog entry, not the head of the whole file:
-          # CHANGELOG.md is ~475KB and newest-first, so a plain truncation puts
+          # CHANGELOG.md is ~490KB and newest-first, so a plain truncation puts
           # several past releases in every release body.
-          changelog=$(git show "$ATTESTED_SHA:CHANGELOG.md" || echo "")
-          notes=$(jq -n --arg changelog "$changelog" --arg version "$VERSION" \
+          #
+          # Handed to jq through --rawfile, never --arg: Linux caps a SINGLE
+          # argv entry at MAX_ARG_STRLEN (128KB), and this file is nearly four
+          # times that, so passing it as an argument dies with "jq: Argument
+          # list too long" and no release is ever created. macOS has no
+          # per-argument cap, so it only ever fails in CI -- the same trap the
+          # paginated `gh api` reads already carry, in the one line that reads
+          # a file instead of an API page. It went unnoticed because the step
+          # exits early when the release already exists, so this line first ran
+          # for real at 19.0.0.
+          changelog_file="${RUNNER_TEMP}/release-changelog.md"
+          git show "$ATTESTED_SHA:CHANGELOG.md" > "$changelog_file" || : > "$changelog_file"
+          notes=$(jq -n --rawfile changelog "$changelog_file" --arg version "$VERSION" \
             '{changelog: $changelog, version: $version}' \
             | node scripts/release-provenance.mjs release-notes | jq -r '.notes')
           notes=${notes:0:60000}

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -323,7 +323,13 @@ describe("the release is created bound to the attested commit", () => {
     // and kills the step before it creates anything.
     expect(body()).not.toContain("head -c");
     expect(body()).toContain("notes=${notes:0:60000}");
-    expect(body()).toContain('CHANGELOG.md" || echo ""');
+    // A repo with no CHANGELOG.md must still get a release. The redirect is
+    // tolerated and leaves an empty file behind for --rawfile to read, which
+    // replaced the old `|| echo ""` when the changelog stopped going through
+    // argv (see the --rawfile guard below).
+    expect(body()).toMatch(
+      /git show "\$ATTESTED_SHA:CHANGELOG\.md" > "\$changelog_file" \|\| : > "\$changelog_file"/
+    );
   });
 });
 
@@ -800,5 +806,28 @@ describe("a cut release clears the pending label off the PR that produced it", (
     expect(post).toContain(">/dev/null");
     expect(post).not.toContain("|| true");
     expect(del).toContain("|| true");
+  });
+});
+
+// `jq --arg` puts the whole value in ONE argv entry, and Linux caps a single
+// entry at MAX_ARG_STRLEN (128KB). CHANGELOG.md is ~490KB, so the release body
+// could never be built that way: the step died with "jq: Argument list too
+// long" and no release was created. It hid for weeks because the step exits
+// early when the release already exists, so the line first ran for real at
+// 19.0.0 -- and froze that release. macOS has no per-argument cap, so it is
+// unreproducible on a developer machine and only a guard keeps it out.
+describe("unbounded file payloads reach jq through --rawfile, never --arg", () => {
+  it.each(
+    names
+  )("%s never hands the changelog to jq as an argument", (name) => {
+    expect(read(name)).not.toMatch(/--arg\s+changelog\b/);
+  });
+
+  it("release-please builds the release body from a file", () => {
+    const body = shell("release-please.yml", "release-please-write");
+    expect(body).toMatch(/--rawfile\s+changelog\s/);
+    // The command substitution is the tell: slurping a file into a shell
+    // variable is what forces it through argv on the next line.
+    expect(body).not.toMatch(/changelog=\$\(\s*git show/);
   });
 });


### PR DESCRIPTION
## Summary

`lobu-v19.0.0` cannot be cut. "Create the tag and release" fails, twice so far:

```
/usr/bin/jq: Argument list too long
SyntaxError: Unexpected end of JSON input
    at file:///home/runner/work/lobu/lobu/scripts/release-provenance.mjs:280:51
```

The whole of `CHANGELOG.md` was handed to jq through `--arg`. Linux caps a single argv entry at `MAX_ARG_STRLEN` (128KB); the file is 496,433 bytes. The release body could never be built, so the tag and release were never created — and with them the release-triggered image build, the npm publish, and the Mac DMG.

macOS has no per-argument cap, only a ~1MB total `ARG_MAX`, so the same line runs fine on a developer machine. This is CI-only by construction.

## Why it hid

The line has been there since #3247 (2026-09-02). The step returns early when the release already exists:

```bash
if gh api "repos/${REPOSITORY}/releases/tags/${TAG}" >/dev/null 2>&1; then
  echo "Release ${TAG} already exists; ..."
  exit 0
fi
```

18.0.0's release existed by the time this step ran, so it took that branch. 19.0.0 is the first version where the line actually executed, and it froze the release.

It is also the same trap the file already documents two steps earlier — "a paginated payload handed to jq via `--argjson` dies with `jq: Argument list too long`" — in the one place that reads a *file* rather than an API page, which is exactly why the existing guard did not cover it.

## The fix

`--rawfile` reads the file directly and never puts it on argv:

```bash
changelog_file="${RUNNER_TEMP}/release-changelog.md"
git show "$ATTESTED_SHA:CHANGELOG.md" > "$changelog_file" || : > "$changelog_file"
notes=$(jq -n --rawfile changelog "$changelog_file" --arg version "$VERSION" \
  '{changelog: $changelog, version: $version}' \
  | node scripts/release-provenance.mjs release-notes | jq -r '.notes')
```

The missing-changelog tolerance the old `|| echo ""` provided is kept: the redirect is tolerated and leaves an empty file for `--rawfile`.

## Validation

Run against the real 19.0.0 changelog from `56e7c9dd0`, through the actual `release-notes` extractor:

```
notes length: 8429
first line:   ### ⚠ BREAKING CHANGES
occurrences of "18.0.0" in the body:  0     <- no bleed from the previous release
occurrences of #3375 / #3376:         2     <- this release's own entries
```

Red is the CI log above (runs 33998052626 and 33998903099); it cannot be reproduced locally, since macOS accepts the 496KB argument — `jq -n --arg changelog "$(cat CHANGELOG.md)"` exits 0 on this machine and produces 499,821 bytes.

## Guards

A new `describe` asserts no workflow hands the changelog to jq as an argument, and that release-please builds the body from a file. Both mutation-proved:

```
MUT A: revert to the --arg form that broke 19.0.0   -> 3 fail
MUT B: keep the file but pass --arg "$(cat "$file")" -> 2 fail
restored                                             -> 79 pass
```

MUT B is the one that matters: it is the shape a well-meaning edit would reach for, and it reintroduces the bug exactly.

The pre-existing assertion on `CHANGELOG.md" || echo ""` is updated to the new redirect form; its intent (a repo with no changelog still gets a release) is unchanged.

`make pre-pr` clean. `bun test scripts/__tests__/release-publish-order.test.ts` → 79 pass.

## Rollout

Once this lands, release-please runs on the new main tip, finds manifest version 19.0.0 with no release, and cuts it — no manual tag needed. #3241's label was corrected by hand earlier tonight and #3376 keeps that from recurring; this PR is the remaining reason the 19.0.0 release itself could not be created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release automation to reliably process large changelog files without hitting operating system argument-size limits.
  - Preserved fallback handling when a changelog is unavailable, allowing release generation to continue with an empty changelog.

- **Tests**
  - Added coverage verifying that large changelog content is handled safely and that the release workflow uses the supported file-based approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->