### PR TITLE
fix: preserve ChatGPT credentials across model overrides

### DIFF
--- a/packages/agent-worker/src/runtime/session-context.ts
+++ b/packages/agent-worker/src/runtime/session-context.ts
@@ -9,7 +9,6 @@ import {
 const logger = createLogger("runtime-session-context");
 
 interface ProviderConfig {
-  credentialEnvVarName?: string;
   defaultProvider?: string;
   /**
    * The primary provider's LOBU id (e.g. "claude"), sent only when it differs
@@ -34,7 +33,7 @@ interface ProviderConfig {
   configProviders?: Record<string, ConfigProviderMeta>;
   /** Installed Lobu provider ID → upstream runtime provider slug. */
   installedProviderRoutes?: Record<string, string>;
-  /** Credential env var placeholders for proxy mode (e.g. OPENAI_API_KEY → "lobu-proxy") */
+  /** Lobu provider ID → credential placeholder for proxy mode. */
   credentialPlaceholders?: Record<string, string>;
 }
 

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -803,19 +803,9 @@ export async function runAISession(
   const credentialStore = new Map<string, string>();
 
   const pc = context.providerConfig;
-  if (pc.credentialEnvVarName) {
-    credentialStore.set("CREDENTIAL_ENV_VAR_NAME", pc.credentialEnvVarName);
-  }
   if (pc.providerBaseUrlMappings) {
     for (const [envVar, url] of Object.entries(pc.providerBaseUrlMappings)) {
       credentialStore.set(envVar, url);
-    }
-  }
-  if (pc.credentialPlaceholders) {
-    for (const [envVar, placeholder] of Object.entries(
-      pc.credentialPlaceholders
-    )) {
-      credentialStore.set(envVar, placeholder);
     }
   }
 
@@ -1142,29 +1132,18 @@ export async function runAISession(
     bashPolicy: toolsPolicy.bashPolicy,
   }).filter((tool) => isToolAllowedByPolicy(tool.name, toolsPolicy));
 
-  // Credential injection — resolve API key from the in-memory credential store,
-  // falling back to process.env only for values that were present at startup.
+  // Select the resolved turn provider's placeholder, not the agent default's
+  // credential or another provider sharing the same SDK environment variable.
   // In-memory only — the worker injects runtime API keys below and never reads
   // or writes an on-disk auth.json (pi-ai 0.73 made the AuthStorage ctor private
   // in favour of these factories).
   const authStorage = AuthStorage.inMemory();
-  const credEnvVar = credentialStore.get("CREDENTIAL_ENV_VAR_NAME") || null;
-  const credValue = credEnvVar
-    ? credentialStore.get(credEnvVar) || process.env[credEnvVar]
-    : null;
-  if (credEnvVar && credValue) {
+  const credValue =
+    pc.credentialPlaceholders?.[providerSlug] ??
+    process.env[getApiKeyEnvVarForProvider(rawProvider)];
+  if (credValue) {
     authStorage.setRuntimeApiKey(provider, credValue);
     logger.info(`Set runtime API key for ${provider}`);
-  } else {
-    // Look up the env var by the canonical gateway slug (e.g. "gemini" → GEMINI_API_KEY),
-    // not the model-registry alias.
-    const fallbackEnvVar = getApiKeyEnvVarForProvider(rawProvider);
-    const fallbackValue =
-      credentialStore.get(fallbackEnvVar) || process.env[fallbackEnvVar];
-    if (fallbackValue) {
-      authStorage.setRuntimeApiKey(provider, fallbackValue);
-      logger.info(`Set runtime API key for ${provider}`);
-    }
   }
 
   // Re-resolve provider base URL after session context may have updated mappings

--- a/packages/server/src/gateway/__tests__/chatgpt-session-credentials.test.ts
+++ b/packages/server/src/gateway/__tests__/chatgpt-session-credentials.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateWorkerToken } from "@lobu/core";
+import { AgentProgressProcessor } from "../../../../agent-worker/src/runtime/processor.js";
+import { runAISession } from "../../../../agent-worker/src/runtime/session-runner.js";
+import { invalidateSessionContextCache } from "../../../../agent-worker/src/runtime/session-context.js";
+import { ApiKeyProviderModule } from "../auth/api-key-provider-module.js";
+import { ChatGPTOAuthModule } from "../auth/chatgpt/chatgpt-oauth-module.js";
+import type { BaseProviderModule } from "../auth/base-provider-module.js";
+import { AuthProfilesManager } from "../auth/settings/auth-profiles-manager.js";
+import { WorkerGateway } from "../worker-dispatch/worker-gateway.js";
+
+const ORG = "org-credential-test";
+const USER = "user-credential-test";
+const AGENT = "agent-credential-test";
+const ACCOUNT = "acct_credential_test";
+const STORED_CREDENTIAL = "synthetic-stored-oauth-credential";
+
+function makeManager() {
+  return new AuthProfilesManager({
+    ephemeralProfiles: { get: () => undefined } as never,
+    declaredAgents: { get: () => undefined } as never,
+    userAuthProfiles: {
+      list: async (userId: string, agentId: string) =>
+        userId === USER && agentId === `__org_oauth__:${ORG}`
+          ? [{
+              id: "profile-credential-test", provider: "chatgpt", model: "*",
+              authType: "oauth", credential: STORED_CREDENTIAL,
+              metadata: { accountId: ACCOUNT, expiresAt: Date.now() + 3_600_000 },
+              createdAt: 0,
+            }]
+          : [],
+    } as never,
+    secretStore: { get: async () => undefined } as never,
+    agentOwnerResolver: async () => USER,
+    agentOrgResolver: async () => ORG,
+  });
+}
+
+const savedEnv = { ...process.env };
+afterEach(() => {
+  for (const key of ["ENCRYPTION_KEY", "DISPATCHER_URL", "WORKER_TOKEN"]) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  invalidateSessionContextCache();
+});
+
+describe("ChatGPT subscription credentials", () => {
+  test("org-bucket account reaches the placeholder without exposing its credential", async () => {
+    const module: BaseProviderModule = new ChatGPTOAuthModule(makeManager());
+    const placeholder = await module.buildCredentialPlaceholder(AGENT, {
+      organizationId: ORG, userId: USER,
+    });
+    expect(placeholder).not.toBe(STORED_CREDENTIAL);
+    expect(placeholder.split(".")).toHaveLength(3);
+    expect(JSON.parse(Buffer.from(placeholder.split(".")[1]!, "base64url").toString()))
+      .toEqual({ "https://api.openai.com/auth": { chatgpt_account_id: ACCOUNT } });
+  });
+
+  test("another user cannot borrow the agent owner's subscription", async () => {
+    const module: BaseProviderModule = new ChatGPTOAuthModule(makeManager());
+    expect(await module.buildCredentialPlaceholder(AGENT, {
+      organizationId: ORG, userId: "unlinked-user",
+    })).toBe("lobu-proxy");
+    expect(await module.buildCredentialPlaceholder(AGENT)).toBe("lobu-proxy");
+  });
+
+  test("model listing retains the requesting user", async () => {
+    const module = new ChatGPTOAuthModule(makeManager());
+    const originalFetch = globalThis.fetch;
+    let authorization: string | null = null;
+    globalThis.fetch = (async (_url, init) => {
+      authorization = new Headers(init?.headers).get("Authorization");
+      return Response.json({ models: [{ slug: "test-model", title: "Test model" }] });
+    }) as typeof fetch;
+    try {
+      expect(await module.getModelOptions(AGENT, USER)).toEqual([
+        { value: "openai-codex/test-model", label: "Test model" },
+      ]);
+      expect(authorization).toBe(`Bearer ${STORED_CREDENTIAL}`);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  for (const defaultProvider of ["chatgpt", "deepseek"]) {
+    for (const reverse of [false, true]) {
+      test(`real worker uses ChatGPT with ${defaultProvider} default; reverse=${reverse}`, async () => {
+        process.env.ENCRYPTION_KEY = Buffer.alloc(32, 7).toString("base64");
+        const manager = makeManager();
+        const chatgpt = new ChatGPTOAuthModule(manager);
+        const openai = new ApiKeyProviderModule({
+          providerId: "openai", providerDisplayName: "OpenAI", providerIconUrl: "",
+          envVarName: "OPENAI_API_KEY", upstreamBaseUrl: "https://openai.example.invalid",
+          sdkCompat: "openai", authProfilesManager: manager,
+        });
+        const deepseek = new ApiKeyProviderModule({
+          providerId: "deepseek", providerDisplayName: "DeepSeek", providerIconUrl: "",
+          envVarName: "DEEPSEEK_API_KEY", upstreamBaseUrl: "https://deepseek.example.invalid",
+          sdkCompat: "openai", authProfilesManager: manager,
+        });
+        const modules = [chatgpt, openai, deepseek];
+        if (reverse) modules.reverse();
+        // Availability is fixture-owned; account lookup and placeholder generation
+        // below use the real provider modules and org-bucket profile manager.
+        for (const module of modules) module.hasSystemKey = () => true;
+        const model = defaultProvider === "chatgpt" ? "chatgpt/gpt-5.5" : "deepseek/default-model";
+        const gateway = new WorkerGateway(
+          { send: async () => undefined } as never,
+          "https://gateway.example.invalid",
+          { getWorkerConfig: async () => ({ mcpServers: {} }) } as never,
+          { getSessionContext: async () => ({
+              agentLayers: { identityMd: "Synthetic test agent", soulMd: "", userMd: "", unconfiguredNotice: "" },
+              platformInstructions: "", networkInstructions: "", skillsInstructions: "", mcpStatus: [],
+            }) } as never,
+          undefined,
+          {
+            getInstalledModules: async () => modules,
+            resolveDispatchModel: async () => ({ model }),
+            findProviderForModel: async (ref: string) => modules.find((m) => m.providerId === ref.split("/")[0]),
+          } as never,
+          { getSettings: async () => ({ models: [model] }) } as never,
+        );
+        const conversationId = `conversation-${defaultProvider}-${reverse}`;
+        const workerToken = generateWorkerToken(USER, conversationId, "worker-test", {
+          channelId: "channel-test", agentId: AGENT, organizationId: ORG,
+        });
+        let upstreamRequests = 0;
+        let receivedAccount: string | null = null;
+        let receivedModel: unknown;
+        let providerConfig: Record<string, unknown> | undefined;
+        const server = Bun.serve({
+          hostname: "127.0.0.1", port: 0,
+          async fetch(request) {
+            const url = new URL(request.url);
+            if (url.pathname === "/worker/session-context") {
+              url.pathname = "/session-context";
+              const response = await gateway.getApp().request(new Request(url, request));
+              const body = await response.clone().json();
+              providerConfig = body.providerConfig;
+              return response;
+            }
+            if (url.pathname.endsWith("/codex/responses")) {
+              // The production adapter probes WebSocket before falling back to SSE.
+              if (request.method !== "POST") return new Response(null, { status: 426 });
+              upstreamRequests++;
+              receivedAccount = request.headers.get("chatgpt-account-id");
+              receivedModel = (await request.json()).model;
+              const item = { id: "msg-test", type: "message", role: "assistant", status: "completed",
+                content: [{ type: "output_text", text: "credential-test-ok", annotations: [] }] };
+              const events = [
+                { type: "response.created", response: { id: "resp-test", status: "in_progress" } },
+                { type: "response.output_item.added", item: { ...item, content: [], status: "in_progress" } },
+                { type: "response.content_part.added", part: { type: "output_text", text: "", annotations: [] } },
+                { type: "response.output_text.delta", delta: "credential-test-ok" },
+                { type: "response.output_item.done", item },
+                { type: "response.completed", response: { id: "resp-test", status: "completed", output: [item],
+                    usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } } },
+              ];
+              return new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+                headers: { "Content-Type": "text/event-stream" },
+              });
+            }
+            return new Response("Unexpected test request", { status: 404 });
+          },
+        });
+        const workspaceDir = await mkdtemp(join(tmpdir(), "lobu-credential-test-"));
+        process.env.DISPATCHER_URL = `http://127.0.0.1:${server.port}`;
+        process.env.WORKER_TOKEN = workerToken;
+        const processor = new AgentProgressProcessor();
+        try {
+          const result = await runAISession({
+            userPrompt: "Reply credential-test-ok. Do not use tools.", customInstructions: "",
+            agentOptions: JSON.stringify({ model: "chatgpt/gpt-5.5", memoryFlush: { enabled: false } }),
+            sessionKey: conversationId, channelId: "channel-test", conversationId, platform: "api",
+            platformMetadata: {}, organizationId: ORG, actorId: USER, credentialSubject: USER,
+            agentId: AGENT, runId: 1, messageId: "message-test", workspaceDir, progressProcessor: processor,
+            onProgress: async () => {}, onSessionFilePathResolved: () => {}, onSteerReady: () => {},
+            onCancelReady: () => {}, onModelResolved: () => {}, loadImageAttachments: async () => [],
+            maybeRunPreCompactionMemoryFlush: async () => {},
+          });
+          expect(result.error).toBeUndefined();
+          expect(result.success).toBe(true);
+          expect(upstreamRequests).toBe(1);
+          expect(receivedAccount).toBe(ACCOUNT);
+          expect(receivedModel).toBe("gpt-5.5");
+          expect(processor.getOutputSnapshot()).toContain("credential-test-ok");
+          expect(JSON.stringify(providerConfig)).not.toContain(STORED_CREDENTIAL);
+          const placeholders = providerConfig?.credentialPlaceholders as Record<string, string>;
+          expect(placeholders.openai).toBe(workerToken);
+          expect(placeholders.deepseek).toBe(workerToken);
+          expect(placeholders.chatgpt).not.toBe(workerToken);
+        } finally {
+          server.stop(true);
+          gateway.shutdown();
+          await rm(workspaceDir, { recursive: true, force: true });
+        }
+      }, 30_000);
+    }
+  }
+});

--- a/packages/server/src/gateway/auth/chatgpt/chatgpt-oauth-module.ts
+++ b/packages/server/src/gateway/auth/chatgpt/chatgpt-oauth-module.ts
@@ -1,4 +1,5 @@
 import type { ModelOption } from "@lobu/core";
+import type { ProviderCredentialContext } from "../../embedded.js";
 import { BaseProviderModule } from "../base-provider-module.js";
 import { extractJwtAccountId } from "../oauth/client.js";
 import { getOAuthProviderConfig } from "../oauth/providers.js";
@@ -44,10 +45,15 @@ export class ChatGPTOAuthModule extends BaseProviderModule {
     this.name = "chatgpt-oauth";
   }
 
-  async buildCredentialPlaceholder(agentId: string): Promise<string> {
+  async buildCredentialPlaceholder(
+    agentId: string,
+    context?: ProviderCredentialContext,
+  ): Promise<string> {
     const profile = await this.authProfilesManager.getBestProfile(
       agentId,
       this.providerId,
+      undefined,
+      context,
     );
     // Try metadata first, then extract from the stored credential JWT
     let accountId = profile?.metadata?.accountId as string | undefined;
@@ -83,9 +89,9 @@ export class ChatGPTOAuthModule extends BaseProviderModule {
 
   async getModelOptions(
     agentId: string,
-    _userId: string,
+    userId: string,
   ): Promise<ModelOption[]> {
-    const token = await this.getCredential(agentId);
+    const token = await this.getCredential(agentId, { userId });
     if (!token) return [];
 
     return fetchModelOptions<{

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -1472,7 +1472,7 @@ export class DeploymentManager {
         };
       }
 
-      // CREDENTIAL_ENV_VAR_NAME and AGENT_DEFAULT_PROVIDER are now
+      // The default provider and per-provider credential placeholders are
       // delivered dynamically via the session context endpoint instead of
       // static process environment.
     }

--- a/packages/server/src/gateway/worker-dispatch/worker-gateway.ts
+++ b/packages/server/src/gateway/worker-dispatch/worker-gateway.ts
@@ -1036,7 +1036,6 @@ export class WorkerGateway {
     organizationId?: string,
     userId?: string
   ): Promise<{
-    credentialEnvVarName?: string;
     defaultProvider?: string;
     defaultProviderSlug?: string;
     defaultModel?: string;
@@ -1163,8 +1162,8 @@ export class WorkerGateway {
       }
     }
 
-    // Build credential placeholders for proxy mode — in-process workers need
-    // these so the runtime doesn't reject requests before they reach the proxy.
+    // Key placeholders by Lobu provider id: providers can share an SDK env var,
+    // and a turn can select a different provider from the agent's default.
     // Providers that authenticate via the worker JWT (e.g. Bedrock) receive
     // the worker token so their placeholder *is* a verifiable credential.
     const credentialPlaceholders: Record<string, string> = {};
@@ -1173,7 +1172,6 @@ export class WorkerGateway {
         provider.hasSystemKey() ||
         (await provider.hasCredentials(agentId, { organizationId, userId }))
       ) {
-        const credVar = provider.getCredentialEnvVarName();
         const placeholder = provider.buildCredentialPlaceholder
           ? await provider.buildCredentialPlaceholder(agentId, {
               organizationId,
@@ -1181,12 +1179,11 @@ export class WorkerGateway {
               workerToken,
             })
           : "lobu-proxy";
-        credentialPlaceholders[credVar] = placeholder;
+        credentialPlaceholders[provider.providerId] = placeholder;
       }
     }
 
     const result: {
-      credentialEnvVarName?: string;
       defaultProvider?: string;
       defaultProviderSlug?: string;
       defaultModel?: string;
@@ -1198,7 +1195,6 @@ export class WorkerGateway {
     } = {};
 
     if (primaryProvider) {
-      result.credentialEnvVarName = primaryProvider.getCredentialEnvVarName();
       const upstream = primaryProvider.getUpstreamConfig?.();
       result.defaultProvider = upstream?.slug || primaryProvider.providerId;
       // The worker is told `defaultProvider` is the UPSTREAM slug (e.g.


### PR DESCRIPTION
## Summary

ChatGPT subscription sign-in succeeds, but an agent turn can fail with `Failed to extract accountId from token` before contacting OpenAI. The ChatGPT module drops the user's credential context, and gateway placeholders keyed by SDK environment variable let OpenAI overwrite ChatGPT's account-bearing placeholder. A per-message ChatGPT override also used the agent default provider's credential.

Pass the existing user context through ChatGPT account lookup and model discovery. Key worker placeholders by Lobu provider ID and select the resolved turn provider's placeholder in the worker. Remove the default-provider credential field and shared environment-variable placeholder selection.

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` passed before commit and again after rebasing onto current main; commit-hook type/lint checks passed.
- [x] Focused tests: 51 passed, 181 assertions across five suites.
- [x] Red-to-green reproduction through an authenticated HTTP gateway, the actual worker session, and a local Codex Responses fixture. Covers both provider orders, ChatGPT and DeepSeek defaults, account-bound request headers, streamed reply delivery, and preventing another user from borrowing the owner's subscription.
- [x] `make review-fix` passed; its one comment correction was inspected.
- [x] [GitHub CI](https://github.com/lobu-ai/lobu/actions/runs/34142910969) passed for `50965a48f28cc12472fcac40c1159b17c263507f`.
- [x] `make review`: correctness confidence 90, simplicity 90, zero bugs and blockers. `make ui-review`: not applicable.

Before the fix:
```text
1 pass
6 fail
Failed to extract accountId from token
```

After the fix:
```text
51 pass
0 fail
181 expect() calls
Ran 51 tests across 5 files.
```

## Notes

Diff: six files, +224/−40 overall; shipping code +20/−40 and tests +204.

The gateway-to-worker session context now keys `credentialPlaceholders` by Lobu provider ID and no longer sends the unused default `credentialEnvVarName`. Deploy matching gateway and worker builds together. No database or tenant configuration migration is required, and real credentials remain in the gateway.

The provider response in the regression is a local fixture. The live ChatGPT subscription check passed after rollout. The Slack check exposed a separate identity-resolution gap, recorded below. Slack identity mapping and scheduled Automation cleanup are outside this PR.

### Production verification — 2026-09-07

- Merged as `bcc07af5586ee1f7821e8633692dfcf5d9bbd5b3` after all 10 required checks passed.
- Production `/api/health` reports the same squash commit. The rollout ancestry gate passed with the merge commit first and deployed revision second.
- App and worker deployments both ready on matching image tag `20260907-164637-002680`.
- Production smoke: **8 passed, 0 failed** (health, DB readiness, rollout, UI/assets, MCP auth challenge, OAuth discovery, TLS).
- Real subscription E2E through `conversations.send`, production gateway and worker, and the actual ChatGPT upstream: explicitly selected `chatgpt/gpt-5.5` while the organization default remained DeepSeek; received exactly `LOBU_CHATGPT_SUBSCRIPTION_PROD_3416_OK`, status `complete`. Used the existing login; no new login flow was needed.
- Slack E2E executed through the paired Chrome browser at 18:21 UTC. One mention with the requested exact-response marker was submitted and persisted by the production inbound handler. The configured model was `chatgpt/gpt-5.5`; the gateway rejected the turn before enqueue with `no connected+routable model provider`, so the full Slack-to-ChatGPT path failed.
- Follow-up diagnosis: the Slack sender already has workspace-scoped Slack identities linked to the same Lobu account used by the successful direct subscription test. The normal message handler passes the raw platform user ID into provider credential lookup instead of using the existing `resolveChatUserIdentity` resolver. This remains present on current `origin/main`; the Slack identity slice was explicitly outside this PR.
- The stored inbound message and server rejection were verified. The bot reply could not be independently read back because subsequent Owletto DOM/screenshot operations returned a cross-extension access error. No automation, provider, or approval-policy configuration was changed during rollout verification.
