### PR TITLE
fix(cli): stop advertising unsupported Files capability

### DIFF
--- a/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
+++ b/packages/cli/src/__tests__/daemon-gateway-origin.test.ts
@@ -110,6 +110,29 @@ describe("lobu daemon", () => {
     expect(start.mock.calls[0]?.[0]?.apiUrl).toBe("https://app.lobu.ai");
   });
 
+  test.each([
+    ["the os.shell default", undefined, ["os.shell"]],
+    [
+      "a normalized explicit list",
+      " os.shell, ,computer_use ",
+      ["os.shell", "computer_use"],
+    ],
+    ["an explicitly empty list", "", []],
+  ])("forwards %s", async (_case, capabilities, expected) => {
+    const start = spyOn(daemonModule, "startDaemonCommand").mockResolvedValue(
+      undefined as never
+    );
+
+    await daemonCommand({
+      apiUrl: "http://127.0.0.1:9564",
+      workerId: "headless:test-capabilities",
+      capabilities,
+      interactiveSession: false,
+    });
+
+    expect(start.mock.calls[0]?.[0]?.capabilities).toEqual(expected);
+  });
+
   test("forwards activeOrg to startDaemonCommand for permission management link", async () => {
     spyOn(context, "resolveContext").mockResolvedValue({
       name: "prod",

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -267,7 +267,7 @@ export async function daemonCommand(options: DaemonOptions): Promise<void> {
     defaultPlatform,
     workerId,
     label: options.label?.trim() || undefined,
-    capabilities: (options.capabilities ?? "os.shell,os.files")
+    capabilities: (options.capabilities ?? "os.shell")
       .split(",")
       .map((entry) => entry.trim())
       .filter(Boolean),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1203,7 +1203,7 @@ Memory:
     )
     .option(
       "--capabilities <a,b>",
-      "Capabilities to advertise (default os.shell,os.files)"
+      "Capabilities to advertise (default os.shell)"
     )
     .option(
       "--label <name>",

--- a/packages/connector-worker/src/bin.ts
+++ b/packages/connector-worker/src/bin.ts
@@ -34,7 +34,7 @@ Options:
                      returns a session OAuth token that expires within 24h;
                      device mode rejects it at startup.
   --capabilities <a,b>  Comma-separated capabilities to advertise (device mode),
-                     e.g. os.files. The server drops anything the platform's
+                     e.g. os.shell. The server drops anything the platform's
                      allowlist does not grant.
   --label <name>     Human-readable device name shown on the Devices page
   --active-org <slug> Org slug used for the action-permissions link printed in device mode
@@ -59,10 +59,10 @@ Examples:
   # Worker daemon
   connector-worker daemon --api-url https://api.example.com
 
-  # Local device worker serving filesystem connectors (local takeout archives)
+  # Local headless device worker running shell commands
   WORKER_API_TOKEN=owl_pat_... connector-worker daemon \\
-    --api-url https://app.lobu.ai --platform macos \\
-    --worker-id "macos:$(hostname -s)" --capabilities os.files \\
+    --api-url https://app.lobu.ai --platform headless \\
+    --worker-id "headless:$(hostname -s)" --capabilities os.shell \\
     --label "$(hostname -s)"
 
   # Connector-runtime parity self-check (CI smoke gate)


### PR DESCRIPTION
## Summary

`lobu daemon` advertised `os.files` by default even though the daemon cannot execute the Node-filesystem Takeout importers that require it. Default registration now declares `os.shell`; the worker's existing `automations.execute` advertisement remains automatic. Both CLI help paths now describe supported Shell setup, and explicit capability lists still pass through unchanged apart from existing whitespace normalization.

## Test plan

- [x] Staged the four intended paths explicitly; `make pre-pr` passed.
- [x] Pre-commit Biome and root TypeScript checks passed.
- [x] Focused CLI, worker advertisement, and Shell suites: 58 passed, 0 failed.
- [x] Required pre-review fixer passed using the alternate Codex reviewer after the default reviewer reached its session limit. Its only change clarified test case labels; its final CLI rerun passed 30/30.
- [x] Ran both freshly built help commands and asserted they show Shell without Files setup.
- [x] Ran the built Node CLI against a loopback mock gateway with a synthetic token; captured its real poll payload, returned a Shell job, and observed successful completion. Repeated with an explicit capability list.

Red, before the fix:

```text
bun test packages/cli/src/__tests__/daemon-gateway-origin.test.ts
Expected: ["os.shell"]
Received: ["os.shell", "os.files"]
29 pass / 1 fail

Built CLI poll capabilities:
{"automations.execute":true,"os.files":true,"os.shell":true}
AssertionError: unexpected os.files advertisement
```

Green, after rebuilding:

```text
bun test packages/cli/src/__tests__/daemon-gateway-origin.test.ts packages/connector-worker/src/__tests__/device-worker-poll-body.test.ts packages/connector-worker/src/__tests__/daemon-builtin-os-shell.test.ts
58 pass / 0 fail / 187 assertions

Built CLI poll capabilities:
{"automations.execute":true,"os.shell":true}
Shell completion: status=success, stdout=lobu-shell-ok, exit_code=0
PASS: built CLI advertisement and Shell action

Explicit list " os.shell, ,computer_use ":
{"automations.execute":true,"computer_use":true,"os.shell":true}
Shell completion: status=success, stdout=lobu-shell-ok, exit_code=0
PASS: built CLI advertisement and Shell action
```

The loopback check verifies CLI startup, wire advertisement, and Shell execution. It does not replace production authorization or rollout verification.

## Notes

Four files, +29/-6: shipping code +6/-6; tests +23/-0. No new files, public API endpoints, schema changes, or migrations. The gateway already replaces device capabilities on poll; existing installations pick up the new default after updating and restarting their daemon. Explicit `--capabilities` configurations are preserved.

This PR removes the false default and obsolete filesystem setup example. It does not retire the `os.files` registry entry, SDK sources exports, or existing importer connections. Native permission stubs, unsupported setup links, and SDK/importer retirement remain separate cleanup slices. No production records or event history were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Daemon startup now defaults to advertising shell capabilities only when no capabilities are specified.
  - Explicit capability lists continue to support whitespace trimming and empty-entry filtering.

- **Documentation**
  - Updated command help text and examples to reflect the shell-only default and headless device workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->