### PR TITLE
fix(ci): stream the CI run list into jq instead of through argv

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -107,10 +107,15 @@ jobs:
             | node scripts/release-provenance.mjs attest-jobs >/dev/null
 
           ci_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml" --jq '.id' | tr -d '\n')
-          ci_runs=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${TAG_SHA}&event=push&branch=main&status=completed&per_page=100")
-          ci_run_id=$(jq -n --argjson body "$ci_runs" --argjson workflow_id "$ci_workflow_id" --arg repo "$REPOSITORY" --arg sha "$TAG_SHA" \
-            '{runs: [$body.workflow_runs[] | . + {repo: .repository.full_name}],
-              expected: {workflow_id: $workflow_id, repo: $repo, event: "push", head_branch: "main", head_sha: $sha, status: "completed", conclusion: "success"}}' \
+          # Piped, never --argjson, for the same reason as the jobs read above:
+          # a run list is one argv entry, and Linux caps that at 128KB. One
+          # push run per sha keeps it near 12KB today, so this is the bound
+          # holding rather than the code -- and a bound nobody enforces is the
+          # shape that already broke the 19.0.0 release body.
+          ci_run_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${TAG_SHA}&event=push&branch=main&status=completed&per_page=100" \
+            | jq --argjson workflow_id "$ci_workflow_id" --arg repo "$REPOSITORY" --arg sha "$TAG_SHA" \
+              '{runs: [.workflow_runs[] | . + {repo: .repository.full_name}],
+                expected: {workflow_id: $workflow_id, repo: $repo, event: "push", head_branch: "main", head_sha: $sha, status: "completed", conclusion: "success"}}' \
             | node scripts/release-provenance.mjs select-run | jq -r '.id')
           echo "attested CI run for ${TAG_SHA}: ${ci_run_id}"
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -115,10 +115,15 @@ jobs:
             current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
             compare_status=$(gh api "repos/${REPOSITORY}/compare/${ATTESTED_SHA}...${current_sha}" --jq '.status')
             [ "$compare_status" = ahead ] || [ "$compare_status" = identical ] || { echo "::error::attested SHA left main while waiting for exact CI (${compare_status})"; exit 1; }
-            ci_runs=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${ATTESTED_SHA}&event=push&branch=main&status=completed&per_page=100")
-            selection=$(jq -n --argjson body "$ci_runs" --argjson workflow_id "$ci_workflow_id" --arg repo "$REPOSITORY" --arg sha "$ATTESTED_SHA" \
-              '{runs: [$body.workflow_runs[] | . + {repo: .repository.full_name}],
-                expected: {workflow_id: $workflow_id, repo: $repo, event: "push", head_branch: "main", head_sha: $sha, status: "completed", conclusion: "success"}}' \
+            # Piped, never --argjson, for the same reason as the jobs read
+            # above: a run list is one argv entry, and Linux caps that at
+            # 128KB. Folding it into the existing `|| selection=""` also means
+            # a transient API blip now costs one more turn of this bounded
+            # wait instead of killing the release outright.
+            selection=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${ATTESTED_SHA}&event=push&branch=main&status=completed&per_page=100" \
+              | jq --argjson workflow_id "$ci_workflow_id" --arg repo "$REPOSITORY" --arg sha "$ATTESTED_SHA" \
+                '{runs: [.workflow_runs[] | . + {repo: .repository.full_name}],
+                  expected: {workflow_id: $workflow_id, repo: $repo, event: "push", head_branch: "main", head_sha: $sha, status: "completed", conclusion: "success"}}' \
               | node scripts/release-provenance.mjs select-run) || selection=""
             if [ -n "$selection" ]; then
               ci_run_id=$(jq -r '.id' <<<"$selection")

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -816,11 +816,38 @@ describe("a cut release clears the pending label off the PR that produced it", (
 // early when the release already exists, so the line first ran for real at
 // 19.0.0 -- and froze that release. macOS has no per-argument cap, so it is
 // unreproducible on a developer machine and only a guard keeps it out.
-describe("unbounded file payloads reach jq through --rawfile, never --arg", () => {
+describe("unbounded payloads reach jq by pipe or --rawfile, never through argv", () => {
+  // Linux caps a SINGLE argv entry at MAX_ARG_STRLEN (128KB), so any value
+  // whose size is set by repository history or an API page count dies with
+  // "jq: Argument list too long" once it outgrows the cap. macOS has no
+  // per-argument cap, so none of these can be reproduced on a dev machine --
+  // the guard is the only thing that keeps the class out. Two have already
+  // bitten: the 490KB CHANGELOG froze the 19.0.0 release outright, and the
+  // paginated jobs read was fixed pre-emptively.
+
+  /** `name=$( … )` capture of a read whose size the repository decides. */
+  const SLURPED = /(\w+)=\$\(\s*(?:gh api|git show|git log)[^)]*/g;
+  /** Anything that collapses the payload to a scalar before it is captured. */
+  const REDUCED = /--jq|\| *jq |node -pe?\b|--template/;
+
   it.each(
     names
-  )("%s never hands the changelog to jq as an argument", (name) => {
-    expect(read(name)).not.toMatch(/--arg\s+changelog\b/);
+  )("%s pipes unbounded reads instead of slurping them", (name) => {
+    const body = read(name);
+    const whole = [...body.matchAll(SLURPED)]
+      .filter((match) => !REDUCED.test(match[0]))
+      .map((match) => match[1]);
+    // A whole payload only becomes a bug once it is handed to jq as an
+    // argument; `<<<` here-strings and `--rawfile` both stay clear of argv.
+    const throughArgv = whole.filter((variable) =>
+      new RegExp(
+        `--argjson\\s+\\w+\\s+"\\$${variable}"|--arg\\s+\\w+\\s+"\\$${variable}"`
+      ).test(body)
+    );
+    expect({ file: name, throughArgv }).toEqual({
+      file: name,
+      throughArgv: [],
+    });
   });
 
   it("release-please builds the release body from a file", () => {
@@ -829,5 +856,11 @@ describe("unbounded file payloads reach jq through --rawfile, never --arg", () =
     // The command substitution is the tell: slurping a file into a shell
     // variable is what forces it through argv on the next line.
     expect(body).not.toMatch(/changelog=\$\(\s*git show/);
+  });
+
+  it("publish attestation streams the CI run list into jq", () => {
+    const body = shell("publish-packages.yml", "attest-publish");
+    expect(body).toMatch(/ci\.yml\/runs[^\n]*\n\s*\| jq /);
+    expect(body).not.toMatch(/--argjson\s+body\s+"\$ci_runs"/);
   });
 });


### PR DESCRIPTION
## What

Finishes the class that #3379 opened. That PR removed one 490KB `jq --arg`; the same shape survived in two more places.

Both `release-please.yml` and `publish-packages.yml` slurped the ci.yml run list into a shell variable and handed it to `jq -n --argjson body "$ci_runs"`. Linux caps a *single* argv entry at `MAX_ARG_STRLEN` (128KB). One push run on a sha is ~12KB today, so what keeps these under the cap is a bound nobody enforces — the same shape that froze the 19.0.0 release outright.

Both now pipe, matching the paginated jobs read immediately above them, which already carried a comment warning against the exact pattern the next line then used.

## Red → green

The guard was named after the changelog; it is now class-wide — any read captured whole and passed through argv, in any workflow. Reverting each of the three call sites turns it red:

| mutation | result |
| --- | --- |
| `publish-packages.yml` back to `--argjson body "$ci_runs"` | 2 fail |
| `release-please.yml` back to `--argjson body "$ci_runs"` | 1 fail |
| `release-please.yml` changelog back to `--arg changelog` (the original #3379 bug) | 2 fail |
| all three fixed | **80 pass, 0 fail** |

The third row is the point: one class-wide assertion now catches the bug that actually froze the release, instead of a rule naming the file it happened in.

It also had to be narrowed once — the first version flagged `ci_workflow_id` (`gh api --jq '.id'`) and `current_version` (`git show … | node -pe`). Both reduce to a scalar before capture, so the rule now ignores anything with a reducer and only flags a payload captured whole.

## Behaviour is identical

Ran both forms against the real 19.0.0 commit `02d7647a`:

```
old ci_run_id=33999810977
new ci_run_id=33999810977
IDENTICAL
```

In `release-please` the pipe folds into the existing `|| selection=""`, so a transient API blip now costs one more turn of a bounded 20-iteration wait instead of aborting the release. That is the only behaviour change, and it is in the safe direction.

## Not merging yet

`publish-packages.yml` is `workflow_dispatch` and resolves from main at dispatch time. The 19.0.0 publish is in flight, so this holds until `@lobu/cli@19.0.0` is on npm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release automation to handle large CI and repository responses more reliably.
  - Preserved existing workflow checks and retry behavior while reducing the risk of failures caused by oversized command data.

- **Tests**
  - Expanded regression coverage for large workflow and version-control responses.
  - Added validation that release publishing continues to process CI run information reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->