### PR TITLE
fix(agent-turn): deliver the timeout when a fleet worker dies mid-turn

### DIFF
--- a/packages/server/src/__tests__/integration/agent-turn-shadow.test.ts
+++ b/packages/server/src/__tests__/integration/agent-turn-shadow.test.ts
@@ -9,10 +9,17 @@ import {
   AgentTurnPollPayloadSchema,
   PollResponseSchema,
 } from '@lobu/core/contracts/worker/protocol';
-import { type MessagePayload, verifyWorkerToken } from '@lobu/core';
+import {
+  AGENT_ERRORS,
+  AgentErrorCode,
+  type MessagePayload,
+  verifyWorkerToken,
+} from '@lobu/core';
 import { Value } from '@sinclair/typebox/value';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { enqueueAgentTurnShadow } from '../../gateway/orchestration/agent-turn-shadow';
+import { reapStaleRuns } from '../../scheduled/check-stalled-executions';
+import { sweepStaleAgentTurnRuns } from '../../worker-api/agent-turn';
 import type { AgentSettingsStore } from '../../gateway/auth/settings/agent-settings-store';
 import type { ProviderCatalogService } from '../../gateway/auth/provider-catalog';
 import type { McpConfigService } from '../../gateway/auth/mcp/config-service';
@@ -1007,5 +1014,192 @@ describe('agent turn completion', () => {
     });
     expect(response.status).toBe(409);
     expect((await runRow(runId)).status).toBe('running');
+  });
+});
+
+/**
+ * The reaper's side of the same distinction: a fleet worker that crashes
+ * mid-turn never reaches the completion route, so the run reaper is the only
+ * thing left that can tell the client. An authoritative turn gets the error
+ * the completion route would have published; a shadow turn ends silently.
+ */
+describe('agent turn reaper', () => {
+  const STALE_THRESHOLD_SECONDS = 60;
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    delete process.env.WORKER_API_TOKEN;
+    process.env[SHADOW_ENV] = AGENT_ID;
+  });
+
+  afterEach(() => {
+    delete process.env[SHADOW_ENV];
+  });
+
+  /** Make the run authoritative, as the cutover will. */
+  async function makeAuthoritative(runId: number) {
+    const sql = getTestDb();
+    await sql`
+      UPDATE runs
+      SET action_input = jsonb_set(action_input, '{turn,shadow}', 'false'::jsonb)
+      WHERE id = ${runId}
+    `;
+  }
+
+  /** The worker died: its last heartbeat is well past any threshold. */
+  async function loseHeartbeat(runId: number) {
+    const sql = getTestDb();
+    await sql`
+      UPDATE runs
+      SET claimed_at = now() - interval '1 hour',
+          last_heartbeat_at = now() - interval '1 hour'
+      WHERE id = ${runId}
+    `;
+  }
+
+  async function threadResponses() {
+    const sql = getTestDb();
+    return (await sql`
+      SELECT action_input FROM runs
+      WHERE queue_name = 'thread_response' AND run_type = 'chat_message'
+      ORDER BY id
+    `) as unknown as Array<{ action_input: Record<string, unknown> }>;
+  }
+
+  it('a crashed worker on an authoritative turn delivers the error instead of hanging the client', async () => {
+    const runId = await claimedShadowRun('fleet-crashed');
+    await makeAuthoritative(runId);
+    await loseHeartbeat(runId);
+
+    // Through the real reaper tick, so the lane is proven reachable from the
+    // 30s interval and not just from its own helper.
+    const result = await reapStaleRuns();
+    expect(result.acquired).toBe(true);
+    expect(result.reaped).toBe(1);
+    // A turn is never re-run behind the user's back.
+    expect(result.retriesCreated).toBe(0);
+
+    const row = await runRow(runId);
+    expect(row.status).toBe('timeout');
+    expect(row.error_message).toBe('worker_heartbeat_lost');
+
+    // The client gets the same thread_response the completion route publishes
+    // on failure, addressed from the run's own reply envelope and rendered
+    // through the shared error catalog.
+    const replies = await threadResponses();
+    expect(replies).toHaveLength(1);
+    expect(replies[0].action_input).toMatchObject({
+      messageId: 'msg-shadow',
+      channelId: 'api_user-shadow',
+      conversationId: 'conv-shadow',
+      userId: 'user-shadow',
+      platform: 'api',
+      error: AGENT_ERRORS[AgentErrorCode.WORKER_DIED].message,
+      errorCode: AgentErrorCode.WORKER_DIED,
+      processedMessageIds: ['msg-shadow'],
+    });
+    expect(replies[0].action_input.finalText).toBeUndefined();
+
+    // A second tick finds nothing: the row is terminal, so no duplicate error.
+    const again = await reapStaleRuns();
+    expect(again.reaped).toBe(0);
+    expect(await threadResponses()).toHaveLength(1);
+  });
+
+  it('a turn no worker ever claimed times out and tells the client it never started', async () => {
+    const org = await createTestOrganization();
+    await enqueueAgentTurnShadow(messageFor(org.id), {
+      agentSettings: settingsStore,
+      catalog: catalogFor(claudeModule()),
+      gatewayUrl: GATEWAY_URL,
+    });
+    const [run] = await shadowRuns();
+    await makeAuthoritative(run.id);
+    const sql = getTestDb();
+    await sql`UPDATE runs SET created_at = now() - interval '1 hour' WHERE id = ${run.id}`;
+
+    expect(await sweepStaleAgentTurnRuns(STALE_THRESHOLD_SECONDS)).toEqual({
+      reaped: 1,
+      delivered: 1,
+    });
+    const row = await runRow(run.id);
+    expect(row.status).toBe('timeout');
+    expect(row.error_message).toBe('worker_claim_timeout');
+    const replies = await threadResponses();
+    expect(replies).toHaveLength(1);
+    expect(replies[0].action_input).toMatchObject({
+      messageId: 'msg-shadow',
+      errorCode: AgentErrorCode.WORKER_STARTUP_FAILED,
+      error: AGENT_ERRORS[AgentErrorCode.WORKER_STARTUP_FAILED].message,
+    });
+  });
+
+  it('a shadow turn times out silently, and a heartbeating turn is left alone', async () => {
+    // Each claimed run is its own org and worker. A stale shadow next to a
+    // fresh authoritative turn shows one sweep reaping the former silently
+    // while leaving the latter untouched.
+    const staleShadow = await claimedShadowRun('fleet-shadow-stale');
+    await loseHeartbeat(staleShadow);
+    const live = await claimedShadowRun('fleet-live');
+    await makeAuthoritative(live);
+
+    expect(await sweepStaleAgentTurnRuns(STALE_THRESHOLD_SECONDS)).toEqual({
+      reaped: 1,
+      delivered: 0,
+    });
+    // The shadow run ends the way the bulk connector reaper ended it before,
+    // but the subprocess lane still owns the conversation's reply, so nothing
+    // reaches the client from here.
+    const shadowRow = await runRow(staleShadow);
+    expect(shadowRow.status).toBe('timeout');
+    expect(shadowRow.error_message).toBe('worker_heartbeat_lost');
+    expect(await threadResponses()).toHaveLength(0);
+    // The live turn just claimed, so its heartbeat is fresh.
+    expect((await runRow(live)).status).toBe('running');
+  });
+
+  it('an authoritative turn with no reply address terminalizes without delivering', async () => {
+    // The deploy-skew case the completion route's 409 covers: a producer that
+    // stamped an authoritative turn without saying where the reply goes. The
+    // reaper has nowhere to deliver to, but the row must not wedge the lane.
+    const runId = await claimedShadowRun('fleet-unaddressed');
+    await makeAuthoritative(runId);
+    await loseHeartbeat(runId);
+    const sql = getTestDb();
+    await sql`UPDATE runs SET action_input = action_input - 'reply' WHERE id = ${runId}`;
+
+    expect(await sweepStaleAgentTurnRuns(STALE_THRESHOLD_SECONDS)).toEqual({
+      reaped: 1,
+      delivered: 0,
+    });
+    expect((await runRow(runId)).status).toBe('timeout');
+    expect(await threadResponses()).toHaveLength(0);
+  });
+
+  it('a worker that completes between the candidate read and the timeout wins', async () => {
+    // The fenced UPDATE re-asserts the staleness predicate, so a heartbeat or
+    // completion that lands after the candidate read makes the reap a no-op
+    // rather than an overwrite of a live answer.
+    const workerId = 'fleet-late';
+    const runId = await claimedShadowRun(workerId);
+    await makeAuthoritative(runId);
+    await loseHeartbeat(runId);
+    const completion = await postAsFleet('/api/workers/complete-agent-turn', {
+      run_id: runId,
+      worker_id: workerId,
+      status: 'completed',
+      text: 'made it just in time',
+    });
+    expect(completion.status).toBe(200);
+
+    expect(await sweepStaleAgentTurnRuns(STALE_THRESHOLD_SECONDS)).toEqual({
+      reaped: 0,
+      delivered: 0,
+    });
+    expect((await runRow(runId)).status).toBe('completed');
+    // Exactly the reply the worker delivered, no timeout error beside it.
+    const replies = await threadResponses();
+    expect(replies).toHaveLength(1);
+    expect(replies[0].action_input).toMatchObject({ finalText: 'made it just in time' });
   });
 });

--- a/packages/server/src/scheduled/check-stalled-executions.ts
+++ b/packages/server/src/scheduled/check-stalled-executions.ts
@@ -19,6 +19,12 @@
  *    full four-lane set here. The browser-worker (Chrome) lane runs out
  *    of a service-worker and also heartbeats now (owletto#186) but uses
  *    its own `chrome.alarms` cadence — it shares this WHERE clause.
+ *  - `agent_turn` — the isolate turn lane, on the same fleet worker with the
+ *    same claim + heartbeat contract, so it shares the staleness predicate
+ *    but not the bulk CTE: an authoritative turn has a client waiting on its
+ *    reply, so its timeout must publish a `thread_response` in the same
+ *    transaction. `sweepStaleAgentTurnRuns` (worker-api/agent-turn.ts) owns
+ *    that, the way `sweepStaleDeviceChatRuns` does for device chat.
  *  - `automation` — driven in-process by the embedded gateway. Lifecycle is
  *    handled by the durable terminal-event resolution (run-completion.ts)
  *    + the dedicated `sweepStaleAutomationRuns` / `resetOrphanedAutomationRuns`
@@ -60,6 +66,7 @@ import {
   DEVICE_FEED_READ_SCRUB_GRACE_SECONDS,
 } from '../lib/device-feed-read-protocol';
 import { buildStaleRunWhereSql } from './stale-run-sweeper';
+import { sweepStaleAgentTurnRuns } from '../worker-api/agent-turn';
 import { sweepStaleDeviceChatRuns } from '../worker-api/device-chat';
 
 /** Advisory-lock key for cross-pod coordination of the stale-run reaper.
@@ -212,10 +219,11 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
   // the executor beat at least once; rows with none are judged on
   // COALESCE(claimed_at, created_at). One threshold covers both paths.
   const staleWhereSql = buildStaleRunWhereSql({
-    // `agent_turn` joins the connector lanes because it runs on the SAME
-    // worker with the same claim + heartbeat contract; without it a crashed
-    // fleet worker leaves the turn `running` forever.
-    runTypes: ['sync', 'action', 'embed_backfill', 'auth', 'agent_turn'],
+    // `agent_turn` runs on the SAME worker with the same claim + heartbeat
+    // contract, but is reaped by `sweepStaleAgentTurnRuns` below rather than
+    // the bulk CTE: an authoritative turn's timeout has to publish the
+    // thread_response its client is waiting on, in the same transaction.
+    runTypes: ['sync', 'action', 'embed_backfill', 'auth'],
     heartbeatSemantics: 'any-heartbeat',
     heartbeatStaleInterval: `${thresholdSeconds} seconds`,
     coarseStaleInterval: `${thresholdSeconds} seconds`,
@@ -556,9 +564,30 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
         );
       }
 
+      // Agent turns share the connector lanes' claim + heartbeat contract but
+      // not their terminal semantics: a crashed fleet worker leaves a client
+      // waiting on an authoritative turn's reply, so the sweep that times the
+      // run out also publishes the thread_response the completion route would
+      // have. A shadow turn terminalizes silently.
+      let agentTurnsReaped = 0;
+      let agentTurnErrorsDelivered = 0;
+      try {
+        const swept = await sweepStaleAgentTurnRuns(thresholdSeconds);
+        agentTurnsReaped = swept.reaped;
+        agentTurnErrorsDelivered = swept.delivered;
+      } catch (err) {
+        logger.error(
+          { error: String(err) },
+          '[reaper] Failed to sweep stale agent turn runs'
+        );
+      }
+
       const reapedRow = reaped[0];
       const reapedCount =
-        deviceChatsReaped + approvalActionsReaped + (reapedRow?.reaped ?? 0);
+        deviceChatsReaped +
+        agentTurnsReaped +
+        approvalActionsReaped +
+        (reapedRow?.reaped ?? 0);
       const retriesCreated = reapedRow?.retries_created ?? 0;
       const syncEligible = reapedRow?.sync_eligible ?? 0;
 
@@ -619,6 +648,8 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
           reaped: reapedCount,
           approvalActionsReaped,
           deviceChatsReaped,
+          agentTurnsReaped,
+          agentTurnErrorsDelivered,
           retriesCreated,
           thresholdSeconds,
         },

--- a/packages/server/src/scheduled/stale-run-sweeper.ts
+++ b/packages/server/src/scheduled/stale-run-sweeper.ts
@@ -1,11 +1,14 @@
 /**
  * Shared stale-run reaping core.
  *
- * Two reapers mark stale `runs` rows as `timeout` when their liveness signal
+ * Three reapers mark stale `runs` rows as `timeout` when their liveness signal
  * lapses. Callers may additionally include never-claimed `pending` rows:
  *
  *   - the connector-lane reaper (scheduled/check-stalled-executions.ts) —
  *     sync/action/embed_backfill/auth, single 120s threshold
+ *   - the agent-turn sweep (worker-api/agent-turn.ts) — `agent_turn` on the
+ *     connector reaper's threshold, one row per transaction so the timeout
+ *     can publish the client's `thread_response` alongside it
  *   - the automation sweep (automations/automation.ts) — 3min heartbeat-stale fast
  *     path + 2h coarse TTL for runs that never heartbeated
  *

--- a/packages/server/src/worker-api/agent-turn.ts
+++ b/packages/server/src/worker-api/agent-turn.ts
@@ -11,8 +11,13 @@
  * client is waiting on, both inside the same fenced terminal transition, the
  * way `device-chat.ts` does for the other non-subprocess lane. Which of the
  * two a run is, is the run's own `turn.shadow`, stamped by the producer.
+ *
+ * `sweepStaleAgentTurnRuns` is the same distinction applied by the stale-run
+ * reaper: a worker that crashes mid-turn never reaches this route, so the
+ * reaper terminalizes the run and, for an authoritative turn, delivers the
+ * error the completion route would have.
  */
-import { parseSessionEntries } from "@lobu/core";
+import { AGENT_ERRORS, AgentErrorCode, parseSessionEntries } from "@lobu/core";
 import {
 	type CompleteAgentTurnRequest,
 	CompleteAgentTurnRequestSchema,
@@ -31,6 +36,8 @@ import {
 } from "../gateway/services/transcript-snapshot";
 import type { Env } from "../index";
 import { runLeaseFence } from "../runs/run-lease";
+import { classifyRunOutcome } from "../runs/run-outcome";
+import { buildStaleRunWhereSql } from "../scheduled/stale-run-sweeper";
 import { stripNul } from "../utils/strip-nul";
 import { authorizeRunForWorker } from "./shared";
 
@@ -274,4 +281,122 @@ export async function completeAgentTurnRun(c: Context<{ Bindings: Env }>) {
 	// woken for a row a rollback would take back.
 	if (!isShadow) await notifyThreadResponse();
 	return c.json({ ok: true, status: failed ? "failed" : "completed" });
+}
+
+/**
+ * Reap stale `agent_turn` runs, delivering the failure where a client is
+ * waiting on one.
+ *
+ * The turn lane shares the connector lanes' claim and heartbeat contract, so
+ * the staleness predicate is theirs (`buildStaleRunWhereSql`): a never-claimed
+ * `pending` row past the threshold, or a `claimed`/`running` row whose
+ * heartbeat lapsed. What differs is what a timeout MEANS. A connector run just
+ * ends; an authoritative turn has a client blocked on its reply, and the
+ * completion route that would have answered it never fires for a worker that
+ * died. Without this the client waits forever with no error ever surfacing.
+ *
+ * Shape and reason follow `sweepStaleDeviceChatRuns`: candidates are read
+ * once, then each is terminalized in its own transaction by an UPDATE that
+ * re-asserts the full predicate, so a worker whose heartbeat or completion
+ * wins after the candidate read makes this a no-op instead of an overwrite.
+ * The `thread_response` joins the same transaction, and the listener is woken
+ * only after commit.
+ *
+ * Delivery follows the run's own envelope, exactly as the completion route
+ * does: a shadow turn (`turn.shadow === true`) delivers nothing, and so does a
+ * run with no `reply` address — there is nowhere to deliver to, and the row
+ * still terminalizes so the lane cannot wedge.
+ */
+export async function sweepStaleAgentTurnRuns(
+	thresholdSeconds: number,
+): Promise<{ reaped: number; delivered: number }> {
+	const sql = getDb();
+	const staleWhereSql = buildStaleRunWhereSql({
+		runTypes: ["agent_turn"],
+		heartbeatSemantics: "any-heartbeat",
+		heartbeatStaleInterval: `${thresholdSeconds} seconds`,
+		coarseStaleInterval: `${thresholdSeconds} seconds`,
+		includePending: true,
+	});
+	const candidates = await sql.unsafe<{
+		id: number | string;
+		status: "pending" | "claimed" | "running";
+		organization_id: string;
+		action_input: {
+			turn?: { shadow?: unknown; conversation_id?: unknown };
+			reply?: TurnReply;
+		} | null;
+	}>(
+		`SELECT id, status, organization_id, action_input
+     FROM public.runs
+     WHERE ${staleWhereSql}
+     ORDER BY id
+     LIMIT 100`,
+	);
+
+	let reaped = 0;
+	let delivered = 0;
+	for (const candidate of candidates) {
+		const runId = Number(candidate.id);
+		const neverClaimed = candidate.status === "pending";
+		const workerError = neverClaimed
+			? "worker_claim_timeout"
+			: "worker_heartbeat_lost";
+		// The catalog owns the prose, as turn-liveness does for the subprocess
+		// lane: a run nobody claimed never started; a lapsed heartbeat is a
+		// worker that died mid-turn.
+		const code = neverClaimed
+			? AgentErrorCode.WORKER_STARTUP_FAILED
+			: AgentErrorCode.WORKER_DIED;
+		const envelope = candidate.action_input ?? {};
+		const reply =
+			envelope.turn?.shadow === true ? undefined : envelope.reply;
+		const outcome = await sql.begin(async (tx) => {
+			const rows = await tx.unsafe<{ id: number | string }>(
+				`UPDATE public.runs
+         SET status = 'timeout',
+             outcome = $2,
+             completed_at = current_timestamp,
+             error_message = $3
+         WHERE id = $1
+           AND status = $4
+           AND ${staleWhereSql}
+         RETURNING id`,
+				[
+					runId,
+					classifyRunOutcome({ status: "timeout" }),
+					workerError,
+					candidate.status,
+				],
+			);
+			if (rows.length === 0) return "won_by_worker";
+			if (!reply) return "reaped";
+			await insertThreadResponseRow(
+				tx,
+				{
+					messageId: reply.message_id,
+					channelId: reply.channel_id,
+					conversationId: String(envelope.turn?.conversation_id ?? ""),
+					userId: reply.user_id,
+					teamId: reply.team_id ?? "api",
+					platform: reply.platform,
+					organizationId: candidate.organization_id,
+					platformMetadata: reply.platform_metadata,
+					error: AGENT_ERRORS[code].message,
+					errorCode: code,
+					processedMessageIds: [reply.message_id],
+					timestamp: Date.now(),
+				},
+				candidate.organization_id,
+			);
+			return "delivered";
+		});
+		if (outcome === "won_by_worker") continue;
+		reaped += 1;
+		if (outcome === "delivered") delivered += 1;
+	}
+	// Outside the transaction, as device-chat does: the listener must not be
+	// woken for a row a rollback would take back.
+	if (delivered > 0) await notifyThreadResponse();
+	return { reaped, delivered };
 }


### PR DESCRIPTION
## What

The isolate turn lane shares the connector lanes' claim and heartbeat contract, so it rode their bulk reaping CTE. But a timeout means something different here: an authoritative turn has a client blocked on its reply, and the completion route that would have answered it never fires for a worker that died. The run went `timeout` and the client waited forever.

This moves `agent_turn` out of the bulk CTE into `sweepStaleAgentTurnRuns`, which terminalizes each candidate in its own transaction and, where the run carries a `reply` address, publishes the `thread_response` in that same transaction — the shape `sweepStaleDeviceChatRuns` already uses for the other non-subprocess lane. A shadow turn, and a run with no reply address, terminalize silently.

Never claimed resolves to `WORKER_STARTUP_FAILED`, a lapsed heartbeat to `WORKER_DIED`, leaving the prose to the catalog as turn-liveness does.

Harmless today — every turn in prod is shadow, and `LOBU_ISOLATE_TURN_SHADOW_AGENTS` is unset. This has to land before the authoritative path is enabled, which is why it is its own change.

## Red → green

Red, with the test present and the source at the parent commit:

```
FAIL agent turn reaper > a crashed worker on an authoritative turn delivers the error instead of hanging the client
AssertionError: expected [] to have a length of 1 but got +0
```

Green:

```
✓ src/__tests__/integration/agent-turn-shadow.test.ts (25 tests)
 Test Files  1 passed (1)
      Tests  25 passed (25)
```

Reaper suites unaffected: `stale-run-reaper.test.ts` + `check-stalled-no-reap.test.ts` → 35 pass, 0 fail. `make pre-pr` clean.

## Behaviour change worth calling out

Unclaimed `agent_turn` runs no longer appear in the `dispatch_unavailable` warn log. They always classified as `fleet_or_unpinned_no_claim` there, since a turn carries no `connection_id`, and every other field in that line (`connector_key`, `device_worker_id`, `platform`) is connector-shaped and null for a turn. The line carried no varying information.

## Not covered

No live fleet worker was killed mid-turn end to end. Coverage is the integration suite, which simulates the lapsed heartbeat by rewriting `last_heartbeat_at` and drives a real `reapStaleRuns()` tick.