### PR TITLE
fix(sdk): report enforced access tiers and normalize connector arguments

### DIFF
--- a/packages/server/src/__tests__/integration/client-sdk-business-errors.test.ts
+++ b/packages/server/src/__tests__/integration/client-sdk-business-errors.test.ts
@@ -114,7 +114,7 @@ describe("ClientSDK business failure boundary", () => {
 			{
 				path: "operations.execute",
 				args: [{ connection_id: 549, operation_key: "dry_run_probe" }],
-				required_access: "external",
+				required_access: "write",
 				authorization_status: "not_evaluated",
 			},
 		]);

--- a/packages/server/src/__tests__/integration/mcp/sdk-tier-reporting.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/sdk-tier-reporting.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Acceptance test for the reported MCP symptom: an mcp:write caller asked
+ * search_sdk about an admin-enforced `external` method, was told it needed
+ * "operate (mcp:write)" — the tier it already had — retried through run_sdk as
+ * instructed, and hit a hard "requires an MCP session with admin access."
+ *
+ * Exercised over a real OAuth-scoped MCP session (HTTP + JSON-RPC), not the
+ * resolver in isolation, so it pins the tier the caller is actually shown.
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAccessToken,
+  createTestOAuthClient,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+import { post } from '../../setup/test-helpers';
+
+describe('MCP SDK tier reporting', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let owner: Awaited<ReturnType<typeof createTestUser>>;
+  let client: Awaited<ReturnType<typeof createTestOAuthClient>>;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    org = await createTestOrganization({ name: 'Tier Report Org', slug: 'tier-report-org' });
+    owner = await createTestUser({ email: 'tier-owner@test.example.com' });
+    await addUserToOrganization(owner.id, org.id, 'owner');
+    client = await createTestOAuthClient();
+  });
+
+  async function session(token: string) {
+    const init = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: '__init__',
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'lobu-test', version: '1.0' },
+        },
+      },
+      token,
+    });
+    const sessionId = init.headers.get('mcp-session-id');
+    expect(sessionId).toBeTruthy();
+    await post(`/mcp/${org.slug}`, {
+      body: { jsonrpc: '2.0', method: 'notifications/initialized' },
+      headers: { 'mcp-session-id': sessionId! },
+      token,
+    });
+    return sessionId!;
+  }
+
+  async function callTool(token: string, sessionId: string, name: string, args: unknown) {
+    const res = await post(`/mcp/${org.slug}`, {
+      body: { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: args } },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    return (body.result?.content ?? []).map((c: any) => c.text ?? '').join('\n');
+  }
+
+  it('tells an mcp:write owner that admin-enforced external methods need administer', async () => {
+    const { token } = await createTestAccessToken(owner.id, org.id, client.client_id, {
+      scope: 'mcp:write profile:read',
+    });
+    const sessionId = await session(token);
+
+    const text = await callTool(token, sessionId, 'search_sdk', {
+      query: 'feeds.trigger connections.test authProfiles.test',
+    });
+
+    // The bug: these advertised "operate (mcp:write)" — the tier the caller
+    // already held — so the client retried into a hard admin rejection.
+    for (const path of ['feeds.trigger', 'connections.test', 'authProfiles.test']) {
+      const line = text.split('\n').find((l: string) => l.includes(path) && l.includes('access:'));
+      expect(line, `no access line rendered for ${path}`).toBeTruthy();
+      expect(line).toContain('administer');
+      expect(line).not.toContain('operate (mcp:write)');
+    }
+  });
+
+  it('reports the resolved tier, never the external marker, on the dry-run wire', async () => {
+    const { token } = await createTestAccessToken(owner.id, org.id, client.client_id, {
+      scope: 'mcp:write profile:read',
+    });
+    const sessionId = await session(token);
+
+    const text = await callTool(token, sessionId, 'run_sdk', {
+      dry_run: true,
+      script:
+        'export default async (_ctx, client) => client.operations.execute(' +
+        '{ connection_id: 1, operation_key: "probe" });',
+    });
+
+    // `external` is a side-effect marker, not a tier. It legitimately stays on
+    // the `access` field (that is the marker, and what keeps the method
+    // write-VISIBLE for progressive OAuth) — but it must never surface as
+    // `required_access`, which is the tier the caller is told to satisfy.
+    expect(text).toContain('operations.execute');
+    expect(text).toMatch(/"required_access":\s*"write"/);
+    expect(text).not.toMatch(/"required_access":\s*"external"/);
+    // The marker itself is still present and correct.
+    expect(text).toMatch(/"access":\s*"external"/);
+  });
+
+  it('keeps admin-enforced external methods visible so progressive OAuth can fire', async () => {
+    const { token } = await createTestAccessToken(owner.id, org.id, client.client_id, {
+      scope: 'mcp:write profile:read',
+    });
+    const sessionId = await session(token);
+
+    // Reporting got stricter; VISIBILITY must not. An owner on mcp:write still
+    // sees the method, so calling it raises the mcp:admin OAuth challenge
+    // instead of the method silently vanishing from discovery.
+    const text = await callTool(token, sessionId, 'search_sdk', { query: 'connections.test' });
+    expect(text).toContain('connections.test');
+  });
+});

--- a/packages/server/src/__tests__/unit/sandbox/action-call.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/action-call.test.ts
@@ -221,6 +221,20 @@ describe("createActionCaller", () => {
 		await expect(method("delete")({ entity_id: 7 })).resolves.toEqual(queued);
 	});
 
+	it.each([
+		["connections", "test", "test", "admin"],
+		["feeds", "trigger_feed", "trigger", "admin"],
+		["operations", "execute", "execute", "write"],
+	])("preflight reports the enforced tier for %s.%s without executing it", async (namespace, action, publicMethod, requiredAccess) => {
+		let executed = false;
+		const { method } = createTestCaller(async () => { executed = true; return {}; }, namespace);
+		const call = method(action, { publicMethod });
+		const preview = await getSdkPreflight(call)?.({});
+		expect(preview?.required_access).toBe(requiredAccess);
+		expect(preview?.authorization_status).toBe("not_evaluated");
+		expect(executed).toBe(false);
+	});
+
 	it("preflights through the handler schema without entering the handler or inspecting its result", async () => {
 		let executed = false;
 		const handler = withValidatedArgs(

--- a/packages/server/src/__tests__/unit/sandbox/sdk-method-access.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-method-access.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { requiredSdkAccess, type MethodAccessMetadata } from "../../../sandbox/method-metadata";
 import {
 	effectiveSdkRequiredTier,
 	resolveSdkAccessGuidance,
@@ -38,12 +39,12 @@ describe("sdkMethodVisible", () => {
 });
 
 describe("SDK access guidance", () => {
-	it("keeps write/external on operate and admin on administer", () => {
-		expect(effectiveSdkRequiredTier("read")).toBe("read");
-		expect(effectiveSdkRequiredTier("write")).toBe("operate");
-		expect(effectiveSdkRequiredTier("external")).toBe("operate");
-		expect(effectiveSdkRequiredTier("admin")).toBe("administer");
-		expect(effectiveSdkRequiredTier(["read", "external", "admin"])).toBe(
+	it("reports each explicit permission tier", () => {
+		expect(effectiveSdkRequiredTier({ access: "read" })).toBe("read");
+		expect(effectiveSdkRequiredTier({ access: "write" })).toBe("operate");
+		expect(effectiveSdkRequiredTier({ access: "external", enforcedTier: "write" })).toBe("operate");
+		expect(effectiveSdkRequiredTier({ access: "admin" })).toBe("administer");
+		expect(effectiveSdkRequiredTier([{ access: "read" }, { access: "external", enforcedTier: "write" }, { access: "admin" }])).toBe(
 			"administer",
 		);
 	});
@@ -61,8 +62,8 @@ describe("SDK access guidance", () => {
 		expect(
 			effectiveSdkRequiredTier({ access: "external", enforcedTier: "write" }),
 		).toBe("operate");
-		// No enforcedTier keeps the historical marker-derived tier.
-		expect(effectiveSdkRequiredTier({ access: "external" })).toBe("operate");
+		// Incomplete metadata is rejected rather than under-reporting permissions.
+		expect(() => effectiveSdkRequiredTier({ access: "external" } as never)).toThrow("no enforced tier");
 	});
 
 	it("takes the strictest enforcedTier across a lifecycle", () => {
@@ -70,7 +71,7 @@ describe("SDK access guidance", () => {
 		// must be the admin the trigger enforces, not the operate its peers imply.
 		expect(
 			effectiveSdkRequiredTier([
-				"read",
+				{ access: "read" },
 				{ access: "external", enforcedTier: "admin" },
 			]),
 		).toBe("administer");
@@ -96,7 +97,7 @@ describe("SDK access guidance", () => {
 	});
 
 	it("marks owner/admin mcp:write callers as progressively authorizable for admin methods", () => {
-		const guidance = resolveSdkAccessGuidance("admin", "owner", [
+		const guidance = resolveSdkAccessGuidance({ access: "admin" }, "owner", [
 			"mcp:read",
 			"mcp:write",
 		]);
@@ -109,7 +110,7 @@ describe("SDK access guidance", () => {
 	});
 
 	it("tells a regular member to hand administer work to an owner/admin", () => {
-		const guidance = resolveSdkAccessGuidance("admin", "member", [
+		const guidance = resolveSdkAccessGuidance({ access: "admin" }, "member", [
 			"mcp:read",
 			"mcp:write",
 			"mcp:admin",
@@ -121,11 +122,37 @@ describe("SDK access guidance", () => {
 	});
 
 	it("recognizes an owner/admin with mcp:admin as ready to administer", () => {
-		const guidance = resolveSdkAccessGuidance("admin", "admin", [
+		const guidance = resolveSdkAccessGuidance({ access: "admin" }, "admin", [
 			"mcp:admin",
 		]);
 
 		expect(guidance.available).toBe(true);
 		expect(guidance.instruction).toBeUndefined();
+	});
+});
+
+describe("requiredSdkAccess", () => {
+	// `MethodAccessMetadata` makes `{ access: "external" }` with no
+	// `enforcedTier` unrepresentable, but tsconfig.json excludes
+	// `src/**/__tests__/**` from the typecheck program, so the compiler does not
+	// police this file. These assert the runtime half: metadata reaching the
+	// resolver from an untyped edge (JSON, a cast) fails loudly instead of
+	// silently under-reporting the tier a caller needs.
+	it("returns the enforced tier for an external method", () => {
+		expect(
+			requiredSdkAccess({ access: "external", enforcedTier: "admin" }),
+		).toBe("admin");
+	});
+
+	it("returns the marker itself for a plainly-tiered method", () => {
+		expect(requiredSdkAccess({ access: "read" })).toBe("read");
+		expect(requiredSdkAccess({ access: "write" })).toBe("write");
+		expect(requiredSdkAccess({ access: "admin" })).toBe("admin");
+	});
+
+	it("throws rather than under-report when an external method has no tier", () => {
+		expect(() =>
+			requiredSdkAccess({ access: "external" } as MethodAccessMetadata),
+		).toThrow("no enforced tier");
 	});
 });

--- a/packages/server/src/__tests__/unit/sandbox/sdk-method-access.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-method-access.test.ts
@@ -48,6 +48,53 @@ describe("SDK access guidance", () => {
 		);
 	});
 
+	it("reports an external method's enforcedTier, not the write its marker implies", () => {
+		// `external` is a side-effect marker, so it mapped to operate for BOTH
+		// visibility and reporting. `connections.test` / `feeds.trigger` /
+		// `authProfiles.test` are external but admin-ENFORCED, so an mcp:write
+		// caller was told "operate (mcp:write)", retried, and hit a hard
+		// "requires an MCP session with admin access."
+		expect(
+			effectiveSdkRequiredTier({ access: "external", enforcedTier: "admin" }),
+		).toBe("administer");
+		// An external method that really is write-enforced still reports operate.
+		expect(
+			effectiveSdkRequiredTier({ access: "external", enforcedTier: "write" }),
+		).toBe("operate");
+		// No enforcedTier keeps the historical marker-derived tier.
+		expect(effectiveSdkRequiredTier({ access: "external" })).toBe("operate");
+	});
+
+	it("takes the strictest enforcedTier across a lifecycle", () => {
+		// A connector lifecycle bundles reads with feeds.trigger; the aggregate
+		// must be the admin the trigger enforces, not the operate its peers imply.
+		expect(
+			effectiveSdkRequiredTier([
+				"read",
+				{ access: "external", enforcedTier: "admin" },
+			]),
+		).toBe("administer");
+	});
+
+	it("sends an mcp:write caller to the admin path for an admin-enforced external method", () => {
+		// The end-to-end symptom: guidance must not say "retry with mcp:write".
+		const guidance = resolveSdkAccessGuidance(
+			{ access: "external", enforcedTier: "admin" },
+			"owner",
+			["mcp:read", "mcp:write"],
+		);
+
+		expect(guidance.requiredTier).toBe("administer");
+		expect(guidance.available).toBe(false);
+		expect(guidance.progressivelyAuthorizable).toBe(true);
+	});
+
+	it("keeps external methods write-VISIBLE even when admin-enforced", () => {
+		// Reporting changed; visibility must not. An owner/admin still needs to
+		// see and call the method to trigger the progressive mcp:admin challenge.
+		expect(sdkMethodVisible("external", "write", "full")).toBe(true);
+	});
+
 	it("marks owner/admin mcp:write callers as progressively authorizable for admin methods", () => {
 		const guidance = resolveSdkAccessGuidance("admin", "owner", [
 			"mcp:read",

--- a/packages/server/src/__tests__/unit/sandbox/sdk-signature-contract.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-signature-contract.test.ts
@@ -197,6 +197,31 @@ describe("ClientSDK object signature contract", () => {
 		]);
 	});
 
+	it("normalizes both connector uninstall argument forms before dispatch", async () => {
+		const connections = builders.connections(ctx, env);
+		await connections.uninstallConnector("fixture.connector");
+		await connections.uninstallConnector({ connector_key: "fixture.connector" } as never);
+		expect(calls).toEqual([
+			{ action: "uninstall_connector", input: { connector_key: "fixture.connector" } },
+			{ action: "uninstall_connector", input: { connector_key: "fixture.connector" } },
+		]);
+	});
+
+	it("rejects malformed connector uninstall arguments before dispatch", async () => {
+		const connections = builders.connections(ctx, env);
+		const invalid: unknown[] = [
+			undefined, null, 3, {}, [],
+			{ connector_key: 3 },
+			{ connector_key: "fixture.connector", force: true },
+		];
+		for (const input of invalid) {
+			await expect(
+				Promise.resolve().then(() => connections.uninstallConnector(input as never)),
+			).rejects.toThrow("connections.uninstallConnector expects the connector_key");
+		}
+		expect(calls).toEqual([]);
+	});
+
 	it("pins both entity-schema discriminators against caller input", async () => {
 		const entitySchema = builders.entitySchema(ctx, env);
 

--- a/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
+++ b/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
@@ -234,6 +234,16 @@ describe("access-model cross-check", () => {
 			const [namespace, method] = path.split(".");
 			const tool = NAMESPACE_TOOL[namespace];
 			if (!tool || !method) continue;
+			// `enforcedTier` disambiguates `external` only; anywhere else it is dead
+			// weight that can silently contradict `access`. Checked before the
+			// branches below so it covers the `.manage` wrappers too — they take the
+			// `expected`-vs-`reported` path, which reads `enforcedTier` only when
+			// `access` is external and so would never notice a stray one.
+			if (meta.access !== "external" && meta.enforcedTier !== undefined) {
+				mismatches.push(
+					`${path}: enforcedTier is only meaningful with access:"external" (access=${meta.access})`,
+				);
+			}
 			// `.manage` is the raw action-passthrough wrapper: it accepts ANY action
 			// of its tool, so it carries the namespace's most-privileged tier rather
 			// than one action's. That is a derivable expectation, not an exemption —

--- a/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
+++ b/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
@@ -217,23 +217,45 @@ describe("access-model cross-check", () => {
 		// Compare the discovery tier `sdkMethodVisible` uses with the tier the
 		// delegated manage_* action enforces.
 		//
-		// `external` is exempt from the exact-match requirement: it is a
-		// side-effect marker (this method calls out to an external system), not a
-		// pure tier. `sdkMethodVisible` treats it as write-visible, and the
-		// project deliberately keeps external methods write-visible even when the
-		// underlying tool action is admin-enforced (see method-metadata.test.ts:
-		// operations.execute / feeds.trigger / connections.test stay "external"
-		// while their trigger_feed / execute / test actions are owner-admin). So
-		// `external` only asserts "not read-tier" — never that it equals admin.
+		// `external` splits the two: it is a side-effect marker (this method calls
+		// out to an external system), not a pure tier. VISIBILITY still follows the
+		// marker — `sdkMethodVisible` keeps external methods write-visible even when
+		// the underlying action is admin-enforced, so an owner/admin can trigger the
+		// progressive mcp:admin OAuth challenge by calling one (operations.execute /
+		// feeds.trigger / connections.test all stay "external" while trigger_feed /
+		// test are owner-admin).
+		//
+		// The tier REPORTED to callers is a separate question, and it must match
+		// enforcement exactly or search_sdk sends an mcp:write caller to retry into
+		// a hard admin rejection. That is what `enforcedTier` carries, and what the
+		// external branch below pins against the live tier map.
 		const mismatches: string[] = [];
 		for (const [path, meta] of Object.entries(METHOD_METADATA)) {
 			const [namespace, method] = path.split(".");
 			const tool = NAMESPACE_TOOL[namespace];
 			if (!tool || !method) continue;
-			// `.manage` is the raw action-passthrough wrapper — it carries the
-			// namespace's most-privileged tier, not a single action, so it has no
-			// single tool-action to compare against.
-			if (method === "manage") continue;
+			// `.manage` is the raw action-passthrough wrapper: it accepts ANY action
+			// of its tool, so it carries the namespace's most-privileged tier rather
+			// than one action's. That is a derivable expectation, not an exemption —
+			// skipping it entirely hid half the `external` class, leaving all five
+			// wrappers reporting "operate (mcp:write)" while four of them accept
+			// admin actions (connections.manage({action:'delete'}) from an mcp:write
+			// caller is the exact symptom this guard exists to catch).
+			if (method === "manage") {
+				// Only the TIER is derivable. Whether a wrapper is also `external` is
+				// a property of its namespace (does it call out to an external
+				// system?), so entities/entitySchema/agents/schedules/classifiers/
+				// viewTemplates legitimately use a plain tier instead.
+				const expected = OWNER_ADMIN_ACTIONS[tool]?.size ? "admin" : "write";
+				const reported =
+					meta.access === "external" ? meta.enforcedTier : meta.access;
+				if (reported !== expected) {
+					mismatches.push(
+						`${path}: reports ${reported ?? "(unset)"} but ${tool} has ${OWNER_ADMIN_ACTIONS[tool]?.size ?? 0} owner-admin action(s), so the passthrough must report "${expected}"${meta.access === "external" ? ' via enforcedTier' : ""}`,
+					);
+				}
+				continue;
+			}
 			if (NO_TOOL_ACTION.has(path)) continue;
 			// The action this method REALLY dispatches, recorded from the live
 			// dispatch path. Never guessed: `feeds.list` dispatches `list_feeds`,
@@ -262,8 +284,27 @@ describe("access-model cross-check", () => {
 					mismatches.push(
 						`${path}: SDK=external but runtime(${tool}.${action})=read`,
 					);
+					continue;
+				}
+				// `external` governs VISIBILITY, but the tier search_sdk REPORTS comes
+				// from `enforcedTier`. It must state the enforced tier exactly:
+				// omitting it on an admin-enforced method reported "operate
+				// (mcp:write)" and sent an mcp:write caller to retry straight into
+				// "requires an MCP session with admin access."; stating the wrong tier
+				// is the same bug with extra confidence.
+				if (meta.enforcedTier !== runtimeTier) {
+					mismatches.push(
+						`${path}: SDK=external enforcedTier=${meta.enforcedTier ?? "(unset)"} but runtime(${tool}.${action})=${runtimeTier} — set enforcedTier to "${runtimeTier}" in method-metadata.ts so the reported tier matches enforcement`,
+					);
 				}
 				continue;
+			}
+			// `enforcedTier` disambiguates `external` only; on a plainly-tiered
+			// method it is dead weight that can silently contradict `access`.
+			if (meta.enforcedTier !== undefined) {
+				mismatches.push(
+					`${path}: enforcedTier is only meaningful with access:"external" (access=${meta.access})`,
+				);
 			}
 			// read / write / admin must match the enforced tier exactly.
 			if (meta.access !== runtimeTier) {

--- a/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
+++ b/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
@@ -25,6 +25,7 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 import { Type } from "@sinclair/typebox";
 import {
 	getRequiredAccessLevel,
+	isPublicReadable,
 	MEMBER_WRITE_ACTIONS,
 	OWNER_ADMIN_ACTIONS,
 	PUBLIC_READ_ACTIONS,
@@ -54,6 +55,7 @@ const TIERED_NAMESPACES = [
 	["catalog", "manage_catalog", "../../tools/admin/manage_catalog", "manageCatalog"],
 	["agents", "manage_agents", "../../tools/admin/manage_agents", "manageAgents"],
 	["schedules", "manage_schedules", "../../tools/admin/manage_schedules", "manageSchedules"],
+	["conversations", "manage_conversations", "../../tools/admin/manage_conversations", "manageConversations"],
 ] as const;
 
 const NAMESPACE_TOOL = Object.fromEntries(
@@ -76,6 +78,8 @@ const NO_TOOL_ACTION = new Set([
 	"entities.search",
 	// Same shape: delegates to the standalone `get_automation` tool.
 	"automations.get",
+	// Uses the owner-scoped current MCP conversation helper, not manage_conversations.
+	"conversations.setTitle",
 ]);
 
 /**
@@ -174,7 +178,12 @@ function declaredRuntimeTier(
 ): ToolAccessLevel | null {
 	const action = payload.action;
 	if (typeof action !== "string") return null;
-	const isExplicitlyDeclared =
+	// These are deliberately authenticated reads: tool-access.ts explicitly
+	// documents their read fallback. Adding them to PUBLIC_READ_ACTIONS would
+	// expose conversation titles to anonymous callers, so test the distinction.
+	const authenticatedConversationRead = tool === "manage_conversations" &&
+		(action === "list" || action === "get");
+	const isExplicitlyDeclared = authenticatedConversationRead ||
 		OWNER_ADMIN_ACTIONS[tool]?.has(action) ||
 		MEMBER_WRITE_ACTIONS[tool]?.has(action) ||
 		PUBLIC_READ_ACTIONS[tool]?.has(action);
@@ -186,6 +195,13 @@ function declaredRuntimeTier(
 }
 
 describe("access-model cross-check", () => {
+	it("keeps conversation reads authenticated while reporting read tier", () => {
+		for (const action of ["list", "get"]) {
+			expect(getRequiredAccessLevel("manage_conversations", { action }, false)).toBe("read");
+			expect(isPublicReadable("manage_conversations", { action })).toBe(false);
+		}
+	});
+
 	it("no manage_* action is declared in conflicting tiers", () => {
 		// The three tier maps partition actions: an action that is both
 		// member-write and owner-admin (or public-read) is a contradiction —

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -5,27 +5,35 @@
 
 export type MethodAccess = "read" | "write" | "external" | "admin";
 
-export interface MethodMetadata {
+/**
+ * A side effect and an authorization tier are different facts.
+ *
+ * `external` is a side-effect marker (this method calls out to an external
+ * system), not a tier. It keeps a method write-VISIBLE so an owner/admin can
+ * trigger the progressive mcp:admin OAuth challenge by calling it — but the
+ * tier REPORTED to callers must match what the delegated `manage_*` action
+ * actually enforces, or an admin-enforced method advertises "operate
+ * (mcp:write)" and sends an mcp:write caller to retry into a hard
+ * "requires an MCP session with admin access." dead end.
+ *
+ * So `external` must pair with the tier `getRequiredAccessLevel` returns for
+ * its underlying action, and a plain tier must not carry a contradictory
+ * override. access-model-cross-check.test.ts pins each value against the live
+ * tier map; visibility is unchanged either way.
+ */
+export type MethodAccessMetadata =
+	| { access: "external"; enforcedTier: Exclude<MethodAccess, "external"> }
+	| { access: Exclude<MethodAccess, "external">; enforcedTier?: never };
+
+/** The same required tier drives discovery and dry-run previews. */
+export function requiredSdkAccess(metadata: MethodAccessMetadata): Exclude<MethodAccess, "external"> {
+	if (metadata.access !== "external") return metadata.access;
+	if (!metadata.enforcedTier) throw new Error("External SDK method has no enforced tier");
+	return metadata.enforcedTier;
+}
+
+export type MethodMetadata = MethodAccessMetadata & {
 	summary: string;
-	access: MethodAccess;
-	/**
-	 * The tier the delegated `manage_*` action actually enforces, for `external`
-	 * methods whose enforcement is stricter than the write visibility `external`
-	 * implies.
-	 *
-	 * `external` is a side-effect marker, not a tier: it keeps a method
-	 * write-VISIBLE so an owner/admin can trigger the progressive mcp:admin OAuth
-	 * challenge by calling it. But the reported tier was derived from that same
-	 * marker, so an admin-enforced external method advertised itself as "operate
-	 * (mcp:write)" — an mcp:write caller was told to retry, then hit a hard
-	 * "requires an MCP session with admin access." dead end.
-	 *
-	 * Set this to the tier `getRequiredAccessLevel` returns for the underlying
-	 * action so the reported tier matches enforcement. Visibility is unchanged.
-	 * Only meaningful alongside `access: "external"`;
-	 * access-model-cross-check.test.ts pins each value against the live tier map.
-	 */
-	enforcedTier?: Exclude<MethodAccess, "external">;
 	/** Exact callable signature when the method shape is easy to misinfer. */
 	signature?: string;
 	throws?: readonly string[];
@@ -35,7 +43,7 @@ export interface MethodMetadata {
 	usageExample?: string;
 	/** Cost hint: 'cheap' | 'normal' | 'expensive'. Normal if omitted. */
 	cost?: "cheap" | "normal" | "expensive";
-}
+};
 
 /** Runtime helpers passed through `ctx`, not dispatchable ClientSDK methods. */
 export const RUNTIME_HELPER_METADATA: Record<string, MethodMetadata> = {

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -8,6 +8,24 @@ export type MethodAccess = "read" | "write" | "external" | "admin";
 export interface MethodMetadata {
 	summary: string;
 	access: MethodAccess;
+	/**
+	 * The tier the delegated `manage_*` action actually enforces, for `external`
+	 * methods whose enforcement is stricter than the write visibility `external`
+	 * implies.
+	 *
+	 * `external` is a side-effect marker, not a tier: it keeps a method
+	 * write-VISIBLE so an owner/admin can trigger the progressive mcp:admin OAuth
+	 * challenge by calling it. But the reported tier was derived from that same
+	 * marker, so an admin-enforced external method advertised itself as "operate
+	 * (mcp:write)" — an mcp:write caller was told to retry, then hit a hard
+	 * "requires an MCP session with admin access." dead end.
+	 *
+	 * Set this to the tier `getRequiredAccessLevel` returns for the underlying
+	 * action so the reported tier matches enforcement. Visibility is unchanged.
+	 * Only meaningful alongside `access: "external"`;
+	 * access-model-cross-check.test.ts pins each value against the live tier map.
+	 */
+	enforcedTier?: Exclude<MethodAccess, "external">;
 	/** Exact callable signature when the method shape is easy to misinfer. */
 	signature?: string;
 	throws?: readonly string[];
@@ -63,7 +81,7 @@ export const METHOD_METADATA: Record<string, MethodMetadata> = {
 	// entities
 	"entities.manage": {
 		summary: "Raw manage_entity action wrapper. Prefer named methods.",
-		access: "write",
+		access: "admin",
 	},
 	"entities.list": {
 		summary:
@@ -534,6 +552,7 @@ export default async (_ctx, client) => {
 		summary:
 			"Raw manage_automations action wrapper. Prefer named methods such as automations.trigger or automations.createVersion.",
 		access: "external",
+		enforcedTier: "admin",
 		example:
 			"await client.automations.manage({ action: 'trigger', automation_id: '42' });",
 	},
@@ -593,6 +612,7 @@ export default async (_ctx, client) => {
 		summary:
 			"Create or reuse an immediate Automation run. The typed result identifies the durable execution owner. Pending runs use their persisted managed_agent, device_worker, or external_client lane. An existing external lease returns owner caller with a resume_claim action when this caller owns it, or owner another_caller with handled_elsewhere. A pending external_client run uses next_action.read (knowledge.read with automation_id + run_id) then automations.completeWindow. created is false when an active run was reused.",
 		access: "external",
+		enforcedTier: "write",
 		signature:
 			"automations.trigger(input: { automation_id: string }): Promise<AutomationTriggerResult>",
 		example:
@@ -679,6 +699,7 @@ export default async (_ctx, client) => {
 	"connections.manage": {
 		summary: "Raw manage_connections action wrapper. Prefer named methods.",
 		access: "external",
+		enforcedTier: "admin",
 	},
 	"connections.list": {
 		summary: "List configured connections in the current organization.",
@@ -778,6 +799,7 @@ export default async (_ctx, client) => {
 		summary:
 			"Inspect a connection's authentication or device availability: OAuth token validity/expiry, env/app-auth presence, browser-session cookies, or (for an auth-free connection pinned to a device) whether the paired device is online. Only the browser-session CDP path makes an outbound network probe; the rest are metadata checks.",
 		access: "external",
+		enforcedTier: "admin",
 		signature:
 			"connections.test(connection_id: number): Promise<unknown> // or connections.test({ connection_id })",
 		example: "await client.connections.test(42);",
@@ -848,6 +870,7 @@ export default async (_ctx, client) => {
 	"operations.manage": {
 		summary: "Raw manage_operations action wrapper. Prefer named methods.",
 		access: "external",
+		enforcedTier: "write",
 	},
 	"operations.listAvailable": {
 		summary:
@@ -858,6 +881,7 @@ export default async (_ctx, client) => {
 		summary:
 			"Execute a connector action. OBJECT signature: execute({ connection_id: number, operation_key: string, input?: object, idempotency_key?: string, automation_source?: { automation_id: number, run_id: number } }). connector_key is not accepted. A durable idempotency_key replays the original run instead of repeating the external request.",
 		access: "external",
+		enforcedTier: "write",
 		cost: "expensive",
 		example:
 			"await client.operations.execute({ connection_id: 42, operation_key: 'create_issue', input: { title: 'Follow up' } });",
@@ -889,6 +913,7 @@ export default async (_ctx, client) => {
 	"feeds.manage": {
 		summary: "Raw manage_feeds action wrapper. Prefer named methods.",
 		access: "external",
+		enforcedTier: "admin",
 	},
 	"feeds.list": {
 		summary:
@@ -938,6 +963,7 @@ export default async (_ctx, client) => {
 		summary:
 			"Trigger an immediate sync for a feed (external side-effect). Pass dry_run: true to execute the connector for real but persist nothing — no events, entities or attachments, and the feed's checkpoint and sync state do not move; the run executes asynchronously, and once it completes a capped preview of what would have been ingested is on its dry_run_preview, readable via feeds.get. Use it to test a feed's config or credentials without writing to the workspace. Two limits: it cannot undo side effects the connector causes UPSTREAM (marking a message read, etc.), and it occupies the feed's single active-sync slot while it runs.",
 		access: "external",
+		enforcedTier: "admin",
 		signature:
 			"feeds.trigger(input: { feed_id: number; dry_run?: boolean }): Promise<unknown>",
 		example:
@@ -948,6 +974,7 @@ export default async (_ctx, client) => {
 	"authProfiles.manage": {
 		summary: "Raw manage_auth_profiles action wrapper. Prefer named methods.",
 		access: "external",
+		enforcedTier: "admin",
 	},
 	"authProfiles.list": {
 		summary: "List reusable auth profiles.",
@@ -966,6 +993,7 @@ export default async (_ctx, client) => {
 	"authProfiles.test": {
 		summary: "Test auth-profile credentials.",
 		access: "external",
+		enforcedTier: "admin",
 		signature:
 			"authProfiles.test(auth_profile_slug: string): Promise<unknown> // or authProfiles.test({ auth_profile_slug })",
 		example: "await client.authProfiles.test('google-calendar-account');",
@@ -994,7 +1022,7 @@ export default async (_ctx, client) => {
 	// classifiers
 	"classifiers.manage": {
 		summary: "Raw manage_classifiers action wrapper. Prefer named methods.",
-		access: "write",
+		access: "admin",
 	},
 	"classifiers.list": {
 		summary: "List classifier templates.",
@@ -1047,7 +1075,7 @@ export default async (_ctx, client) => {
 	// viewTemplates
 	"viewTemplates.manage": {
 		summary: "Raw manage_view_templates action wrapper. Prefer named methods.",
-		access: "write",
+		access: "admin",
 	},
 	"viewTemplates.get": {
 		summary:

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -816,6 +816,9 @@ export default async (_ctx, client) => {
 	"connections.uninstallConnector": {
 		summary: "Uninstall a connector definition.",
 		access: "admin",
+		signature:
+			"connections.uninstallConnector(connector_key: string): Promise<unknown> // or connections.uninstallConnector({ connector_key })",
+		example: "await client.connections.uninstallConnector('rss');",
 	},
 	"connections.getConnectorSource": {
 		summary:

--- a/packages/server/src/sandbox/namespaces/connections.ts
+++ b/packages/server/src/sandbox/namespaces/connections.ts
@@ -125,7 +125,14 @@ export function buildConnectionsNamespace(
 		}),
 		uninstallConnector: method("uninstall_connector", {
 			publicMethod: "uninstallConnector",
-			mapArgs: (connector_key) => ({ connector_key }),
+			mapArgs: (connector_key) => ({
+				connector_key: idArg(
+					"connections.uninstallConnector",
+					"connector_key",
+					connector_key,
+					"string",
+				),
+			}),
 		}),
 		getConnectorSource: method("get_connector_source", {
 			publicMethod: "getConnectorSource",

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -133,7 +133,12 @@ interface SdkCallTraceEntry {
 	access: MethodAccess | "unknown";
 	args: unknown[];
 	skipped: boolean;
-	required_access?: MethodAccess;
+	/**
+	 * Resolved tier, never the `external` side-effect marker: preflight maps an
+	 * external method through its `enforcedTier`, and the public `run_sdk`
+	 * schema drops any entry that still carries `external`.
+	 */
+	required_access?: Exclude<MethodAccess, "external">;
 	authorization_status?: "not_evaluated";
 }
 

--- a/packages/server/src/sandbox/sdk-method-access.ts
+++ b/packages/server/src/sandbox/sdk-method-access.ts
@@ -37,9 +37,11 @@ type SdkMethodAccessInput = MethodAccessMetadata | readonly MethodAccessMetadata
 export function effectiveSdkRequiredTier(
 	methodAccess: SdkMethodAccessInput,
 ): SdkRequiredTier {
-	const accesses: readonly MethodAccessMetadata[] = Array.isArray(methodAccess)
-		? methodAccess
-		: [methodAccess as MethodAccessMetadata];
+	// `Array.isArray` does not narrow a readonly-array union, so discriminate on
+	// the object shape instead: casting here would reopen the hole the
+	// MethodAccessMetadata union exists to close.
+	const accesses: readonly MethodAccessMetadata[] =
+		"access" in methodAccess ? [methodAccess] : methodAccess;
 	const required = accesses.reduce<ToolAccessLevel>((highest, access) => {
 		const candidate = requiredSdkAccess(access);
 		return TOOL_ACCESS_RANK[candidate] > TOOL_ACCESS_RANK[highest]

--- a/packages/server/src/sandbox/sdk-method-access.ts
+++ b/packages/server/src/sandbox/sdk-method-access.ts
@@ -9,7 +9,7 @@ import {
 	resolveSdkMaxAccessLevel,
 	type ToolAccessLevel,
 } from "../auth/tool-access";
-import type { MethodAccess } from "./method-metadata";
+import { requiredSdkAccess, type MethodAccess, type MethodAccessMetadata } from "./method-metadata";
 
 export type SdkDiscoveryMode = "read" | "full";
 export type SdkRequiredTier = "read" | "operate" | "administer";
@@ -26,36 +26,8 @@ function requiredToolAccess(methodAccess: MethodAccess): ToolAccessLevel {
 	return "read";
 }
 
-/**
- * One method's access as the tier resolvers consume it: either the bare
- * `MethodAccess` marker, or that marker paired with the tier its delegated
- * `manage_*` action really enforces.
- *
- * Reporting and VISIBILITY deliberately diverge for `external`. Visibility
- * stays keyed on the marker (write-visible, so an owner/admin can trigger the
- * progressive mcp:admin challenge by calling the method); only the tier we
- * REPORT follows `enforcedTier`.
- */
-export interface SdkMethodAccess {
-	access: MethodAccess;
-	enforcedTier?: Exclude<MethodAccess, "external">;
-}
-
-export type SdkMethodAccessInput =
-	| MethodAccess
-	| SdkMethodAccess
-	| readonly (MethodAccess | SdkMethodAccess)[];
-
-/**
- * The tool-access level a method's tier REPORTING should be based on: the
- * declared `enforcedTier` when the method carries one, else the marker's own
- * mapping.
- */
-function reportedToolAccess(entry: MethodAccess | SdkMethodAccess): ToolAccessLevel {
-	if (typeof entry === "string") return requiredToolAccess(entry);
-	if (entry.enforcedTier) return requiredToolAccess(entry.enforcedTier);
-	return requiredToolAccess(entry.access);
-}
+/** Reporting requires complete metadata; a bare external marker loses its tier. */
+type SdkMethodAccessInput = MethodAccessMetadata | readonly MethodAccessMetadata[];
 
 /**
  * Public discovery tier for one method or a multi-method lifecycle — the tier
@@ -65,12 +37,11 @@ function reportedToolAccess(entry: MethodAccess | SdkMethodAccess): ToolAccessLe
 export function effectiveSdkRequiredTier(
 	methodAccess: SdkMethodAccessInput,
 ): SdkRequiredTier {
-	const accesses: readonly (MethodAccess | SdkMethodAccess)[] =
-		typeof methodAccess === "string" || !Array.isArray(methodAccess)
-			? [methodAccess as MethodAccess | SdkMethodAccess]
-			: (methodAccess as readonly (MethodAccess | SdkMethodAccess)[]);
+	const accesses: readonly MethodAccessMetadata[] = Array.isArray(methodAccess)
+		? methodAccess
+		: [methodAccess as MethodAccessMetadata];
 	const required = accesses.reduce<ToolAccessLevel>((highest, access) => {
-		const candidate = reportedToolAccess(access);
+		const candidate = requiredSdkAccess(access);
 		return TOOL_ACCESS_RANK[candidate] > TOOL_ACCESS_RANK[highest]
 			? candidate
 			: highest;

--- a/packages/server/src/sandbox/sdk-method-access.ts
+++ b/packages/server/src/sandbox/sdk-method-access.ts
@@ -26,14 +26,51 @@ function requiredToolAccess(methodAccess: MethodAccess): ToolAccessLevel {
 	return "read";
 }
 
-/** Public discovery tier for one method or a multi-method lifecycle. */
+/**
+ * One method's access as the tier resolvers consume it: either the bare
+ * `MethodAccess` marker, or that marker paired with the tier its delegated
+ * `manage_*` action really enforces.
+ *
+ * Reporting and VISIBILITY deliberately diverge for `external`. Visibility
+ * stays keyed on the marker (write-visible, so an owner/admin can trigger the
+ * progressive mcp:admin challenge by calling the method); only the tier we
+ * REPORT follows `enforcedTier`.
+ */
+export interface SdkMethodAccess {
+	access: MethodAccess;
+	enforcedTier?: Exclude<MethodAccess, "external">;
+}
+
+export type SdkMethodAccessInput =
+	| MethodAccess
+	| SdkMethodAccess
+	| readonly (MethodAccess | SdkMethodAccess)[];
+
+/**
+ * The tool-access level a method's tier REPORTING should be based on: the
+ * declared `enforcedTier` when the method carries one, else the marker's own
+ * mapping.
+ */
+function reportedToolAccess(entry: MethodAccess | SdkMethodAccess): ToolAccessLevel {
+	if (typeof entry === "string") return requiredToolAccess(entry);
+	if (entry.enforcedTier) return requiredToolAccess(entry.enforcedTier);
+	return requiredToolAccess(entry.access);
+}
+
+/**
+ * Public discovery tier for one method or a multi-method lifecycle — the tier
+ * REPORTED to callers, so an `external` method with an `enforcedTier` reports
+ * that stricter tier rather than the write its marker implies.
+ */
 export function effectiveSdkRequiredTier(
-	methodAccess: MethodAccess | readonly MethodAccess[],
+	methodAccess: SdkMethodAccessInput,
 ): SdkRequiredTier {
-	const accesses: readonly MethodAccess[] =
-		typeof methodAccess === "string" ? [methodAccess] : methodAccess;
+	const accesses: readonly (MethodAccess | SdkMethodAccess)[] =
+		typeof methodAccess === "string" || !Array.isArray(methodAccess)
+			? [methodAccess as MethodAccess | SdkMethodAccess]
+			: (methodAccess as readonly (MethodAccess | SdkMethodAccess)[]);
 	const required = accesses.reduce<ToolAccessLevel>((highest, access) => {
-		const candidate = requiredToolAccess(access);
+		const candidate = reportedToolAccess(access);
 		return TOOL_ACCESS_RANK[candidate] > TOOL_ACCESS_RANK[highest]
 			? candidate
 			: highest;
@@ -46,7 +83,7 @@ export function effectiveSdkRequiredTier(
 }
 
 export function formatSdkRequiredTier(
-	methodAccess: MethodAccess | readonly MethodAccess[],
+	methodAccess: SdkMethodAccessInput,
 ): string {
 	const tier = effectiveSdkRequiredTier(methodAccess);
 	if (tier === "administer") {
@@ -71,7 +108,7 @@ export interface SdkAccessGuidance {
  * it can never turn a regular member into a workspace administrator.
  */
 export function resolveSdkAccessGuidance(
-	methodAccess: MethodAccess | readonly MethodAccess[],
+	methodAccess: SdkMethodAccessInput,
 	memberRole: string | null | undefined,
 	scopes: readonly string[] | null | undefined,
 ): SdkAccessGuidance {

--- a/packages/server/src/sandbox/sdk-preflight.ts
+++ b/packages/server/src/sandbox/sdk-preflight.ts
@@ -1,10 +1,10 @@
 import type { MethodAccess } from "./method-metadata";
-import { METHOD_METADATA } from "./method-metadata";
+import { METHOD_METADATA, requiredSdkAccess } from "./method-metadata";
 import { getArgsValidator } from "../tools/validate-args";
 
 export interface SdkPreflightResult {
 	args: unknown[];
-	required_access: MethodAccess;
+	required_access: Exclude<MethodAccess, "external">;
 	authorization_status: "not_evaluated";
 }
 
@@ -54,7 +54,7 @@ export function createValidatedSdkMethod<
 		}
 		return {
 			args: options.projectArgs?.(validated) ?? [validated],
-			required_access: metadata.access,
+			required_access: requiredSdkAccess(metadata),
 			authorization_status: "not_evaluated",
 		};
 	};

--- a/packages/server/src/tools/connector-discovery.ts
+++ b/packages/server/src/tools/connector-discovery.ts
@@ -86,10 +86,14 @@ function lifecycleForCaller(
   lifecycle: string,
   ctx: ToolContext
 ): string {
+  // Whole metadata, not the bare `access` marker: a connector lifecycle
+  // includes `feeds.trigger`, an `external` method whose manage_feeds action is
+  // admin-enforced. Dropping its `enforcedTier` reported the lifecycle as
+  // operate-tier and told an mcp:write caller to proceed into a hard rejection.
   const accesses = methodPaths.map((path) => {
-    const access = METHOD_METADATA[path]?.access;
-    if (!access) throw new Error(`Missing SDK metadata for lifecycle method: ${path}`);
-    return access;
+    const meta = METHOD_METADATA[path];
+    if (!meta) throw new Error(`Missing SDK metadata for lifecycle method: ${path}`);
+    return meta;
   });
   const guidance = resolveSdkAccessGuidance(accesses, ctx.memberRole, ctx.scopes);
   if (guidance.available) return lifecycle;

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -78,7 +78,6 @@ const PublicSideEffectPreviewEntrySchema = Type.Object({
     [
       Type.Literal("read"),
       Type.Literal("write"),
-      Type.Literal("external"),
       Type.Literal("admin"),
     ],
     { description: "Access tier required by the proposed SDK method." },
@@ -193,7 +192,6 @@ function asPublicPreviewEntry(value: unknown): PublicSideEffectPreviewEntry | nu
   const requiredAccess =
     row.required_access === "read" ||
     row.required_access === "write" ||
-    row.required_access === "external" ||
     row.required_access === "admin"
       ? row.required_access
       : null;

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -190,18 +190,22 @@ function hiddenMethodNote(
 	if (policyDenied.has(path)) {
 		return `${path} is blocked by this agent's agent_config permissions.`;
 	}
+	// Pass the whole metadata, not just `meta.access`: an `external` method
+	// carries the tier its manage_* action really enforces on `enforcedTier`, and
+	// the reported tier must match enforcement or the caller is sent to retry
+	// into a hard admin rejection.
 	const guidance = resolveSdkAccessGuidance(
-		meta.access,
+		meta,
 		ctx.allowCrossOrg ? "owner" : ctx.memberRole,
 		ctx.scopes,
 	);
 	if (mode === "read" && meta.access !== "read") {
 		if (guidance.available || guidance.progressivelyAuthorizable) {
-			return `${path} exists but requires run_sdk (access: ${formatSdkRequiredTier(meta.access)}). Retry with mode='full'. ${guidance.progressivelyAuthorizable ? guidance.instruction ?? "" : ""}`.trim();
+			return `${path} exists but requires run_sdk (access: ${formatSdkRequiredTier(meta)}). Retry with mode='full'. ${guidance.progressivelyAuthorizable ? guidance.instruction ?? "" : ""}`.trim();
 		}
-		return `${path} is not available at your access tier (access: ${formatSdkRequiredTier(meta.access)}). ${guidance.instruction ?? ""}`.trim();
+		return `${path} is not available at your access tier (access: ${formatSdkRequiredTier(meta)}). ${guidance.instruction ?? ""}`.trim();
 	}
-	return `${path} is not available at your access tier (access: ${formatSdkRequiredTier(meta.access)}). ${guidance.instruction ?? ""}`.trim();
+	return `${path} is not available at your access tier (access: ${formatSdkRequiredTier(meta)}). ${guidance.instruction ?? ""}`.trim();
 }
 
 /**
@@ -228,7 +232,7 @@ function renderDrillDown(path: string, meta: MethodMetadata): string {
 	lines.push(path);
 	lines.push(`  ${meta.summary}`);
 	lines.push(
-		`  access: ${formatSdkRequiredTier(meta.access)}${meta.cost ? ` (cost: ${meta.cost})` : ""}`
+		`  access: ${formatSdkRequiredTier(meta)}${meta.cost ? ` (cost: ${meta.cost})` : ""}`
 	);
 	if (meta.signature) {
 		lines.push(`  signature: ${meta.signature}`);
@@ -475,7 +479,9 @@ async function sdkMethodSearch(
 				p.toLowerCase().startsWith(prefix)
 			);
 			if (hiddenNs.length > 0) {
-				const accesses = hiddenNs.map(([, meta]) => meta.access);
+				// Full metadata, not the bare marker: an `external` method's
+				// `enforcedTier` is what the namespace's aggregate tier must reflect.
+				const accesses = hiddenNs.map(([, meta]) => meta);
 				const accessLabels = [...new Set(accesses.map(formatSdkRequiredTier))]
 					.sort()
 					.join(", ");


### PR DESCRIPTION
## Summary
Correct SDK discovery to report enforced access tiers without weakening authorization or changing write-visible discovery. Normalize connector uninstall arguments through the existing idArg helper.

## Verification on 4d21f82a2f8daa16f1fad11774a907df1ea43663
- Server Bun unit suite: 1,428 passed, 2 skipped, 0 failed across 145 files.
- Vitest access-model cross-check: 4 passed, DB-free.
- Signature regression suite: 9 passed, including two new connector uninstall tests for both accepted forms and malformed argument rejection.
- Negative control: restoring the old uninstall mapper makes both new tests fail; restoring the fixed mapper yields 9/9 passing. No live connector was uninstalled; dispatch handlers are test doubles.
- Metadata negative control also rejects a stray enforcedTier on a non-external method.
- make pre-pr passed all five stages, pre-commit passed, git diff --check passed.
- Exact scope: eight files, 240 additions / 32 deletions. This preparation pass added only 25 test lines; runtime code unchanged.

## Remaining gates
DRAFT: prepared for owner review, not yet merge-ready. Exact-head GitHub CI was restarted by the test commit. Required independent review-fix and pi-review are still outstanding: the prior supported Claude review stopped at the account session limit; Codex is not logged in. A green CodeRabbit draft status was a skipped review, not a semantic approval. No check or branch-protection bypass.

## Owner direction
DO NOT MERGE and do not enable auto-merge. Burak will resume the existing Herdr session, review the work, and decide when to merge. Preserve the session and worktree. No production rollout, API/DB redesign, or permission widening is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - SDK discovery and dry-run previews now report the actual required access tier for externally gated methods.
  - Access guidance is now consistent with runtime authorization, including admin-level requirements.
  - External-only markers are no longer shown as required access tiers in public previews.
  - Connector uninstall requests now validate inputs and support both positional and named formats, with clearer errors for invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->