### PR TITLE
fix(worker): drain queued commands without poll interval gaps

### DIFF
--- a/packages/connector-worker/src/__tests__/worker-capacity-daemon.test.ts
+++ b/packages/connector-worker/src/__tests__/worker-capacity-daemon.test.ts
@@ -2,7 +2,152 @@ import { describe, expect, test } from "bun:test";
 import { WorkerHttpError } from "../daemon/client";
 import { WorkerPollLoop } from "../daemon/poll-loop";
 
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
 describe("worker daemon capacity polling", () => {
+  for (const throws of [false, true]) {
+    test(`drains ten queued commands without interval gaps (executor throws: ${throws})`, async () => {
+      const executed: number[] = [];
+      let claimed = 0;
+      const loop = new WorkerPollLoop({
+        client: {
+          healthCheck: async () => true,
+          poll: async (capacity: number) => capacity > 0 && claimed < 10
+            ? { run_id: ++claimed, run_type: "action" }
+            : { next_poll_seconds: 1 },
+        } as never,
+        pollIntervalMs: 1000,
+        execute: async (job) => {
+          executed.push(job.run_id!);
+          if (throws) throw new Error("command failed");
+        },
+      });
+      const running = loop.start();
+      try {
+        await Bun.sleep(100);
+        expect(executed).toEqual(Array.from({ length: 10 }, (_, i) => i + 1));
+      } finally {
+        loop.stop();
+        await running;
+      }
+    });
+  }
+
+  test("fills free slots immediately without exceeding concurrency", async () => {
+    const finish = deferred();
+    const capacities: number[] = [];
+    let executions = 0;
+    const loop = new WorkerPollLoop({
+      client: {
+        healthCheck: async () => true,
+        poll: async (capacity: number) => {
+          capacities.push(capacity);
+          return capacity > 0
+            ? { run_id: capacities.length, run_type: "action" }
+            : { next_poll_seconds: 1 };
+        },
+      } as never,
+      maxConcurrentJobs: 3,
+      pollIntervalMs: 1000,
+      execute: async () => {
+        executions++;
+        await finish.promise;
+      },
+    });
+    const running = loop.start();
+    try {
+      await Bun.sleep(100);
+      expect(executions).toBe(3);
+      expect(capacities).toEqual([3, 2, 1]);
+    } finally {
+      loop.stop();
+      finish.resolve();
+      await running;
+      await loop.waitForActiveJobs(1000, 1);
+    }
+  });
+
+  test("does not lose a capacity wakeup while a zero-capacity poll is in flight", async () => {
+    const finish = deferred();
+    const pollingAtCapacity = deferred();
+    const idleReply = deferred<{ next_poll_seconds: number }>();
+    const capacities: number[] = [];
+    let loop: WorkerPollLoop;
+    loop = new WorkerPollLoop({
+      client: {
+        healthCheck: async () => true,
+        poll: async (capacity: number) => {
+          capacities.push(capacity);
+          if (capacities.length === 1) return { run_id: 1, run_type: "action" };
+          if (capacities.length === 2) {
+            pollingAtCapacity.resolve();
+            return idleReply.promise;
+          }
+          loop.stop();
+          return {};
+        },
+      } as never,
+      pollIntervalMs: 5,
+      execute: async () => finish.promise,
+    });
+    const running = loop.start();
+    try {
+      await pollingAtCapacity.promise;
+      finish.resolve();
+      await loop.waitForActiveJobs(1000, 1);
+      idleReply.resolve({ next_poll_seconds: 1 });
+      const repolled = await Promise.race([
+        running.then(() => true),
+        Bun.sleep(100).then(() => false),
+      ]);
+      expect(repolled).toBe(true);
+      expect(capacities).toEqual([1, 0, 1]);
+    } finally {
+      loop.stop();
+      finish.resolve();
+      idleReply.resolve({ next_poll_seconds: 1 });
+      await running;
+    }
+  });
+
+  test("completion cannot interrupt poll-error backoff but shutdown can", async () => {
+    const finish = deferred();
+    const pollFailed = deferred();
+    let polls = 0;
+    const loop = new WorkerPollLoop({
+      client: {
+        healthCheck: async () => true,
+        poll: async () => {
+          if (++polls === 1) return { run_id: 1, run_type: "action" };
+          pollFailed.resolve();
+          throw new WorkerHttpError(503, "/api/workers/poll", "retry");
+        },
+      } as never,
+      pollIntervalMs: 100,
+      execute: async () => finish.promise,
+    });
+    const running = loop.start();
+    try {
+      await pollFailed.promise;
+      finish.resolve();
+      await Bun.sleep(20);
+      expect(polls).toBe(2);
+      loop.stop();
+      expect(await Promise.race([
+        running.then(() => true),
+        Bun.sleep(20).then(() => false),
+      ])).toBe(true);
+    } finally {
+      loop.stop();
+      finish.resolve();
+      await running;
+    }
+  });
+
   test("runs credential maintenance before polls only when no job is active", async () => {
     const order: string[] = [];
     let releaseJob: (() => void) | undefined;

--- a/packages/connector-worker/src/daemon/poll-loop.ts
+++ b/packages/connector-worker/src/daemon/poll-loop.ts
@@ -49,6 +49,8 @@ export class WorkerPollLoop {
   private running = false;
   private admittingJobs = true;
   private activeJobs = 0;
+  private capacityVersion = 0;
+  private wakePoll?: (capacityReleased?: boolean) => void;
 
   constructor(options: WorkerPollLoopOptions) {
     this.client = options.client;
@@ -78,9 +80,14 @@ export class WorkerPollLoop {
     while (this.running) {
       if (this.activeJobs === 0) await this.beforeIdlePoll?.();
       let nextDelayMs: number | undefined;
+      // A job may finish while the HTTP poll is in flight, before its wait
+      // exists. Keep that completion observable when deciding whether to wait.
+      let capacityVersion: number | undefined = this.capacityVersion;
       try {
         nextDelayMs = await this.pollAndExecute();
       } catch (err) {
+        // Server errors retain their retry backoff even if a slot opens.
+        capacityVersion = undefined;
         if (
           this.failClosedOnPollAuthError &&
           err instanceof WorkerHttpError &&
@@ -95,7 +102,7 @@ export class WorkerPollLoop {
         const delayMs = nextDelayMs === undefined || this.maxIdleDelayMs === undefined
           ? requestedDelayMs
           : Math.min(requestedDelayMs, this.maxIdleDelayMs);
-        await this.sleep(delayMs);
+        await this.waitForNextPoll(delayMs, capacityVersion);
       }
     }
     log.info('[daemon] Stopped');
@@ -105,6 +112,7 @@ export class WorkerPollLoop {
     log.info('[daemon] Stopping...');
     this.running = false;
     this.admittingJobs = false;
+    this.wakePoll?.();
   }
 
   async waitForActiveJobs(timeoutMs = 30000, pollMs = 500): Promise<boolean> {
@@ -156,7 +164,30 @@ export class WorkerPollLoop {
       })
       .finally(() => {
         this.activeJobs--;
+        this.capacityVersion++;
+        this.wakePoll?.(true);
       });
+    // Fill remaining slots while the queue has work, then wait for capacity
+    // or the normal heartbeat instead of delaying every successful claim.
+    return this.activeJobs < this.maxConcurrentJobs ? 0 : undefined;
+  }
+
+  private waitForNextPoll(ms: number, capacityVersion: number | undefined): Promise<void> {
+    if (
+      !this.running ||
+      (capacityVersion !== undefined && capacityVersion !== this.capacityVersion)
+    ) return Promise.resolve();
+
+    return new Promise((resolve) => {
+      const wake = (capacityReleased = false) => {
+        if (capacityReleased && capacityVersion === undefined) return;
+        clearTimeout(timer);
+        this.wakePoll = undefined;
+        resolve();
+      };
+      const timer = setTimeout(wake, ms);
+      this.wakePoll = wake;
+    });
   }
 
   private sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary

Ten quick MCP commands queued together could exceed the 60-second claim deadline because the daemon waited 10 seconds between claims, including after a command had already finished. The shared poll loop now fills free slots immediately and wakes when an executor releases capacity. Completions during an in-flight poll are remembered, so the subsequent idle wait cannot lose that wakeup.

Server idle hints, retry backoff, capacity limits, authentication refusal, credential maintenance and shutdown/draining behavior remain covered. Shutdown also cancels the pending poll timer.

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` and commit-hook Biome/typecheck passed.
- [x] Five new regressions reproduced red against the old poll loop: 8 passed, 5 failed.
- [x] Updated capacity and Mac daemon suites: 34 passed, 0 failed, 59 assertions.
- [x] `make review-fix` completed using the documented independent Codex reviewer selection; no edits or defects found. Claude's quota was unavailable.
- [x] Built the full package graph on isolated Linux, packed the actual publisher manifests and installed the candidate tarballs with npm outside the workspace. All installed @lobu dependencies were verified to come from those candidate tarballs.
- [x] Real MCP client → gateway/Postgres → installed daemon → shell: all 13 scenarios passed, including the ten-request burst, 20 sequential commands, idempotency, failed commands, timeout/process cleanup, credential isolation and restart. The candidate included the reporting/device-link change in #3406, now merged into this branch's base.
- [x] Verified the fixture removed its HOME/database and gateway/daemon/Postgres processes.
- [x] GitHub CI passed: https://github.com/lobu-ai/lobu/actions/runs/34130147441
- [x] Final semantic review passed using the documented independent Codex reviewer; UI review passed as not applicable.

Red output:
```text
8 pass
5 fail
Ran 13 tests across 1 file.
```
Green output:
```text
34 pass
0 fail
59 expect() calls
Ran 34 tests across 2 files.
```
Packaged MCP output:
```text
[OK] 20 sequential commands preserve results and execute once
[OK] 10 concurrent MCP requests preserve correlation and execute once
[OK] failed command is reported and the next command succeeds
[OK] timeout terminates the command and releases daemon capacity
[OK] shell commands cannot inherit the daemon credential
[OK] daemon restart reconnects the same device and serves another command
Daemon MCP smoke: 13 passed, 0 failed
```
The previous packaged candidate without this fix produced 12 passed, 1 failed, with four of ten burst requests unclaimed after 60000ms.

## Notes

Two files: +32/−1 runtime lines and +145 test lines. The unconditional poll sleep was replaced by a wakeable wait; no API endpoints, DB tables/columns, migrations, credentials, flags or compatibility paths were added. Claims remain Postgres-mediated; the added counter only tracks this process's executor capacity.

Planned for 19.2.0 alongside the already-merged Better Auth installation fix and #3406. The fresh npm install matrix must be green after publication.
