### PR TITLE
fix(auth): block deleting a user's personal organization

### DIFF
--- a/packages/server/src/__tests__/unit/personal-org-delete-guard.test.ts
+++ b/packages/server/src/__tests__/unit/personal-org-delete-guard.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import {
+	isPersonalOrgDeletionBlocked,
+	readPersonalOrgOwnerId,
+} from "../../auth/personal-org-provisioning";
+
+/**
+ * The personal org anchors device pairing, `workerOrgIds`, and auto-wire.
+ * Deleting it strands the account (403 on pair, 403 on every worker poll,
+ * silent auto-wire no-op), so `beforeDeleteOrganization` refuses it. These
+ * cover the predicate that hook calls.
+ *
+ * The guard RESTRICTS an action, so every ambiguous input must fail open —
+ * treating an unreadable row as personal would make team orgs undeletable.
+ */
+
+const USER = "user_abc123";
+const OTHER = "user_zzz999";
+
+describe("readPersonalOrgOwnerId", () => {
+	test("reads the marker from a JSON string (the DB column shape)", () => {
+		const raw = JSON.stringify({ personal_org_for_user_id: USER });
+		expect(readPersonalOrgOwnerId(raw)).toBe(USER);
+	});
+
+	test("reads the marker from an object (the Better Auth hook shape)", () => {
+		expect(readPersonalOrgOwnerId({ personal_org_for_user_id: USER })).toBe(
+			USER,
+		);
+	});
+
+	test("returns null for metadata without the marker", () => {
+		expect(readPersonalOrgOwnerId(JSON.stringify({ theme: "dark" }))).toBeNull();
+		expect(readPersonalOrgOwnerId({})).toBeNull();
+	});
+
+	test("returns null for absent metadata", () => {
+		expect(readPersonalOrgOwnerId(null)).toBeNull();
+		expect(readPersonalOrgOwnerId(undefined)).toBeNull();
+	});
+
+	test("returns null for unparseable metadata rather than throwing", () => {
+		expect(readPersonalOrgOwnerId("{not json")).toBeNull();
+	});
+
+	test("returns null for a non-string or empty marker", () => {
+		expect(readPersonalOrgOwnerId({ personal_org_for_user_id: 42 })).toBeNull();
+		expect(
+			readPersonalOrgOwnerId({ personal_org_for_user_id: null }),
+		).toBeNull();
+		expect(readPersonalOrgOwnerId({ personal_org_for_user_id: "" })).toBeNull();
+	});
+});
+
+describe("isPersonalOrgDeletionBlocked", () => {
+	test("blocks the owner deleting their own personal org", () => {
+		const meta = JSON.stringify({ personal_org_for_user_id: USER });
+		expect(isPersonalOrgDeletionBlocked(meta, USER)).toBe(true);
+	});
+
+	test("allows deleting a team org", () => {
+		const meta = JSON.stringify({ theme: "dark" });
+		expect(isPersonalOrgDeletionBlocked(meta, USER)).toBe(false);
+		expect(isPersonalOrgDeletionBlocked(null, USER)).toBe(false);
+	});
+
+	test("does not block on someone else's personal-org marker", () => {
+		// Defensive: better-auth already gates delete on ownership, so this
+		// should be unreachable. The guard is about protecting YOUR anchor —
+		// it must not become a second, differently-worded authz check.
+		const meta = JSON.stringify({ personal_org_for_user_id: OTHER });
+		expect(isPersonalOrgDeletionBlocked(meta, USER)).toBe(false);
+	});
+
+	test("fails open on unreadable metadata so team orgs stay deletable", () => {
+		expect(isPersonalOrgDeletionBlocked("{not json", USER)).toBe(false);
+	});
+});

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -44,7 +44,10 @@ import {
 	resolveLoginProviderCredentials,
 	resolveRequestOrganizationId,
 } from "./config";
-import { findExistingPersonalOrg } from "./personal-org-provisioning";
+import {
+	findExistingPersonalOrg,
+	isPersonalOrgDeletionBlocked,
+} from "./personal-org-provisioning";
 import { persistLoginSlackIdentity } from "./subject-identities";
 
 function gravatarUrl(email: string): string {
@@ -304,6 +307,24 @@ export async function createAuth(
 				allowUserToCreateOrganization: true,
 				creatorRole: "owner",
 				organizationHooks: {
+					// A personal org is not user-deletable — see
+					// `isPersonalOrgDeletionBlocked` for why. The marker is read off
+					// the org row the hook already provides, so no second query is
+					// needed. Deleting a team org you own is unaffected.
+					beforeDeleteOrganization: async ({ organization: org, user }) => {
+						if (
+							isPersonalOrgDeletionBlocked(
+								(org as { metadata?: unknown }).metadata,
+								user.id,
+							)
+						) {
+							throw new APIError("FORBIDDEN", {
+								code: "PERSONAL_ORGANIZATION_CANNOT_BE_DELETED",
+								message:
+									"Your personal workspace can't be deleted — devices and personal connections are bound to it.",
+							});
+						}
+					},
 					// If a user manually creates a private org while they have no
 					// personal-org marker yet, tag it as their personal one. Without
 					// this, `personal_org_for_user_id` only gets set by the

--- a/packages/server/src/auth/personal-org-provisioning.ts
+++ b/packages/server/src/auth/personal-org-provisioning.ts
@@ -104,6 +104,48 @@ async function lockPersonalOrgForUser(userId: string, sql: Sql): Promise<void> {
   `;
 }
 
+/**
+ * Read the `personal_org_for_user_id` marker off an `organization` row.
+ *
+ * `organization.metadata` is a `text` column holding JSON, but Better Auth
+ * hands hooks an already-parsed object, so accept both shapes. Anything that
+ * fails to parse, or carries a non-string marker, returns null: callers use
+ * this to *restrict* an action, so an unreadable row must not be treated as
+ * personal.
+ */
+export function readPersonalOrgOwnerId(metadata: unknown): string | null {
+	let parsed: Record<string, unknown> | null = null;
+	if (typeof metadata === "string") {
+		try {
+			parsed = JSON.parse(metadata) as Record<string, unknown> | null;
+		} catch {
+			return null;
+		}
+	} else if (metadata && typeof metadata === "object") {
+		parsed = metadata as Record<string, unknown>;
+	}
+	const marker = parsed?.personal_org_for_user_id;
+	return typeof marker === "string" && marker.length > 0 ? marker : null;
+}
+
+/**
+ * A user's personal org is not user-deletable.
+ *
+ * Device tokens are force-bound to it (the device-worker grant in
+ * `oauth/routes.ts`), the device-worker middleware builds `workerOrgIds` from
+ * it, and auto-wire targets it unconditionally (`device-reconcile.ts`).
+ * Deleting it strands the account rather than freeing a workspace: pairing
+ * 403s with "No personal organization is provisioned", existing workers 403 on
+ * every poll, and auto-wire silently returns []. Team orgs stay deletable.
+ */
+export function isPersonalOrgDeletionBlocked(
+	metadata: unknown,
+	actingUserId: string,
+): boolean {
+	const ownerId = readPersonalOrgOwnerId(metadata);
+	return ownerId !== null && ownerId === actingUserId;
+}
+
 export async function findExistingPersonalOrg(
 	userId: string,
 	sql: Sql,


### PR DESCRIPTION
## Summary
- The personal org is a **structural anchor**, not one workspace among several: device tokens are force-bound to it (device-worker grant, `oauth/routes.ts`), the device-worker middleware builds `workerOrgIds` from it (`index.ts`), and auto-wire targets it unconditionally (`device-reconcile.ts`).
- Deleting it doesn't free a workspace — it **strands the account**: pairing 403s with *"No personal organization is provisioned"*, existing workers 403 on every poll, and auto-wire silently returns `[]`.
- The UI exposed this via `organization.delete()` (`organization-settings-page.tsx:248`) with no guard, and there was no server-side hook either. `afterCreateOrganization` already exists to re-tag a manually created org as personal — patching this same hole *after* the fact. This closes it at the source.

Team orgs stay deletable. The guard restricts an action, so unreadable metadata **fails open** rather than making team orgs undeletable.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (all 5 gates; `make pr-full` not run)
- [x] Tests run: `bun test src/__tests__/unit/personal-org-delete-guard.test.ts` — 10 pass, 0 fail
- [ ] Bug fix: red→fix→green — **see caveat below**
- [ ] Bot runtime unchanged; no eval needed

### Verification detail

New unit suite (10 tests) covers the marker predicate: both metadata shapes (DB `text` JSON and the parsed object Better Auth hands hooks), missing/absent/unparseable metadata, non-string and empty markers, and the fail-open path.

Guard reachability was verified against Better Auth's actual call contract — `crud-org.mjs` `await`s `beforeDeleteOrganization({organization, user})` *before* `adapter.deleteOrganization()`, so a throw aborts the delete:

```
personal -> FORBIDDEN: PERSONAL_ORGANIZATION_CANNOT_BE_DELETED
personal deleted? false (want false)
team deleted? true (want true)
```

**Caveat — no live red reproduced.** The original 403 symptom needs a real paired device, which I could not stand up here. The failure mode is asserted from the code paths above plus the existing in-repo comment at `auth/index.tsx` naming the cause ("anyone whose auto-provisioned org was deleted"). Worth a manual check on a staging account before relying on this.

## Notes
- `make review-fix` could not run — the Codex credential returns `401 Unauthorized`. Working tree was left clean; it changed nothing. Needs re-auth, unrelated to this diff.
- **Follow-up not in this PR:** users *already* in the stranded state are not healed by this guard. A backfill may be needed; the count is unqueried (could be zero).
- Deliberately scoped narrow: the four-way `ORDER BY member."createdAt" ASC` default-workspace fallback (`lobu/gateway.ts`, `auth/routes.ts`, `auth/oauth/routes.ts`, `chat-instance-manager.ts`) is untouched. It's real duplication but no user-visible bug was found behind it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Personal organizations are now protected from deletion by their owners.
  - Attempting to delete a protected personal organization displays an access-denied error.
  - Team organizations and organizations owned by other users remain deletable.
  - Protection continues to work when organization metadata is stored in supported formats, while unreadable metadata does not block deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->