### PR TITLE
fix(cli): clear explicit automation model overrides

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/automation-model-clearing.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/automation-model-clearing.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  defineAgent,
+  defineAutomation,
+  defineConfig,
+} from "../../../../config/define.js";
+import { executePlan } from "../apply-cmd.js";
+import { ApplyClient, type RemoteAutomation } from "../client.js";
+import { buildAttributionAndOwned, toBaseline } from "../deployment.js";
+import type { DesiredAutomation, DesiredState } from "../desired-state.js";
+import { computeDiff, type RemoteSnapshot } from "../diff.js";
+import { mapProjectToDesiredState } from "../map-config.js";
+
+function emptyState(): DesiredState {
+  return {
+    agents: [],
+    prune: false,
+    memorySchema: { entityTypes: [], relationshipTypes: [] },
+    automations: [],
+    connectors: { definitions: [], authProfiles: [], connections: [] },
+    providers: [],
+    requiredSecrets: [],
+  };
+}
+
+function snapshot(automation: RemoteAutomation): RemoteSnapshot {
+  return {
+    agents: [],
+    agentSettings: new Map(),
+    entityTypes: [],
+    relationshipTypes: [],
+    automations: [automation],
+    connectorDefinitions: [],
+    authProfiles: [],
+    connections: [],
+    feedsByConnectionId: new Map(),
+    inferenceProviders: [],
+  };
+}
+
+describe("Automation model overrides", () => {
+  test("maps explicit model removal from declarative config", () => {
+    const agent = defineAgent({ id: "worker" });
+    const state = mapProjectToDesiredState(
+      defineConfig({
+        agents: [agent],
+        automations: [
+          defineAutomation({
+            slug: "digest",
+            agent,
+            prompt: "Summarize.",
+            model: null,
+          }),
+        ],
+      }),
+      {}
+    );
+    expect(state.automations[0]?.model).toBeNull();
+  });
+
+  test("omitting a model still preserves an existing override", () => {
+    const state = emptyState();
+    state.automations = [
+      { slug: "digest", agent: "worker", prompt: "Summarize." },
+    ];
+    const remote = snapshot({
+      slug: "digest",
+      managed_agent_id: "worker",
+      prompt: "Summarize.",
+      execution_config: { model: "existing/model", timeout_seconds: 300 },
+    });
+    expect(
+      computeDiff(state, remote).rows.every((row) => row.verb === "noop")
+    ).toBe(true);
+    expect(
+      buildAttributionAndOwned(state, remote).attribution.automations[0]
+        ?.execution_config
+    ).toEqual(remote.automations[0]?.execution_config);
+  });
+
+  test.each([
+    [
+      "new/model",
+      { model: "old/model", timeout_seconds: 300 },
+      { model: "new/model", timeout_seconds: 300 },
+    ],
+    [
+      null,
+      { model: "old/model", timeout_seconds: 300 },
+      { timeout_seconds: 300 },
+    ],
+    [null, { model: "old/model" }, null],
+  ])("updates only the model and records a stable second apply: %j", async (model, executionConfig, expected) => {
+    const state = emptyState();
+    const desiredAutomation = {
+      slug: "digest",
+      agent: "worker",
+      prompt: "Summarize.",
+      model,
+    } satisfies DesiredAutomation;
+    state.automations = [desiredAutomation];
+    const remoteAutomation: RemoteAutomation = {
+      automation_id: "42",
+      slug: "digest",
+      managed_agent_id: "worker",
+      prompt: "Summarize.",
+      triggers: [],
+      execution_config: executionConfig,
+    };
+    const remote = snapshot(remoteAutomation);
+    const baseline = toBaseline(
+      buildAttributionAndOwned(
+        {
+          ...state,
+          automations: [{ ...desiredAutomation, model: "old/model" }],
+        },
+        remote
+      )
+    );
+    const plan = computeDiff(state, remote, { baseline });
+    expect(plan.rows.some((row) => row.verb === "drift")).toBe(false);
+    const updateAutomation = mock(async () => undefined);
+    await executePlan(
+      {
+        state,
+        remote,
+        plan,
+        client: { updateAutomation } as unknown as ApplyClient,
+      },
+      []
+    );
+    expect(updateAutomation).toHaveBeenCalledWith({
+      automation_id: "42",
+      execution_config: expected,
+    });
+
+    const recorded = buildAttributionAndOwned(state, remote);
+    expect(recorded.attribution.automations[0]?.execution_config).toEqual(
+      expected
+    );
+    remoteAutomation.execution_config = expected;
+    const second = computeDiff(state, remote, {
+      baseline: toBaseline(recorded),
+    });
+    expect(second.rows.every((row) => row.verb === "noop")).toBe(true);
+  });
+
+  test("creates an Automation with a cleared model on the HTTP wire", async () => {
+    const state = emptyState();
+    state.automations = [
+      {
+        slug: "digest",
+        agent: "worker",
+        prompt: "Summarize.",
+        model: null,
+        triggers: [],
+      },
+    ];
+    const remote = { ...snapshot({ slug: "unused" }), automations: [] };
+    const requests: unknown[] = [];
+    const client = new ApplyClient(
+      {
+        apiBaseUrl: "http://localhost:9999",
+        orgSlug: "synthetic-org",
+        token: "synthetic-token",
+      },
+      (async (_url: unknown, init?: RequestInit) => {
+        requests.push(JSON.parse(String(init?.body)));
+        return Response.json({ automation_id: "42" });
+      }) as typeof fetch
+    );
+    await executePlan(
+      { state, remote, plan: computeDiff(state, remote), client },
+      []
+    );
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      action: "create",
+      managed_agent_id: "worker",
+      execution_config: null,
+      triggers: [],
+    });
+  });
+});

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -60,7 +60,11 @@ import {
   renderPostApplyPunchList,
   renderProgress,
 } from "./render.js";
-import { declaredConnectorKeys, referencedConnectorKeys } from "./shared.js";
+import {
+  automationExecutionConfig,
+  declaredConnectorKeys,
+  referencedConnectorKeys,
+} from "./shared.js";
 
 interface ApplyOptions {
   cwd?: string;
@@ -955,7 +959,10 @@ export async function executePlan(
           min_cooldown_seconds: w.minCooldownSeconds,
           tags: w.tags,
           agent_kind: w.agentKind,
-          execution_config: w.model ? { model: w.model } : undefined,
+          execution_config:
+            w.model !== undefined
+              ? automationExecutionConfig(w.model)
+              : undefined,
           outputs: w.outputs,
           classifiers: w.classifiers,
         });
@@ -1018,16 +1025,12 @@ export async function executePlan(
             ...(scalarForUpdate.includes("agent_kind")
               ? { agent_kind: w.agentKind ?? null }
               : {}),
-            ...(scalarForUpdate.includes("execution_config") && w.model
+            ...(scalarForUpdate.includes("execution_config")
               ? {
-                  // The server assigns execution_config wholesale, so preserve
-                  // remote keys (timeout_seconds, permission_mode, …) and
-                  // override only the model — otherwise a model drift would
-                  // silently drop config set outside this project.
-                  execution_config: {
-                    ...(remote?.execution_config ?? {}),
-                    model: w.model,
-                  },
+                  execution_config: automationExecutionConfig(
+                    w.model,
+                    remote?.execution_config
+                  ),
                 }
               : {}),
           });

--- a/packages/cli/src/commands/_lib/apply/deployment.ts
+++ b/packages/cli/src/commands/_lib/apply/deployment.ts
@@ -22,6 +22,7 @@ import {
   effectiveRelationshipTypeAfterApply,
   projectDesiredAutomation,
 } from "./diff.js";
+import { automationExecutionConfig } from "./shared.js";
 
 export function mintApplyId(): string {
   return `apl_${randomUUID()}`;
@@ -286,12 +287,10 @@ export function buildAttributionAndOwned(
       min_cooldown_seconds: p.minCooldownSeconds,
       tags: p.tags,
       agent_kind: p.agentKind,
-      // The three-way baseline must record the execution_config the apply just
-      // wrote (including the merged remote keys), or a later model edit is
+      // The three-way baseline must record the effective execution_config after
+      // apply (including preserved remote keys), or a later model edit is
       // misclassified as "remote moved" blocking drift instead of an update.
-      execution_config: p.model
-        ? { ...(r?.execution_config ?? {}), model: p.model }
-        : (r?.execution_config ?? null),
+      execution_config: automationExecutionConfig(d.model, r?.execution_config),
       outputs: p.outputs,
       classifiers: p.classifiers,
     };

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -142,8 +142,8 @@ export interface DesiredAutomation {
   reactionsGuidance?: string;
   /** UUID of a device worker to pin this automation's runs to (see `device_workers.id`). */
   deviceWorkerId?: string;
-  /** Model alias/id passed to the device's local CLI (`--model`) on device runs. */
-  model?: string;
+  /** Execution model override; omitted preserves remote, null clears it. */
+  model?: string | null;
   /** Minimum seconds between two firings of this automation (0 = no cooldown). */
   minCooldownSeconds?: number;
   /** Free-form tags for filtering. */

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -1607,8 +1607,8 @@ function diffAutomation(
     scalar.push("agent_kind");
   }
   if (
-    desired.model &&
-    desired.model !== (remote.execution_config?.model ?? undefined)
+    desired.model !== undefined &&
+    desired.model !== (remote.execution_config?.model ?? null)
   ) {
     scalar.push("execution_config");
   }

--- a/packages/cli/src/commands/_lib/apply/shared.ts
+++ b/packages/cli/src/commands/_lib/apply/shared.ts
@@ -37,6 +37,18 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** A model declaration owns only the model key, preserving other execution options. */
+export function automationExecutionConfig(
+  model: string | null | undefined,
+  remote?: Record<string, unknown> | null
+): Record<string, unknown> | null {
+  if (model === undefined) return remote ?? null;
+  const config = { ...remote };
+  if (model === null) delete config.model;
+  else config.model = model;
+  return Object.keys(config).length > 0 ? config : null;
+}
+
 /**
  * Keys of locally-declared connector definitions whose key is already known.
  * A `null` key (an auto-discovered `*.connector.ts` the server compiles) can't

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -736,11 +736,10 @@ export interface Automation {
    */
   deviceWorkerId?: string;
   /**
-   * Model alias/id passed to the device's local CLI (`--model`) when this
-   * Automation runs on a device (see `agentKind`/`deviceWorkerId`). Omitted on
-   * cloud runs, which use the owning agent's model.
+   * Model override for managed or device execution. Omit to preserve a stored
+   * override; null removes it so execution uses the agent/provider defaults.
    */
-  model?: string;
+  model?: string | null;
   /**
    * A sibling `.ts` reaction script (`./reactions/foo.reaction.ts`) compiled +
    * run in a sandboxed isolate when the Automation fires, built with


### PR DESCRIPTION
## Summary

`lobu apply` could set an Automation model override, but could not remove it: omitting `model` intentionally preserves the stored value. Accept `model: null` to remove only the model key while preserving other execution settings. Record the cleared value in the deployment baseline so the next apply is a no-op.

## Test plan

- [x] Targeted apply tests: `bun test packages/cli/src/commands/_lib/apply/__tests__` — 370 passed, 0 failed.
- [x] Regression reproduced before the fix and passed afterward:

```text
Before (new model-clearing regression tests on origin/main):
2 pass, 3 fail
  - model-only override: update was not sent
  - model plus timeout: update was not sent
  - explicit null create: execution_config was omitted

After:
6 pass, 0 fail (includes ordinary model replacement)
All apply tests: 370 pass, 0 fail; 819 expectations
```

- [x] `make pre-pr` (build, typecheck, lint, dead-code and naming gates)
- [x] Built CLI against an isolated server: create, clear, preserve unrelated settings, omitted-model preservation, and repeat apply. Verified persisted values through the server API; archived all four synthetic Automations and deleted the synthetic agent afterward.

```text
PASS persisted extras: {"timeout_seconds":300}
PASS persisted only-model: null
PASS persisted omitted: {"model":"opus","timeout_seconds":600}
PASS persisted created-null: null
Repeat cleared config: no changes
PASS built CLI -> live server -> persisted config -> repeated no-op
```
- [x] GitHub CI passed on `71c6923911a7c4d8fe323cf5a48869ebffa68140`.
- [x] `make review-fix`, `make review` (0 bugs, 0 blockers), and `make ui-review` (not applicable).

## Notes

Final diff: 7 files, +221/−24 lines. Implementation: +37/−24; tests: +184 in one new regression test file.

This is a CLI configuration bug fix. The server already supports replacing or clearing `execution_config`; this PR changes no server endpoints, database schema, scheduler, or skill ownership.
