### PR TITLE
fix(mcp): key activity projections by authenticated user

### DIFF
--- a/db/migrations/20260907183000_mcp_activity_actor_identity.sql
+++ b/db/migrations/20260907183000_mcp_activity_actor_identity.sql
@@ -1,0 +1,96 @@
+-- migrate:up
+-- This rebuilds a mutable Recent projection, never the events audit ledger.
+-- Deployment quiesces writers: the primary-key cutover is incompatible with
+-- the previous writer. Only the existing 14-day Recent window is rebuilt.
+-- Source SELECT measured on production: 12,894 calls in 1.083s (2026-09-07).
+-- This times the source read, not the complete projection rebuild.
+DO $migration$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.mcp_client_conversations'::regclass
+      AND conname = 'mcp_client_conversations_actor_pkey'
+  ) THEN
+    RETURN;
+  END IF;
+
+  CREATE TEMP TABLE mcp_activity_calls ON COMMIT DROP AS
+    SELECT e.organization_id, e.created_by AS user_id, e.client_id,
+      COALESCE(NULLIF(e.metadata->>'mcp_conversation_id', ''),
+        NULLIF(e.metadata->>'mcp_session_id', '')) AS activity_id,
+      NULLIF(e.metadata->>'mcp_session_id', '') AS session_id,
+      e.metadata->>'agent_id' AS agent_id,
+      e.payload_data->>'tool_name' AS tool_name,
+      e.payload_data->>'success' IS DISTINCT FROM 'true' AS failed,
+      e.occurred_at, e.id
+    FROM public.events e
+    WHERE e.semantic_type = 'audit' AND e.origin_type = 'tool_invocation'
+      AND e.client_id IS NOT NULL
+      AND e.payload_data->>'tool_name' IS NOT NULL
+      AND COALESCE(NULLIF(e.metadata->>'mcp_conversation_id', ''),
+        NULLIF(e.metadata->>'mcp_session_id', '')) IS NOT NULL
+      AND e.occurred_at > now() - interval '14 days';
+
+  -- A legacy row can combine multiple actors. Preserve its title only when
+  -- the entire recorded lifetime is covered and all calls identify its user.
+  CREATE TEMP TABLE mcp_activity_titles ON COMMIT DROP AS
+    SELECT mc.user_id, mc.client_identity, mc.conversation_id, mc.title, mc.updated_at
+    FROM public.mcp_client_conversations mc
+    JOIN mcp_activity_calls c ON c.organization_id = mc.organization_id
+      AND c.client_id = mc.client_identity AND c.activity_id = mc.conversation_id
+    WHERE mc.title IS NOT NULL AND mc.user_id IS NOT NULL
+      AND mc.first_activity_at > now() - interval '14 days'
+    GROUP BY mc.organization_id, mc.client_identity, mc.conversation_id
+    HAVING count(*) = mc.call_count
+      AND bool_and(c.user_id IS NOT NULL AND c.user_id = mc.user_id);
+
+  DELETE FROM public.mcp_client_conversations;
+  ALTER TABLE public.mcp_client_conversations DROP CONSTRAINT mcp_client_conversations_pkey;
+  ALTER TABLE public.mcp_client_conversations ALTER COLUMN organization_id DROP NOT NULL;
+  ALTER TABLE public.mcp_client_conversations ALTER COLUMN user_id SET NOT NULL;
+  ALTER TABLE public.mcp_client_conversations ADD CONSTRAINT mcp_client_conversations_actor_pkey
+    PRIMARY KEY (user_id, client_identity, conversation_id);
+
+  WITH activity AS (
+    SELECT user_id, client_id, activity_id,
+      CASE WHEN count(organization_id) = count(*) AND count(DISTINCT organization_id) = 1
+        THEN min(organization_id) ELSE NULL END AS organization_id,
+      COALESCE(jsonb_agg(DISTINCT session_id) FILTER (WHERE session_id IS NOT NULL), '[]'::jsonb) AS session_ids,
+      (array_agg(agent_id ORDER BY occurred_at DESC, id DESC))[1] AS agent_id,
+      (array_agg(tool_name ORDER BY occurred_at DESC, id DESC))[1] AS last_action,
+      jsonb_agg(DISTINCT tool_name) AS tools,
+      count(*) AS call_count, count(*) FILTER (WHERE failed) AS failed_count,
+      min(occurred_at) AS first_activity_at, max(occurred_at) AS last_activity_at
+    FROM mcp_activity_calls
+    WHERE user_id IS NOT NULL
+    GROUP BY user_id, client_id, activity_id
+  )
+  INSERT INTO public.mcp_client_conversations (
+    user_id, client_identity, conversation_id, organization_id, client_id,
+    transport_session_ids, agent_id, title, last_action, tools, call_count,
+    failed_count, first_activity_at, last_activity_at
+  )
+  SELECT a.user_id, a.client_id, a.activity_id, a.organization_id, a.client_id,
+    a.session_ids, a.agent_id, title.title, a.last_action, a.tools, a.call_count,
+    a.failed_count, a.first_activity_at, a.last_activity_at
+  FROM activity a
+  LEFT JOIN LATERAL (
+    SELECT t.title FROM mcp_activity_titles t
+    WHERE t.user_id = a.user_id AND t.client_identity = a.client_id
+      AND t.conversation_id = a.activity_id
+    ORDER BY t.updated_at DESC, t.title
+    LIMIT 1
+  ) title ON true;
+
+  DROP INDEX IF EXISTS public.mcp_client_conversations_recent;
+  DROP INDEX IF EXISTS public.mcp_activity_scope_client_recent;
+  CREATE INDEX mcp_activity_actor_recent
+    ON public.mcp_client_conversations (user_id, last_activity_at DESC);
+  CREATE INDEX mcp_activity_actor_client_recent
+    ON public.mcp_client_conversations (user_id, client_id, activity_kind, last_activity_at DESC)
+    WHERE client_id IS NOT NULL AND call_count > 0;
+END
+$migration$;
+
+-- migrate:down
+-- Forward-only: restoring the workspace key would merge different actors.

--- a/packages/server/src/__tests__/integration/events/get-content-mcp-activity-filter.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-mcp-activity-filter.test.ts
@@ -175,10 +175,10 @@ describe('getContent > exact MCP activity filter on sibling SQL paths', () => {
 
     await sql`
       INSERT INTO mcp_client_conversations (
-        organization_id, client_identity, conversation_id,
+        organization_id, user_id, client_identity, conversation_id,
         transport_session_ids, client_id, last_action, call_count
       ) VALUES (
-        ${org.id}, ${clientId}, ${CONVERSATION_ID},
+        ${org.id}, ${user.id}, ${clientId}, ${CONVERSATION_ID},
         ${sql.json(['transport-old', 'transport-new'])}, ${clientId}, 'read_knowledge', 1
       )
     `;

--- a/packages/server/src/__tests__/integration/mcp/client-activity-identity.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/client-activity-identity.test.ts
@@ -1,0 +1,103 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import { recordMcpConversationActivity, setCurrentMcpConversationTitle } from '../../../lobu/stores/mcp-client-conversations';
+import { resolveActionOrigin } from '../../../notifications/action-origin';
+import { resolveMcpActivitySessionIds } from '../../../tools/get_content/mcp-activity-filter';
+import type { ToolContext } from '../../../tools/registry';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import { addUserToOrganization, createTestAccessToken, createTestOAuthClient, createTestOrganization, createTestUser, seedSystemEntityTypes } from '../../setup/test-fixtures';
+import { get } from '../../setup/test-helpers';
+
+describe('MCP activity actor identity', () => {
+  let org: { id: string; slug: string };
+  let secondOrg: { id: string; slug: string };
+  let userId: string;
+  let otherUserId: string;
+  let clientId: string;
+  let token: string;
+
+  function context(actor: string, activity: string, workspace = org.id): ToolContext {
+    return {
+      organizationId: workspace, userId: actor, memberRole: 'owner',
+      isAuthenticated: true, tokenType: 'oauth', clientId,
+      mcpConversationId: activity, mcpSessionId: `${activity}-${actor}`,
+      scopes: ['mcp:read', 'mcp:write'],
+    } as ToolContext;
+  }
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    org = await createTestOrganization({ slug: 'activity-actor-first' });
+    secondOrg = await createTestOrganization({ slug: 'activity-actor-second' });
+    userId = (await createTestUser({ email: 'activity-actor@example.test' })).id;
+    otherUserId = (await createTestUser({ email: 'activity-other@example.test' })).id;
+    await addUserToOrganization(userId, org.id, 'owner');
+    await addUserToOrganization(otherUserId, org.id, 'owner');
+    await addUserToOrganization(userId, secondOrg.id, 'owner');
+    clientId = (await createTestOAuthClient({ owner_user_id: userId })).client_id;
+    token = (await createTestAccessToken(userId, org.id, clientId, { scope: 'mcp:read mcp:write' })).token;
+  });
+
+  it('separates two users with the same client-supplied conversation ID', async () => {
+    const first = context(userId, 'shared-host-id');
+    const second = context(otherUserId, 'shared-host-id');
+    await recordMcpConversationActivity({ ctx: first, toolName: 'query_sdk', failed: false });
+    await recordMcpConversationActivity({ ctx: second, toolName: 'run_sdk', failed: true });
+    await setCurrentMcpConversationTitle(first, 'My conversation');
+    await setCurrentMcpConversationTitle(second, 'Other private conversation');
+    const rows = await getDb()`SELECT user_id, title, call_count, failed_count, transport_session_ids
+      FROM mcp_client_conversations WHERE client_identity = ${clientId}
+        AND conversation_id = 'shared-host-id' ORDER BY user_id`;
+    expect(rows).toHaveLength(2);
+    expect(rows.find(row => row.user_id === userId)).toMatchObject({
+      title: 'My conversation', call_count: 1, failed_count: 0, transport_session_ids: [first.mcpSessionId],
+    });
+    expect(rows.find(row => row.user_id === otherUserId)).toMatchObject({
+      title: 'Other private conversation', call_count: 1, failed_count: 1, transport_session_ids: [second.mcpSessionId],
+    });
+    expect(await resolveMcpActivitySessionIds(getDb(), userId, [clientId], 'shared-host-id')).toEqual([first.mcpSessionId]);
+    expect(await resolveMcpActivitySessionIds(getDb(), otherUserId, [clientId], 'shared-host-id')).toEqual([second.mcpSessionId]);
+    await expect(resolveMcpActivitySessionIds(getDb(), null, [clientId], 'shared-host-id')).rejects.toThrow(/not found/i);
+    expect(await resolveActionOrigin(first)).toMatchObject({ label: expect.stringContaining('My conversation') });
+    expect(await resolveActionOrigin(second)).toMatchObject({ label: expect.stringContaining('Other private conversation') });
+    const response = await get(`/api/${org.slug}/clients/activity-scopes`, { token });
+    expect(response.status).toBe(200);
+    const body = await response.json() as { scopes: Array<{ title: string }> };
+    expect(body.scopes.map(row => row.title)).toContain('My conversation');
+    expect(body.scopes.map(row => row.title)).not.toContain('Other private conversation');
+  });
+
+  it('keeps one actor activity when the execution target changes', async () => {
+    await recordMcpConversationActivity({ ctx: context(userId, 'two-targets'), toolName: 'run_sdk', failed: false });
+    await recordMcpConversationActivity({ ctx: context(userId, 'two-targets', secondOrg.id), toolName: 'query_sdk', failed: false });
+    const rows = await getDb()`SELECT organization_id, call_count FROM mcp_client_conversations
+      WHERE user_id = ${userId} AND conversation_id = 'two-targets'`;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ organization_id: null, call_count: 2 });
+    const response = await get(`/api/${org.slug}/clients/activity-scopes`, { token });
+    const body = await response.json() as { scopes: Array<{ activityId: string; callCount: number }> };
+    expect(body.scopes.find(row => row.activityId === 'two-targets')?.callCount).toBe(2);
+  });
+
+  it('materializes workspace-free titles and concurrent calls in Postgres', async () => {
+    const ctx = { ...context(userId, 'unbound-title'), organizationId: null };
+    await setCurrentMcpConversationTitle(ctx, 'Account conversation');
+    await Promise.all(Array.from({ length: 8 }, (_, index) => recordMcpConversationActivity({
+      ctx: { ...ctx, mcpSessionId: `reconnect-${index}` }, toolName: 'list_organizations', failed: index === 0,
+    })));
+    const [row] = await getDb()`SELECT organization_id, title, call_count, failed_count,
+      transport_session_ids, activity_kind FROM mcp_client_conversations
+      WHERE user_id = ${userId} AND conversation_id = 'unbound-title'`;
+    expect(row).toMatchObject({ organization_id: null, title: 'Account conversation',
+      call_count: 8, failed_count: 1, activity_kind: 'conversation' });
+    expect(row.transport_session_ids).toHaveLength(9);
+  });
+
+  it('does not create personal Recent rows for an unattributed caller', async () => {
+    const ctx = { ...context(userId, 'anonymous-activity'), userId: null };
+    await recordMcpConversationActivity({ ctx, toolName: 'query_sdk', failed: false });
+    expect(await getDb()`SELECT 1 FROM mcp_client_conversations WHERE conversation_id = 'anonymous-activity'`).toHaveLength(0);
+    await expect(setCurrentMcpConversationTitle(ctx, 'No owner')).rejects.toThrow(/user/i);
+  });
+});

--- a/packages/server/src/__tests__/integration/migrations/mcp-activity-actor-migration.test.ts
+++ b/packages/server/src/__tests__/integration/migrations/mcp-activity-actor-migration.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from 'node:fs';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import { createTestOAuthClient, createTestOrganization, createTestUser, seedSystemEntityTypes } from '../../setup/test-fixtures';
+
+const migration = readFileSync(new URL(
+  '../../../../../../db/migrations/20260907183000_mcp_activity_actor_identity.sql', import.meta.url,
+), 'utf8').split('-- migrate:down')[0]!;
+
+describe('MCP activity actor migration', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+  });
+
+  it('rebuilds recent activity by actual actor, preserves proven titles and leaves events unchanged on replay', async () => {
+    const first = await createTestOrganization({ slug: 'migration-activity-first' });
+    const second = await createTestOrganization({ slug: 'migration-activity-second' });
+    const user = await createTestUser({ email: 'migration-activity-owner@example.test' });
+    const other = await createTestUser({ email: 'migration-activity-other@example.test' });
+    const client = (await createTestOAuthClient({ owner_user_id: user.id })).client_id;
+    const rollback = new Error('rollback isolated migration fixture');
+
+    await expect(getDb().begin(async tx => {
+      // Reconstruct the retired schema only within this rolled-back transaction.
+      await tx`DELETE FROM mcp_client_conversations`;
+      await tx.unsafe(`
+        ALTER TABLE mcp_client_conversations DROP CONSTRAINT mcp_client_conversations_actor_pkey;
+        ALTER TABLE mcp_client_conversations ALTER COLUMN user_id DROP NOT NULL;
+        ALTER TABLE mcp_client_conversations ALTER COLUMN organization_id SET NOT NULL;
+        ALTER TABLE mcp_client_conversations ADD CONSTRAINT mcp_client_conversations_pkey
+          PRIMARY KEY (organization_id, client_identity, conversation_id);
+        DROP INDEX mcp_activity_actor_recent;
+        DROP INDEX mcp_activity_actor_client_recent;
+        CREATE INDEX mcp_client_conversations_recent ON mcp_client_conversations (organization_id, last_activity_at DESC);
+        CREATE INDEX mcp_activity_scope_client_recent ON mcp_client_conversations (organization_id, client_id, activity_kind, last_activity_at DESC);
+      `);
+
+      async function call(actor: string | null, workspace: string | null, activity: string, failed = false, old = false) {
+        await tx`
+          INSERT INTO events (organization_id, created_by, client_id, semantic_type,
+            origin_type, metadata, payload_data, occurred_at)
+          VALUES (${workspace}, ${actor}, ${client}, 'audit', 'tool_invocation',
+            ${tx.json({ mcp_conversation_id: activity, mcp_session_id: `${activity}-${actor}-${workspace}` })},
+            ${tx.json({ tool_name: failed ? 'run_sdk' : 'list_organizations', success: !failed })},
+            now() - ${old ? '30 days' : '1 hour'}::interval)
+        `;
+      }
+      async function legacy(actor: string | null, workspace: string, activity: string, title: string, count: number) {
+        await tx`
+          INSERT INTO mcp_client_conversations (organization_id, user_id, client_identity,
+            client_id, conversation_id, title, last_action, call_count, first_activity_at)
+          VALUES (${workspace}, ${actor}, ${client}, ${client}, ${activity}, ${title},
+            'list_organizations', ${count}, now() - interval '2 hours')
+        `;
+      }
+
+      await call(user.id, first.id, 'mixed');
+      await call(other.id, first.id, 'mixed', true);
+      await legacy(other.id, first.id, 'mixed', 'Ambiguous legacy title', 2);
+      await call(user.id, first.id, 'safe-title');
+      await legacy(user.id, first.id, 'safe-title', 'Preserved title', 1);
+      await call(user.id, first.id, 'two-workspaces');
+      await call(user.id, second.id, 'two-workspaces');
+      await legacy(user.id, first.id, 'two-workspaces', 'Earlier target', 1);
+      await legacy(user.id, second.id, 'two-workspaces', 'Later target', 1);
+      await call(user.id, null, 'unbound');
+      await call(null, first.id, 'unattributed');
+      await legacy(null, first.id, 'unattributed', 'No known actor', 1);
+      await call(user.id, first.id, 'old', false, true);
+      await legacy(user.id, first.id, 'old', 'Outside Recent window', 1);
+      const before = await tx`SELECT id, organization_id, created_by, metadata, payload_data, occurred_at
+        FROM events WHERE client_id = ${client} ORDER BY id`;
+
+      await tx.unsafe(migration);
+      const rows = await tx`SELECT user_id, conversation_id, organization_id, title, call_count,
+        failed_count, transport_session_ids, activity_kind FROM mcp_client_conversations
+        WHERE client_identity = ${client} ORDER BY conversation_id, user_id`;
+      expect(rows).toHaveLength(5);
+      const mixed = rows.filter(row => row.conversation_id === 'mixed');
+      expect(mixed).toHaveLength(2);
+      expect(mixed.every(row => row.title === null && Number(row.call_count) === 1)).toBe(true);
+      expect(mixed.find(row => row.user_id === other.id)?.failed_count).toBe(1);
+      expect(rows.find(row => row.conversation_id === 'safe-title')?.title).toBe('Preserved title');
+      expect(rows.find(row => row.conversation_id === 'two-workspaces')).toMatchObject({ organization_id: null, call_count: 2 });
+      expect(rows.find(row => row.conversation_id === 'unbound')).toMatchObject({ organization_id: null, call_count: 1 });
+      expect(rows.some(row => row.conversation_id === 'unattributed' || row.conversation_id === 'old')).toBe(false);
+
+      // A replay must not rebuild again and erase new projection-only state.
+      await tx`UPDATE mcp_client_conversations SET title = 'Title after cutover', call_count = call_count + 1
+        WHERE user_id = ${user.id} AND conversation_id = 'safe-title'`;
+      await tx.unsafe(migration);
+      const [replayed] = await tx`SELECT title, call_count FROM mcp_client_conversations
+        WHERE user_id = ${user.id} AND conversation_id = 'safe-title'`;
+      expect(replayed).toMatchObject({ title: 'Title after cutover', call_count: 2 });
+      expect(await tx`SELECT id, organization_id, created_by, metadata, payload_data, occurred_at
+        FROM events WHERE client_id = ${client} ORDER BY id`).toEqual(before);
+      const indexes = await tx`SELECT indexname FROM pg_indexes WHERE tablename = 'mcp_client_conversations'`;
+      expect(indexes.map(row => row.indexname)).toEqual(expect.arrayContaining([
+        'mcp_client_conversations_actor_pkey', 'mcp_activity_actor_recent', 'mcp_activity_actor_client_recent',
+      ]));
+      expect(indexes.map(row => row.indexname)).not.toContain('mcp_client_conversations_recent');
+      // Demonstrate that actor-scoped Recent reads back through an ordered
+      // replacement index rather than scanning and sorting the projection.
+      // One busy actor: the primary key alone would still need a sort.
+      await tx`INSERT INTO mcp_client_conversations (user_id, client_identity, client_id, conversation_id,
+          last_action, call_count, last_activity_at)
+        SELECT ${user.id}, ${client}, ${client}, 'index-activity-' || n, 'run_sdk', 1,
+          now() - make_interval(mins => n)
+        FROM generate_series(1, 5000) AS n`;
+      await tx`ANALYZE mcp_client_conversations`;
+      const plan = await tx`EXPLAIN (FORMAT JSON, COSTS OFF) SELECT conversation_id
+        FROM mcp_client_conversations WHERE user_id = ${user.id} AND client_id = ${client}
+          AND activity_kind = 'conversation' AND call_count > 0
+          AND last_activity_at > now() - interval '14 days'
+        ORDER BY last_activity_at DESC LIMIT 20`;
+      const planText = JSON.stringify(plan);
+      expect(planText).toMatch(/mcp_activity_actor_(client_)?recent/);
+      expect(planText).not.toMatch(/Seq Scan|"Node Type":"Sort"/);
+      throw rollback;
+    })).rejects.toBe(rollback);
+  });
+});

--- a/packages/server/src/__tests__/integration/notifications/mcp-activity-notifications.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/mcp-activity-notifications.test.ts
@@ -106,6 +106,10 @@ describe('MCP activity notification attribution', () => {
       })
     ).token;
 
+    // Each reader owns a separate activity even when the host reuses an ID.
+    await recordMcpConversationActivity({
+      ctx: conversationContext(otherOwnerId), toolName: 'manage_operations', failed: false,
+    });
     await recordMcpConversationActivity({
       ctx: conversationContext(ownerId),
       toolName: 'manage_operations',

--- a/packages/server/src/lobu/client-activity-scope-routes.ts
+++ b/packages/server/src/lobu/client-activity-scope-routes.ts
@@ -52,7 +52,7 @@ function displayAction(value: string): string {
 routes.get("/", mcpAuth, async (c) => {
 	const auth = requireOrgUser(c);
 	if (!auth) return c.json({ error: "Organization user required" }, 401);
-	const { organizationId, userId } = auth;
+	const { userId } = auth;
 	const rawLimit = Number.parseInt(c.req.query("limit") ?? "20", 10);
 	const limit = Math.min(
 		Math.max(Number.isNaN(rawLimit) ? 20 : rawLimit, 1),
@@ -88,7 +88,6 @@ routes.get("/", mcpAuth, async (c) => {
       JOIN public.events e ON e.id = target.event_id
       WHERE target.user_id = ${userId}
         AND target.read_at IS NULL
-        AND e.organization_id = ${organizationId}
         AND e.client_id IS NOT NULL
         AND COALESCE(
           e.metadata->>'mcp_conversation_id',
@@ -107,7 +106,7 @@ routes.get("/", mcpAuth, async (c) => {
     LEFT JOIN unread_notifications notification_count
       ON notification_count.client_id = mc.client_id
       AND notification_count.activity_id = mc.conversation_id
-    WHERE mc.organization_id = ${organizationId}
+    WHERE mc.user_id = ${userId}
       ${
 				clientIds.length > 0
 					? sql`AND mc.client_id = ANY(${pgTextArray(clientIds)}::text[])`

--- a/packages/server/src/lobu/stores/mcp-client-conversations.ts
+++ b/packages/server/src/lobu/stores/mcp-client-conversations.ts
@@ -60,7 +60,7 @@ function oauthClientId(ctx: McpActivityContext): string | null {
 	return ctx.tokenType === "oauth" ? (ctx.clientId ?? null) : null;
 }
 
-function transportSessionIds(ctx: ToolContext): string[] {
+function transportSessionIds(ctx: McpActivityContext): string[] {
 	const sessionId = currentMcpActivityAttribution(ctx)?.transportSessionId;
 	return sessionId ? [sessionId] : [];
 }
@@ -76,13 +76,17 @@ export function normalizeMcpConversationTitle(value: string): string {
 	return [...cleaned].slice(0, MAX_TITLE_LENGTH).join("");
 }
 
+type ActivityWriteContext = McpActivityContext & Pick<ToolContext, "userId" | "agentId"> & {
+	organizationId: string | null;
+};
+
 export async function recordMcpConversationActivity(args: {
-	ctx: ToolContext;
+	ctx: ActivityWriteContext;
 	toolName: string;
 	failed: boolean;
 }): Promise<void> {
 	const identity = currentMcpActivityAttribution(args.ctx);
-	if (!identity) return;
+	if (!identity || !args.ctx.userId) return;
 	try {
 		const sql = getDb();
 		// `last_action` stores the RAW tool name, the same contract the migration
@@ -97,17 +101,18 @@ export async function recordMcpConversationActivity(args: {
         client_id, user_id, agent_id, last_action, tools, call_count, failed_count
       ) VALUES (
         ${args.ctx.organizationId}, ${identity.clientIdentity}, ${identity.activityId},
-        ${sql.json(sessionIds)}, ${clientId}, ${args.ctx.userId ?? null},
+        ${sql.json(sessionIds)}, ${clientId}, ${args.ctx.userId},
         ${args.ctx.agentId ?? null}, ${label}, ${sql.json([args.toolName])}, 1, ${args.failed ? 1 : 0}
       )
-      ON CONFLICT (organization_id, client_identity, conversation_id) DO UPDATE SET
+      ON CONFLICT (user_id, client_identity, conversation_id) DO UPDATE SET
+        organization_id = CASE WHEN public.mcp_client_conversations.organization_id = EXCLUDED.organization_id
+          THEN EXCLUDED.organization_id ELSE NULL END,
         transport_session_ids = CASE
           WHEN jsonb_array_length(EXCLUDED.transport_session_ids) = 0
             OR public.mcp_client_conversations.transport_session_ids ? (EXCLUDED.transport_session_ids->>0)
           THEN public.mcp_client_conversations.transport_session_ids
           ELSE public.mcp_client_conversations.transport_session_ids || EXCLUDED.transport_session_ids END,
         client_id = COALESCE(EXCLUDED.client_id, public.mcp_client_conversations.client_id),
-        user_id = COALESCE(EXCLUDED.user_id, public.mcp_client_conversations.user_id),
         agent_id = COALESCE(EXCLUDED.agent_id, public.mcp_client_conversations.agent_id),
         last_action = EXCLUDED.last_action,
         tools = CASE WHEN public.mcp_client_conversations.tools ? ${args.toolName}
@@ -127,9 +132,10 @@ export async function recordMcpConversationActivity(args: {
 }
 
 export async function setCurrentMcpConversationTitle(
-	ctx: ToolContext,
+	ctx: ActivityWriteContext,
 	value: string,
 ) {
+	if (!ctx.userId) throw new Error("User context required to title MCP activity.");
 	const identity = currentMcpActivityAttribution(ctx);
 	if (!identity)
 		throw new Error(
@@ -150,11 +156,13 @@ export async function setCurrentMcpConversationTitle(
       client_id, user_id, agent_id, title, last_action
     ) VALUES (
       ${ctx.organizationId}, ${identity.clientIdentity}, ${identity.activityId},
-      ${sql.json(sessionIds)}, ${clientId}, ${ctx.userId ?? null},
+      ${sql.json(sessionIds)}, ${clientId}, ${ctx.userId},
       ${ctx.agentId ?? null}, ${title}, 'set_title'
     )
-    ON CONFLICT (organization_id, client_identity, conversation_id)
+    ON CONFLICT (user_id, client_identity, conversation_id)
     DO UPDATE SET title = EXCLUDED.title,
+      organization_id = CASE WHEN public.mcp_client_conversations.organization_id = EXCLUDED.organization_id
+        THEN EXCLUDED.organization_id ELSE NULL END,
       transport_session_ids = CASE
         WHEN jsonb_array_length(EXCLUDED.transport_session_ids) = 0
           OR public.mcp_client_conversations.transport_session_ids ? (EXCLUDED.transport_session_ids->>0)

--- a/packages/server/src/notifications/action-origin.ts
+++ b/packages/server/src/notifications/action-origin.ts
@@ -42,7 +42,7 @@ async function automationOrigin(
 }
 
 async function mcpConversationOrigin(
-	organizationId: string,
+	userId: string | null,
 	activity: { clientIdentity: string; activityId: string },
 ): Promise<ActionOrigin> {
 	const rows = await getDb()<{
@@ -52,7 +52,7 @@ async function mcpConversationOrigin(
 		SELECT mc.title, oc.client_name
 		FROM mcp_client_conversations mc
 		LEFT JOIN oauth_clients oc ON oc.id = mc.client_id
-		WHERE mc.organization_id = ${organizationId}
+		WHERE mc.user_id = ${userId}
 		  AND mc.client_identity = ${activity.clientIdentity}
 		  AND mc.conversation_id = ${activity.activityId}
 		LIMIT 1
@@ -75,12 +75,13 @@ async function resolveConversationActionOrigin(params: {
 	conversationId?: string | null;
 	agentId?: string | null;
 	clientIdentity?: string | null;
+	userId?: string | null;
 }): Promise<ActionOrigin> {
 	let title: string | null = null;
 	const sourcePlatform = params.platform?.trim().toLowerCase() || null;
 	const storedPlatform = sourcePlatform === "api" ? "web" : sourcePlatform;
 	if (storedPlatform === "mcp" && params.conversationId && params.clientIdentity) {
-		return mcpConversationOrigin(params.organizationId, {
+		return mcpConversationOrigin(params.userId ?? null, {
 			clientIdentity: params.clientIdentity,
 			activityId: params.conversationId,
 		});
@@ -115,6 +116,7 @@ export async function resolveInteractionActionOrigin(params: {
 	conversationId?: string | null;
 	agentId?: string | null;
 	clientIdentity?: string | null;
+	userId?: string | null;
 	automationId?: number | null;
 	source?: string | null;
 }): Promise<ActionOrigin> {
@@ -146,6 +148,7 @@ export async function resolveInteractionActionOrigin(params: {
 		conversationId: params.conversationId,
 		agentId: params.agentId,
 		clientIdentity: params.clientIdentity,
+		userId: params.userId,
 	}).catch(() => ({ kind: "conversation", label: fallback }));
 }
 
@@ -159,7 +162,7 @@ export async function resolveActionOrigin(
 		}
 		const mcpActivity = currentMcpActivityAttribution(ctx);
 		if (mcpActivity) {
-			return await mcpConversationOrigin(ctx.organizationId, mcpActivity);
+			return await mcpConversationOrigin(ctx.userId, mcpActivity);
 		}
 		if (ctx.sourceContext?.conversationId) {
 			return await resolveConversationActionOrigin({

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -356,7 +356,7 @@ async function getContentImpl(
   const mcpSessionIds = hasMcpActivityId
     ? await resolveMcpActivitySessionIds(
         sql,
-        ctx.organizationId,
+        ctx.userId,
         args.client_ids as string[],
         args.mcp_activity_id as string
       )

--- a/packages/server/src/tools/get_content/mcp-activity-filter.ts
+++ b/packages/server/src/tools/get_content/mcp-activity-filter.ts
@@ -13,14 +13,14 @@ interface ActivityTransportRow {
  */
 export async function resolveMcpActivitySessionIds(
 	sql: DbClient,
-	organizationId: string,
+	userId: string | null,
 	clientIds: string[],
 	activityId: string,
 ): Promise<string[]> {
 	const rows = await sql<ActivityTransportRow>`
     SELECT transport_session_ids
     FROM public.mcp_client_conversations
-    WHERE organization_id = ${organizationId}
+    WHERE user_id = ${userId}
       AND client_id = ANY(${pgTextArray(clientIds)}::text[])
       AND conversation_id = ${activityId}
   `;

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -645,8 +645,9 @@ async function approvalOrigin(row: ApprovalContentItem, ctx: ToolContext): Promi
     automation_id: number | null;
     initiator_ref: Record<string, unknown> | null;
     original_client_id: string | null;
+    created_by_user_id: string | null;
   }>`
-    SELECT r.automation_id, r.initiator_ref, original.client_id AS original_client_id
+    SELECT r.automation_id, r.initiator_ref, r.created_by_user_id, original.client_id AS original_client_id
     FROM runs r
     LEFT JOIN LATERAL (
       SELECT e.client_id
@@ -675,6 +676,7 @@ async function approvalOrigin(row: ApprovalContentItem, ctx: ToolContext): Promi
   if (!automationId && !conversationId) return { kind: 'direct', label: 'Direct request' };
   return resolveInteractionActionOrigin({
     organizationId: ctx.organizationId,
+    userId: runs[0]?.created_by_user_id ?? null,
     automationId,
     conversationId,
     // get_content's `platform` column carries the event's connector_key, never a


### PR DESCRIPTION
## Summary
MCP activity currently merges different users when their client supplies the same conversation ID. Rekey the existing projection on its existing user_id so each actor owns their Recent entry, and a conversation spanning targets stays one activity.

- Replace workspace conflict keys and Recent indexes with actor keys; allow organization_id to be NULL target metadata.
- Rebuild only the existing 14-day Recent window from events.created_by. Preserve custom titles only when the old row's complete ownership is proven. Source events and IDs remain unchanged; replay is a no-op.
- Update the existing writer, title lookup, Recent reader, activity resolver, and approval-card origin together. Reuse runs.created_by_user_id for origin attribution.

Diff: 11 files, +361/-22; runtime +32/-20, migration +96, tests +233/-2.

This is approved consolidation slice A. OAuth default selection and the account API/UI cutover remain slice B; this PR does not claim to remove them. No new table, ownership column, endpoint, or history UI.

## Test plan
- [x] Focused database integration tests: migration/backfill/replay, concurrent writers, actor isolation, multi-target merging, existing approval cards and activity filtering.
- [x] Real local HTTP MCP: two synthetic users initialize /mcp, call discovery, set different titles with run_sdk, and read only their own Recent row despite sharing one host conversation ID.
- [x] Disposable live database and server cleaned up after verification.
- [x] Migration SQL lint passed.
- [x] make pre-pr (build, strict per-package typecheck, dead-code, naming and runtime funnel gates).
- [x] Commit hooks, canonical GitHub CI, semantic review and UI applicability gate.
- [x] Fable: 0 bugs, 0 blockers, simplicity 80, bug-free confidence 88; independently ran 61 tests. UI gate: not applicable.

Red on the old model:
```text
Test Files  1 failed (1)
     Tests  4 failed (4)
  Duration  14.77s
```
Green on the settled diff:
```text
Test Files  8 passed (8)
     Tests  91 passed (91)
  Duration  17.28s
```
Live HTTP result:
```text
actor A: MCP initialize/discovery/title and own Recent read passed
actor B: MCP initialize/discovery/title and own Recent read passed
Verified 2 independent activity rows for one shared host conversation ID
```

## Notes
The forward migration uses the existing deployment writer-quiescence hook (verified migrations.enabled=true on the production HelmRelease; chart hooks stop both app and worker deployments before unmarked migrations) because the old conflict key cannot write after the rekey. It replaces mutable projection rows, never deletes or rewrites events. Old ambiguous/unattributed projection rows are not assigned to a guessed user. Existing workspace event access remains governed by its current policy. A read-only EXPLAIN ANALYZE of the exact source scan on production read 12,894 eligible audit calls in 1.083s using existing client/semantic indexes; production estimates are 3.92M events and 9,219 projection rows. This measures the source read, not the complete migration. SQL remains transactional: timeout/failure rolls the projection and key changes back, and the existing deployment hook handles recovery.
