### PR TITLE
fix(connectors): let a cold WhatsApp tab finish hydrating

### DIFF
--- a/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
@@ -225,6 +225,33 @@ describe("canonical WhatsApp identity and cutover", () => {
     );
   });
 
+  /**
+   * Measured against the live prod tab on 2026-09-06: a cold WhatsApp Web load
+   * traces 0:0 -> 5:0 -> 947:0 -> 947:23 -> ... -> 947:547 and is STILL
+   * climbing at t=24s. Readiness needs the `me:chatCount:msgCount` signature to
+   * hold for 500ms, so a 25s budget expired mid-stream on every run -- the feed
+   * failed `stores_settling` 9 times out of 10 and ingested nothing for days.
+   *
+   * The run itself is not the constraint: the executor allows 600s and each
+   * probe is its own fenced dispatch, so 25s was arbitrarily tight rather than
+   * a real bound. A warm tab still answers in ~1s, so raising this only changes
+   * how long a COLD tab is allowed to finish.
+   */
+  it("budgets readiness for a cold hydration, not just a warm tab", () => {
+    const source = readFileSync(
+      new URL("../whatsapp_web.ts", import.meta.url),
+      "utf8"
+    );
+    const match = source.match(/const READY_TIMEOUT_MS = ([\d_]+);/);
+    if (!match?.[1]) {
+      throw new Error("whatsapp_web.ts no longer declares READY_TIMEOUT_MS");
+    }
+    const readyTimeoutMs = Number(match[1].replaceAll("_", ""));
+    // A cold tab was still streaming at 24s; anything at or under that cannot
+    // outlast one measured hydration.
+    expect(readyTimeoutMs).toBeGreaterThanOrEqual(90_000);
+  });
+
   it("collects strictly after the cutover so ingested rows never replay", () => {
     const { request } = buildCollectionPlan({
       checkpoint: {
@@ -514,7 +541,10 @@ describe("sync over the generic chrome bridge", () => {
     const { dispatcher } = makeDispatcher({
       probe: () => {
         calls += 1;
-        if (calls === 1) Date.now = () => realNow() + 60_000;
+        // Jump past READY_TIMEOUT_MS so the readiness loop gives up on the
+        // first retry instead of polling for the whole (now cold-hydration
+        // sized) budget.
+        if (calls === 1) Date.now = () => realNow() + 10 * 60_000;
         return {
           ok: false,
           error: { state: "hydrating", reason: "stores_settling" },
@@ -530,6 +560,28 @@ describe("sync over the generic chrome bridge", () => {
     } finally {
       Date.now = realNow;
     }
+  });
+
+  /**
+   * `collect` re-checks readiness inside the page, so a message arriving between
+   * the passing probe and the collect dispatch surfaces `stores_settling` from
+   * the COLLECT path rather than the readiness loop. That is an ordinary race,
+   * not a broken feed: unclassified it counts against the consecutive-failure
+   * budget and walks an otherwise healthy feed toward a hard pause.
+   */
+  it("treats collect-phase hydration as transient, not a real failure", async () => {
+    const { dispatcher } = makeDispatcher({
+      probe: () => ({ ok: true, state: "ready", message_count: 1, chat_count: 1 }),
+      collect: () => ({
+        ok: false,
+        error: { state: "hydrating", reason: "stores_settling" },
+      }),
+    });
+    await expect(
+      messagesFeed().sync(syncCtx(null, dispatcher))
+    ).rejects.toThrow(
+      /^\[lobu:dependency_unavailable:browser_source_hydrating\] WhatsApp Web hydrating: stores_settling/
+    );
   });
 
   it("bumps the WhatsApp connector version for readiness semantics", () => {

--- a/packages/connectors/src/whatsapp_web.ts
+++ b/packages/connectors/src/whatsapp_web.ts
@@ -73,7 +73,28 @@ import {
 } from "./whatsapp-web-helpers.js";
 import { whatsAppWebAdapterProgram } from "./whatsapp-web-adapter.js";
 
-const READY_TIMEOUT_MS = 25_000;
+/**
+ * How long a run waits for WhatsApp Web to finish hydrating before giving up.
+ *
+ * Measured on the live prod tab (2026-09-06): a cold load traces
+ * 0:0 -> 5:0 -> 947:0 -> 947:23 -> ... -> 947:547 and is still climbing at
+ * t=24s, converging near 947:941. Readiness needs the `me:chatCount:msgCount`
+ * signature to hold still for 500ms, so the old 25s budget expired mid-stream
+ * every time: the feed failed `stores_settling` on 9 of its last 10 runs and
+ * ingested nothing for three days.
+ *
+ * 25s was never a real bound -- the executor allows a 600s run and each probe
+ * is its own fenced dispatch. A warm tab answers in ~1s, so this ceiling only
+ * governs how long a COLD tab may take, and it must outlast one full hydration
+ * with margin.
+ *
+ * This is the server-side half of the fix. The other half lives in the
+ * extension: a `persistent: true` navigate re-issues CDP `Page.navigate` on the
+ * plain-navigate path, reloading the very tab whose state it means to reuse, so
+ * every run pays cold hydration. Until that ships, this budget is what lets a
+ * cold run finish at all.
+ */
+const READY_TIMEOUT_MS = 120_000;
 const READY_POLL_INTERVAL_MS = 500;
 /**
  * Per-item budget, enforced by the ADAPTER inside the page.
@@ -895,6 +916,35 @@ export default class WhatsAppWebConnector extends ConnectorRuntime<
   ): Promise<SyncResult<BrowserCheckpoint>> {
     const dispatcher = requireExtensionDispatcher(ctx);
     const tabId = await readyWhatsAppTab(dispatcher);
+    return await this.collectMessages(ctx, dispatcher, tabId);
+  }
+
+  /**
+   * The collect phase re-checks readiness inside the page, so a message landing
+   * between the passing probe and this dispatch surfaces the same transient
+   * `stores_settling` here. `readyWhatsAppTab` classifies that as a dependency
+   * failure; without the same treatment on this path an ordinary race counts
+   * against the feed's consecutive-failure budget and walks it toward a pause.
+   */
+  private async collectMessages(
+    ctx: SyncContext<BrowserCheckpoint, WhatsAppWebConfig>,
+    dispatcher: ChromeActionDispatcher,
+    tabId: number
+  ): Promise<SyncResult<BrowserCheckpoint>> {
+    try {
+      return await this.collectMessagesInner(ctx, dispatcher, tabId);
+    } catch (error) {
+      const transient = classifyWhatsAppReadinessFailure(error);
+      if (transient) throw new Error(transient);
+      throw error;
+    }
+  }
+
+  private async collectMessagesInner(
+    ctx: SyncContext<BrowserCheckpoint, WhatsAppWebConfig>,
+    dispatcher: ChromeActionDispatcher,
+    tabId: number
+  ): Promise<SyncResult<BrowserCheckpoint>> {
     const { checkpoint, request } = buildCollectionPlan({
       checkpoint: ctx.checkpoint as Record<string, unknown> | null,
       config: ctx.config as Record<string, unknown>,


### PR DESCRIPTION
## Summary
The WhatsApp feed has ingested **nothing since 2026-09-03**. Of its last 10 runs, **9 failed `WhatsApp Web hydrating: stores_settling`** — not the 90s timeout fixed in #3382, which accounts for the other 1.

Measured against the live prod tab today, a cold WhatsApp Web load traces:

```
0:0 → 5:0 → 947:0 → 947:23 → 947:80 → ... → 947:547   (still climbing at t=24s)
```

converging near `947:941`. Readiness requires the `me:chatCount:msgCount` signature to hold still for 500ms, so the **25s** budget expired mid-stream every time.

25s was never a real bound — the executor allows a 600s run and each probe is its own fenced dispatch. A warm tab answers in ~1s, so this ceiling only governs how long a **cold** tab may take. Raised to 120s, outlasting one measured hydration with margin.

Also classifies a **collect-phase** `stores_settling` as transient. `collect` re-checks readiness inside the page, so a message landing between the passing probe and the collect dispatch produced an unclassified failure that consumed the feed's consecutive-failure budget and walked a healthy feed toward a hard pause.

## Test plan
- [x] Intended files staged explicitly, `make pre-pr` clean (all 5 gates)
- [x] Tests: `bun test packages/connectors/src/__tests__/` — **404 pass, 0 fail**
- [x] Bug fix: red→green pasted below

**Red** (budget at 25s):
```
Expected: >= 90000
Received: 25000
(fail) budgets readiness for a cold hydration, not just a warm tab
```

**Green** (120s): `39 pass, 0 fail`

**Negative control** — removed the collect-phase classification with its test in place and confirmed it fails again, so the test isn't passing vacuously.

## Notes
**This is one half of the fix.** The root cause is in the extension: on the plain-navigate path (`apps/chrome/tools.js:1940`) a `persistent: true` navigate calls `navigateTab()` unconditionally, issuing CDP `Page.navigate`, which performs a full document load even to an identical URL. The `cs_scrape` path (`:1824`) *does* guard this with an `origin+pathname` check; the plain path has no guard. So the connector reloads the very tab whose hot state it means to reuse, and every run pays cold hydration.

Proven in prod: planted a JS global on the tab, called `navigate(persistent:true)` to the same URL — same `tab_id`, but the global was gone and `performance.now()` reset 52s → 5s. Reproduced 3×, with and without `wait_for_load`.

That fix ships separately (extension → Web Store → per-browser auto-update). This PR ships today with the server and is what lets a cold run finish meanwhile.

Adversarial review flagged and I verified: `stores_settling` failures take a branch (`run-lifecycle.ts:1070`) that updates only `last_error`/`next_run_at` and does **not** touch `consecutive_failures` — confirmed by `last_sync_at` frozen at 10:36 while runs continued to 16:25. So the counter is stuck at 17, there was no imminent hard-pause, and the feed was silently dead rather than failing loudly.

The `READY_TIMEOUT_MS` test derives the value from source rather than hardcoding it, and the existing hydration test now fast-forwards past the constant instead of a fixed 60s so it can't be broken by future budget changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WhatsApp Web synchronization reliability during slower or cold starts by allowing additional time for the service to become ready.
  - Prevented temporary readiness issues during message collection from being treated as consecutive feed failures.
  - Reduced synchronization failures caused by timing differences between readiness checks and message collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->