### PR TITLE
fix: retain tool audits without a workspace

### DIFF
--- a/db/migrations/20260907160000_unbound_tool_audit_events.sql
+++ b/db/migrations/20260907160000_unbound_tool_audit_events.sql
@@ -49,7 +49,8 @@ END $$;
 
 DROP TRIGGER IF EXISTS require_unbound_tool_audit_actor ON public.events;
 CREATE TRIGGER require_unbound_tool_audit_actor BEFORE INSERT ON public.events
-FOR EACH ROW EXECUTE FUNCTION public.require_unbound_tool_audit_actor();
+FOR EACH ROW WHEN (NEW.organization_id IS NULL)
+EXECUTE FUNCTION public.require_unbound_tool_audit_actor();
 
 -- migrate:down
 -- Forward-only: existing unbound audit records must remain append-only.

--- a/db/migrations/20260907160000_unbound_tool_audit_events.sql
+++ b/db/migrations/20260907160000_unbound_tool_audit_events.sql
@@ -1,0 +1,55 @@
+-- migrate:up
+-- Only standalone tool-call audits may have no workspace. In particular,
+-- resource links must not expose a private call through workspace visibility.
+--
+-- OPERATIONAL COST: adding the NOT VALID constraint and dropping NOT NULL are
+-- catalog-only operations, but VALIDATE scans the full events table with the
+-- earlier ACCESS EXCLUSIVE lock held until the migration transaction ends. This has not been timed on
+-- a production-sized copy; deployment quiesces application writers first.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.events'::regclass
+      AND conname = 'events_unbound_tool_audit'
+  ) THEN
+    ALTER TABLE public.events ADD CONSTRAINT events_unbound_tool_audit CHECK (
+      organization_id IS NOT NULL OR (
+        semantic_type = 'audit' AND origin_type IS NOT DISTINCT FROM 'tool_invocation'
+        AND COALESCE(cardinality(entity_ids), 0) = 0
+        AND COALESCE(cardinality(linked_org_ids), 0) = 0
+        AND connector_key IS NULL AND connection_id IS NULL
+        AND feed_key IS NULL AND feed_id IS NULL AND run_id IS NULL
+        AND automation_id IS NULL AND automation_version_id IS NULL
+        AND identity_ns IS NULL AND identity_key IS NULL
+        AND supersedes_event_id IS NULL AND superseded_by IS NULL
+        AND interaction_type = 'none'
+      )
+    ) NOT VALID;
+  END IF;
+END $$;
+
+-- Validate before relaxing NOT NULL; existing rows retain their ownership.
+-- squawk-ignore prefer-robust-stmts -- the guarded block above creates the constraint; dbmate wraps both statements in one transaction
+ALTER TABLE public.events VALIDATE CONSTRAINT events_unbound_tool_audit;
+-- squawk-ignore prefer-robust-stmts,ban-drop-not-null -- the validated constraint is the replacement invariant; nullable rows are the purpose of this migration
+ALTER TABLE public.events ALTER COLUMN organization_id DROP NOT NULL;
+
+-- Require an actor at insertion, while allowing the existing user FK to
+-- anonymize created_by on account deletion without deleting audit history.
+CREATE OR REPLACE FUNCTION public.require_unbound_tool_audit_actor()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.organization_id IS NULL AND NEW.created_by IS NULL THEN
+    RAISE EXCEPTION 'A tool audit without a workspace requires a user'
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS require_unbound_tool_audit_actor ON public.events;
+CREATE TRIGGER require_unbound_tool_audit_actor BEFORE INSERT ON public.events
+FOR EACH ROW EXECUTE FUNCTION public.require_unbound_tool_audit_actor();
+
+-- migrate:down
+-- Forward-only: existing unbound audit records must remain append-only.

--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import type { ContentItem } from '@lobu/connector-sdk';
 import { REDACTED_SENTINEL } from '@lobu/core';
 import { beforeAll, describe, expect, it } from 'vitest';
@@ -667,5 +668,86 @@ describe('tool invocation audit coverage', () => {
     expect(row!.payload_data.success).toBe(false);
     expect(row!.payload_data.error).toMatchObject({ name: expect.any(String) });
     expect(row!.payload_data.error).not.toHaveProperty('message');
+  });
+
+  it('records workspace discovery without choosing an organization', async () => {
+    const user = await createTestUser({ email: 'unbound-audit@example.test' });
+    await executeTool('list_organizations', {}, {} as Env, {
+      ...authCtxFor('oauth'),
+      userId: user.id,
+      organizationId: null,
+      tokenOrganizationId: null,
+      memberRole: null,
+      clientId: null,
+      grantedOrganizationIds: [],
+      mcpSessionId: 'unbound-audit-session',
+    });
+
+    const sql = getDb();
+    const [event] = await sql`
+      SELECT id, organization_id, created_by, payload_data, metadata
+      FROM events WHERE created_by = ${user.id}
+        AND origin_type = 'tool_invocation'
+    `;
+    expect(event).toBeDefined();
+    expect(event.organization_id).toBeNull();
+    expect(event.payload_data).toMatchObject({ tool_name: 'list_organizations', success: true });
+    expect(event.metadata.mcp_session_id).toBe('unbound-audit-session');
+
+    // A workspace role cannot grant access to a call that has no workspace.
+    for (const role of ['owner', 'admin', 'member'] as const) {
+      const result = await executeTool('read_knowledge', {
+        content_ids: [Number(event.id)], limit: 1,
+      }, {} as Env, { ...authCtxFor('session'), memberRole: role });
+      expect((result as { content: unknown[] }).content).toEqual([]);
+    }
+    const queried = await executeTool('query_sql', {
+      sql: `SELECT id FROM events WHERE id = ${event.id}`, limit: 1,
+    }, {} as Env, authCtxFor('session'));
+    expect((queried as { rows: unknown[] }).rows).toEqual([]);
+
+    const publicOrg = await createTestOrganization({ slug: 'unbound-audit-public', visibility: 'public' });
+    const publicRead = await executeTool('read_knowledge', {
+      content_ids: [Number(event.id)], limit: 1,
+    }, {} as Env, {
+      ...authCtxFor('session'), organizationId: publicOrg.id,
+      userId: null, memberRole: null, isAuthenticated: false,
+      tokenType: 'anonymous', scopedToOrg: true, allowCrossOrg: false,
+    });
+    expect((publicRead as { content: unknown[] }).content).toEqual([]);
+
+    // Preserve the existing FK lifecycle: deleting the account anonymizes the
+    // actor without deleting or rewriting its append-only event payload.
+    await sql`DELETE FROM "user" WHERE id = ${user.id}`;
+    const [retained] = await sql`SELECT created_by, payload_data FROM events WHERE id = ${event.id}`;
+    expect(retained.created_by).toBeNull();
+    expect(retained.payload_data).toEqual(event.payload_data);
+
+    const migration = readFileSync(new URL(
+      '../../../../../../db/migrations/20260907160000_unbound_tool_audit_events.sql', import.meta.url,
+    ), 'utf8').split('-- migrate:down')[0]!;
+    await sql.unsafe(migration);
+    const [replayed] = await sql`SELECT created_by, payload_data FROM events WHERE id = ${event.id}`;
+    expect(replayed).toEqual(retained);
+  });
+
+  it('rejects unattributed or workspace-linked events without a workspace', async () => {
+    const sql = getDb();
+    await expect(sql`
+      INSERT INTO events (semantic_type, origin_type)
+      VALUES ('audit', 'tool_invocation')
+    `).rejects.toMatchObject({ code: '23514' });
+    for (const shape of [
+      "'content', 'tool_invocation', NULL, NULL, NULL",
+      "'audit', NULL, NULL, NULL, NULL",
+      "'audit', 'tool_invocation', ARRAY[1]::bigint[], NULL, NULL",
+      "'audit', 'tool_invocation', NULL, ARRAY['other-workspace']::text[], NULL",
+      "'audit', 'tool_invocation', NULL, NULL, 1",
+    ]) {
+      await expect(sql.unsafe(`
+        INSERT INTO events (created_by, semantic_type, origin_type, entity_ids, linked_org_ids, connection_id)
+        VALUES ($1, ${shape})
+      `, [ownerId])).rejects.toMatchObject({ code: '23514' });
+    }
   });
 });

--- a/packages/server/src/lobu/stores/mcp-client-conversations.ts
+++ b/packages/server/src/lobu/stores/mcp-client-conversations.ts
@@ -5,6 +5,11 @@ import type { ToolContext } from "../../tools/registry.js";
 const logger = createLogger("mcp-client-conversations");
 const MAX_TITLE_LENGTH = 200;
 
+type McpActivityContext = Pick<
+	ToolContext,
+	"mcpConversationId" | "mcpSessionId" | "clientId" | "tokenType"
+>;
+
 export interface McpActivityAttribution {
 	clientIdentity: string;
 	clientId: string | null;
@@ -20,7 +25,7 @@ function boundedId(value: string | null | undefined): string | null {
 }
 
 export function currentMcpActivityAttribution(
-	ctx: ToolContext,
+	ctx: McpActivityContext,
 ): McpActivityAttribution | null {
 	const hostConversationId = boundedId(ctx.mcpConversationId);
 	const transportSessionId = boundedId(ctx.mcpSessionId);
@@ -40,7 +45,7 @@ export function currentMcpActivityAttribution(
 	};
 }
 
-export function currentMcpActivityEventMetadata(ctx: ToolContext): {
+export function currentMcpActivityEventMetadata(ctx: McpActivityContext): {
 	mcp_session_id: string | null;
 	mcp_conversation_id: string | null;
 } {
@@ -51,7 +56,7 @@ export function currentMcpActivityEventMetadata(ctx: ToolContext): {
 	};
 }
 
-function oauthClientId(ctx: ToolContext): string | null {
+function oauthClientId(ctx: McpActivityContext): string | null {
 	return ctx.tokenType === "oauth" ? (ctx.clientId ?? null) : null;
 }
 

--- a/packages/server/src/tools/audit.ts
+++ b/packages/server/src/tools/audit.ts
@@ -225,12 +225,15 @@ export async function recordToolInvocationAudit(
     const request = captureRequest(params);
     if (request) Object.assign(payload, request);
     const success = payload.success === true;
-    const eventParams = {
+    await insertEvent({
+      entityIds: [],
+      organizationId: params.ctx.organizationId,
       originId: `tool_invocation:${params.toolName}:${Date.now()}:${randomUUID()}`,
       title: `${params.toolName} ${success ? 'completed' : 'failed'}`,
-      payloadType: 'empty' as const,
+      payloadType: 'empty',
       payloadData: payload,
-      originType: 'tool_invocation' as const,
+      semanticType: AUDIT_SEMANTIC_TYPE,
+      originType: 'tool_invocation',
       metadata: {
         category: 'audit',
         event_type: 'tool_invocation.completed',
@@ -239,28 +242,9 @@ export async function recordToolInvocationAudit(
         agent_id: params.ctx.agentId ?? null,
         ...currentMcpActivityEventMetadata(params.ctx),
       },
+      createdBy: params.ctx.userId ?? null,
       clientId: params.ctx.clientId ?? null,
-    };
-    if (params.ctx.organizationId === null) {
-      if (params.ctx.userId === null) {
-        throw new Error('An unbound tool audit requires a user');
-      }
-      await insertEvent({
-        ...eventParams,
-        entityIds: [],
-        organizationId: null,
-        semanticType: AUDIT_SEMANTIC_TYPE,
-        createdBy: params.ctx.userId,
-      });
-    } else {
-      await insertEvent({
-        ...eventParams,
-        entityIds: [],
-        organizationId: params.ctx.organizationId,
-        semanticType: AUDIT_SEMANTIC_TYPE,
-        createdBy: params.ctx.userId ?? null,
-      });
-    }
+    });
   } catch (auditError) {
     logger.warn(
       { err: auditError, toolName: params.toolName },

--- a/packages/server/src/tools/audit.ts
+++ b/packages/server/src/tools/audit.ts
@@ -38,7 +38,8 @@ interface ToolInvocationAuditParams {
   result?: unknown;
   error?: unknown;
   durationMs: number;
-  ctx: ToolContext;
+  ctx: Pick<ToolContext, 'userId' | 'tokenType' | 'clientId' | 'agentId' |
+    'mcpSessionId' | 'mcpConversationId'> & { organizationId: string | null };
 }
 
 function captureRequest(params: ToolInvocationAuditParams): Record<string, unknown> | null {
@@ -224,15 +225,12 @@ export async function recordToolInvocationAudit(
     const request = captureRequest(params);
     if (request) Object.assign(payload, request);
     const success = payload.success === true;
-    await insertEvent({
-      entityIds: [],
-      organizationId: params.ctx.organizationId,
+    const eventParams = {
       originId: `tool_invocation:${params.toolName}:${Date.now()}:${randomUUID()}`,
       title: `${params.toolName} ${success ? 'completed' : 'failed'}`,
-      payloadType: 'empty',
+      payloadType: 'empty' as const,
       payloadData: payload,
-      semanticType: AUDIT_SEMANTIC_TYPE,
-      originType: 'tool_invocation',
+      originType: 'tool_invocation' as const,
       metadata: {
         category: 'audit',
         event_type: 'tool_invocation.completed',
@@ -241,9 +239,28 @@ export async function recordToolInvocationAudit(
         agent_id: params.ctx.agentId ?? null,
         ...currentMcpActivityEventMetadata(params.ctx),
       },
-      createdBy: params.ctx.userId ?? null,
       clientId: params.ctx.clientId ?? null,
-    });
+    };
+    if (params.ctx.organizationId === null) {
+      if (params.ctx.userId === null) {
+        throw new Error('An unbound tool audit requires a user');
+      }
+      await insertEvent({
+        ...eventParams,
+        entityIds: [],
+        organizationId: null,
+        semanticType: AUDIT_SEMANTIC_TYPE,
+        createdBy: params.ctx.userId,
+      });
+    } else {
+      await insertEvent({
+        ...eventParams,
+        entityIds: [],
+        organizationId: params.ctx.organizationId,
+        semanticType: AUDIT_SEMANTIC_TYPE,
+        createdBy: params.ctx.userId ?? null,
+      });
+    }
   } catch (auditError) {
     logger.warn(
       { err: auditError, toolName: params.toolName },

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -327,31 +327,26 @@ export async function executeTool(
       throw new Error('User context required.');
     }
     if (toolName === 'list_organizations') {
-      // This early return sits BEFORE the shared audit seam below, so it must
-      // audit its own invocation AND materialize the same conversation
-      // projection — a client whose only call is this one still belongs in the
-      // client-conversation listing. The event needs an owning org: use the
-      // bound org when there is one; a session with no bound org has no ledger
-      // to write into, and toToolContext would throw on it anyway.
+      // OAuth/PAT account discovery is audited even before a workspace is selected.
       const startTime = Date.now();
-      const auditIfOrgBound = async (outcome: {
+      const auditOutcome = async (outcome: {
         result?: unknown;
         error?: unknown;
       }) => {
-        if (!authCtx.organizationId) return;
-        const ctx = toToolContext(authCtx);
         await recordToolInvocationAudit({
           toolName,
           args,
           ...outcome,
           durationMs: Date.now() - startTime,
-          ctx,
+          ctx: authCtx,
         });
-        await recordMcpConversationActivity({
-          ctx,
-          toolName,
-          failed: outcome.error !== undefined || isSoftErrorResult(outcome.result),
-        });
+        if (authCtx.organizationId) {
+          await recordMcpConversationActivity({
+            ctx: toToolContext(authCtx),
+            toolName,
+            failed: outcome.error !== undefined || isSoftErrorResult(outcome.result),
+          });
+        }
       };
       try {
         const result = await trackMCPToolCall(toolName, args, () =>
@@ -366,10 +361,10 @@ export async function executeTool(
                 : authCtx.grantedOrganizationIds,
           })
         );
-        await auditIfOrgBound({ result });
+        await auditOutcome({ result });
         return result;
       } catch (error) {
-        await auditIfOrgBound({ error });
+        await auditOutcome({ error });
         throw error;
       }
     }

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -177,6 +177,21 @@ export interface InsertEventParams {
   clientId?: string | null;
 }
 
+type InternalInsertEventParams = Omit<InsertEventParams, 'organizationId'> & {
+  organizationId: string | null;
+};
+
+type UnboundToolInvocationAuditEventParams = Pick<
+  InsertEventParams,
+  'originId' | 'title' | 'payloadType' | 'payloadData' | 'metadata' | 'clientId'
+> & {
+  entityIds: [];
+  organizationId: null;
+  semanticType: 'audit';
+  originType: 'tool_invocation';
+  createdBy: string;
+};
+
 /**
  * How an insertEvent call settled.
  *
@@ -327,7 +342,7 @@ function normalizedTimestamp(value?: Date | string | null): string | null {
 
 async function findCurrentEventByOrigin(
   sql: DbClient,
-  params: InsertEventParams
+  params: InternalInsertEventParams
 ): Promise<
   | {
       id: number;
@@ -377,7 +392,7 @@ async function findCurrentEventByOrigin(
 
 function isSemanticallyEqual(
   existing: NonNullable<Awaited<ReturnType<typeof findCurrentEventByOrigin>>>,
-  params: InsertEventParams
+  params: InternalInsertEventParams
 ): boolean {
   return (
     (existing.title ?? null) === (params.title ?? null) &&
@@ -440,7 +455,7 @@ function isSemanticallyEqual(
 async function applyVolatileState(
   eventId: number,
   existing: { metadata: Record<string, unknown> | null; score: number | null },
-  params: InsertEventParams,
+  params: InternalInsertEventParams,
   sql: DbClient
 ): Promise<boolean> {
   const patch = volatileMetadataPatch(params.metadata);
@@ -542,7 +557,7 @@ function nullableNumber(value: number | string | null): number | null {
 async function loadEventLineage(
   sql: DbClient,
   supersedesEventId: number,
-  params: InsertEventParams
+  params: InternalInsertEventParams
 ): Promise<EventLineage> {
   const rows = await sql`
     SELECT connector_key, connection_id, feed_key, feed_id, run_id,
@@ -611,26 +626,39 @@ function isEventsClientIdForeignKeyViolation(error: unknown): boolean {
  * instead of the singleton pool — used by the identity engine to keep its
  * fact + derivation writes atomic.
  */
-export async function insertEvent(
+interface InsertEventOptions {
+  onConflictUpdate?: boolean;
+  sql?: DbClient;
+  /** Raw browser identity used only to supersede a pre-containment row. */
+  sourceOriginId?: string;
+  /** Transactional hook for durable derived work such as Automation runs. */
+  afterPersist?: (event: InsertedEvent, sql: DbClient) => Promise<void>;
+  /**
+   * Set only after connector attribution has scrubbed and rebuilt the
+   * server-owned identity-scope projection keys from durable identities.
+   */
+  trustedIdentityScopeProjections?: boolean;
+}
+
+export function insertEvent(
   params: InsertEventParams,
-  options?: {
-    onConflictUpdate?: boolean;
-    sql?: DbClient;
-    /** Raw browser identity used only to supersede a pre-containment row. */
-    sourceOriginId?: string;
-    /** Transactional hook for durable derived work such as Automation runs. */
-    afterPersist?: (event: InsertedEvent, sql: DbClient) => Promise<void>;
-    /**
-     * Set only after connector attribution has scrubbed and rebuilt the
-     * server-owned identity-scope projection keys from durable identities.
-     */
-    trustedIdentityScopeProjections?: boolean;
-  }
+  options?: InsertEventOptions
+): Promise<InsertedEvent>;
+export function insertEvent(
+  params: UnboundToolInvocationAuditEventParams,
+  options?: undefined
+): Promise<InsertedEvent>;
+export async function insertEvent(
+  params: InternalInsertEventParams,
+  options?: InsertEventOptions
 ): Promise<InsertedEvent> {
+  if (params.organizationId === null && options !== undefined) {
+    throw new Error('Unbound tool audits do not accept insert options');
+  }
   // This is the physical write funnel for event content. Connector items,
   // Automation output, and approval metadata all converge here. stripNulDeep
   // preserves Dates and other class instances.
-  params = stripNulDeep(params) as InsertEventParams;
+  params = stripNulDeep(params) as InternalInsertEventParams;
   if (!options?.trustedIdentityScopeProjections) {
     params = {
       ...params,

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -93,7 +93,7 @@ export async function lockEventDedupIdentity(
 
 export interface InsertEventParams {
   entityIds: number[];
-  organizationId: string;
+  organizationId: string | null;
   originId: string;
 
   title?: string | null;
@@ -176,21 +176,6 @@ export interface InsertEventParams {
   createdBy?: string | null;
   clientId?: string | null;
 }
-
-type InternalInsertEventParams = Omit<InsertEventParams, 'organizationId'> & {
-  organizationId: string | null;
-};
-
-type UnboundToolInvocationAuditEventParams = Pick<
-  InsertEventParams,
-  'originId' | 'title' | 'payloadType' | 'payloadData' | 'metadata' | 'clientId'
-> & {
-  entityIds: [];
-  organizationId: null;
-  semanticType: 'audit';
-  originType: 'tool_invocation';
-  createdBy: string;
-};
 
 /**
  * How an insertEvent call settled.
@@ -342,7 +327,7 @@ function normalizedTimestamp(value?: Date | string | null): string | null {
 
 async function findCurrentEventByOrigin(
   sql: DbClient,
-  params: InternalInsertEventParams
+  params: InsertEventParams
 ): Promise<
   | {
       id: number;
@@ -392,7 +377,7 @@ async function findCurrentEventByOrigin(
 
 function isSemanticallyEqual(
   existing: NonNullable<Awaited<ReturnType<typeof findCurrentEventByOrigin>>>,
-  params: InternalInsertEventParams
+  params: InsertEventParams
 ): boolean {
   return (
     (existing.title ?? null) === (params.title ?? null) &&
@@ -455,7 +440,7 @@ function isSemanticallyEqual(
 async function applyVolatileState(
   eventId: number,
   existing: { metadata: Record<string, unknown> | null; score: number | null },
-  params: InternalInsertEventParams,
+  params: InsertEventParams,
   sql: DbClient
 ): Promise<boolean> {
   const patch = volatileMetadataPatch(params.metadata);
@@ -557,7 +542,7 @@ function nullableNumber(value: number | string | null): number | null {
 async function loadEventLineage(
   sql: DbClient,
   supersedesEventId: number,
-  params: InternalInsertEventParams
+  params: InsertEventParams
 ): Promise<EventLineage> {
   const rows = await sql`
     SELECT connector_key, connection_id, feed_key, feed_id, run_id,
@@ -626,39 +611,29 @@ function isEventsClientIdForeignKeyViolation(error: unknown): boolean {
  * instead of the singleton pool — used by the identity engine to keep its
  * fact + derivation writes atomic.
  */
-interface InsertEventOptions {
-  onConflictUpdate?: boolean;
-  sql?: DbClient;
-  /** Raw browser identity used only to supersede a pre-containment row. */
-  sourceOriginId?: string;
-  /** Transactional hook for durable derived work such as Automation runs. */
-  afterPersist?: (event: InsertedEvent, sql: DbClient) => Promise<void>;
-  /**
-   * Set only after connector attribution has scrubbed and rebuilt the
-   * server-owned identity-scope projection keys from durable identities.
-   */
-  trustedIdentityScopeProjections?: boolean;
-}
-
-export function insertEvent(
-  params: InsertEventParams,
-  options?: InsertEventOptions
-): Promise<InsertedEvent>;
-export function insertEvent(
-  params: UnboundToolInvocationAuditEventParams,
-  options?: undefined
-): Promise<InsertedEvent>;
 export async function insertEvent(
-  params: InternalInsertEventParams,
-  options?: InsertEventOptions
+  params: InsertEventParams,
+  options?: {
+    onConflictUpdate?: boolean;
+    sql?: DbClient;
+    /** Raw browser identity used only to supersede a pre-containment row. */
+    sourceOriginId?: string;
+    /** Transactional hook for durable derived work such as Automation runs. */
+    afterPersist?: (event: InsertedEvent, sql: DbClient) => Promise<void>;
+    /**
+     * Set only after connector attribution has scrubbed and rebuilt the
+     * server-owned identity-scope projection keys from durable identities.
+     */
+    trustedIdentityScopeProjections?: boolean;
+  }
 ): Promise<InsertedEvent> {
-  if (params.organizationId === null && options !== undefined) {
-    throw new Error('Unbound tool audits do not accept insert options');
+  if (params.organizationId === null && options?.afterPersist) {
+    throw new Error('Workspace activation requires an organization');
   }
   // This is the physical write funnel for event content. Connector items,
   // Automation output, and approval metadata all converge here. stripNulDeep
   // preserves Dates and other class instances.
-  params = stripNulDeep(params) as InternalInsertEventParams;
+  params = stripNulDeep(params) as InsertEventParams;
   if (!options?.trustedIdentityScopeProjections) {
     params = {
       ...params,
@@ -1236,7 +1211,7 @@ async function findConnectionlessEventByIdempotencyKey(
  * retries converge across replicas; callers never need process-local state.
  */
 export async function insertConnectionlessWorkspaceEvent(
-  params: InsertEventParams,
+  params: InsertEventParams & { organizationId: string },
   idempotencyKey: string,
   options?: { sql?: DbClient }
 ): Promise<InsertedEvent> {
@@ -1304,7 +1279,7 @@ export async function insertConnectionlessWorkspaceEvent(
  * ordinary readers and non-key updates never wait on an audit write.
  */
 async function insertAuditEventPruningDeletedEntityRefs(
-  params: InsertEventParams,
+  params: InsertEventParams & { organizationId: string },
   db: DbClient,
   afterPersist?: (event: InsertedEvent, tx: DbClient) => Promise<void>
 ): Promise<InsertedEvent> {
@@ -1351,7 +1326,7 @@ async function insertAuditEventPruningDeletedEntityRefs(
  * pass a new `subject`.
  */
 export async function insertConnectionlessAuditEvent(
-  params: InsertEventParams,
+  params: InsertEventParams & { organizationId: string },
   eventType: AuditEventType,
   options?: ConnectionlessAuditInsertOptions
 ): Promise<InsertedEvent> {


### PR DESCRIPTION
## Summary
Workspace discovery could run with a user and no workspace, but the executor skipped its audit record because events required an organization. Allow standalone, user-attributed tool audits in the existing events table and record that early-return path without choosing a workspace.

The database permits a missing organization only for a tool audit without entity, connection, feed, Automation, identity, supersession, or workspace links. A user is required at insertion; the existing created_by foreign key can still anonymize attribution on account deletion while retaining the event. Workspace activation helpers continue requiring an organization.

No new tables, ownership columns, history pages, API routes, or SDK contracts. Existing workspace event ownership and Recent behavior are unchanged. The six-file diff is +167/-25: shipping +29/-25, migration +56, tests +82. This prerequisite is net-positive overall.

## Test plan
- [x] GitHub CI and independent Fable review passed for 6035012a4cad9b1e813ab4d70383f3fedc018bcb (simplicity 80, zero bugs or blockers). All 10 required checks passed before squash merge 4d06dac2417fd172dbe5cd24e366edfae4d86377.
- [x] Intended paths staged explicitly; make pre-pr passed locally.
- [x] Focused integration suites: 52 tests across audit, activity summaries, public visibility and historical MCP links; 5 additional tests cover workspace Automation transactionality and audit type stamping.
- [x] Server typecheck, migration lint and diff checks passed.
- [x] Real local HTTP MCP initialize and list_organizations returned 200 for an explicitly scoped session; the existing event contained the correct workspace and user. Dedicated synthetic database and preview server cleaned up.
- [x] Regression reproduced before implementation and passed afterward:

```text
Before: 1 failed, 21 passed; the workspace-less discovery call had no audit event.
After review changes: 6 test files, 57 passed.
```

## Notes
This is the event-storage prerequisite for removing default workspaces. It does not remove the OAuth default selector or the MCP initialization requirement yet. A live unbound OAuth initialize still returns the existing missing-workspace error; the new unbound audit path is verified through the executor with real PostgreSQL. Those execution/consent changes belong to the next slice.

The migration neither copies nor deletes existing events. It preserves existing IDs, payloads and workspace attribution. Migration replay and account deletion are covered. Other users, workspace admins, public reads and workspace SQL cannot read the unbound record.

The migration validates the new constraint against the events table and is not marked online-safe. Production-sized migration timing has not been measured.
