### PR TITLE
fix(deploy): validate migration prerequisites before quiescing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1634,6 +1634,13 @@ jobs:
           cp -r "$tmp/node_modules/postgres" node_modules/postgres
           node scripts/migrate-up.mjs
 
+      - name: Production migration entrypoint and upgrade prerequisites
+        env:
+          MIGRATION_TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/lobu_ci?sslmode=disable
+        # Real PostgreSQL and start.sh, with only kubectl replaced by a recorder.
+        # Includes the historical schema plus legacy NULL actors missed by an empty DB.
+        run: node --test scripts/__tests__/migration-entrypoint.node-test.mjs
+
       - name: Verify migrations are listed in the schema_migrations table
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/lobu_ci?sslmode=disable

--- a/charts/lobu/Chart.yaml
+++ b/charts/lobu/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lobu
 description: Lobu Platform - Never forget anything. User content analysis with AI.
 type: application
-version: 19.2.0
+version: 19.2.1
 appVersion: 19.2.0
 keywords:
   - lobu

--- a/charts/lobu/files/migrate-upgrade.sh
+++ b/charts/lobu/files/migrate-upgrade.sh
@@ -55,14 +55,12 @@ restore_on_failure() {
 # Quiescing scales the app to zero for the length of a pod restart, which the
 # ingress answers with 503. Only a schema change the old code cannot run
 # against needs that window, and most deploys ship none, so ask the ledger
-# first. Fail closed: only the check's two definitive "safe" statuses skip the
-# quiesce -- 3 (nothing pending) and 4 (everything pending is marked
-# backward-compatible). An unset check or any other status, including a crash,
-# still quiesces.
+# first, including its read-only prerequisite checks. Only a successful check
+# permits deployment. An unknown answer aborts before touching old replicas.
 migrations_pending() {
   if [ -z "$pending_check" ]; then
-    echo 'no pending-migration check configured; quiescing'
-    return 0
+    echo 'ERROR: no pending-migration check configured; aborting before quiesce' >&2
+    exit 1
   fi
   set +e
   # Word splitting is intended: the check is configured as a full command line.
@@ -76,7 +74,8 @@ migrations_pending() {
     return 1
   fi
   if [ "$pending_status" -ne 0 ]; then
-    echo "pending-migration check failed with status $pending_status; quiescing" >&2
+    echo "ERROR: pending-migration check failed with status $pending_status; aborting before quiesce" >&2
+    exit "$pending_status"
   fi
   return 0
 }

--- a/charts/lobu/tests/migrate-upgrade-recovery.sh
+++ b/charts/lobu/tests/migrate-upgrade-recovery.sh
@@ -46,6 +46,8 @@ printf 'pending-check\n' >>"$PENDING_LOG"
 exit "${PENDING_EXIT_CODE:-0}"
 PENDING
 chmod +x "$test_dir/pending-check"
+export MIGRATION_PENDING_CHECK="$test_dir/pending-check"
+export PENDING_LOG="$pending_log"
 
 set +e
 COMMAND_LOG="$command_log" \
@@ -157,25 +159,36 @@ if [ -s "$command_log" ]; then
   exit 1
 fi
 
-# Fail closed: a check that cannot answer must still quiesce.
-: >"$command_log"
-: >"$migration_log"
-COMMAND_LOG="$command_log" \
-MIGRATION_LOG="$migration_log" \
-PENDING_LOG="$pending_log" \
-KUBECTL_BIN="$test_dir/kubectl" \
-NAMESPACE=lobu \
-APP_DEPLOYMENT=lobu-app \
-APP_SELECTOR='app.kubernetes.io/instance=lobu,app.kubernetes.io/component=api' \
-WORKER_DEPLOYMENT=lobu-worker \
-WORKER_SELECTOR='app.kubernetes.io/instance=lobu,app.kubernetes.io/component=worker' \
-MIGRATION_PENDING_CHECK="$test_dir/pending-check" \
-PENDING_EXIT_CODE=7 \
-  sh "$orchestrator" "$test_dir/migrate"
+# An inconclusive check must leave the healthy deployments alone.
+for pending_code in 1 7 127 137 missing; do
+  : >"$command_log"
+  : >"$migration_log"
+  check_command="$test_dir/pending-check"
+  if [ "$pending_code" = missing ]; then
+    check_command=''
+    pending_code=1
+  fi
+  set +e
+  COMMAND_LOG="$command_log" \
+  MIGRATION_LOG="$migration_log" \
+  PENDING_LOG="$pending_log" \
+  KUBECTL_BIN="$test_dir/kubectl" \
+  NAMESPACE=lobu \
+  APP_DEPLOYMENT=lobu-app \
+  APP_SELECTOR='app.kubernetes.io/instance=lobu,app.kubernetes.io/component=api' \
+  WORKER_DEPLOYMENT=lobu-worker \
+  WORKER_SELECTOR='app.kubernetes.io/instance=lobu,app.kubernetes.io/component=worker' \
+  MIGRATION_PENDING_CHECK="$check_command" \
+  PENDING_EXIT_CODE="$pending_code" \
+    sh "$orchestrator" "$test_dir/migrate"
+  check_status=$?
+  set -e
 
-grep -Fxq 'scale deployment lobu-app --replicas=0' "$command_log"
-grep -Fxq 'scale deployment lobu-worker --replicas=0' "$command_log"
-grep -Fxq 'migrate' "$migration_log"
+  if [ "$check_status" -eq 0 ] || [ -s "$command_log" ] || [ -s "$migration_log" ]; then
+    echo "failed pending check ($pending_code) unexpectedly proceeded with deployment" >&2
+    exit 1
+  fi
+done
 
 # A real pending migration still gets the full quiesce.
 : >"$command_log"

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -375,14 +375,16 @@ migrations:
   enabled: false
   # Incompatible migrations cannot run while an old app or worker still uses
   # the previous schema. An upgrade first asks the schema_migrations ledger
-  # whether anything is pending (migrate-up.mjs --check-pending); if nothing
-  # is, or every pending migration is marked -- lobu:no-quiesce (backward
+  # whether anything is pending (migrate-up.mjs --check-pending), which also
+  # validates any declared prerequisites (docs/MIGRATIONS.md); if nothing is
+  # pending, or every pending migration is marked -- lobu:no-quiesce (backward
   # compatible), the deployments keep serving and Helm rolls without downtime.
-  # When an incompatible migration is pending -- or the check cannot answer --
-  # the upgrade records the current replica counts, scales both deployments to
-  # zero, and waits for their pods to terminate before migrating. A failed
-  # migration restores those counts; after success Helm applies the new
-  # release's configured replica counts.
+  # When an incompatible migration is pending, the upgrade records the current
+  # replica counts, scales both deployments to zero, and waits for their pods
+  # to terminate before migrating. A check that fails or cannot answer aborts
+  # the upgrade before anything is scaled. A failed migration restores those
+  # counts; after success Helm applies the new release's configured replica
+  # counts.
   quiesceBeforeUpgrade:
     image: bitnami/kubectl@sha256:9e369df7ab3386b736d162348f167bcc02cb4ba3f5203e9151be854437d6e0af
     pullPolicy: IfNotPresent

--- a/db/migrations/preconditions/20260622310000_drop_classifier_version_id.sql
+++ b/db/migrations/preconditions/20260622310000_drop_classifier_version_id.sql
@@ -1,0 +1,16 @@
+-- External prerequisite of the classifier contract. Unlike migrations that
+-- backfill/rebuild their own data, this one requires the operator's backfill.
+-- On a fresh install the expand migration has not created the column yet.
+DO $precondition$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'event_classifications'
+      AND column_name = 'classifier_id'
+  ) THEN
+    IF EXISTS (SELECT 1 FROM public.event_classifications WHERE classifier_id IS NULL) THEN
+      RAISE EXCEPTION 'event_classifications.classifier_id contains NULL rows; run scripts/backfill-classifier-stable-id.sh before deploying';
+    END IF;
+  END IF;
+END
+$precondition$;

--- a/docker/app/start.sh
+++ b/docker/app/start.sh
@@ -2,6 +2,7 @@
 set -e
 
 MODE="${1:-server}"
+app_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 
 echo "Starting Lobu backend (Node)"
 echo "================================"
@@ -45,113 +46,6 @@ try {
 NODE
 }
 
-# Fail FAST, before the migration runner touches anything, when a PENDING migration will
-# `ALTER COLUMN ... SET NOT NULL` on a column that still has NULL rows. That is
-# the signature of a contract migration whose out-of-band backfill precondition
-# was skipped (incident 2026-06-24: a classifier-collapse contract migration hit
-# this, the migration failed mid-run, the Helm pre-upgrade hook failed, and the
-# HelmRelease wedged + rolled back for hours, spamming #devops). The database
-# error ("column X contains null values") is buried after partial work; this
-# surfaces the exact table.column + NULL count + remediation up front.
-#
-# Fail OPEN by design: any parse/connect/unknown error logs a warning and
-# continues so the preflight can never itself become a new deploy wedge. It only
-# HARD-fails when it positively finds NULLs in an existing targeted column.
-preflight_not_null_preconditions() {
-  echo "Checking pending migrations for unsatisfied NOT NULL preconditions..."
-  MIGRATIONS_DIR=/app/db/migrations node --input-type=module <<'NODE'
-import postgres from "postgres";
-import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-
-const databaseUrl = process.env.DATABASE_URL;
-const dir = process.env.MIGRATIONS_DIR || "/app/db/migrations";
-if (!databaseUrl) {
-  console.error("ERROR: DATABASE_URL not set");
-  process.exit(1);
-}
-
-const sql = postgres(databaseUrl, { max: 1, connect_timeout: 10, idle_timeout: 1, onnotice: () => {} });
-
-try {
-  let applied;
-  try {
-    const rows = await sql`SELECT version FROM schema_migrations`;
-    applied = new Set(rows.map((r) => r.version));
-  } catch {
-    // Fresh DB with no schema_migrations yet → nothing applied and no rows that
-    // could violate a NOT NULL. Nothing to check.
-    console.log("schema_migrations not present — skipping NOT NULL preflight");
-    process.exit(0);
-  }
-
-  let files;
-  try {
-    files = readdirSync(dir).filter((f) => f.endsWith(".sql")).sort();
-  } catch (e) {
-    console.warn(`preflight: cannot read ${dir} (${e.message}) — skipping`);
-    process.exit(0);
-  }
-
-  const violations = [];
-  for (const file of files) {
-    const version = file.split("_")[0];
-    if (applied.has(version)) continue; // already applied
-
-    let text;
-    try {
-      text = readFileSync(join(dir, file), "utf8");
-    } catch {
-      continue;
-    }
-    // Only consider the up section, statement by statement. A statement that
-    // both names a table and SETs a column NOT NULL targets an existing column.
-    const up = text.split(/--\s*migrate:down/i)[0];
-    for (const stmt of up.split(";")) {
-      if (!/alter\s+column/i.test(stmt) || !/set\s+not\s+null/i.test(stmt)) continue;
-      const tableM = stmt.match(/alter\s+table\s+(?:only\s+)?(?:public\.)?"?(\w+)"?/i);
-      const colM = stmt.match(/alter\s+column\s+"?(\w+)"?\s+set\s+not\s+null/i);
-      if (!tableM || !colM) continue;
-      const table = tableM[1];
-      const col = colM[1];
-      try {
-        // table/col are \w+ extracted from our own migration files — not user input.
-        const rows = await sql.unsafe(
-          `SELECT count(*)::bigint AS n FROM public.${table} WHERE ${col} IS NULL`
-        );
-        const n = Number(rows[0]?.n ?? 0);
-        if (n > 0) violations.push({ file, table, col, n });
-      } catch (e) {
-        // Column/table may be created by an earlier still-pending migration, so
-        // it can't be pre-verified — let the migration runner handle it. Fail open.
-        console.warn(`preflight: cannot check ${table}.${col} (${file}): ${e.message}`);
-      }
-    }
-  }
-
-  if (violations.length > 0) {
-    console.error("");
-    console.error("ERROR: refusing to run migrations — a pending NOT NULL constraint has unbacked NULLs:");
-    for (const v of violations) {
-      console.error(`  - ${v.file}: ${v.table}.${v.col} SET NOT NULL, but ${v.n} row(s) are NULL`);
-    }
-    console.error("");
-    console.error("This is a contract migration whose out-of-band backfill must run to completion FIRST");
-    console.error("(see the migration header / scripts/). Run the backfill, confirm 0 NULLs, then redeploy.");
-    console.error("Aborting before migrations so the deploy fails fast with a clear cause, not mid-migration.");
-    process.exit(1);
-  }
-  console.log("NOT NULL preflight passed");
-} catch (error) {
-  // Never let an unexpected preflight error block a deploy.
-  console.warn(`preflight: unexpected error, continuing (${error instanceof Error ? error.message : String(error)})`);
-  process.exit(0);
-} finally {
-  await sql.end({ timeout: 1 }).catch(() => {});
-}
-NODE
-}
-
 run_migrations() {
   if [ -z "$DATABASE_URL" ]; then
     echo "ERROR: DATABASE_URL not set"
@@ -162,16 +56,14 @@ run_migrations() {
     preflight_database
   fi
 
-  preflight_not_null_preconditions
-
   echo ""
   echo "Running database migrations..."
   # Statement-at-a-time for transaction:false (CONCURRENTLY + heal DO). Plain
   # dbmate Exec's the whole up section as one simple-query batch, which Postgres
   # wraps in an implicit transaction that CREATE INDEX CONCURRENTLY refuses.
   # scripts/migrate-up.mjs uses the existing public.schema_migrations ledger.
-  MIGRATIONS_DIR="${MIGRATIONS_DIR:-/app/db/migrations}" \
-    node /app/scripts/migrate-up.mjs
+  MIGRATIONS_DIR="${MIGRATIONS_DIR:-$app_dir/db/migrations}" \
+    node "$app_dir/scripts/migrate-up.mjs"
   echo "Migrations complete"
 }
 

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -1,6 +1,6 @@
 # Migrations
 
-dbmate-managed SQL under `db/migrations/`. Names are `<UTC-yyyymmddHHMMSS>_<slug>.sql` with a `-- migrate:up` / `-- migrate:down` split. Pre-upgrade Helm hook runs `dbmate up` against the prod database before the app rolls.
+dbmate-managed SQL under `db/migrations/`. Names are `<UTC-yyyymmddHHMMSS>_<slug>.sql` with a `-- migrate:up` / `-- migrate:down` split. The pre-upgrade Helm hook invokes `docker/app/start.sh migrate`, which runs `scripts/migrate-up.mjs` against the database before the app rolls. The runner records versions in the dbmate-compatible ledger.
 
 Most migrations are routine: an additive column, a small index, a view bump. The risk lives in the ones that **rewrite a hot table** or **rebuild a large index**. Get those wrong and prod stalls under `ACCESS EXCLUSIVE` until the database's `statement_timeout` fires, after which dbmate exits non-zero, the migration leaves no row in `schema_migrations`, and the app deploys forward into a schema it expects but doesn't have. That's the 2026-05-16 outage in one sentence ([PR #767](https://github.com/lobu-ai/lobu/pull/767)).
 
@@ -35,9 +35,21 @@ Rules:
 - The marker must be **its own comment line**. Prose mentioning it does not arm it.
 - It asserts something about the **application**, not the DDL: that the code running *before* this deploy keeps working against the post-migration schema. Nothing inspects your SQL, because backward compatibility is a property of sequencing rather than of the DDL verbs — a `DROP COLUMN` is safe once nothing reads that column, and a widened `CHECK` constraint is safe because it only ever accepts more. Only you know where the migration sits in that sequence.
 - **Every** pending migration in the deploy must carry it, or the whole batch quiesces. One unmarked migration removes the fast path for all of them.
-- Everything fails closed. Unmarked, unreadable, unparseable, or a pending-check that crashes all quiesce exactly as before.
+- An unmarked migration quiesces only after validation succeeds. An unreadable migration, failed prerequisite, or crashed pending check aborts deployment before any scaling. A missing pending-check command also aborts.
 
 Leave the marker off when the running code would actually break: a column it still reads is going away, a constraint is being tightened under it, or a new `NOT NULL` column has no `DEFAULT` to fill in for inserts that predate it. That is what the window exists for.
+
+---
+
+## External migration prerequisites
+
+When a migration requires an operator to complete work **before deployment**, add a SQL sidecar at `db/migrations/preconditions/<exact migration filename>`. The runner executes sidecars for pending migrations in a read-only transaction with a 10-second statement timeout, before the upgrade hook stops any replicas. A failed assertion, SQL error, timeout, or unreadable file blocks deployment. A sidecar with no matching migration is an error.
+
+Use `DO` / `RAISE EXCEPTION` with an actionable message to assert a prerequisite. A successful statement passes; returning `false` from a `SELECT` does **not** fail a check. Sidecars cannot backfill or change the schema. They must handle the schema before *any* pending migration runs, including a fresh install where an earlier expand migration has not created the table or column yet. The classifier contract sidecar is an example of an external backfill check.
+
+Do not declare an external prerequisite when the migration itself repairs the data. The runner does not infer prerequisites by scanning `SET NOT NULL`: a migration can legitimately clear, rebuild, or backfill those NULLs before adding its constraint. Keep assertions about intermediate migration state inside that migration.
+
+The same runner checks prerequisites under its existing advisory lock before applying migrations, including direct startup and fresh installs. This recheck can catch a prerequisite that changed after the hook's check; it is not a guarantee that concurrent writers cannot invalidate data later. Applied migrations do not rerun their sidecars. Keep sidecars with their owning migrations when squashing or removing history; historical migration SQL remains immutable.
 
 ---
 

--- a/scripts/__tests__/migration-entrypoint.node-test.mjs
+++ b/scripts/__tests__/migration-entrypoint.node-test.mjs
@@ -1,0 +1,287 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+
+// Run with `node --test <this file>`. The name sits outside bun's `*.test.*`
+// discovery on purpose: `bun test scripts` must stay hermetic, and this suite
+// needs a real PostgreSQL service.
+// Explicit test service URL; each test creates and drops only its own database.
+assert.ok(
+  process.env.MIGRATION_TEST_DATABASE_URL,
+  "MIGRATION_TEST_DATABASE_URL is required"
+);
+const admin = postgres(process.env.MIGRATION_TEST_DATABASE_URL, { max: 1 });
+after(() => admin.end());
+const root = fileURLToPath(new URL("../../", import.meta.url));
+const actorMigration = "20260907183000_mcp_activity_actor_identity.sql";
+const contractMigration = "20260622310000_drop_classifier_version_id.sql";
+
+async function fixture(t) {
+  const database = `migration_test_${randomUUID().replaceAll("-", "")}`;
+  await admin.unsafe(`CREATE DATABASE ${database}`);
+  const url = new URL(process.env.MIGRATION_TEST_DATABASE_URL);
+  url.pathname = `/${database}`;
+  const sql = postgres(url.toString(), { max: 1, onnotice: () => undefined });
+  const dir = mkdtempSync(join(tmpdir(), "migration-entrypoint-"));
+  t.after(async () => {
+    await sql.end();
+    await admin.unsafe(`DROP DATABASE ${database} WITH (FORCE)`);
+    rmSync(dir, { recursive: true, force: true });
+  });
+  const migrations = join(dir, "db/migrations");
+  mkdirSync(join(migrations, "preconditions"), { recursive: true });
+  copyFileSync(join(root, "docker/app/start.sh"), join(dir, "start.sh"));
+  symlinkSync(join(root, "scripts"), join(dir, "scripts"), "dir");
+  symlinkSync(join(root, "node_modules"), join(dir, "node_modules"), "dir");
+  const commands = join(dir, "kubectl.log");
+  writeFileSync(commands, "");
+  writeFileSync(
+    join(dir, "kubectl"),
+    `#!/bin/sh
+printf '%s\\n' "$*" >> "$COMMAND_LOG"
+case "$*" in *'get deployment'*) printf '1';; esac
+`,
+    { mode: 0o755 }
+  );
+  const env = {
+    ...process.env,
+    DATABASE_URL: url.toString(),
+    NODE_ENV: "production",
+    MIGRATIONS_DIR: migrations,
+    MIGRATION_PENDING_CHECK: `node ${join(root, "scripts/migrate-up.mjs")} --check-pending`,
+    KUBECTL_BIN: join(dir, "kubectl"),
+    COMMAND_LOG: commands,
+    NAMESPACE: "migration-test",
+    APP_DEPLOYMENT: "test-api",
+    APP_SELECTOR: "component=api",
+    WORKER_DEPLOYMENT: "test-worker",
+    WORKER_SELECTOR: "component=worker",
+  };
+  function run(args) {
+    const result = spawnSync(args[0], args.slice(1), {
+      cwd: dir,
+      env,
+      encoding: "utf8",
+      timeout: 120_000,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    assert.ifError(result.error);
+    return { status: result.status, output: result.stdout + result.stderr };
+  }
+  return {
+    sql,
+    dir,
+    migrations,
+    run,
+    commands: () => readFileSync(commands, "utf8"),
+    upgrade: () =>
+      run([
+        "sh",
+        join(root, "charts/lobu/files/migrate-upgrade.sh"),
+        "bash",
+        join(dir, "start.sh"),
+        "migrate",
+      ]),
+    migrate: () => run(["bash", join(dir, "start.sh"), "migrate"]),
+    check: () =>
+      run(["node", join(root, "scripts/migrate-up.mjs"), "--check-pending"]),
+  };
+}
+
+async function contractFixture(t) {
+  const f = await fixture(t);
+  await f.sql.unsafe(`
+    CREATE TABLE schema_migrations (version text PRIMARY KEY);
+    CREATE TABLE event_classifications (classifier_id text);
+    INSERT INTO event_classifications VALUES (NULL);
+  `);
+  writeFileSync(
+    join(f.migrations, contractMigration),
+    `-- migrate:up
+ALTER TABLE event_classifications ALTER COLUMN classifier_id SET NOT NULL;
+`
+  );
+  copyFileSync(
+    join(root, "db/migrations/preconditions", contractMigration),
+    join(f.migrations, "preconditions", contractMigration)
+  );
+  return f;
+}
+
+test("external backfill fails before scaling or migration; passes after backfill", async (t) => {
+  const f = await contractFixture(t);
+  const blocked = f.upgrade();
+  assert.notEqual(blocked.status, 0, blocked.output);
+  assert.match(blocked.output, /classifier_id.*NULL/);
+  assert.equal(f.commands(), "", blocked.output);
+  assert.equal((await f.sql`SELECT * FROM schema_migrations`).length, 0);
+  const direct = f.migrate();
+  assert.notEqual(direct.status, 0, direct.output);
+  assert.match(direct.output, /classifier_id.*NULL/);
+  await f.sql`UPDATE event_classifications SET classifier_id = 'synthetic-classifier'`;
+  const applied = f.upgrade();
+  assert.equal(applied.status, 0, applied.output);
+  assert.match(f.commands(), /scale deployment test-api --replicas=0/);
+  assert.match(f.commands(), /scale deployment test-worker --replicas=0/);
+  assert.equal((await f.sql`SELECT * FROM schema_migrations`).length, 1);
+  // An applied prerequisite is no longer evaluated.
+  writeFileSync(
+    join(f.migrations, "preconditions", contractMigration),
+    "SELECT 1 / 0;"
+  );
+  assert.equal(f.check().status, 3);
+});
+
+test("read-only preconditions reject attempted writes without scaling", async (t) => {
+  const f = await contractFixture(t);
+  writeFileSync(
+    join(f.migrations, "preconditions", contractMigration),
+    "UPDATE event_classifications SET classifier_id = 'forbidden';"
+  );
+  const result = f.upgrade();
+  assert.notEqual(result.status, 0, result.output);
+  assert.match(result.output, /read-only transaction/);
+  assert.equal(f.commands(), "");
+  assert.equal(
+    (await f.sql`SELECT classifier_id FROM event_classifications`)[0]
+      .classifier_id,
+    null
+  );
+});
+
+test("a broken precondition still blocks a no-quiesce migration", async (t) => {
+  const f = await contractFixture(t);
+  writeFileSync(
+    join(f.migrations, contractMigration),
+    "-- migrate:up\n-- lobu:no-quiesce\nSELECT 1;"
+  );
+  writeFileSync(
+    join(f.migrations, "preconditions", contractMigration),
+    "SELECT missing_column FROM event_classifications;"
+  );
+  const result = f.upgrade();
+  assert.notEqual(result.status, 0, result.output);
+  assert.match(result.output, /missing_column/);
+  assert.equal(f.commands(), "");
+});
+
+test("unreadable migration files abort before scaling", async (t) => {
+  const f = await fixture(t);
+  await f.sql`CREATE TABLE schema_migrations (version text PRIMARY KEY)`;
+  symlinkSync(
+    join(f.dir, "missing.sql"),
+    join(f.migrations, "20990101000000_missing.sql")
+  );
+  const result = f.upgrade();
+  assert.notEqual(result.status, 0, result.output);
+  assert.equal(f.commands(), "");
+});
+
+test("missing directives and unmatched prerequisites abort before scaling", async (t) => {
+  const f = await fixture(t);
+  await f.sql`CREATE TABLE schema_migrations (version text PRIMARY KEY)`;
+  const file = "20990101000000_probe.sql";
+  writeFileSync(join(f.migrations, file), "SELECT 1;");
+  const invalid = f.upgrade();
+  assert.notEqual(invalid.status, 0, invalid.output);
+  assert.match(invalid.output, /missing -- migrate:up/);
+  assert.equal(f.commands(), "");
+  writeFileSync(join(f.migrations, file), "-- migrate:up\nSELECT 1;");
+  writeFileSync(
+    join(f.migrations, "preconditions", "unmatched.sql"),
+    "SELECT 1;"
+  );
+  const unmatched = f.upgrade();
+  assert.notEqual(unmatched.status, 0, unmatched.output);
+  assert.match(unmatched.output, /no matching migration/);
+  assert.equal(f.commands(), "");
+});
+
+test("a compatible migration validates and applies without touching replicas", async (t) => {
+  const f = await fixture(t);
+  await f.sql`CREATE TABLE schema_migrations (version text PRIMARY KEY)`;
+  const file = "20990101000000_compatible.sql";
+  writeFileSync(
+    join(f.migrations, file),
+    "-- migrate:up\nSELECT 1;\n-- migrate:down\n-- lobu:no-quiesce\nSELECT 1;"
+  );
+  // A rollback-only compatibility declaration cannot authorize the upgrade.
+  assert.equal(f.check().status, 0);
+  writeFileSync(
+    join(f.migrations, file),
+    "-- migrate:up\n-- lobu:no-quiesce\nCREATE TABLE test_projection (id int);"
+  );
+  writeFileSync(join(f.migrations, "preconditions", file), "SELECT 1;");
+  assert.equal(f.check().status, 4);
+  const result = f.upgrade();
+  assert.equal(result.status, 0, result.output);
+  assert.equal(f.commands(), "");
+  assert.equal((await f.sql`SELECT * FROM test_projection`).length, 0);
+  assert.equal(f.check().status, 3);
+});
+
+test("legacy MCP NULL actors rebuild through the production entrypoint and hook", async (t) => {
+  const f = await fixture(t);
+  // Apply the actual historical schema, then seed the state the empty-DB CI missed.
+  for (const file of readdirSync(join(root, "db/migrations"))) {
+    if (file.endsWith(".sql") && file < actorMigration) {
+      copyFileSync(join(root, "db/migrations", file), join(f.migrations, file));
+    }
+  }
+  copyFileSync(
+    join(root, "db/migrations/preconditions", contractMigration),
+    join(f.migrations, "preconditions", contractMigration)
+  );
+  const previous = f.migrate();
+  assert.equal(previous.status, 0, previous.output);
+  await f.sql.unsafe(`
+    INSERT INTO organization (id, name, slug) VALUES ('synthetic-org', 'Migration test', 'migration-test');
+    INSERT INTO public."user" (id, name, email) VALUES ('synthetic-user', 'Migration test', 'migration@example.test');
+    INSERT INTO oauth_clients (id, redirect_uris) VALUES ('synthetic-client', ARRAY['https://example.test/callback']);
+    INSERT INTO mcp_client_conversations (organization_id, client_identity, conversation_id, last_action)
+      SELECT 'synthetic-org', 'synthetic-client', 'legacy-' || n, 'test_action' FROM generate_series(1, 3) n;
+    INSERT INTO events (organization_id, client_id, created_by, semantic_type, origin_type, metadata, payload_data, occurred_at)
+      VALUES ('synthetic-org', 'synthetic-client', 'synthetic-user', 'audit', 'tool_invocation',
+        '{"mcp_conversation_id":"known-actor"}', '{"tool_name":"test_action","success":true}', now());
+  `);
+  const eventsBefore = await f.sql`SELECT * FROM events ORDER BY id`;
+  copyFileSync(
+    join(root, "db/migrations", actorMigration),
+    join(f.migrations, actorMigration)
+  );
+  assert.equal(f.check().status, 0);
+  assert.equal(
+    (await f.sql`SELECT * FROM mcp_client_conversations WHERE user_id IS NULL`)
+      .length,
+    3
+  );
+  const upgraded = f.upgrade();
+  assert.equal(upgraded.status, 0, upgraded.output);
+  assert.match(f.commands(), /scale deployment test-api --replicas=0/);
+  assert.deepEqual(
+    Array.from(
+      await f.sql`SELECT user_id, conversation_id FROM mcp_client_conversations`
+    ),
+    [{ user_id: "synthetic-user", conversation_id: "known-actor" }]
+  );
+  assert.deepEqual(await f.sql`SELECT * FROM events ORDER BY id`, eventsBefore);
+  assert.equal(f.check().status, 3);
+  const replay = f.migrate();
+  assert.equal(replay.status, 0, replay.output);
+  assert.deepEqual(await f.sql`SELECT * FROM events ORDER BY id`, eventsBefore);
+});

--- a/scripts/migrate-up.mjs
+++ b/scripts/migrate-up.mjs
@@ -12,18 +12,19 @@
  *   MIGRATIONS_DIR=/app/db/migrations node scripts/migrate-up.mjs
  *   DATABASE_URL=... node scripts/migrate-up.mjs --check-pending
  *
- * --check-pending applies nothing. It reports whether any migration file is
- * missing from the ledger and encodes the answer in the exit status, so the
- * chart's pre-upgrade hook can skip its scale-to-zero quiesce on the common
- * deploy that ships no schema change:
+ * --check-pending applies nothing. It validates declared prerequisites
+ * (db/migrations/preconditions/, see docs/MIGRATIONS.md) and reports whether
+ * any migration file is missing from the ledger, encoding the answer in the
+ * exit status so the chart's pre-upgrade hook can skip its scale-to-zero
+ * quiesce on the common deploy that ships no schema change:
  *   0 - at least one migration is pending (the caller must quiesce)
  *   3 - the ledger is complete, nothing is pending (safe to skip the quiesce)
  *   4 - migrations are pending, but every one of them carries the author's
  *       `-- lobu:no-quiesce` declaration, so the old replicas can keep
  *       serving across the migration
- *   1 - the answer could not be determined (the caller must quiesce)
- * Only the definitive 3 and 4 unlock the fast path; every other status,
- * including a crash, leaves the caller quiescing.
+ *   1 - validation failed or the answer is unknown (abort before quiescing)
+ * Only 0 permits quiescing; 3 and 4 allow migration without stopping replicas.
+ * Any other status, including a crash, must abort the deployment.
  */
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -45,15 +46,6 @@ const CHECK_PENDING_COMPATIBLE_EXIT = 4;
  * only the author can make the call.
  */
 const NO_QUIESCE_MARKER = /^--[ \t]*lobu:no-quiesce\b/m;
-
-/** Unreadable counts as unmarked, so anything unexpected still quiesces. */
-function isMarkedNoQuiesce(dir, file) {
-  try {
-    return NO_QUIESCE_MARKER.test(readFileSync(join(dir, file), "utf-8"));
-  } catch {
-    return false;
-  }
-}
 
 const checkPendingOnly = process.argv.slice(2).includes("--check-pending");
 const migrationsDir =
@@ -91,13 +83,59 @@ function parseTransactionOption(markerLine) {
 function loadMigrationUp(dir, file) {
   const content = readFileSync(join(dir, file), "utf-8");
   const upMarker = content.match(/^--\s*migrate:up(.*)$/m);
-  const transaction = parseTransactionOption(upMarker?.[0] ?? "-- migrate:up");
-  const sql = content
-    .split(/^--\s*migrate:down.*$/m)[0]
+  if (!upMarker) throw new Error(`${file}: missing -- migrate:up directive`);
+  const transaction = parseTransactionOption(upMarker[0]);
+  const up = content.split(/^--\s*migrate:down.*$/m)[0];
+  const sql = up
     .replace(/^--\s*migrate:up.*$/m, "")
     .replace(/^SET transaction_timeout = 0;\s*$/gm, "")
     .trim();
-  return { sql, transaction };
+  return { sql, transaction, noQuiesce: NO_QUIESCE_MARKER.test(up) };
+}
+
+function loadPendingMigrations(applied) {
+  const dir = join(migrationsDir, "preconditions");
+  let checks = [];
+  try {
+    checks = readdirSync(dir);
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+  for (const file of checks) {
+    if (!migrationFiles.includes(file)) {
+      throw new Error(`Precondition ${file} has no matching migration`);
+    }
+  }
+  return migrationFiles
+    .filter((file) => !applied.has(file.split("_")[0]))
+    .map((file) => ({
+      file,
+      ...loadMigrationUp(migrationsDir, file),
+      precondition: checks.includes(file)
+        ? readFileSync(join(dir, file), "utf8")
+        : "",
+    }));
+}
+
+async function validatePreconditions(sqlClient, pending) {
+  const checks = pending.filter((migration) => migration.precondition);
+  if (checks.length === 0) return;
+  // Author-written assertions describe external prerequisites, not effects of
+  // the migration itself. Postgres enforces read-only access before quiescence.
+  await sqlClient.begin("read only", async (tx) => {
+    await tx.unsafe("SET LOCAL statement_timeout = '10s'");
+    for (const migration of checks) {
+      try {
+        await tx.unsafe(migration.precondition);
+        console.log(`Precondition passed: ${migration.file}`);
+      } catch (error) {
+        throw new Error(
+          `Precondition failed: ${migration.file}: ${error.message}`,
+          { cause: error }
+        );
+      }
+    }
+  });
 }
 
 /** Dollar-quote / string-literal aware statement splitter (see migration-loader.ts). */
@@ -229,9 +267,8 @@ if (checkPendingOnly) {
       `SELECT version FROM public.schema_migrations`
     );
     const applied = new Set(appliedRows.map((r) => r.version));
-    pending = migrationFiles.filter(
-      (file) => !applied.has(file.split("_")[0] ?? "")
-    );
+    pending = loadPendingMigrations(applied);
+    await validatePreconditions(sql, pending);
   } catch (error) {
     console.error(
       `ERROR: could not determine pending migrations: ${
@@ -246,20 +283,20 @@ if (checkPendingOnly) {
     console.log("No pending migrations");
     process.exit(CHECK_PENDING_NONE_EXIT);
   }
-  console.log(`Pending migrations (${pending.length}): ${pending.join(", ")}`);
+  console.log(
+    `Pending migrations (${pending.length}): ${pending.map((migration) => migration.file).join(", ")}`
+  );
 
   // Quiescing costs a full scale-to-zero, which the ingress answers with 503.
   // A migration the running code can already serve against does not need it.
-  const unmarked = pending.filter(
-    (file) => !isMarkedNoQuiesce(migrationsDir, file)
-  );
+  const unmarked = pending.filter((migration) => !migration.noQuiesce);
   if (unmarked.length === 0) {
     console.log(
       "Every pending migration is marked -- lobu:no-quiesce; the quiesce can be skipped."
     );
     process.exit(CHECK_PENDING_COMPATIBLE_EXIT);
   }
-  for (const file of unmarked) {
+  for (const { file } of unmarked) {
     console.log(`  ${file}: not marked -- lobu:no-quiesce`);
   }
   process.exit(0);
@@ -281,11 +318,12 @@ try {
     `SELECT version FROM public.schema_migrations`
   );
   const applied = new Set(appliedRows.map((r) => r.version));
+  const pending = loadPendingMigrations(applied);
+  await validatePreconditions(sql, pending);
 
-  for (const file of migrationFiles) {
+  for (const up of pending) {
+    const { file } = up;
     const version = file.split("_")[0] ?? "";
-    if (applied.has(version)) continue;
-    const up = loadMigrationUp(migrationsDir, file);
     if (!up.sql) continue;
 
     console.log(`Applying: ${file}`);


### PR DESCRIPTION
## Summary

The upgrade hook could stop healthy API and worker replicas before discovering a migration prerequisite failure. In #3417, the startup regex rejected three legacy NULL actors even though the migration rebuilds that projection before adding its NOT NULL constraint.

Remove the inferred NOT NULL preflight. The migration runner now evaluates explicit SQL prerequisites in read-only transactions before the hook can scale replicas, and rechecks them under the migration lock before applying anything. The existing classifier contract keeps its external-backfill prerequisite in an owning SQL sidecar. Missing or failed pending checks abort deployment; successful no-pending and compatible-migration checks retain their existing fast paths.

## Test plan

- [x] Intended files staged explicitly and `make pre-pr` passed (canonical full graph runs on GitHub CI; optional `make pr-full` not run).
- [x] Real PostgreSQL 18: `node --test scripts/__tests__/migration-entrypoint.node-test.mjs` with an explicit test service URL; 7 passed. Each test creates and drops its own database.
- [x] `bun test scripts --timeout 30000`: 374 passed, 0 failed, including the runner guard tests.
- [x] `make review-fix` completed; its edits were inspected and the affected tests rerun.
- [x] GitHub CI passed for `603949bceb5f1138d544ca7310a25a4f406bd52f`, including migrations and integration; Helm CI and `ui-review` passed.
- [x] Final `make review` passed with the independent Codex reviewer: 88/100 bug-free confidence, zero bugs, zero blockers. All 10 required checks passed before `make land` merged the PR; no review waiver was used.
- [x] `sh charts/lobu/tests/migrate-upgrade-recovery.sh`, Helm lint, and upgrade rendering passed.
- [x] Bug fix: red and green outputs below.

Red, original hook with the failure regression:
```text
pending-migration check failed with status 1; quiescing
all old database clients are quiesced; running migration
failed pending check (1) unexpectedly proceeded with deployment
```

Red, the original startup precheck JavaScript extracted from origin/main and executed against the historical-schema fixture:
```text
ERROR: refusing to run migrations — a pending NOT NULL constraint has unbacked NULLs:
  - 20260907183000_mcp_activity_actor_identity.sql: mcp_client_conversations.user_id SET NOT NULL, but 3 row(s) are NULL
1 !== 0
```

Green, the actual startup script and upgrade hook against PostgreSQL (kubectl is a command recorder):
```text
✔ external backfill fails before scaling or migration; passes after backfill
✔ read-only preconditions reject attempted writes without scaling
✔ a broken precondition still blocks a no-quiesce migration
✔ unreadable migration files abort before scaling
✔ missing directives and unmatched prerequisites abort before scaling
✔ a compatible migration validates and applies without touching replicas
✔ legacy MCP NULL actors rebuild through the production entrypoint and hook
ℹ tests 7
ℹ pass 7
ℹ fail 0
migration upgrade failure recovery passed
```

The legacy test applies the real migration history before the actor cutover, seeds three NULL-actor projection rows and an attributable audit event, then verifies the rebuilt activity, migration ledger, replay, and unchanged audit events.

## Notes

Diff: 10 files, +444/−178. Runtime/chart files: −53 net lines; tests: +300; CI/docs: +19. Deletes the 107-line inferred-prerequisite scanner and the separate unreadable-as-unmarked helper. Adds one SQL prerequisite sidecar and one Node integration test file.

No public API, table, column, or historical migration changes. The chart version advances to 19.2.1 so the hook change can be reconciled. Retry policy, restored-readiness verification, and the emergency-hold runbook are the next recovery PR. Production rollout has not been exercised; this PR does not remove the emergency deployment hold.
