### PR TITLE
test(cli): add scheduled daemon MCP smoke reporting

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -197,5 +197,6 @@ jobs:
   verify-published-artifact:
     needs: publish-packages
     uses: ./.github/workflows/published-artifact-smoke.yml
+    secrets: inherit
     with:
       version: ${{ needs.publish-packages.outputs.published-version }}

--- a/.github/workflows/published-artifact-smoke.yml
+++ b/.github/workflows/published-artifact-smoke.yml
@@ -71,6 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.image }}
     timeout-minutes: 25
+    outputs:
+      tested-version: ${{ steps.tested-version.outputs.version }}
     steps:
       - name: Install prerequisites
         run: |
@@ -112,6 +114,19 @@ jobs:
               bash scripts/published-artifact-smoke.sh"
           fi
 
+      - name: Record the installed CLI version
+        id: tested-version
+        if: always()
+        run: |
+          for file in /tmp/lobu-artifact-smoke*/version.txt; do
+            [ -f "$file" ] || continue
+            version=$(cat "$file")
+            if echo "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "version=$version" >> "$GITHUB_OUTPUT"
+              break
+            fi
+          done
+
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v7
@@ -120,3 +135,23 @@ jobs:
           path: /tmp/lobu-artifact-smoke*/**
           if-no-files-found: ignore
           retention-days: 7
+
+  report:
+    needs: smoke
+    if: always() && (github.event_name == 'schedule' || needs.smoke.result != 'success')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report published CLI and daemon smoke
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEPLOY_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          VERSION: ${{ needs.smoke.outputs.tested-version || 'install failed before version detection' }}
+          RESULT: ${{ needs.smoke.result }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_DEPLOY_WEBHOOK_URL not set; notification unavailable."
+            exit 0
+          fi
+          payload=$(jq -nc --arg text "CLI and daemon MCP smoke: ${RESULT}. Tested CLI: ${VERSION}. Four Linux environments. Results and failure logs: ${RUN_URL}" '{text: $text}')
+          curl --fail-with-body -sS -X POST -H 'Content-type: application/json' \
+            --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/packages/connector-worker/src/__tests__/device-mode-requires-durable-token.test.ts
+++ b/packages/connector-worker/src/__tests__/device-mode-requires-durable-token.test.ts
@@ -101,7 +101,7 @@ describe("device mode requires a durable token", () => {
     expect(stderr).toContain("Starting worker daemon");
     expect(stderr).toContain("device mode: platform=macos");
     expect(stderr).toContain(
-      "Manage action permissions (Approval vs Auto) at: http://127.0.0.1:1/test-org/connectors"
+      "Manage action permissions (Approval vs Auto) at: http://127.0.0.1:1/test-org/connectors/device/test-device"
     );
   }, 20000);
 

--- a/packages/connector-worker/src/daemon/start.ts
+++ b/packages/connector-worker/src/daemon/start.ts
@@ -204,9 +204,9 @@ export async function startDaemonCommand(
       `[cli] device mode: platform=${platform} capabilities=${capabilities.join(',') || '(none)'}`
     );
     if (opts.activeOrg) {
-      const connectorsUrl = `${opts.apiUrl.replace(/\/+$/, '')}/${opts.activeOrg}/connectors`;
+      const deviceUrl = `${opts.apiUrl.replace(/\/+$/, '')}/${encodeURIComponent(opts.activeOrg)}/connectors/device/${encodeURIComponent(workerId)}`;
       log.info(
-        `[cli] Manage action permissions (Approval vs Auto) at: ${connectorsUrl}`
+        `[cli] Manage action permissions (Approval vs Auto) at: ${deviceUrl}`
       );
     }
   }

--- a/scripts/daemon-mcp-smoke.mjs
+++ b/scripts/daemon-mcp-smoke.mjs
@@ -1,0 +1,557 @@
+#!/usr/bin/env node
+// Real MCP transport -> gateway/Postgres -> installed `lobu daemon` -> shell.
+// Owns its gateway, temporary HOME/database, daemon and command files. Every
+// command goes through MCP; the plain HTTP requests bootstrap a disposable
+// local owner, mint the daemon's device token, list its devices, and set its
+// action permissions through the same session-authenticated endpoint as the
+// web UI.
+//
+// Local run against the working tree, before publishing:
+//   node scripts/pack-cli-smoke.mjs /tmp/lobu-candidate
+//   node scripts/daemon-mcp-smoke.mjs /tmp/lobu-candidate/node_modules/@lobu/cli/bin/lobu.js
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { randomBytes, randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+
+const cli = resolve(process.argv[2] ?? "");
+if (!process.argv[2] || !existsSync(cli)) {
+  throw new Error(
+    "Usage: daemon-mcp-smoke.mjs <installed-lobu-bin> [failure-log-directory]"
+  );
+}
+const requireCli = createRequire(cli);
+// Use the actual installed CLI's MCP client dependency, without importing any
+// gateway handlers or source-only test clients.
+const { Client } = await import(
+  pathToFileURL(requireCli.resolve("@modelcontextprotocol/sdk/client/index.js"))
+);
+const { StreamableHTTPClientTransport } = await import(
+  pathToFileURL(
+    requireCli.resolve("@modelcontextprotocol/sdk/client/streamableHttp.js")
+  )
+);
+// Canonical path: the shell reports its physical cwd, and macOS tmpdirs are
+// symlinks.
+const work = await realpath(await mkdtemp(join(tmpdir(), "lobu-daemon-mcp-")));
+const home = join(work, "home");
+const project = join(work, "project");
+const commandDir = join(work, "commands with spaces");
+for (const dir of [home, project, commandDir]) mkdirSync(dir);
+writeFileSync(
+  join(project, "lobu.config.ts"),
+  "export default { agents: [] };\n"
+);
+const port = await freePort();
+const proxyPort = await freePort();
+const origin = `http://127.0.0.1:${port}`;
+const env = {
+  PATH: `${dirname(process.execPath)}:${process.env.PATH}`,
+  HOME: home,
+  TMPDIR: work,
+  LANG: "C",
+  NO_COLOR: "1",
+  DATABASE_URL: home,
+  HOST: "127.0.0.1",
+  PORT: String(port),
+  WORKER_PROXY_PORT: String(proxyPort),
+  PUBLIC_GATEWAY_URL: origin,
+  ENCRYPTION_KEY: randomBytes(32).toString("base64"),
+  LOBU_DISABLE_SYSTEMD_RUN: "1",
+};
+const children = [];
+const clients = [];
+const secrets = [env.ENCRYPTION_KEY];
+const logs = new Map();
+const workerId = `headless:smoke-${randomUUID()}`;
+let passes = 0;
+let failures = 0;
+let connection;
+let mcp;
+let org;
+let daemon;
+let failed = false;
+const overall = setTimeout(() => {
+  console.error("Daemon MCP smoke exceeded its 10 minute deadline");
+  process.kill(process.pid, "SIGTERM");
+}, 600_000);
+
+function start(name, args, extraEnv = {}) {
+  const child = spawn(process.execPath, [cli, ...args], {
+    cwd: project,
+    env: { ...env, ...extraEnv },
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.name = name;
+  logs.set(name, "");
+  for (const stream of [child.stdout, child.stderr]) {
+    stream.on("data", (data) =>
+      logs.set(name, (logs.get(name) + data).slice(-2_000_000))
+    );
+  }
+  child.on("error", (error) => logs.set(name, logs.get(name) + error.message));
+  children.push(child);
+  return child;
+}
+
+async function stop(child) {
+  if (!child?.pid) return;
+  try {
+    process.kill(-child.pid, "SIGTERM");
+  } catch (error) {
+    if (error.code !== "ESRCH") throw error;
+  }
+  const deadline = Date.now() + 8_000;
+  while (
+    child.exitCode === null &&
+    child.signalCode === null &&
+    Date.now() < deadline
+  )
+    await delay(100);
+  try {
+    process.kill(-child.pid, "SIGKILL");
+  } catch (error) {
+    if (error.code !== "ESRCH") throw error;
+  }
+}
+
+async function until(description, probe, timeout = 90_000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const result = await probe();
+    if (result) return result;
+    await delay(250);
+  }
+  throw new Error(`Timed out: ${description}`);
+}
+
+async function check(description, action) {
+  await action();
+  passes++;
+  console.log(`[OK] ${description}`);
+}
+
+// Once setup succeeds, collect independent failures so a broken burst does
+// not hide timeout, credential-isolation or restart regressions in the report.
+async function scenario(description, action) {
+  try {
+    await check(description, action);
+  } catch (error) {
+    failed = true;
+    failures++;
+    console.error(`[FAIL] ${description}: ${error.message}`);
+  }
+}
+
+async function json(path, { method = "GET", body, headers = {} } = {}) {
+  const response = await fetch(`${origin}${path}`, {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    signal: AbortSignal.timeout(20_000),
+  });
+  const result = await response.json();
+  assert.equal(
+    response.ok,
+    true,
+    `HTTP ${response.status} ${path}: ${JSON.stringify(result)}`
+  );
+  return result;
+}
+
+async function connect(token) {
+  const client = new Client({ name: "lobu-daemon-smoke", version: "1.0.0" });
+  clients.push(client);
+  await client.connect(
+    new StreamableHTTPClientTransport(new URL(`${origin}/mcp/${org.slug}`), {
+      requestInit: { headers: { authorization: `Bearer ${token}` } },
+    })
+  );
+  return client;
+}
+
+async function sdk(method, args, client = mcp, tool = "run_sdk") {
+  const script = `export default async (ctx, client) => client.${method}(${JSON.stringify(args)});`;
+  const reply = await client.callTool(
+    { name: tool, arguments: { script, timeout_ms: 180_000 } },
+    undefined,
+    { timeout: 195_000 }
+  );
+  assert.notEqual(reply.isError, true, JSON.stringify(reply.content));
+  const result = reply.structuredContent;
+  assert.ok(result, `Missing structured MCP result for ${method}`);
+  assert.equal(result.success, true, JSON.stringify(result));
+  assert.equal(result.return_truncated, undefined, "MCP result was truncated");
+  return result.return_value;
+}
+
+async function execute(command, input = {}, key = randomUUID(), client = mcp) {
+  return sdk(
+    "operations.execute",
+    {
+      connection_id: connection.connection_id,
+      operation_key: "run",
+      input: { command, cwd: commandDir, ...input },
+      idempotency_key: key,
+    },
+    client
+  );
+}
+
+function completed(result, stdout) {
+  assert.equal(result.status, "completed", JSON.stringify(result));
+  assert.equal(result.output.success, true, JSON.stringify(result.output));
+  assert.equal(result.output.exit_code, 0);
+  assert.equal(result.output.stdout, stdout);
+  assert.equal(result.output.timed_out, false);
+}
+
+async function failedCommand(command, input, expectedError) {
+  // The public SDK throws for failed operations; inspect the persisted result
+  // through MCP after asserting the caller received the expected error.
+  await assert.rejects(() => execute(command, input), expectedError);
+  const { runs } = await sdk(
+    "operations.listRuns",
+    {
+      connection_id: connection.connection_id,
+      operation_key: "run",
+      run_types: ["action"],
+      limit: 1,
+    },
+    mcp,
+    "query_sdk"
+  );
+  assert.equal(runs.length, 1);
+  assert.equal(runs[0].input.command, command);
+  const { run } = await sdk("operations.getRun", runs[0].id, mcp, "query_sdk");
+  assert.ok(["failed", "timeout"].includes(run.status), JSON.stringify(run));
+  return run;
+}
+
+async function main() {
+  const server = start("gateway", ["run", "--port", String(port)]);
+  await check(
+    "installed CLI boots an isolated gateway and Postgres",
+    async () => {
+      await until(
+        "gateway readiness",
+        async () => {
+          assert.equal(
+            server.exitCode,
+            null,
+            "Gateway exited before readiness"
+          );
+          return fetch(`${origin}/health/ready`, {
+            signal: AbortSignal.timeout(2_000),
+          })
+            .then((response) => response.ok)
+            .catch(() => false);
+        },
+        180_000
+      );
+    }
+  );
+  const bootstrapResponse = await fetch(`${origin}/api/local-init`, {
+    method: "POST",
+    headers: { "x-lobu-client": "daemon-smoke" },
+    signal: AbortSignal.timeout(20_000),
+  });
+  assert.equal(bootstrapResponse.status, 200, "Local owner bootstrap failed");
+  const bootstrap = await bootstrapResponse.json();
+  org = bootstrap.organization;
+  secrets.push(bootstrap.session_token, bootstrap.device_token);
+  const cookie = bootstrapResponse.headers
+    .getSetCookie()
+    .find((value) => value.startsWith(`${bootstrap.cookie_name}=`))
+    ?.split(";")[0];
+  assert.ok(cookie, "Local bootstrap must issue a signed owner session cookie");
+  secrets.push(cookie);
+  const sessionHeaders = { cookie, origin };
+  mcp = await connect(bootstrap.device_token);
+  await check("MCP handshake, tools discovery and authentication", async () => {
+    const { tools } = await mcp.listTools();
+    for (const name of ["run_sdk", "query_sdk", "search_sdk"])
+      assert.ok(tools.some((tool) => tool.name === name));
+    await assert.rejects(() => connect("owl_pat_invalid_smoke_token"));
+  });
+  const minted = await json("/api/me/devices/mint-child-token", {
+    method: "POST",
+    headers: { authorization: `Bearer ${bootstrap.device_token}` },
+    body: {
+      platform: "headless",
+      worker_id: workerId,
+      label: "Daemon MCP smoke",
+    },
+  });
+  secrets.push(minted.access_token);
+  const daemonEnv = {
+    WORKER_API_TOKEN: minted.access_token,
+    LOBU_ORG: org.slug,
+  };
+  const daemonArgs = [
+    "daemon",
+    "--api-url",
+    origin,
+    "--worker-id",
+    workerId,
+    "--capabilities",
+    "os.shell",
+    "--no-interactive-session",
+  ];
+  daemon = start("daemon", daemonArgs, daemonEnv);
+  await check(
+    "daemon registers and advertises an executable shell connection",
+    async () => {
+      connection = await until("os.shell device connection", async () => {
+        assert.equal(
+          daemon.exitCode,
+          null,
+          "Daemon exited before advertising shell operations"
+        );
+        const result = await sdk(
+          "operations.listAvailable",
+          { connector_key: "os.shell" },
+          mcp,
+          "query_sdk"
+        );
+        logs.set("discovery", JSON.stringify(result, null, 2));
+        return result.operations
+          ?.find((operation) => operation.operation_key === "run")
+          ?.execution_targets.find((target) => target.executable);
+      });
+    }
+  );
+  await check("startup links to this device's detail page", async () => {
+    const expected = `${origin}/${encodeURIComponent(org.slug)}/connectors/device/${encodeURIComponent(workerId)}`;
+    assert.ok(
+      logs.get("daemon").includes(expected),
+      `Missing device URL: ${expected}`
+    );
+  });
+  await check("default approval prevents shell execution", async () => {
+    const result = await execute("printf forbidden > approval-marker");
+    assert.equal(result.status, "pending_approval", JSON.stringify(result));
+    await delay(1_000);
+    assert.equal(existsSync(join(commandDir, "approval-marker")), false);
+    await assert.rejects(() =>
+      sdk("operations.approve", { run_id: result.run_id })
+    );
+  });
+  // A disposable local owner's real web session authorizes subsequent tests.
+  // Tokens never change action_modes or approve operations.
+  const current = await json(`/api/${org.slug}/manage_connections`, {
+    method: "POST",
+    headers: sessionHeaders,
+    body: { action: "get", connection_id: connection.connection_id },
+  });
+  await json(`/api/${org.slug}/manage_connections`, {
+    method: "POST",
+    headers: sessionHeaders,
+    body: {
+      action: "update",
+      connection_id: connection.connection_id,
+      config: { ...current.connection.config, action_modes: { run: "auto" } },
+    },
+  });
+  await scenario(
+    "stdout, stderr, exit code, cwd and stdin round-trip",
+    async () => {
+      const result = await execute("pwd; cat; printf smoke-stderr >&2", {
+        stdin: "smoke-stdin",
+      });
+      completed(result, `${commandDir}\nsmoke-stdin`);
+      assert.equal(result.output.stderr, "smoke-stderr");
+    }
+  );
+  await scenario(
+    "20 sequential commands preserve results and execute once",
+    async () => {
+      for (let i = 0; i < 20; i++) {
+        completed(
+          await execute(`printf 'seq-${i}\\n' >> sequential; printf seq-${i}`),
+          `seq-${i}`
+        );
+      }
+      assert.deepEqual(
+        readFileSync(join(commandDir, "sequential"), "utf8").trim().split("\n"),
+        Array.from({ length: 20 }, (_, i) => `seq-${i}`)
+      );
+    }
+  );
+  await scenario(
+    "10 concurrent MCP requests preserve correlation and execute once",
+    async () => {
+      const results = await Promise.allSettled(
+        Array.from({ length: 10 }, async (_, i) => {
+          const result = await execute(
+            `printf 'parallel-${i}\\n' >> parallel; printf parallel-${i}`
+          );
+          completed(result, `parallel-${i}`);
+          return result.run_id;
+        })
+      );
+      const rejected = results.filter((result) => result.status === "rejected");
+      assert.equal(
+        rejected.length,
+        0,
+        rejected.map((result) => result.reason.message).join("\n")
+      );
+      assert.equal(new Set(results.map((result) => result.value)).size, 10);
+      assert.deepEqual(
+        readFileSync(join(commandDir, "parallel"), "utf8")
+          .trim()
+          .split("\n")
+          .sort(),
+        Array.from({ length: 10 }, (_, i) => `parallel-${i}`).sort()
+      );
+    }
+  );
+  await scenario(
+    "idempotent replay returns the original run without re-execution",
+    async () => {
+      const key = randomUUID();
+      const command = "printf 'once\\n' >> replay; printf once";
+      const first = await execute(command, {}, key);
+      const second = await execute(command, {}, key);
+      completed(first, "once");
+      completed(second, "once");
+      assert.equal(first.run_id, second.run_id);
+      assert.equal(readFileSync(join(commandDir, "replay"), "utf8"), "once\n");
+    }
+  );
+  await scenario(
+    "failed command is reported and the next command succeeds",
+    async () => {
+      const run = await failedCommand(
+        "printf failure-stderr >&2; exit 7",
+        {},
+        /Shell command exited with code 7/
+      );
+      assert.equal(run.output.exit_code, 7, JSON.stringify(run));
+      assert.equal(run.output.stderr, "failure-stderr");
+      completed(await execute("printf after-failure"), "after-failure");
+    }
+  );
+  await scenario(
+    "timeout terminates the command and releases daemon capacity",
+    async () => {
+      const run = await failedCommand(
+        "echo $$ > timeout-pid; sleep 20; printf leaked > timeout-marker",
+        { timeout_ms: 1_000 },
+        /Shell command timed out/
+      );
+      assert.equal(run.output.timed_out, true, JSON.stringify(run));
+      const pid = Number(
+        readFileSync(join(commandDir, "timeout-pid"), "utf8").trim()
+      );
+      assert.ok(Number.isSafeInteger(pid) && pid > 1);
+      await until(
+        "timed-out shell is reaped",
+        async () => {
+          try {
+            process.kill(pid, 0);
+            return false;
+          } catch (error) {
+            if (error.code === "ESRCH") return true;
+            throw error;
+          }
+        },
+        5_000
+      );
+      completed(await execute("printf after-timeout"), "after-timeout");
+      assert.equal(existsSync(join(commandDir, "timeout-marker")), false);
+    }
+  );
+  await scenario(
+    "shell commands cannot inherit the daemon credential",
+    async () => {
+      completed(
+        await execute(
+          'printf "%s|%s" "${WORKER_API_TOKEN-unset}" "${DATABASE_URL-unset}"'
+        ),
+        "unset|unset"
+      );
+    }
+  );
+  await scenario(
+    "daemon restart reconnects the same device and serves another command",
+    async () => {
+      await stop(daemon);
+      daemon = start("daemon-restarted", daemonArgs, daemonEnv);
+      completed(await execute("printf after-restart"), "after-restart");
+      const devices = await json("/api/me/devices", {
+        headers: sessionHeaders,
+      });
+      assert.equal(
+        devices.devices.filter((device) => device.worker_id === workerId)
+          .length,
+        1
+      );
+    }
+  );
+}
+
+async function cleanup() {
+  clearTimeout(overall);
+  await Promise.allSettled(clients.map((client) => client.close()));
+  for (const child of children.toReversed()) await stop(child);
+  if (failed) {
+    const output = resolve(process.argv[3] ?? "daemon-mcp-smoke-logs");
+    mkdirSync(output, { recursive: true });
+    for (const [name, raw] of logs) {
+      let text = raw;
+      for (const secret of secrets.filter(Boolean))
+        text = text.replaceAll(secret, "[redacted]");
+      text = text
+        .replace(/owl_pat_[A-Za-z0-9_-]+/g, "[redacted]")
+        .replace(
+          /([?&](?:token|session_token|sessionToken)=)[^\s&]+/g,
+          "$1[redacted]"
+        );
+      writeFileSync(join(output, `${name}.log`), text);
+    }
+    console.error(`Failure logs: ${output}`);
+  }
+  await rm(work, { recursive: true, force: true });
+}
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, async () => {
+    failed = true;
+    await cleanup();
+    process.exit(1);
+  });
+}
+try {
+  await main();
+  console.log(`Daemon MCP smoke: ${passes} passed, ${failures} failed`);
+  if (failures > 0) process.exitCode = 1;
+} catch (error) {
+  failed = true;
+  console.error(error);
+  console.error(`Daemon MCP smoke: ${passes} passed, ${failures + 1} failed`);
+  process.exitCode = 1;
+} finally {
+  await cleanup();
+}
+
+async function freePort() {
+  const server = createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address();
+  await new Promise((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve()))
+  );
+  return port;
+}

--- a/scripts/pack-cli-smoke.mjs
+++ b/scripts/pack-cli-smoke.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// Install the candidate package graph outside the workspace, using the same
+// manifest transforms as publication. No source-tree resolution or registry
+// copies of sibling @lobu packages may stand in for the candidate.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { __testing as publisher } from "./publish-packages.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const destination = resolve(process.argv[2] ?? "");
+if (!process.argv[2])
+  throw new Error("Usage: pack-cli-smoke.mjs <empty-directory>");
+mkdirSync(destination); // Refuse to overwrite an existing installation.
+const staging = join(destination, "packages");
+mkdirSync(staging);
+const tarballs = [];
+for (const { dir, transform } of publisher.PACKAGES) {
+  if (dir === "packages/promptfoo-provider") continue;
+  const source = join(root, dir);
+  const pkg = transform(
+    JSON.parse(readFileSync(join(source, "package.json"), "utf8"))
+  );
+  const target = join(staging, pkg.name.replaceAll("/", "-"));
+  mkdirSync(target);
+  for (const file of [
+    ...pkg.files.filter((file) => !file.startsWith("!")),
+    "README.md",
+    "LICENSE",
+  ]) {
+    if (!existsSync(join(source, file))) continue;
+    cpSync(join(source, file), join(target, file), { recursive: true });
+  }
+  writeFileSync(
+    join(target, "package.json"),
+    `${JSON.stringify(pkg, null, 2)}\n`
+  );
+  const tarball = join(destination, `${pkg.name.replaceAll("/", "-")}.tgz`);
+  run("bun", ["pm", "pack", "--filename", tarball], target);
+  tarballs.push(tarball);
+}
+writeFileSync(join(destination, "package.json"), '{"private":true}\n');
+// npm is intentional: this tests the consumer installer, including its own
+// resolver and lifecycle scripts. Workspace development still uses Bun.
+run(
+  "npm",
+  ["install", "--no-audit", "--no-fund", "--omit=dev", ...tarballs],
+  destination
+);
+const lock = JSON.parse(
+  readFileSync(join(destination, "package-lock.json"), "utf8")
+);
+for (const [path, pkg] of Object.entries(lock.packages)) {
+  if (/(?:^|\/)node_modules\/@lobu\/[^/]+$/.test(path)) {
+    assert.ok(
+      pkg.resolved?.startsWith("file:"),
+      `${path} resolved outside the candidate tarballs`
+    );
+    assert.notEqual(pkg.link, true, `${path} is a workspace link`);
+  }
+}
+console.log(
+  `Candidate CLI: ${join(destination, "node_modules/@lobu/cli/bin/lobu.js")}`
+);
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, { cwd, stdio: "inherit" });
+  if (result.error) throw result.error;
+  if (result.status !== 0)
+    throw new Error(`${command} failed (${result.status})`);
+}

--- a/scripts/published-artifact-smoke.sh
+++ b/scripts/published-artifact-smoke.sh
@@ -150,6 +150,7 @@ fi
 pass "installed, bin present"
 
 RESOLVED="$("$LOBU_BIN" --version 2>&1 | tr -d '[:space:]')"
+printf '%s\n' "$RESOLVED" > "$WORK/version.txt"
 if [ -n "$RESOLVED" ]; then pass "lobu --version -> $RESOLVED"; else fail "lobu --version produced nothing"; fi
 
 # Run from a directory that is deliberately outside the npm install tree. A
@@ -343,6 +344,15 @@ if grep -qE "tool\(s\)" "$MCP_OUT"; then
   pass "lobu call --list (admin tool surface)"
 else
   fail "lobu call --list exposed no tools"; tail -15 "$MCP_OUT" >&2
+fi
+
+# The CLI quickstart above exercises an agent worker. Device command execution
+# has a separate process/credential/queue path, driven here by a real MCP client
+# against the SAME installed npm artifact and its installed sibling packages.
+if node "$REPO_ROOT/scripts/daemon-mcp-smoke.mjs" "$LOBU_BIN" "$WORK/daemon-mcp-logs"; then
+  pass "daemon MCP command lifecycle"
+else
+  fail "daemon MCP command lifecycle"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Exercise the installed CLI with a real MCP client, gateway, Postgres and headless daemon. Cover approval enforcement, command I/O, 20 sequential commands, 10 concurrent requests, idempotency, failures, timeouts, credential isolation and restart.

Run this with the existing four-environment published-artifact canary at 07:00 UTC daily, on main pushes, after publication and manually. Report daily results and other failures to the existing Slack destination, including the installed version and run/log link. No new PR trigger or required check.

Daemon startup now prints its existing device-detail URL. Previously it hardcoded the generic connector list even though it already knew the worker ID.

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` and commit-hook Biome/typecheck passed.
- [x] Targeted daemon startup suite: 8 passed, 0 failed, 21 assertions.
- [x] Device-link regression reproduced red before changing the implementation, then green.
- [x] Both Node scripts parse, shell syntax passes, workflow YAML parses, and the artifact workflow has no PR trigger.
- [x] Final packaged Linux MCP run completed against a clean npm installation of the candidate tarballs: 12 scenarios passed, 1 existing runtime failure detected. The tarball-origin assertion passed for every installed @lobu package.
- [x] GitHub CI passed: https://github.com/lobu-ai/lobu/actions/runs/34123120379
- [x] UI review passed as not applicable (no Owletto pointer change).
- [x] Final semantic review passed using the documented independent Codex reviewer selection: confidence 84, bugs 0, blockers 0. All required checks passed before merge.

Device-link red output:
```text
Expected substring: .../test-org/connectors/device/test-device
Received: .../test-org/connectors
0 pass, 1 fail
```
After the fix:
```text
8 pass
0 fail
21 expect() calls
```

Packaged end-to-end output (Node 22 on isolated Linux):
```text
[OK] installed CLI boots an isolated gateway and Postgres
[OK] MCP handshake, tools discovery and authentication
[OK] daemon registers and advertises an executable shell connection
[OK] startup links to this device's detail page
[OK] default approval prevents shell execution
[OK] stdout, stderr, exit code, cwd and stdin round-trip
[OK] 20 sequential commands preserve results and execute once
[FAIL] 10 concurrent MCP requests preserve correlation and execute once
       4 requests were never claimed within 60000ms; device last polled 0s ago
[OK] idempotent replay returns the original run without re-execution
[OK] failed command is reported and the next command succeeds
[OK] timeout terminates the command and releases daemon capacity
[OK] shell commands cannot inherit the daemon credential
[OK] daemon restart reconnects the same device and serves another command
Daemon MCP smoke: 12 passed, 1 failed
```

## Notes

The new burst scenario has already exposed an existing runtime failure: the poll loop waits 10 seconds between claims even after a trivial command completes, so queued requests can exceed the 60-second claim deadline. The canary keeps this failure visible and continues the independent scenarios. Fixing the shared poll loop is a separate runtime slice.

The package helper applies the real publisher manifest transforms, installs candidate tarballs with npm outside the workspace, and verifies every installed @lobu package came from those tarballs. The daemon fixture uses a disposable local owner and device token and deletes its processes/database afterward; saved failure logs are redacted. Cleanup was verified after the final run, and the temporary sandbox was deleted.

No API endpoints, database tables or columns added or changed. No legacy runtime paths deleted. The generic startup link was replaced.

The manual failure-notification path is verified. The daily schedule activates after merge. Still unverified: a successful scheduled report, the daemon scenarios across all four containers (the published CLI currently fails before that phase), and the macOS native device bridge.


Manual workflow verification:
- Triggered this branch with `version=latest`: https://github.com/lobu-ai/lobu/actions/runs/34125675165
- All four containers installed CLI 19.1.0 and each recorded 7 checks passed, 1 failed at startup. Each log contains the Better Auth schema error and invalid/expired access-token error. The daemon MCP phase was not reached.
- All four diagnostic artifacts uploaded successfully.
- The report job ran with `VERSION=19.1.0` and `RESULT=failure`; the Slack webhook returned `ok` at 2026-09-07 13:16:22 UTC: https://github.com/lobu-ai/lobu/actions/runs/34125675165/job/101756161100
- This verifies failure detection and Slack acceptance. It does not mean the released CLI is healthy or that a person has read the message in Slack.
- No code changes were needed for this manual verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated device action-permission links to direct users to the specific device endpoint, improving accuracy and context.

- **Quality and Reliability**
  - Expanded published CLI verification to cover command execution, concurrency, failures, timeouts, credential isolation, and daemon reconnection.
  - Added validation that published packages install independently without workspace links.
  - Smoke-test results now record the tested CLI version and report scheduled or failed runs through Slack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->