### PR TITLE
fix(connectors): stop the WhatsApp collect budget racing the run fence

### DIFF
--- a/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
@@ -190,6 +190,41 @@ describe("canonical WhatsApp identity and cutover", () => {
     expect(source).not.toContain("request.deadline");
   });
 
+  /**
+   * The extension fences EVERY claimed run at RUN_TIMEOUT_MS (90s) from the
+   * moment it is claimed, and each `dispatcher.dispatch("evaluate", ...)` is
+   * its own such run. The in-page history budget therefore cannot equal the
+   * fence: the adapter would be entitled to spend the entire run paging
+   * history and still owe a serialize-and-return, which it can never afford.
+   * That is the exact shape that stalled feed 309 in prod -- every run died
+   * as `run timed out after 90000ms`, so the checkpoint never advanced and
+   * the next run repeated the identical oversized work.
+   */
+  it("leaves the collect budget headroom under the extension run fence", () => {
+    // Read the fence from the extension rather than hardcoding it: the two
+    // constants live in different repos with nothing linking them, so a
+    // hardcoded copy would keep passing while prod broke again.
+    const background = readFileSync(
+      new URL("../../../owletto/apps/chrome/background.js", import.meta.url),
+      "utf8"
+    );
+    const fenceMatch = background.match(
+      /const RUN_TIMEOUT_MS = ([\d_]+);/
+    );
+    if (!fenceMatch?.[1]) {
+      throw new Error(
+        "background.js no longer declares RUN_TIMEOUT_MS; the collect budget's headroom is now unverified"
+      );
+    }
+    const runFenceMs = Number(fenceMatch[1].replaceAll("_", ""));
+    const { request } = buildCollectionPlan({});
+    expect(Number(request.budget_ms)).toBeLessThan(runFenceMs);
+    // Enough headroom for the round trip the answer still has to make.
+    expect(runFenceMs - Number(request.budget_ms)).toBeGreaterThanOrEqual(
+      20_000
+    );
+  });
+
   it("collects strictly after the cutover so ingested rows never replay", () => {
     const { request } = buildCollectionPlan({
       checkpoint: {

--- a/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
@@ -196,7 +196,7 @@ describe("canonical WhatsApp identity and cutover", () => {
    * its own such run. The in-page history budget therefore cannot equal the
    * fence: the adapter would be entitled to spend the entire run paging
    * history and still owe a serialize-and-return, which it can never afford.
-   * That is the exact shape that stalled feed 309 in prod -- every run died
+   * That is the exact shape that stalled a prod feed -- every run died
    * as `run timed out after 90000ms`, so the checkpoint never advanced and
    * the next run repeated the identical oversized work.
    */

--- a/packages/connectors/src/whatsapp-web-helpers.ts
+++ b/packages/connectors/src/whatsapp-web-helpers.ts
@@ -29,8 +29,21 @@ export const MAX_MEDIA_PER_RUN = 12;
  * bound is MAX_CHATS_PER_RUN * MAX_LOADS_PER_CHAT, so this only catches a
  * `loadEarlierMsgs` that hangs: without it a stuck load burns the whole device
  * action and the run returns nothing instead of the messages already collected.
+ *
+ * It MUST stay strictly under the extension's run fence. Every
+ * `dispatch("evaluate", ...)` is claimed as its own chrome action run, and
+ * `background.js` fences each one at RUN_TIMEOUT_MS (90s) from the moment it
+ * is claimed. At 90s this budget equalled that fence, so the adapter was
+ * entitled to spend the entire run paging history and still owed a
+ * serialize-and-return it could never afford. The run died as `run timed out
+ * after 90000ms`, and because a failed run discards its collected messages the
+ * checkpoint never advanced -- the next run repeated the same oversized work.
+ * That stalled a prod feed for three days at 17 consecutive failures.
+ *
+ * 60s leaves 30s of headroom for the dispatch round trip and the answer's
+ * serialization, matching the media phase's own budget.
  */
-const COLLECT_BUDGET_MS = 90_000;
+const COLLECT_BUDGET_MS = 60_000;
 
 export type ChatFilter = "all" | "individual" | "group";
 


### PR DESCRIPTION
## Summary
- WhatsApp feed 309 has ingested **nothing since 2026-09-03T06:00:52Z** — 17 consecutive failures, all `run timed out after 90000ms`, `items_collected` frozen at 30,276 and 0 events written since the first failure.
- Cause is a budget that exactly equals its own fence. Every `dispatch("evaluate", ...)` is claimed as its own chrome action run, and `background.js` fences each one at `RUN_TIMEOUT_MS` (90s) from claim. `COLLECT_BUDGET_MS` was also 90s, so the adapter could spend the whole run paging history and still owed a serialize-and-return it could never afford.
- It stays stuck rather than degrading: a failed run discards its collected messages, so the checkpoint never advances and the next run repeats the identical oversized work.

Drops the in-page budget to 60s, leaving 30s of headroom for the dispatch round trip and serialization — matching the media phase's own budget.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (all 5 gates)
- [x] Tests run: `bun test packages/connectors/src/__tests__/` — 402 pass, 0 fail
- [x] Bug fix: red→fix→green outputs pasted below

**Red** (budget at 90s, reproducing the prod condition):
```
expect(received).toBeLessThan(expected)
Expected: < 90000
Received: 90000
(fail) leaves the collect budget headroom under the extension run fence
 0 pass, 1 fail
```

**Green** (budget at 60s):
```
 38 pass, 0 fail
Ran 38 tests across 1 file.
```

**Negative control** — reverted the constant to 90s with the fix's test in place and confirmed it fails again, so the test genuinely catches the regression rather than passing vacuously.

## Notes
The test reads `RUN_TIMEOUT_MS` out of `background.js` instead of hardcoding 90000. The two constants live in different repos with nothing linking them, so a hardcoded copy would keep passing while prod broke again. This follows the existing "still matches the executor timeout message it depends on" precedent in the same suite.

Audited the other three dispatch sites for the same class: navigate/probe are short single dispatches, and media passes `MEDIA_ITEM_TIMEOUT_MS` (20s). `collect` was the only op whose single dispatch could reach the fence.

`make review-fix` could not run — the Codex credential returns `401 Unauthorized`, so it never reviewed the diff. Unrelated to this change.

Feed 309 has backed off to 6-hour retries after 17 failures, so it will need a nudge after this deploys rather than self-healing promptly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WhatsApp Web collection reliability by reducing the collection time budget, allowing additional time for results to return before the extension run limit.
  * Reduced the likelihood of collection attempts timing out and leaving feeds stalled after repeated failures.

* **Tests**
  * Added coverage to verify the collection budget remains safely below the extension’s execution limit, with sufficient headroom for response processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->