### PR TITLE
feat(agent-turn): deliver the isolate lane's reply and transcript

### DIFF
--- a/packages/server/src/__tests__/integration/agent-turn-shadow.test.ts
+++ b/packages/server/src/__tests__/integration/agent-turn-shadow.test.ts
@@ -760,16 +760,222 @@ describe('agent turn completion', () => {
     expect((await runRow(runId)).status).toBe('running');
   });
 
-  it('refuses to record a reply for a turn that did not declare itself observational', async () => {
-    const workerId = 'fleet-authoritative';
+  it('an authoritative turn publishes the reply and appends the transcript', async () => {
+    const workerId = 'fleet-delivers';
     const runId = await claimedShadowRun(workerId);
-    // Strip the flag the producer sets. This is the deploy-skew shape the guard
-    // exists for: a producer that starts marking turns authoritative before the
-    // reply path exists would otherwise have every reply recorded and dropped.
+    // Flip the run the way the cutover will: authoritative, with the reply
+    // envelope the producer stamps beside the guest's turn.
     const sql = getTestDb();
     await sql`
       UPDATE runs
       SET action_input = jsonb_set(action_input, '{turn,shadow}', 'false'::jsonb)
+      WHERE id = ${runId}
+    `;
+
+    const response = await postAsFleet('/api/workers/complete-agent-turn', {
+      run_id: runId,
+      worker_id: workerId,
+      status: 'completed',
+      text: 'the isolate lane answered',
+      transcript: [{ role: 'assistant', content: [{ type: 'text', text: 'the isolate lane answered' }] }],
+    });
+    expect(response.status).toBe(200);
+
+    const row = await runRow(runId);
+    expect(row.status).toBe('completed');
+
+    // The reply is queued for the same thread_response delivery the subprocess
+    // lane uses, addressed from the run's own reply envelope.
+    const [reply] = (await sql`
+      SELECT action_input FROM runs
+      WHERE queue_name = 'thread_response' AND run_type = 'chat_message'
+      ORDER BY id DESC LIMIT 1
+    `) as unknown as Array<{ action_input: Record<string, unknown> }>;
+    expect(reply.action_input).toMatchObject({
+      messageId: 'msg-shadow',
+      channelId: 'api_user-shadow',
+      conversationId: 'conv-shadow',
+      userId: 'user-shadow',
+      platform: 'api',
+      finalText: 'the isolate lane answered',
+    });
+
+    // And the turn joins the conversation's transcript, so the next turn's
+    // history includes it.
+    const [snapshot] = (await sql`
+      SELECT snapshot_jsonl FROM agent_transcript_snapshot WHERE run_id = ${runId}
+    `) as unknown as Array<{ snapshot_jsonl: string }>;
+    const entries = snapshot.snapshot_jsonl
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => JSON.parse(line));
+    expect(entries.map((entry) => entry.message.role)).toEqual([
+      'user',
+      'assistant',
+    ]);
+    // Block-array content, the shape every other writer of this table emits
+    // and the shape `historyMessages` reads back for the next turn.
+    expect(entries.map((entry) => entry.message.content)).toEqual([
+      [{ type: 'text', text: 'what is the shadow lane?' }],
+      [{ type: 'text', text: 'the isolate lane answered' }],
+    ]);
+    // The reply is chained onto the user message, so the next turn's parent
+    // walk reaches both.
+    expect(entries[1].parentId).toBe(entries[0].id);
+  });
+
+  it('an oversize prior transcript starts a continuation instead of hanging the client', async () => {
+    const workerId = 'fleet-delivers-oversize';
+    const runId = await claimedShadowRun(workerId);
+    const sql = getTestDb();
+    const [run] = (await sql`
+      SELECT organization_id FROM runs WHERE id = ${runId}
+    `) as unknown as Array<{ organization_id: string }>;
+
+    // A prior transcript already past the 4MB cap. Appending to it would build
+    // a row the table refuses, and this insert shares the terminal
+    // transaction, so without the continuation fallback the rollback would
+    // take the run transition and the reply with it.
+    const bulky = `${'x'.repeat(5 * 1024 * 1024)}`;
+    const priorLine = JSON.stringify({
+      type: 'message',
+      id: 'prior-assistant',
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: { role: 'assistant', content: [{ type: 'text', text: bulky }] },
+    });
+    // The snapshot's `run_id` is a real foreign key, so the prior transcript
+    // needs the run that produced it.
+    const [prior] = (await sql`
+      INSERT INTO runs (organization_id, run_type, queue_name, status, action_input)
+      VALUES (${run.organization_id}, 'agent_turn', 'agent_turns', 'completed', '{}'::jsonb)
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+    await sql`
+      INSERT INTO agent_transcript_snapshot
+        (organization_id, agent_id, conversation_id, run_id,
+         snapshot_jsonl, byte_size, terminal_status)
+      VALUES (${run.organization_id}, ${AGENT_ID}, 'conv-shadow', ${prior.id},
+              ${`${priorLine}\n`}, ${Buffer.byteLength(priorLine, 'utf8') + 1}, 'completed')
+    `;
+
+    await sql`
+      UPDATE runs
+      SET action_input = jsonb_set(action_input, '{turn,shadow}', 'false'::jsonb)
+      WHERE id = ${runId}
+    `;
+
+    const response = await postAsFleet('/api/workers/complete-agent-turn', {
+      run_id: runId,
+      worker_id: workerId,
+      status: 'completed',
+      text: 'answered despite the long history',
+    });
+    expect(response.status).toBe(200);
+    expect((await runRow(runId)).status).toBe('completed');
+
+    // The client still gets its answer — the whole point of the fallback.
+    const [reply] = (await sql`
+      SELECT action_input FROM runs
+      WHERE queue_name = 'thread_response' AND run_type = 'chat_message'
+      ORDER BY id DESC LIMIT 1
+    `) as unknown as Array<{ action_input: Record<string, unknown> }>;
+    expect(reply.action_input).toMatchObject({
+      messageId: 'msg-shadow',
+      finalText: 'answered despite the long history',
+    });
+
+    // And the stored row is a compact continuation carrying only this turn,
+    // not the oversize prefix. The prior run's row stays queryable.
+    const [snapshot] = (await sql`
+      SELECT snapshot_jsonl, byte_size FROM agent_transcript_snapshot WHERE run_id = ${runId}
+    `) as unknown as Array<{ snapshot_jsonl: string; byte_size: number }>;
+    expect(snapshot.byte_size).toBeLessThan(4 * 1024 * 1024);
+    const entries = snapshot.snapshot_jsonl
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => JSON.parse(line));
+    expect(entries.map((entry) => entry.message.role)).toEqual([
+      'user',
+      'assistant',
+    ]);
+    // A continuation has no prior tail to chain onto.
+    expect(entries[0].parentId).toBeNull();
+    const [{ n }] = (await sql`
+      SELECT count(*)::int AS n FROM agent_transcript_snapshot WHERE run_id = ${prior.id}
+    `) as unknown as Array<{ n: number }>;
+    expect(n).toBe(1);
+  });
+
+  it('a failed authoritative turn delivers the error instead of hanging the client', async () => {
+    const workerId = 'fleet-delivers-error';
+    const runId = await claimedShadowRun(workerId);
+    const sql = getTestDb();
+    await sql`
+      UPDATE runs
+      SET action_input = jsonb_set(action_input, '{turn,shadow}', 'false'::jsonb)
+      WHERE id = ${runId}
+    `;
+
+    const response = await postAsFleet('/api/workers/complete-agent-turn', {
+      run_id: runId,
+      worker_id: workerId,
+      status: 'failed',
+      error: 'the provider refused',
+    });
+    expect(response.status).toBe(200);
+
+    const [reply] = (await sql`
+      SELECT action_input FROM runs
+      WHERE queue_name = 'thread_response' AND run_type = 'chat_message'
+      ORDER BY id DESC LIMIT 1
+    `) as unknown as Array<{ action_input: Record<string, unknown> }>;
+    expect(reply.action_input).toMatchObject({ messageId: 'msg-shadow', error: 'the provider refused' });
+    // A failed turn writes no transcript: there is no answer to remember.
+    const [{ n }] = (await sql`
+      SELECT count(*)::int AS n FROM agent_transcript_snapshot WHERE run_id = ${runId}
+    `) as unknown as Array<{ n: number }>;
+    expect(n).toBe(0);
+  });
+
+  it('a shadow turn still delivers nothing', async () => {
+    const workerId = 'fleet-shadow-silent';
+    const runId = await claimedShadowRun(workerId);
+    const sql = getTestDb();
+    const [before] = (await sql`
+      SELECT count(*)::int AS n FROM runs WHERE queue_name = 'thread_response'
+    `) as unknown as Array<{ n: number }>;
+
+    const response = await postAsFleet('/api/workers/complete-agent-turn', {
+      run_id: runId,
+      worker_id: workerId,
+      status: 'completed',
+      text: 'an observational copy',
+    });
+    expect(response.status).toBe(200);
+
+    const [after] = (await sql`
+      SELECT count(*)::int AS n FROM runs WHERE queue_name = 'thread_response'
+    `) as unknown as Array<{ n: number }>;
+    expect(after.n).toBe(before.n);
+    const [{ n }] = (await sql`
+      SELECT count(*)::int AS n FROM agent_transcript_snapshot WHERE run_id = ${runId}
+    `) as unknown as Array<{ n: number }>;
+    expect(n).toBe(0);
+  });
+
+  it('refuses an authoritative turn that carries nowhere to deliver', async () => {
+    const workerId = 'fleet-authoritative';
+    const runId = await claimedShadowRun(workerId);
+    // Authoritative, but with the reply envelope removed — the deploy-skew
+    // shape where a newer producer marks turns authoritative and an older one
+    // stamped no address. Completing it would transition the run and drop the
+    // answer, leaving the client waiting forever, so it stays claimable.
+    const sql = getTestDb();
+    await sql`
+      UPDATE runs
+      SET action_input =
+        jsonb_set(action_input, '{turn,shadow}', 'false'::jsonb) - 'reply'
       WHERE id = ${runId}
     `;
 

--- a/packages/server/src/__tests__/integration/agent-turn-shadow.test.ts
+++ b/packages/server/src/__tests__/integration/agent-turn-shadow.test.ts
@@ -832,10 +832,11 @@ describe('agent turn completion', () => {
       SELECT organization_id FROM runs WHERE id = ${runId}
     `) as unknown as Array<{ organization_id: string }>;
 
-    // A prior transcript already past the 4MB cap. Appending to it would build
-    // a row the table refuses, and this insert shares the terminal
-    // transaction, so without the continuation fallback the rollback would
-    // take the run transition and the reply with it.
+    // A prior transcript already past MAX_SNAPSHOT_BYTES, the cap every other
+    // writer of this table honours. Appending to it would build a row well
+    // past that cap, and this insert shares the terminal transaction, so
+    // without the continuation fallback the oversize row would ride along
+    // with the run transition and the reply.
     const bulky = `${'x'.repeat(5 * 1024 * 1024)}`;
     const priorLine = JSON.stringify({
       type: 'message',

--- a/packages/server/src/gateway/orchestration/agent-turn-shadow.ts
+++ b/packages/server/src/gateway/orchestration/agent-turn-shadow.ts
@@ -80,6 +80,24 @@ const HISTORY_MESSAGE_LIMIT = 12;
 const HISTORY_MESSAGE_CHARS = 16_000;
 const TURN_MESSAGE_CHARS = 32_000;
 
+/**
+ * Where an agent turn's reply is delivered. This rides `action_input` beside
+ * the guest's envelope rather than inside it: delivery is the host's business,
+ * and the poll route lifts only `turn` and `credential` out, so these fields
+ * never cross into the isolate. `completeAgentTurnRun` is the only reader.
+ *
+ * `team_id` is optional for the same reason `MessagePayload.teamId` is: Slack
+ * carries the workspace id in `platform_metadata` instead.
+ */
+export interface TurnReply {
+  message_id: string;
+  channel_id: string;
+  user_id: string;
+  team_id?: string;
+  platform: string;
+  platform_metadata?: Record<string, unknown>;
+}
+
 type TurnEnvelope = AgentTurnPollPayload["turn"];
 type TurnTools = NonNullable<TurnEnvelope["tools"]>;
 type BuiltinTool = NonNullable<TurnTools["builtin"]>[number];
@@ -642,6 +660,20 @@ export async function enqueueAgentTurnShadow(
       shadow: true,
     };
 
+    // Where this turn's reply would be delivered, kept beside the envelope
+    // rather than inside it: the guest has no use for a channel id, and the
+    // poll route lifts only `turn` and `credential` out of `action_input`, so
+    // a third sibling never crosses into the isolate. The completion route
+    // reads it to publish the same thread_response the subprocess lane does.
+    const reply: TurnReply = {
+      message_id: data.messageId,
+      channel_id: data.channelId,
+      user_id: data.userId,
+      team_id: data.teamId,
+      platform: data.platform,
+      platform_metadata: data.platformMetadata,
+    };
+
     const sql = getDb();
     const rows = await sql<{ id: number }>`
       INSERT INTO runs (
@@ -649,7 +681,7 @@ export async function enqueueAgentTurnShadow(
         approval_status, action_input, created_at
       ) VALUES (
         ${data.organizationId}, 'agent_turn', 'pending',
-        'auto', ${sql.json({ turn, credential: provider.credential })},
+        'auto', ${sql.json({ turn, credential: provider.credential, reply })},
         current_timestamp
       )
       RETURNING id

--- a/packages/server/src/worker-api/agent-turn.ts
+++ b/packages/server/src/worker-api/agent-turn.ts
@@ -2,21 +2,33 @@
  * Completion for an agent turn run.
  *
  * A shadow turn reports what the isolate produced and stops there: the
- * conversation's reply still comes from the subprocess lane, so nothing here
- * writes a thread response, a transcript snapshot or a turn marker. What it
- * does write is the transcript the turn produced, onto the run row, which is
- * how the two lanes are compared while the shadow runs.
+ * conversation's reply still comes from the subprocess lane, so nothing is
+ * delivered. What it writes is the transcript the turn produced, onto the run
+ * row, which is how the two lanes are compared while the shadow runs.
  *
- * When the lane becomes authoritative this is where the reply and the snapshot
- * join, on the same fenced terminal transition.
+ * An authoritative turn additionally delivers: it appends the turn to the
+ * conversation's transcript snapshot and publishes the `thread_response` the
+ * client is waiting on, both inside the same fenced terminal transition, the
+ * way `device-chat.ts` does for the other non-subprocess lane. Which of the
+ * two a run is, is the run's own `turn.shadow`, stamped by the producer.
  */
+import { parseSessionEntries } from "@lobu/core";
 import {
 	type CompleteAgentTurnRequest,
 	CompleteAgentTurnRequestSchema,
 } from "@lobu/core/contracts/worker/protocol";
 import { Value } from "@sinclair/typebox/value";
 import type { Context } from "hono";
-import { getDb } from "../db/client";
+import { type DbClient, getDb } from "../db/client";
+import type { TurnReply } from "../gateway/orchestration/agent-turn-shadow";
+import {
+	insertThreadResponseRow,
+	notifyThreadResponse,
+} from "../gateway/orchestration/turn-liveness";
+import {
+	MAX_SNAPSHOT_BYTES,
+	readSnapshotJsonl,
+} from "../gateway/services/transcript-snapshot";
 import type { Env } from "../index";
 import { runLeaseFence } from "../runs/run-lease";
 import { stripNul } from "../utils/strip-nul";
@@ -24,6 +36,99 @@ import { authorizeRunForWorker } from "./shared";
 
 /** What of the turn's own text is kept on the run row for the shadow diff. */
 const MAX_OUTPUT_TAIL = 2_000;
+
+/**
+ * Append this turn's user message and reply to the conversation's transcript
+ * snapshot, in the session-jsonl shape `parseSessionEntries` reads back — the
+ * same blob the shadow producer already loads for history.
+ *
+ * `content` is pi's block array, not a bare string: every other writer of this
+ * table emits blocks, and the readers that flatten it (`transcriptText`,
+ * `trimContent`) are the only reason a bare string would survive at all.
+ *
+ * The row is keyed by `run_id`, and the lease fence already refuses a second
+ * completion of the same run, so this insert never conflicts in practice —
+ * `DO NOTHING` matches `device-chat.ts` and keeps a durable transcript
+ * unoverwritable if one ever does.
+ */
+async function appendTurnSnapshot(
+	tx: DbClient,
+	args: {
+		organizationId: string;
+		agentId: string;
+		conversationId: string;
+		runId: number;
+		userText: string;
+		assistantText: string;
+	},
+): Promise<void> {
+	if (!args.agentId || !args.conversationId) return;
+	const previous = await readSnapshotJsonl({
+		organizationId: args.organizationId,
+		agentId: args.agentId,
+		conversationId: args.conversationId,
+		client: tx,
+	});
+	const now = new Date().toISOString();
+	const prior = parseSessionEntries(previous ?? "").entries;
+	const userId = `agent-turn-${args.runId}-user`;
+	const entry = (
+		id: string,
+		role: string,
+		text: string,
+		parentId: string | null,
+	) =>
+		JSON.stringify({
+			type: "message",
+			id,
+			parentId,
+			timestamp: now,
+			message: { role, content: [{ type: "text", text }] },
+		});
+
+	// The turn is one user message and one reply, so the chain is fixed: the
+	// reply hangs off the user message when there is one, off the prior tail
+	// when the turn carried no text.
+	const render = (base: string, tailId: string | null) => {
+		const lines: string[] = [];
+		if (args.userText) lines.push(entry(userId, "user", args.userText, tailId));
+		if (args.assistantText) {
+			lines.push(
+				entry(
+					`agent-turn-${args.runId}-assistant`,
+					"assistant",
+					args.assistantText,
+					args.userText ? userId : tailId,
+				),
+			);
+		}
+		return lines.length > 0 ? `${base}${lines.join("\n")}\n` : null;
+	};
+	const base = previous
+		? previous.endsWith("\n")
+			? previous
+			: `${previous}\n`
+		: "";
+	let snapshot = render(base, prior[prior.length - 1]?.id ?? null);
+	if (snapshot === null) return;
+	if (Buffer.byteLength(snapshot, "utf8") > MAX_SNAPSHOT_BYTES) {
+		// A long-running conversation must not make the current turn fail: this
+		// insert is inside the terminal transaction, so an oversize row would
+		// roll back the completion and the reply and hang the client forever.
+		// Start a compact continuation; the prior run's row stays queryable.
+		snapshot = render("", null) as string;
+	}
+	await tx`
+    INSERT INTO public.agent_transcript_snapshot
+      (organization_id, agent_id, conversation_id, run_id,
+       snapshot_jsonl, byte_size, terminal_status)
+    VALUES
+      (${args.organizationId}, ${args.agentId}, ${args.conversationId}, ${args.runId},
+       ${snapshot}, ${Buffer.byteLength(snapshot, "utf8")}, 'completed')
+    ON CONFLICT (organization_id, agent_id, conversation_id, run_id)
+    DO NOTHING
+  `;
+}
 
 export async function completeAgentTurnRun(c: Context<{ Bindings: Env }>) {
 	let rawBody: unknown;
@@ -45,9 +150,10 @@ export async function completeAgentTurnRun(c: Context<{ Bindings: Env }>) {
 	const rows = await sql<{
 		status: string;
 		claimed_by: string | null;
+		organization_id: string;
 		action_input: Record<string, unknown> | null;
 	}>`
-    SELECT status, claimed_by, action_input
+    SELECT status, claimed_by, organization_id, action_input
     FROM public.runs
     WHERE id = ${body.run_id}
       AND run_type = 'agent_turn'
@@ -63,25 +169,34 @@ export async function completeAgentTurnRun(c: Context<{ Bindings: Env }>) {
 		});
 	}
 
-	// `turn.shadow` is the run's own statement about what its reply is FOR, and
-	// this is the gate that gives it force. Today every producer sets it, and
-	// the only thing this endpoint does with a reply is record it. A turn that
-	// declared itself authoritative would therefore have its reply silently
-	// dropped, so refuse it instead: whichever PR wires the reply path lands
-	// that publish and this branch together.
-	const envelope = (run.action_input ?? {}) as { turn?: { shadow?: unknown } };
-	if (envelope.turn?.shadow !== true) {
+	// `turn.shadow` is the run's own statement about what its reply is FOR.
+	// A shadow records and stops; an authoritative turn also delivers. The
+	// producer stamps it, so a run cannot change its mind here.
+	const envelope = (run.action_input ?? {}) as {
+		turn?: {
+			shadow?: unknown;
+			agent_id?: unknown;
+			conversation_id?: unknown;
+			message_text?: unknown;
+		};
+		reply?: TurnReply;
+	};
+	const isShadow = envelope.turn?.shadow === true;
+	// Delivery needs somewhere to deliver TO. A producer that stamped an
+	// authoritative turn without a reply envelope would otherwise transition
+	// the run to completed and drop the answer, leaving the client waiting
+	// forever; refusing keeps the run claimable instead.
+	if (!isShadow && !envelope.reply) {
 		return c.json(
-			{
-				error:
-					"Agent turn runs are observational: this endpoint records a reply, it does not deliver one",
-			},
-			409
+			{ error: "Authoritative agent turn has no reply envelope" },
+			409,
 		);
 	}
 
+	const organizationId = run.organization_id;
 	const failed = body.status === "failed";
-	const error = typeof body.error === "string" ? stripNul(body.error).trim() : "";
+	const error =
+		typeof body.error === "string" ? stripNul(body.error).trim() : "";
 	const text = typeof body.text === "string" ? stripNul(body.text) : "";
 	// The turn's own output goes back on the row it came from, so a shadow run
 	// is diffable against the subprocess reply without a second table.
@@ -95,20 +210,68 @@ export async function completeAgentTurnRun(c: Context<{ Bindings: Env }>) {
 		},
 	};
 
-	const transitioned = await sql`
-    UPDATE public.runs
-    SET status = ${failed ? "failed" : "completed"},
-        completed_at = current_timestamp,
-        error_message = ${failed ? error || "agent turn failed" : null},
-        output_tail = ${text ? text.slice(-MAX_OUTPUT_TAIL) : null},
-        exit_reason = ${body.exit_reason ?? (failed ? "error_message" : "ok")},
-        action_input = ${sql.json(result)}
-    WHERE id = ${body.run_id}
-      ${runLeaseFence(sql, body.worker_id)}
-    RETURNING id
-  `;
-	if (transitioned.length === 0) {
-		return c.json({ ok: true, status: failed ? "failed" : "completed", idempotent: true });
+	// One fenced transition. When the turn is authoritative the snapshot and
+	// the thread_response join it inside the same transaction, so a client can
+	// never observe a completed run whose answer was not persisted.
+	const transitioned = await sql.begin(async (tx) => {
+		const terminal = await tx`
+      UPDATE public.runs
+      SET status = ${failed ? "failed" : "completed"},
+          completed_at = current_timestamp,
+          error_message = ${failed ? error || "agent turn failed" : null},
+          output_tail = ${text ? text.slice(-MAX_OUTPUT_TAIL) : null},
+          exit_reason = ${body.exit_reason ?? (failed ? "error_message" : "ok")},
+          action_input = ${sql.json(result)}
+      WHERE id = ${body.run_id}
+        ${runLeaseFence(tx, body.worker_id)}
+      RETURNING id
+    `;
+		if (terminal.length === 0) return false;
+		if (isShadow) return true;
+
+		const reply = envelope.reply as TurnReply;
+		const agentId = String(envelope.turn?.agent_id ?? "");
+		const conversationId = String(envelope.turn?.conversation_id ?? "");
+		if (!failed) {
+			await appendTurnSnapshot(tx, {
+				organizationId,
+				agentId,
+				conversationId,
+				runId: body.run_id,
+				userText: String(envelope.turn?.message_text ?? ""),
+				assistantText: text,
+			});
+		}
+		await insertThreadResponseRow(
+			tx,
+			{
+				messageId: reply.message_id,
+				channelId: reply.channel_id,
+				conversationId,
+				userId: reply.user_id,
+				teamId: reply.team_id ?? "api",
+				platform: reply.platform,
+				organizationId,
+				platformMetadata: reply.platform_metadata,
+				...(failed
+					? { error: error || "agent turn failed" }
+					: { finalText: text }),
+				processedMessageIds: [reply.message_id],
+				timestamp: Date.now(),
+			},
+			organizationId,
+		);
+		return true;
+	});
+	if (!transitioned) {
+		return c.json({
+			ok: true,
+			status: failed ? "failed" : "completed",
+			idempotent: true,
+		});
 	}
+	// Outside the transaction, as device-chat does: the listener must not be
+	// woken for a row a rollback would take back.
+	if (!isShadow) await notifyThreadResponse();
 	return c.json({ ok: true, status: failed ? "failed" : "completed" });
 }


### PR DESCRIPTION
## Summary
- The isolate lane produced a turn and stopped. `completeAgentTurnRun` 409'd any authoritative run, so nothing reached the client and nothing joined the conversation's history — the remaining gap between the two lanes.
- An authoritative turn now appends to the conversation's transcript snapshot and publishes the `thread_response` the client is waiting on, both inside the same fenced terminal transition, so a client can never observe a completed run whose answer was not persisted. A shadow turn still records on its own row and delivers nothing.
- No contract change. The reply address rides `action_input` beside the existing `credential` key, and `poll.ts` returns `payload: { turn }` only, so it never crosses into the isolate.

Reuses existing machinery rather than adding a second path: `insertThreadResponseRow` / `notifyThreadResponse` and the single-transaction shape from `device-chat.ts` (the other non-subprocess lane), plus `readSnapshotJsonl` and `parseSessionEntries`.

**Still shadow-only.** Every turn is stamped `shadow: true` by the producer, so this changes nothing in production today; it makes the cutover a flag flip rather than a rewrite.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (build, typecheck, knip, naming, funnel gates)
- [x] Tests run: `cd packages/server && bun run test -- run src/__tests__/integration/agent-turn-shadow.test.ts` → **20 passed (20)**
- [ ] Bug fix: red→fix→green — n/a, this is new delivery behaviour, covered by new tests
- [ ] If bot runtime changed: n/a

New coverage: an authoritative turn delivering reply + transcript; a failed turn delivering the error instead of hanging; a shadow turn staying silent; an authoritative turn with no reply envelope being refused; an oversize prior transcript starting a continuation.

The oversize-continuation branch was mutation-tested rather than trusted: disabling the cap made the assertion fail with `expected 5243467 to be less than 4194304`, confirming the test exercises the fallback and not just a happy path.

## Notes
Two gaps found while reviewing, both deliberately out of scope:

1. `scheduled/check-stalled-executions.ts` reaps stale `agent_turn` runs and emits no `thread_response`. Harmless today (every turn is shadow), but once the authoritative path is enabled a crashed fleet worker would hang the client forever — the same failure the new `!isShadow && !envelope.reply` guard exists to prevent. Different file and lane; **must land before the cutover.**
2. The writer emits no leading `{type:"session"}` header line, unlike `device-chat.ts`. Degrades to `sessionId: "unknown"` in `agent-history.ts` rather than breaking.

`tool_use` SSE parity is not here: the isolate lane currently streams nothing at all (deltas and tool calls are counted and discarded), so that needs a streaming channel plus a protocol decision, not an extra event.

One pre-existing test changed meaning: it stripped `turn.shadow` to prove the route refuses undeliverable turns, but the producer now always stamps a reply address, so it was passing for the wrong reason. It now strips the envelope too, which is the deploy-skew case the guard actually covers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authoritative agent turns now deliver thread replies and appear in transcript history.
  * Oversized transcripts automatically use a compact continuation while preserving reply delivery.
  * Failed authoritative turns return an error response without adding transcript content.

* **Bug Fixes**
  * Shadow turns continue to suppress replies.
  * Invalid or incomplete reply data now prevents run completion and preserves the running state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->