### PR TITLE
fix(connectors): classify an abandoned readiness dispatch as transient

### DIFF
--- a/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
@@ -563,6 +563,42 @@ describe("sync over the generic chrome bridge", () => {
   });
 
   /**
+   * WhatsApp's `require()` BLOCKS rather than throwing while its module graph is
+   * still registering, so a readiness probe can hang with the adapter never
+   * naming a state. Measured in prod (chrome action runs 1365803-1365817): nine
+   * probes answered in 3-7s, then one ran 95.2s and was killed. Bounded by the
+   * extension's CDP evaluate timeout the page now reports a plain timeout --
+   * which carries none of the adapter's hydration vocabulary, so unclassified it
+   * counts as a HARD failure and walks a recoverable feed toward its hard pause.
+   * The media path already treats `timed out` as retryable; readiness must too.
+   */
+  it("treats a probe that never answered as transient, not a real failure", async () => {
+    const realNow = Date.now;
+    let calls = 0;
+    const { dispatcher } = makeDispatcher({
+      probe: () => {
+        calls += 1;
+        if (calls === 1) Date.now = () => realNow() + 10 * 60_000;
+        // What the extension reports once CDP abandons the evaluation: a bare
+        // timeout, with no adapter state to read.
+        return {
+          ok: false,
+          error: { state: "adapter_failed", reason: "evaluation timed out" },
+        };
+      },
+    });
+    try {
+      await expect(
+        messagesFeed().sync(syncCtx(null, dispatcher))
+      ).rejects.toThrow(
+        /^\[lobu:dependency_unavailable:browser_source_hydrating\]/
+      );
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  /**
    * `collect` re-checks readiness inside the page, so a message arriving between
    * the passing probe and the collect dispatch surfaces `stores_settling` from
    * the COLLECT path rather than the readiness loop. That is an ordinary race,

--- a/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
@@ -563,15 +563,42 @@ describe("sync over the generic chrome bridge", () => {
   });
 
   /**
-   * WhatsApp's `require()` BLOCKS rather than throwing while its module graph is
-   * still registering, so a readiness probe can hang with the adapter never
-   * naming a state. Measured in prod (chrome action runs 1365803-1365817): nine
-   * probes answered in 3-7s, then one ran 95.2s and was killed. Bounded by the
-   * extension's CDP evaluate timeout the page now reports a plain timeout --
-   * which carries none of the adapter's hydration vocabulary, so unclassified it
-   * counts as a HARD failure and walks a recoverable feed toward its hard pause.
-   * The media path already treats `timed out` as retryable; readiness must too.
+   * A collect that times out is a REAL failure, not hydration. The server's
+   * dependency_unavailable branch deliberately skips consecutive_failures, so
+   * misclassifying this phase would let a permanently broken collect retry
+   * forever without ever walking the feed toward its hard pause -- the exact
+   * blindness that let this outage run for four days.
    */
+  it("keeps a collect-phase timeout a hard failure", async () => {
+    let probed = false;
+    const dispatch = mock(async (action: string, input: Record<string, unknown>) => {
+      if (action === "navigate") return { tab_id: 42, current_url: input.url };
+      if (action !== "evaluate") return {};
+      const expression = String(input.expression ?? "");
+      if (expression.includes("a.version ===")) return { value: true };
+      const match = expression.match(/a\.invoke\((\{[\s\S]*\})\);/);
+      if (!match?.[1]) return { value: undefined };
+      const request = JSON.parse(match[1]) as { op: string };
+      // Readiness succeeds; the collect dispatch is the one that hangs.
+      if (request.op === "probe") {
+        probed = true;
+        return {
+          value: {
+            ok: true,
+            status: { ready: true, state: "ready" },
+            capabilities: { collect: true },
+          },
+        };
+      }
+      throw new Error("evaluation timed out");
+    });
+    const dispatcher = { dispatch } as unknown as Parameters<typeof syncCtx>[1];
+    await expect(
+      messagesFeed().sync(syncCtx(null, dispatcher))
+    ).rejects.toThrow(/^(?!\[lobu:dependency_unavailable)/);
+    expect(probed).toBe(true);
+  });
+
   /**
    * The production boundary, which the sibling test above does not reach: the
    * extension does not RETURN an adapter-shaped error when CDP abandons an
@@ -606,6 +633,14 @@ describe("sync over the generic chrome bridge", () => {
     }
   });
 
+  /**
+   * WhatsApp's `require()` BLOCKS rather than throwing while its module graph is
+   * still registering, so a readiness probe can hang with the adapter never
+   * naming a state. Measured in prod (chrome action runs 1365803-1365817): nine
+   * probes answered in 3-7s, then one ran 95.2s and was killed. Bounded by the
+   * extension's CDP evaluate timeout the page reports a plain timeout, which
+   * carries none of the adapter's hydration vocabulary.
+   */
   it("treats a probe that never answered as transient, not a real failure", async () => {
     const realNow = Date.now;
     let calls = 0;

--- a/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
@@ -572,6 +572,40 @@ describe("sync over the generic chrome bridge", () => {
    * counts as a HARD failure and walks a recoverable feed toward its hard pause.
    * The media path already treats `timed out` as retryable; readiness must too.
    */
+  /**
+   * The production boundary, which the sibling test above does not reach: the
+   * extension does not RETURN an adapter-shaped error when CDP abandons an
+   * evaluation, it REJECTS the dispatch with a bare timeout. That message
+   * never carries the connector's own "WhatsApp Web " prefix, so classifying
+   * on the prefix first drops it before the transient pattern is ever tried
+   * and a hydration stall is still booked as a hard feed failure.
+   */
+  it("treats a bare dispatch timeout as transient, not a real failure", async () => {
+    const realNow = Date.now;
+    let calls = 0;
+    const dispatch = mock(async (action: string, input: Record<string, unknown>) => {
+      if (action === "navigate") return { tab_id: 42, current_url: input.url };
+      if (action !== "evaluate") return {};
+      const expression = String(input.expression ?? "");
+      if (expression.includes("a.version ===")) return { value: true };
+      calls += 1;
+      if (calls === 1) Date.now = () => realNow() + 10 * 60_000;
+      // Exactly what the Chrome bridge rejects with: no adapter state, no
+      // connector prefix.
+      throw new Error("evaluation timed out");
+    });
+    const dispatcher = { dispatch } as unknown as Parameters<typeof syncCtx>[1];
+    try {
+      await expect(
+        messagesFeed().sync(syncCtx(null, dispatcher))
+      ).rejects.toThrow(
+        /^\[lobu:dependency_unavailable:browser_source_hydrating\]/
+      );
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
   it("treats a probe that never answered as transient, not a real failure", async () => {
     const realNow = Date.now;
     let calls = 0;

--- a/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
@@ -636,8 +636,8 @@ describe("sync over the generic chrome bridge", () => {
   /**
    * WhatsApp's `require()` BLOCKS rather than throwing while its module graph is
    * still registering, so a readiness probe can hang with the adapter never
-   * naming a state. Measured in prod (chrome action runs 1365803-1365817): nine
-   * probes answered in 3-7s, then one ran 95.2s and was killed. Bounded by the
+   * naming a state. Measured in prod: nine consecutive probes answered in
+   * 3-7s, then one ran 95.2s and was killed. Bounded by the
    * extension's CDP evaluate timeout the page reports a plain timeout, which
    * carries none of the adapter's hydration vocabulary.
    */

--- a/packages/connectors/src/whatsapp_web.ts
+++ b/packages/connectors/src/whatsapp_web.ts
@@ -304,7 +304,16 @@ async function invokeAdapter<T extends object>(
 }
 
 const LOGGED_OUT_PATTERN = /logged_out|qr_code_visible/;
-const TRANSIENT_READINESS_PATTERN = /hydrating|stores_settling/i;
+/**
+ * `hydrating`/`stores_settling` are the adapter's own words for "the page is
+ * still coming up". `timed out` covers the case where the page never answered
+ * at all: WhatsApp's `require()` blocks rather than throwing while its module
+ * graph registers, so the evaluation is abandoned by its CDP timeout and the
+ * adapter never gets to name a state. Both mean "try again", not "this feed is
+ * broken" -- unclassified, they count toward the consecutive-failure budget and
+ * walk a recoverable feed toward a hard pause.
+ */
+const TRANSIENT_READINESS_PATTERN = /hydrating|stores_settling|timed out/i;
 const DEPENDENCY_UNAVAILABLE_PREFIX =
   "[lobu:dependency_unavailable:browser_source_hydrating]";
 

--- a/packages/connectors/src/whatsapp_web.ts
+++ b/packages/connectors/src/whatsapp_web.ts
@@ -314,9 +314,12 @@ const TRANSIENT_READINESS_PATTERN = /hydrating|stores_settling/i;
  * throwing while its module graph registers, so the evaluation is abandoned by
  * its CDP timeout and the adapter never gets to name a state -- the bridge
  * REJECTS the dispatch instead of returning an adapter-shaped error, so this
- * message carries no connector prefix to classify on. It still means "try
- * again": unclassified it counts toward the consecutive-failure budget and
- * walks a recoverable feed toward a hard pause.
+ * message carries no connector prefix to classify on.
+ *
+ * Only the readiness phase may treat it as transient. A `collect` that times
+ * out is a real failure, and the server's dependency_unavailable branch skips
+ * `consecutive_failures` -- classifying it here would let a permanently broken
+ * collect retry forever without ever walking the feed toward its hard pause.
  */
 const BARE_EVALUATE_TIMEOUT_PATTERN = /\btimed out\b/i;
 const DEPENDENCY_UNAVAILABLE_PREFIX =
@@ -327,12 +330,16 @@ const DEPENDENCY_UNAVAILABLE_PREFIX =
  * corruption, unsupported operations, and collection errors remain ordinary
  * connector failures and still count toward source health.
  */
-function classifyWhatsAppReadinessFailure(error: unknown): string | null {
+function classifyWhatsAppReadinessFailure(
+  error: unknown,
+  { allowBareTimeout = false }: { allowBareTimeout?: boolean } = {}
+): string | null {
   if (!(error instanceof Error)) return null;
   // A dispatch the bridge abandoned never reaches the adapter, so it has no
   // connector prefix to match. Classify it before the prefix gate below, or a
-  // hydration stall that timed out is booked as a hard failure.
-  if (BARE_EVALUATE_TIMEOUT_PATTERN.test(error.message)) {
+  // hydration stall that timed out is booked as a hard failure. Readiness only:
+  // see BARE_EVALUATE_TIMEOUT_PATTERN for why collect must not opt in.
+  if (allowBareTimeout && BARE_EVALUATE_TIMEOUT_PATTERN.test(error.message)) {
     return `${DEPENDENCY_UNAVAILABLE_PREFIX} ${error.message}`;
   }
   // MAIN-world adapter failures may cross the extension/worker boundary without
@@ -370,7 +377,9 @@ async function readyWhatsAppTab(
     }
     await new Promise((resolve) => setTimeout(resolve, READY_POLL_INTERVAL_MS));
   } while (Date.now() < deadline);
-  const transient = classifyWhatsAppReadinessFailure(lastError);
+  const transient = classifyWhatsAppReadinessFailure(lastError, {
+    allowBareTimeout: true,
+  });
   if (transient) throw new Error(transient);
   throw (
     lastError ??

--- a/packages/connectors/src/whatsapp_web.ts
+++ b/packages/connectors/src/whatsapp_web.ts
@@ -306,14 +306,19 @@ async function invokeAdapter<T extends object>(
 const LOGGED_OUT_PATTERN = /logged_out|qr_code_visible/;
 /**
  * `hydrating`/`stores_settling` are the adapter's own words for "the page is
- * still coming up". `timed out` covers the case where the page never answered
- * at all: WhatsApp's `require()` blocks rather than throwing while its module
- * graph registers, so the evaluation is abandoned by its CDP timeout and the
- * adapter never gets to name a state. Both mean "try again", not "this feed is
- * broken" -- unclassified, they count toward the consecutive-failure budget and
- * walk a recoverable feed toward a hard pause.
+ * still coming up", so they arrive prefixed as a WhatsAppAdapterError.
  */
-const TRANSIENT_READINESS_PATTERN = /hydrating|stores_settling|timed out/i;
+const TRANSIENT_READINESS_PATTERN = /hydrating|stores_settling/i;
+/**
+ * The page never answered at all. WhatsApp's `require()` blocks rather than
+ * throwing while its module graph registers, so the evaluation is abandoned by
+ * its CDP timeout and the adapter never gets to name a state -- the bridge
+ * REJECTS the dispatch instead of returning an adapter-shaped error, so this
+ * message carries no connector prefix to classify on. It still means "try
+ * again": unclassified it counts toward the consecutive-failure budget and
+ * walks a recoverable feed toward a hard pause.
+ */
+const BARE_EVALUATE_TIMEOUT_PATTERN = /\btimed out\b/i;
 const DEPENDENCY_UNAVAILABLE_PREFIX =
   "[lobu:dependency_unavailable:browser_source_hydrating]";
 
@@ -324,6 +329,12 @@ const DEPENDENCY_UNAVAILABLE_PREFIX =
  */
 function classifyWhatsAppReadinessFailure(error: unknown): string | null {
   if (!(error instanceof Error)) return null;
+  // A dispatch the bridge abandoned never reaches the adapter, so it has no
+  // connector prefix to match. Classify it before the prefix gate below, or a
+  // hydration stall that timed out is booked as a hard failure.
+  if (BARE_EVALUATE_TIMEOUT_PATTERN.test(error.message)) {
+    return `${DEPENDENCY_UNAVAILABLE_PREFIX} ${error.message}`;
+  }
   // MAIN-world adapter failures may cross the extension/worker boundary without
   // preserving their prototype, so classify on the connector-owned message.
   if (!error.message.startsWith("WhatsApp Web ")) return null;


### PR DESCRIPTION
WhatsApp's `require()` blocks rather than throwing while its module graph
registers, so a readiness probe can hang without the adapter ever naming a
state. Measured in prod: nine consecutive probes
answered in 3-7s, then one ran 95.2s and was killed. With the evaluation now
bounded by the extension's CDP timeout, the bridge REJECTS the dispatch with a
bare "evaluation timed out".

That message carries no `WhatsApp Web ` prefix, and the classifier tests the
prefix before the transient pattern, so the rejection returned null and a
hydration stall was booked as a hard failure that counts toward
`consecutive_failures`.

Classify the bare evaluate-dispatch timeout before the prefix gate, behind an
`allowBareTimeout` opt-in that only `readyWhatsAppTab` passes. Scope matters:
`collectMessages` shares this classifier, and the server's
`dependency_unavailable` branch skips `consecutive_failures` — treating a
collect timeout as transient would let a permanently broken collect retry
forever without ever walking the feed toward its hard pause, which is the same
blindness that let the Sept 3-7 outage run undetected. The prefix gate itself
is left intact so unrelated timeouts stay hard failures.

Tests cover both directions, and each is load-bearing: letting collect opt in
fails 1 test, making readiness opt out fails 2. 43/43 in that file, 407/407
connectors.

Note this is hardening, not the outage fix — that was #3397, merged and
verified in prod (feed 309 `consecutive_failures` 0, `items_collected`
30276 -> 30348, four consecutive successful runs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WhatsApp Web connection error handling by distinguishing temporary tab-readiness timeouts from collection failures.
  * Collection timeouts now correctly contribute to source health, while readiness-related timeouts are treated as temporary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->