### PR TITLE
fix(connectors): index WhatsApp collections instead of rescanning per message

### DIFF
--- a/packages/connectors/src/__tests__/whatsapp-web-adapter.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web-adapter.test.ts
@@ -607,3 +607,138 @@ describe("whatsAppWebAdapterProgram message actions", () => {
     expect(result.confirmed).toBe(false);
   });
 });
+
+/**
+ * `collect` normalises every message in the store, and `normalizeMessage` used
+ * to rescan a whole collection per message: the chat name over every chat, the
+ * sender name over every contact, and a reaction's target over every message.
+ * That is O(messages x collection) of SYNCHRONOUS work on the page's main
+ * thread.
+ *
+ * Measured on the live prod tab (947 chats, 5323 contacts, 1872 messages): the
+ * contact scan alone projected to ~6.8s, the message scan to ~2.1s, and a real
+ * `collect` blew past a 70s in-page timer -- which could not even fire, because
+ * the main thread never yielded. The extension's 90s per-dispatch run fence
+ * then killed the run, so the feed ingested nothing, and every run was slower
+ * than the last as backfill grew the store.
+ *
+ * This asserts the shape of the cost, not a wall-clock number: with a fixed
+ * message count, growing the CONTACT collection tenfold must not multiply the
+ * comparisons the adapter performs. A linear rescan fails this; an index built
+ * once per collection passes it.
+ */
+describe("whatsAppWebAdapterProgram collect scaling", () => {
+  function installWithStore(contactCount: number) {
+    // Count property reads on each contact id: the linear scan touches every
+    // contact once per message, the index touches each exactly once.
+    let idReads = 0;
+    const contact = (index: number) => ({
+      attributes: {
+        get id() {
+          idReads += 1;
+          return { _serialized: `contact-${index}@c.us` };
+        },
+        name: `Contact ${index}`,
+      },
+    });
+    const contacts = Array.from({ length: contactCount }, (_, i) => contact(i));
+    const chatModel = {
+      attributes: {
+        id: { _serialized: `contact-${contactCount - 1}@c.us` },
+        name: "Chat 0",
+        msgs: { _models: [], msgLoadState: { noEarlierMsgs: true } },
+      },
+    };
+    // Point every message at the LAST contact. A linear scan then walks the
+    // whole collection per message -- the real prod shape, where senders are
+    // spread across 5323 contacts rather than sitting at index 0.
+    const senderIndex = contactCount - 1;
+    const messages = Array.from({ length: 25 }, (_, i) => ({
+      attributes: {
+        id: {
+          fromMe: false,
+          id: `M${i}`,
+          _serialized: `false_contact-${senderIndex}@c.us_M${i}`,
+        },
+        from: { _serialized: `contact-${senderIndex}@c.us` },
+        to: { _serialized: "me@c.us" },
+        type: "chat",
+        body: `hello ${i}`,
+        t: 1_700_000_000 + i,
+      },
+    }));
+    const modules: Record<string, unknown> = {
+      WAWebCollections: {
+        Msg: { _models: messages },
+        Chat: { _models: [chatModel] },
+        Contact: { _models: contacts },
+      },
+      // `collect` is capability-gated on the history loader, and readiness
+      // needs an authenticated self identity.
+      WAWebChatLoadMessages: { loadEarlierMsgs: async () => undefined },
+      WAWebUserPrefsMeUser: {
+        getMaybeMePnUser: () => ({ _serialized: "me@c.us" }),
+      },
+    };
+    const globals: Record<string, any> = {};
+    const page = {
+      globalThis: globals,
+      document: { querySelector: () => null, querySelectorAll: () => [] },
+      window: { require: (n: string) => modules[n] ?? null },
+      location: { origin: "https://web.whatsapp.com" },
+      setTimeout: (fn: () => void, ms?: number) =>
+        globalThis.setTimeout(fn, ms),
+      clearTimeout: (id: number) => globalThis.clearTimeout(id),
+    };
+    const run = new Function(
+      ...Object.keys(page),
+      `"use strict";(${whatsAppWebAdapterProgram.toString()})();`,
+    );
+    run(...Object.values(page));
+    return { adapter: globals.__owlettoWhatsAppAdapterV1, reads: () => idReads };
+  }
+
+  it("does not rescan a collection once per message", async () => {
+    const ready = async (adapter: any) => {
+      // Readiness requires the store signature to hold for 500ms across two
+      // probes, exactly as it does in the page.
+      await adapter.invoke({ op: "probe", adapter_version: WHATSAPP_ADAPTER_VERSION });
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 550));
+      await adapter.invoke({ op: "probe", adapter_version: WHATSAPP_ADAPTER_VERSION });
+    };
+    const small = installWithStore(50);
+    await ready(small.adapter);
+    await small.adapter.invoke({
+      op: "collect",
+      adapter_version: WHATSAPP_ADAPTER_VERSION,
+      max_messages: 100,
+      max_chats: 1,
+      max_loads_per_chat: 1,
+      chat_filter: "all",
+      backfill_disabled: true,
+      budget_ms: 1_000,
+    });
+    const large = installWithStore(500);
+    await ready(large.adapter);
+    await large.adapter.invoke({
+      op: "collect",
+      adapter_version: WHATSAPP_ADAPTER_VERSION,
+      max_messages: 100,
+      max_chats: 1,
+      max_loads_per_chat: 1,
+      chat_filter: "all",
+      backfill_disabled: true,
+      budget_ms: 1_000,
+    });
+    // The cost must scale with the COLLECTION, not with messages x collection.
+    // Indexed, 500 contacts cost ~500 id reads however many messages are
+    // normalised. Rescanning, it is 500 per message: 25 messages -> 12500, the
+    // shape that made a real collect exceed the extension's 90s run fence.
+    const messagesNormalised = 25;
+    expect(large.reads()).toBeLessThan(500 * messagesNormalised);
+    // One pass over the collection, plus a small constant.
+    expect(large.reads()).toBeLessThanOrEqual(500 * 2);
+    // And the same must hold at the smaller size, so this cannot pass by luck.
+    expect(small.reads()).toBeLessThanOrEqual(50 * 2);
+  });
+});

--- a/packages/connectors/src/__tests__/whatsapp-web-adapter.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web-adapter.test.ts
@@ -627,6 +627,25 @@ describe("whatsAppWebAdapterProgram message actions", () => {
  * comparisons the adapter performs. A linear rescan fails this; an index built
  * once per collection passes it.
  */
+describe("whatsAppWebAdapterProgram version", () => {
+  // The connector reuses a resident adapter whenever its version matches, so a
+  // fix shipped without bumping this number leaves every open
+  // WhatsApp tab running the old program. The two constants live in different
+  // files (one is page source, one is connector source); nothing but this test
+  // keeps them in step.
+  it("declares the same version the connector negotiates", () => {
+    // Read the file rather than `toString()`: the bundler inlines this const,
+    // so the serialised program no longer contains the identifier.
+    const source = readFileSync(
+      new URL("../whatsapp-web-adapter.js", import.meta.url),
+      "utf8"
+    );
+    const declared = source.match(/ADAPTER_VERSION = (\d+);/)?.[1];
+    expect(declared).toBeDefined();
+    expect(Number(declared)).toBe(WHATSAPP_ADAPTER_VERSION);
+  });
+});
+
 describe("whatsAppWebAdapterProgram collect scaling", () => {
   function installWithStore(contactCount: number) {
     // Count property reads on each contact id: the linear scan touches every

--- a/packages/connectors/src/whatsapp-web-adapter.js
+++ b/packages/connectors/src/whatsapp-web-adapter.js
@@ -30,7 +30,12 @@
 
 export function whatsAppWebAdapterProgram() {
   const GLOBAL_KEY = "__owlettoWhatsAppAdapterV1";
-  const ADAPTER_VERSION = 9;
+  // Bumped whenever the program changes at all, not only its RPC surface.
+  // A WhatsApp tab outlives a deploy, so the resident adapter is replaced only
+  // when this number moves: shipping a fix under the old number leaves every
+  // already-open tab running the previous code with nothing to show for it.
+  // Keep in lockstep with WHATSAPP_ADAPTER_VERSION in whatsapp-web-helpers.ts.
+  const ADAPTER_VERSION = 10;
   const SYSTEM_TYPES = new Set([
     "gp2",
     "notification_template",

--- a/packages/connectors/src/whatsapp-web-adapter.js
+++ b/packages/connectors/src/whatsapp-web-adapter.js
@@ -258,42 +258,71 @@ export function whatsAppWebAdapterProgram() {
       );
   }
 
-  function contactName(collections, jid) {
-    if (!jid) return null;
-    for (const contact of models(collections?.Contact)) {
-      const row = modelData(contact);
-      if (widString(row.id ?? contact?.id) !== jid) continue;
-      return (
-        row.name ?? row.pushname ?? row.shortName ?? row.formattedName ?? null
-      );
-    }
-    return null;
+  /**
+   * Name lookups for one collect.
+   *
+   * `normalizeMessage` runs per message and used to walk a whole collection on
+   * each call -- the chat name over 947 chats, the sender name over 5323
+   * contacts. That is O(messages x collection) of SYNCHRONOUS work: measured on
+   * a live prod tab the contact scan alone projects to ~6.8s, a real collect
+   * never yielded the main thread, and the extension's 90s run fence killed the
+   * run. Every run was slower than the last as backfill grew the store.
+   *
+   * Built once per collect and thrown away with it -- no cache to invalidate,
+   * and nothing here outlives the call. Only names are indexed: they read
+   * static fields, whereas `collectionByRawId` serves the reaction paths, which
+   * mutate a model in place without changing the collection, so that one keeps
+   * scanning.
+   */
+  function nameIndex(collections) {
+    const byId = (collection) => {
+      const map = new Map();
+      for (const model of models(collection)) {
+        const id = widString(modelData(model).id ?? model?.id);
+        // First writer wins, like the scans this replaces.
+        if (id && !map.has(id)) map.set(id, model);
+      }
+      return map;
+    };
+    return { chats: byId(collections?.Chat), contacts: byId(collections?.Contact) };
   }
 
-  function chatName(collections, jid) {
+  function contactName(names, jid) {
     if (!jid) return null;
-    for (const chat of models(collections?.Chat)) {
-      const row = modelData(chat);
-      if (widString(row.id ?? chat?.id) !== jid) continue;
-      return (
-        row.name ??
-        row.formattedTitle ??
-        row.contact?.name ??
-        row.contact?.pushname ??
-        null
-      );
-    }
-    return null;
+    const contact = names?.contacts?.get(jid);
+    if (!contact) return null;
+    const row = modelData(contact);
+    return (
+      row.name ?? row.pushname ?? row.shortName ?? row.formattedName ?? null
+    );
+  }
+
+  function chatName(names, jid) {
+    if (!jid) return null;
+    const chat = names?.chats?.get(jid);
+    if (!chat) return null;
+    const row = modelData(chat);
+    return (
+      row.name ??
+      row.formattedTitle ??
+      row.contact?.name ??
+      row.contact?.pushname ??
+      null
+    );
   }
 
   async function normalizeMessage(
     model,
     eventType = "snapshot",
-    collectionsOverride = null
+    collectionsOverride = null,
+    names = null
   ) {
     const collections =
       collectionsOverride ?? requireFirst(["WAWebCollections"]);
     if (!collections) return null;
+    // A single normalise (the watch path) builds its own; a collect passes one
+    // in so the whole run shares it.
+    const nameLookup = names ?? nameIndex(collections);
     let row = modelData(model);
     let key = row.id ?? model?.id;
     let id = rawId(key);
@@ -341,11 +370,11 @@ export function whatsAppWebAdapterProgram() {
       id,
       chat_jid: chat.jid,
       chat_lid: chat.lid,
-      chat_name: chatName(collections, widString(chatRaw)),
+      chat_name: chatName(nameLookup, widString(chatRaw)),
       sender_jid: sender.jid,
       sender_lid: sender.lid,
       push_name:
-        contactName(collections, widString(senderRaw)) ??
+        contactName(nameLookup, widString(senderRaw)) ??
         row.notifyName ??
         null,
       participant: participant.jid,
@@ -813,8 +842,14 @@ export function whatsAppWebAdapterProgram() {
     );
     const normalized = [];
     const quarantined = [];
+    const names = nameIndex(collections);
     for (const model of uniqueMessageModels(collections)) {
-      const message = await normalizeMessage(model, "reconcile", collections);
+      const message = await normalizeMessage(
+        model,
+        "reconcile",
+        collections,
+        names
+      );
       if (!message) continue;
       if (message.timestamp <= 0) {
         quarantined.push({
@@ -1029,9 +1064,15 @@ export function whatsAppWebAdapterProgram() {
       });
     }
     const normalized = [];
+    const names = nameIndex(collections);
     for (const candidate of candidates) {
       const model = candidate?.msg ?? candidate?.message ?? candidate;
-      const message = await normalizeMessage(model, "search", collections);
+      const message = await normalizeMessage(
+        model,
+        "search",
+        collections,
+        names
+      );
       // The relay boundary rejects placeholder rows without a stable
       // timestamp. Exclude them before slicing/counting so a page cannot
       // collapse to zero rows after transport and replay the same cursor.

--- a/packages/connectors/src/whatsapp-web-helpers.ts
+++ b/packages/connectors/src/whatsapp-web-helpers.ts
@@ -15,7 +15,7 @@
 
 import type { EventEnvelope } from "@lobu/connector-sdk";
 
-export const WHATSAPP_ADAPTER_VERSION = 9;
+export const WHATSAPP_ADAPTER_VERSION = 10;
 export const WHATSAPP_ORIGIN = "https://web.whatsapp.com";
 const WHATSAPP_SOURCE = "whatsapp_web";
 const RECENT_OVERLAP_SECONDS = 15 * 60;


### PR DESCRIPTION
## Root cause of the WhatsApp outage

`collect` normalises every message in the store, and `normalizeMessage` rescanned a whole collection on **each one**:

- `chatName()` — linear scan of every chat
- `contactName()` — linear scan of every contact
- `collectionByRawId()` — linear scan of every message, per reaction

That is **O(messages × collection)** of *synchronous* work on the page's main thread.

## Measured on the live prod tab

947 chats, **5323 contacts**, 1872 messages:

| | |
|---|---|
| Contact scan, projected over the store | **~6.8s** |
| Message scan, projected | **~2.1s** |
| Chat scan, projected | ~0.6s |
| Real `collect` against a 70s in-page timer | **exceeded it** — the timer could not even fire, because the main thread never yielded |

The extension's 90s per-dispatch run fence then killed the run. The feed ingested nothing, every run was slower than the last as backfill grew the store, and the page was left unresponsive for minutes afterwards.

This also explains why the earlier fixes did not resolve it: `navigate` was already down to 1.0s after owletto#1017, and `probe` answers in 4.5s. The cost was never in any single call — it was the quadratic total.

## Fix

Build each lookup once per collection, cached on the collection under a symbol and rebuilt whenever the model count changes (so a `collect` that loads history still sees new rows). The same `Map` shape `uniqueMessageModels` already uses in this file.

## Red/green

New test `does not rescan a collection once per message`, asserting the *shape* of the cost rather than a wall-clock number — it counts id property reads:

- **With the bug**: 25 messages × 500 contacts = **12500 reads** → fails
- **With the fix**: **500 reads** (one pass) → passes

Verified by reverting `contactName` to its linear scan with the test in place (`Expected: < 12500, Received: 12500`).

Full connectors suite **405/405**; adapter suite 23/23 including the serialisation guards (the new symbols live inside the program function, so the adapter still serialises self-contained); `make pre-pr` and the pre-commit hook clean.

## Not proved here

Unit and in-page measurement. A live sync against a reloaded extension has **not** been run with this change — it ships in the adapter, which the connector injects, so it needs a server deploy to take effect. Live acceptance still owed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved WhatsApp message collection and search performance, especially for larger contact and chat collections.

* **Compatibility**
  * Updated the WhatsApp adapter version to keep installed adapters synchronized with the latest connector changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->