### PR TITLE
fix(linkedin): decode home-feed post identities

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1847,7 +1847,7 @@ describe("LinkedInConnector home_feed", () => {
     };
     expect(cfg.rowSelector).toContain("replaceableComment_urn:li:comment");
     expect(cfg.expandRows.rowSelector).toContain('[componentkey^="expanded"]');
-    expect(cfg.expandRows.identity).toEqual(cfg.fields.post_identity);
+    expect(cfg.expandRows.identity).toMatchObject(cfg.fields.post_identity);
     expect(cfg.expandRows.expected.textRegex).toContain("comments?");
     expect(cfg.expandRows.expected.selector).toContain(
       cfg.fields.comment_count_text.selector
@@ -2039,6 +2039,66 @@ describe("LinkedInConnector home_feed", () => {
       }
     }
   };
+
+  test.each([
+    ["CgoIjsejvOXquuse", "activity", "1111111111111111111"],
+    ["EgoIqtXqtLDAsMJc", "ugcPost", "3333333333333333333"],
+    // Current ids exceed 2^62, so the ZigZag varint fills all ten bytes.
+    ["CgsIgICIqvf8v8fMAQ", "activity", "7370000000000000000"],
+  ])("reads encoded %s post identities from comment tools", async (encoded, namespace, postId) => {
+    const res = await syncHomeFeedDom(`
+      <div componentkey="expandedfixture_tokenFeedType_MAIN_FEED_RELEVANCE">
+        <button aria-label="Open control menu for post by Fixture Author"></button>
+        <p>Fixture Author • 1st A current feed card with a durable encoded identity</p>
+        <div id="replaceableComment_urn:li:comment:(urn:li:${namespace}:${postId},2222222222222222222)">
+          <p>Fixture Commenter • A native comment that stays linked to its parent</p>
+        </div>
+        <div id="${encoded}-replaceableCommentToolsfixture_tokenFeedType_MAIN_FEED_RELEVANCE"></div>
+      </div>`);
+    expect(res.events).toMatchObject([
+      {
+        origin_id: `li_home_${namespace}_${postId}`,
+        source_url: `https://www.linkedin.com/feed/update/urn:li:${namespace}:${postId}`,
+      },
+      {
+        origin_id: "li_comment_2222222222222222222",
+        origin_parent_id: `li_home_${namespace}_${postId}`,
+      },
+    ]);
+    expect(res.metadata.comment_threads_complete).toBe(true);
+  });
+
+  test.each([
+    "%%%",
+    "GgIIAg",
+    "CgoIjsejvOXquus",
+    "CgIIAw",
+    "CgoIjsejvOXquuseAA",
+  ])("rejects malformed or unsupported encoded post identity %s", async (encoded) => {
+    await expect(
+      syncHomeFeedDom(`
+        <div componentkey="expandedfixture_tokenFeedType_MAIN_FEED_RELEVANCE">
+          <p>Fixture Author • 1st A post whose identity must not be guessed</p>
+          <div id="${encoded}-replaceableCommentToolsfixture_token"></div>
+        </div>`)
+    ).rejects.toThrow("invalid encoded post identity");
+  });
+
+  test("rejects duplicate encoded identities despite different recycled card keys", async () => {
+    await expect(
+      syncHomeFeedDom(
+        ["first", "second"]
+          .map(
+            (token) => `
+      <div componentkey="expanded${token}FeedType_MAIN_FEED_RELEVANCE">
+        <p>Fixture Author • 1st A duplicated card cannot own expansion evidence</p>
+        <div id="CgoIjsejvOXquuse-replaceableCommentTools${token}"></div>
+      </div>`
+          )
+          .join("")
+      )
+    ).rejects.toThrow("home feed produced no post rows");
+  });
 
   test("expands a 4-comment thread from 3 rendered comments and emits all durable comments", async () => {
     const activityId = "8111111111111111111";
@@ -3174,7 +3234,7 @@ describe("prepare_comment helpers", () => {
     expect(action?.inputSchema?.properties).not.toHaveProperty(
       "browser_connection_id"
     );
-    expect(c.definition.version).toBe("3.11.10");
+    expect(c.definition.version).toBe("3.11.11");
     expect(String(action?.description ?? "")).toMatch(
       /NEVER opens a tab or submits/i
     );

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -428,7 +428,11 @@ interface HomeFeedRow {
    * treat it as best-effort and prefer `post_identity` for durable identity.
    */
   post_url?: string;
-  /** Rendered identifier containing LinkedIn's stable shareId / ugcPostId. */
+  /**
+   * Rendered identifier carrying the stable post id: a readable shareId /
+   * ugcPostId / activity URN, or the encoded comment-tools id that
+   * `decodeHomeFeedPostIdentity` turns into a URN before ingestion.
+   */
   post_identity?: string;
   /** Every profile/company anchor in the card, each with its accessible name. */
   links?: HomeFeedLink[];
@@ -466,7 +470,51 @@ const HOME_FEED_COMMENT_COUNT_LABEL_SELECTOR =
 const HOME_FEED_POST_CONTROL_SELECTOR =
   '[role="button"]:not([id^="replaceableComment_"] *):not([componentkey^="commentsSectionContainer"] *), button:not([id^="replaceableComment_"] *):not([componentkey^="commentsSectionContainer"] *), a:not([id^="replaceableComment_"] *):not([componentkey^="commentsSectionContainer"] *)';
 const HOME_FEED_POST_IDENTITY_SELECTOR =
-  '[id*="shareId="], [id*="ugcPostId="], [id*="urn:li:activity:"]';
+  ':is([id*="shareId="], [id*="ugcPostId="], [id*="urn:li:activity:"], [id*="-replaceableCommentTools"]):not([id^="replaceableComment_"]):not([id^="replaceableComment_"] *)';
+
+/** Current comment-tool ids encode a typed post URN, followed by the recycled
+ * card key. Decode only the typed prefix: field 1 is activity, field 2 ugcPost;
+ * each contains field 1 as a protobuf sint64 (ZigZag). Native comment URNs and
+ * the corresponding live post URLs independently confirm those namespaces. */
+function decodeHomeFeedPostIdentity(
+  raw: string | undefined
+): string | undefined {
+  const marker = "-replaceableCommentTools";
+  if (!raw?.includes(marker)) return raw;
+  const invalid = () =>
+    new Error(
+      "LinkedIn returned an invalid encoded post identity. No home-feed events were persisted."
+    );
+  let bytes: string;
+  try {
+    bytes = atob(
+      raw.slice(0, raw.indexOf(marker)).replace(/-/g, "+").replace(/_/g, "/")
+    );
+  } catch {
+    throw invalid();
+  }
+  const tag = bytes.charCodeAt(0);
+  if (
+    (tag !== 10 && tag !== 18) ||
+    bytes.length < 4 ||
+    bytes.length > 13 ||
+    bytes.charCodeAt(1) !== bytes.length - 2 ||
+    bytes.charCodeAt(2) !== 8
+  ) {
+    throw invalid();
+  }
+  let encoded = 0n;
+  for (let i = 3; i < bytes.length; i++) {
+    const byte = bytes.charCodeAt(i);
+    const isLast = i === bytes.length - 1;
+    if (Boolean(byte & 128) === isLast) throw invalid();
+    encoded |= BigInt(byte & 127) << BigInt(7 * (i - 3));
+  }
+  if ((encoded & 1n) !== 0n || encoded >= 1n << 64n || encoded < 200_000n) {
+    throw invalid();
+  }
+  return `urn:li:${tag === 10 ? "activity" : "ugcPost"}:${encoded >> 1n}`;
+}
 
 /**
  * Selectors for the virtualized linkedin.com/feed/ DOM. Home-feed posts are
@@ -494,6 +542,9 @@ const HOME_FEED_SCRAPE_CONFIG = {
       selector: HOME_FEED_POST_IDENTITY_SELECTOR,
       take: "attr",
       attr: "id",
+      // Exclude the recycled card-key suffix from expansion ownership.
+      regex: "^(.*?)(?:-replaceableCommentTools|$)",
+      group: 1,
     },
     expected: {
       // Keep this aligned with the post-level comment count fields below. The
@@ -589,8 +640,8 @@ const HOME_FEED_SCRAPE_CONFIG = {
       maxWaitMs: 1500,
     },
     post_identity: {
-      // Current feed cards embed the durable id in a translatable-commentary
-      // element id even when every visible anchor points back to /feed/.
+      // Readable commentary URNs and encoded comment-tool ids both carry the
+      // durable post identity. parseRows decodes the latter before ingestion.
       selector: HOME_FEED_POST_IDENTITY_SELECTOR,
       take: "attr",
       attr: "id",
@@ -2943,7 +2994,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft for the human to Post; verify_staged_comment checks whether that draft appeared as a comment.",
-    version: "3.11.10",
+    version: "3.11.11",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com
@@ -3508,7 +3559,11 @@ export default class LinkedInConnector extends ConnectorRuntime<
         ...HOME_FEED_SCRAPE_CONFIG,
         scroll: { ...HOME_FEED_SCRAPE_CONFIG.scroll, max: maxScrolls },
       },
-      parseRows: (raw) => raw as HomeFeedRow[],
+      parseRows: (raw) =>
+        (raw as HomeFeedRow[]).map((row) => ({
+          ...row,
+          post_identity: decodeHomeFeedPostIdentity(row.post_identity),
+        })),
       allowedOrigins: LINKEDIN_ALLOWED_ORIGINS,
       existingTabMatch: "linkedin.com/feed/",
       persistent: true,


### PR DESCRIPTION
## Summary

LinkedIn's current home-feed cards put their durable post identity in an encoded `replaceableCommentTools` marker. The scraper required a readable URN before expanding a post, so it discarded these cards and reported an empty feed even though Chrome returned their content with a reduced scrape configuration.

Decode the marker's activity or ugcPost identity before building events, keep the recycled card key out of expansion ownership, and prevent nested comment identities from being selected as the post identity. Invalid or unsupported encodings fail without persisting a partial batch. The connector version becomes 3.11.11; all 13 feed keys remain.

## Test plan

- [x] Targeted red reproduction against the original connector: both encoded-identity DOM fixtures fail with the production zero-row error.
- [x] Intended files staged explicitly; `make pre-pr` passed, with GitHub CI as the canonical full gate.
- [x] `make review-fix` completed; its decoder cleanup and full-width ID fixture were inspected and retested.
- [x] `bun test examples/personal-agent/__tests__`: 315 passed, 0 failed, including malformed encodings, duplicate expansion identities, full-width IDs, and comment-parent links.
- [x] Server `bun run test -- run src/__tests__/integration/sandbox/connector-isolate-lane.test.ts`: 9 passed.
- [x] The canonical flatten/compile pipeline produced an isolate-eligible artifact. Running that artifact in a real V8 isolate over captured live scrape rows produced 2 posts and 7 comments, all linked to their parents, with complete coverage.
- [x] `make review` passed on the settled HEAD: zero bugs, zero blockers; reviewer independently ran all 150 LinkedIn tests.
- [x] GitHub CI passed for `90ff87b23dc03d46ba3d27b2fd6b42f903953820`; `make ui-review` passed as not applicable.
- [x] Fresh signed-in Chrome run using the final scrape configuration: 2 posts, 7 comments, complete coverage of 2/2 and 5/5. No workspace events persisted by this probe.

Red:
```
LinkedIn is logged in, but the home feed produced no post rows.
0 pass
2 fail
```

Green:
```
315 pass
0 fail
Compiled artifact: posts=2 comments=7 linked=true complete=true
```

## Notes

Installed 3.11.11 in the target workspace after merging squash commit `bab5a55800a4d791fac1f08b20d940468faf28b9`, verified reachable from `origin/main`. The installation used the reviewed, flattened source with only whitespace/comments removed to fit the SDK payload limit; server validation passed, all 13 feed keys remain, and installed-source readback matched the submitted artifact exactly. Active compiled code hash: `bf4df41403ef35cfd38e76b0c8e335d7fb58564a2df13fa86149762715038f41`.

Production verification on 2026-09-07 at 11:37 UTC succeeded on 3.11.11 after bringing the existing LinkedIn feed tab to the foreground. A dry run returned 24 items, followed by a real sync that persisted 5 posts and 19 comments. Direct stored-event reads confirmed all 24 source identities and every comment-to-post link. The feed is active with last-sync status success, no error, and zero consecutive failures.

The same open tab rejected script injection before it was focused. Focusing restored access without changing the site-permission grant. Automatic recovery when Chrome leaves an open tab unresponsive remains unverified and outside this connector-identity change.

No new files, API endpoints, database tables, or columns. No takeout, approval-policy, device-pin, or schedule changes.
