### PR TITLE
fix(test): verify Slack API smoke replies

### DIFF
--- a/config/slack-app-manifest.qa-user.json
+++ b/config/slack-app-manifest.qa-user.json
@@ -3,11 +3,17 @@
     "name": "Lobu QA User",
     "description": "QA-only Slack app that sends test messages as a real user",
     "background_color": "#2c3e50",
-    "long_description": "This app exists solely to mint a user OAuth token (xoxp-) for automated QA of Lobu agents. It is installed to a workspace by the developer, who then copies the User OAuth Token into QA_SLACK_USER_TOKEN. The test-bot.sh script uses that token to call chat.postMessage as the installing user, so the target Lobu bot sees a genuine Slack event instead of a gateway-forged message. This app has no bot user, no event subscriptions, and no slash commands — it is intentionally minimal."
+    "long_description": "This app exists solely to mint a user OAuth token (xoxp-) for automated QA of Lobu agents. It is installed to a workspace by the developer, who then copies the User OAuth Token into QA_SLACK_USER_TOKEN. The test-bot.sh script uses that token to post as the installing user and read the target bot's thread reply, so the smoke test exercises a genuine Slack event instead of a gateway-forged message. This app has no bot user, no event subscriptions, and no slash commands — it is intentionally minimal."
   },
   "oauth_config": {
     "scopes": {
-      "user": ["chat:write"]
+      "user": [
+        "channels:history",
+        "chat:write",
+        "groups:history",
+        "im:history",
+        "mpim:history"
+      ]
     }
   },
   "settings": {

--- a/scripts/__tests__/test-bot-slack.test.ts
+++ b/scripts/__tests__/test-bot-slack.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const script = resolve(import.meta.dir, "../test-bot.sh");
+const marker = "SLACK_SMOKE_SYNTHETIC_OK";
+
+describe("Slack API smoke", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "slack-smoke-"));
+    mkdirSync(join(dir, "bin"));
+    writeFileSync(join(dir, "bin/lobu"), "#!/bin/sh\nexit 1\n", {
+      mode: 0o755,
+    });
+    writeFileSync(
+      join(dir, "bin/curl"),
+      `#!${process.execPath}
+import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+const url = args.find(arg => arg.startsWith("http")) || "";
+const method = url.split("/").pop();
+appendFileSync(process.env.CALL_LOG, method + "\\n");
+if (!url.startsWith("https://slack.com/api/")) process.exit(22);
+let result;
+if (method === "auth.test") {
+  result = { ok: true, user_id: args.some(arg => arg.includes("target-token")) ? "U_TARGET" : "U_QA" };
+} else if (method === "chat.postMessage") {
+  result = { ok: true, channel: "C_TEST", ts: "1000.000001" };
+} else if (method === "conversations.replies") {
+  const data = args[args.indexOf("-d") + 1] || "";
+  if (!data.includes("oldest=1000.000001")) process.exit(23);
+  result = JSON.parse(process.env.SLACK_REPLIES);
+} else {
+  result = { ok: false, error: "unexpected_method" };
+}
+console.log(JSON.stringify(result));
+`,
+      { mode: 0o755 }
+    );
+  });
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function run(replies: unknown, overrides: Record<string, string> = {}) {
+    const result = Bun.spawnSync(
+      ["bash", script, `<@U_TARGET> Reply exactly ${marker}`],
+      {
+        cwd: dir,
+        env: {
+          PATH: `${join(dir, "bin")}:${process.env.PATH}`,
+          HOME: process.env.HOME,
+          TEST_PLATFORM: "slack",
+          TEST_CHANNEL: "C_TEST",
+          TEST_TIMEOUT: "2",
+          TEST_AUTH_TOKEN: "synthetic-lobu-token",
+          QA_SLACK_USER_TOKEN: "qa-token",
+          QA_SLACK_TARGET_USER_ID: "U_TARGET",
+          TEST_EXPECT_RESPONSE: marker,
+          CALL_LOG: join(dir, "calls"),
+          SLACK_REPLIES: JSON.stringify(replies),
+          ...overrides,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      }
+    );
+    return {
+      code: result.exitCode,
+      output: result.stdout.toString() + result.stderr.toString(),
+      calls: existsSync(join(dir, "calls"))
+        ? readFileSync(join(dir, "calls"), "utf8").trim().split("\n")
+        : [],
+    };
+  }
+
+  const reply = (user: string, text: string) => ({
+    user,
+    bot_id: "B_SYNTHETIC",
+    ts: "1000.000002",
+    text,
+  });
+
+  it("uses only Slack APIs and needs no Lobu login", () => {
+    const result = run(
+      { ok: true, messages: [reply("U_TARGET", marker)] },
+      {
+        TEST_AUTH_TOKEN: "",
+        QA_SLACK_USER_TOKEN: "",
+        QA_SLACK_BOT_TOKEN: "qa-token",
+        SLACK_BOT_TOKEN: "target-token",
+        QA_SLACK_TARGET_USER_ID: "",
+      }
+    );
+    expect(result.code).toBe(0);
+    expect(result.output).toContain(marker);
+    expect(result.calls).toEqual([
+      "auth.test",
+      "auth.test",
+      "chat.postMessage",
+      "conversations.replies",
+    ]);
+  });
+
+  it("selects the target bot's reply rather than another app's reply", () => {
+    const result = run({
+      ok: true,
+      messages: [
+        reply("U_OTHER", "Unrelated bot response"),
+        reply("U_TARGET", marker),
+      ],
+    });
+    expect(result.code).toBe(0);
+    expect(result.output).toContain(`Matched expected response: ${marker}`);
+  });
+
+  it("accepts the expected reply even when the target bot posts again", () => {
+    const result = run({
+      ok: true,
+      messages: [
+        reply("U_TARGET", marker),
+        reply("U_TARGET", "Later status update"),
+      ],
+    });
+    expect(result.code).toBe(0);
+    expect(result.output).toContain(`Matched expected response: ${marker}`);
+  });
+
+  it("fails when Lobu replies with an authentication error", () => {
+    const result = run({
+      ok: true,
+      messages: [reply("U_TARGET", "Provider is not connected")],
+    });
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("Provider is not connected");
+    expect(result.output).not.toContain("All messages sent successfully");
+  });
+
+  it("does not accept the expected text from a different bot", () => {
+    const result = run({ ok: true, messages: [reply("U_OTHER", marker)] });
+    expect(result.code).toBe(1);
+  });
+
+  it("reports a Slack read error instead of treating it as no reply", () => {
+    const result = run({ ok: false, error: "missing_scope" });
+    expect(result.code).toBe(1);
+    expect(result.output).toContain(
+      "conversations.replies failed: missing_scope"
+    );
+  });
+
+  it("rejects a sender that is also the target before posting", () => {
+    const result = run(
+      { ok: true, messages: [] },
+      { QA_SLACK_TARGET_USER_ID: "U_QA" }
+    );
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("same Slack user");
+    expect(result.calls).not.toContain("chat.postMessage");
+  });
+
+  it("never falls back to a forged gateway message for an exact-response smoke", () => {
+    const result = run({ ok: true, messages: [] }, { QA_SLACK_USER_TOKEN: "" });
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("requires Slack with a QA sender token");
+    expect(result.calls).toEqual([]);
+  });
+
+  it("does not let a QA token override normal platform auto-detection", () => {
+    const result = run(
+      { ok: true, messages: [] },
+      { TEST_PLATFORM: "", TEST_EXPECT_RESPONSE: "" }
+    );
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("No platform detected");
+    expect(result.calls).toEqual(["test-targets", "test-targets"]);
+  });
+});

--- a/scripts/test-bot.sh
+++ b/scripts/test-bot.sh
@@ -9,15 +9,23 @@ set -euo pipefail
 #   TEST_PLATFORM   - "slack", "whatsapp", or "telegram" (default: auto-detect)
 #   TEST_CHANNEL    - Channel ID (Slack), phone number (WhatsApp), or peer/chat ID (Telegram)
 #   TEST_TIMEOUT    - Timeout in seconds (default: 120)
+#   TEST_EXPECT_RESPONSE - Exact Slack reply required for a successful smoke test
 #
 # Platform-specific:
 #   Slack: QA_SLACK_CHANNEL, QA_SLACK_USER_TOKEN (xoxp-) to send as real user,
 #          or QA_SLACK_BOT_TOKEN (xoxb- from a *separate* QA-only Slack app) to
-#          send as a distinct bot — the target bot's isMessageFromSelf filter
-#          only skips its own bot_id, so a different app's bot posts through.
-#          Optional SLACK_BOT_TOKEN for reply polling when QA tokens absent.
+#          send an explicit target mention as a distinct bot. The sender or
+#          SLACK_BOT_TOKEN needs the relevant history scope for reply polling.
+#          QA_SLACK_TARGET_USER_ID identifies the bot whose reply must match;
+#          alternatively, SLACK_BOT_TOKEN resolves the target via auth.test.
+#          When present, SLACK_BOT_TOKEN is also used for reply polling.
 #   WhatsApp: WHATSAPP_SELF_PHONE (defaults to bot's own number for self-chat)
 #   Telegram: TELEGRAM_TEST_CHAT_ID, TG_API_ID, TG_API_HASH (uses tguser to send as real user)
+#
+# Slack smoke example (tokens already exported):
+#   marker="LOBU_SMOKE_$(date +%s)"
+#   TEST_PLATFORM=slack TEST_EXPECT_RESPONSE="$marker" ./scripts/test-bot.sh \
+#     "<@$QA_SLACK_TARGET_USER_ID> Reply exactly $marker. Do not use tools."
 
 GATEWAY_URL="${GATEWAY_URL:-http://localhost:8787/lobu}"
 
@@ -134,6 +142,15 @@ if [ -f .env ]; then
     done < .env
 fi
 
+QA_SEND_TOKEN="${QA_SLACK_USER_TOKEN:-${QA_SLACK_BOT_TOKEN:-}}"
+if [ -z "${TEST_PLATFORM:-}" ] && [ -n "${TEST_EXPECT_RESPONSE:-}" ] && [ -n "$QA_SEND_TOKEN" ]; then
+    TEST_PLATFORM=slack
+fi
+if [ -n "${TEST_EXPECT_RESPONSE:-}" ] && { [ "${TEST_PLATFORM:-}" != "slack" ] || [ -z "$QA_SEND_TOKEN" ]; }; then
+    echo "❌ TEST_EXPECT_RESPONSE requires Slack with a QA sender token"
+    exit 1
+fi
+
 resolve_auth_token() {
     if [ -n "${TEST_AUTH_TOKEN:-}" ]; then
         printf '%s\n' "$TEST_AUTH_TOKEN"
@@ -248,9 +265,12 @@ PY
 # Fetch gateway's active test targets once; used for both platform auto-detect
 # and agent-id fallback so explicit TEST_PLATFORM runs still resolve the owning
 # agent (otherwise the default `test-<platform>` placeholder has no provider).
-TEST_TARGETS=$(curl -sf "$GATEWAY_URL/internal/connections/test-targets" 2>/dev/null || \
-    curl -sf "$GATEWAY_URL/api/internal/connections/test-targets" 2>/dev/null || \
-    echo "")
+TEST_TARGETS=""
+if [ "${TEST_PLATFORM:-}" != "slack" ] || [ -z "$QA_SEND_TOKEN" ]; then
+    TEST_TARGETS=$(curl -sf "$GATEWAY_URL/internal/connections/test-targets" 2>/dev/null || \
+        curl -sf "$GATEWAY_URL/api/internal/connections/test-targets" 2>/dev/null || \
+        echo "")
+fi
 
 if [ -n "$TEST_TARGETS" ] && [ -z "${TEST_AGENT_ID:-}" ]; then
     if [ -n "${TEST_PLATFORM:-}" ]; then
@@ -298,11 +318,40 @@ TIMEOUT="${TEST_TIMEOUT:-120}"
 # Platform-specific setup
 case "$TEST_PLATFORM" in
     slack)
-        AUTH_TOKEN="$(resolve_auth_token)"
+        AUTH_TOKEN=""
+        if [ -z "$QA_SEND_TOKEN" ]; then
+            AUTH_TOKEN="$(resolve_auth_token)"
+        fi
         CHANNEL="${TEST_CHANNEL:-${QA_SLACK_CHANNEL:-}}"
         if [ -z "$CHANNEL" ]; then
             echo "❌ QA_SLACK_CHANNEL or TEST_CHANNEL environment variable is required for Slack"
             exit 1
+        fi
+        if [ -n "$QA_SEND_TOKEN" ]; then
+            TARGET_BOT_USER_ID="${QA_SLACK_TARGET_USER_ID:-}"
+            if [ -z "$TARGET_BOT_USER_ID" ] && [ -n "${SLACK_BOT_TOKEN:-}" ]; then
+                TARGET_AUTH=$(curl -fsS --max-time 30 https://slack.com/api/auth.test \
+                    -H "Authorization: Bearer $SLACK_BOT_TOKEN")
+                if ! printf '%s' "$TARGET_AUTH" | jq -e '.ok == true' >/dev/null; then
+                    echo "❌ Target auth.test failed: $(printf '%s' "$TARGET_AUTH" | jq -r '.error')"
+                    exit 1
+                fi
+                TARGET_BOT_USER_ID=$(printf '%s' "$TARGET_AUTH" | jq -r '.user_id // empty')
+            fi
+            if [ -z "$TARGET_BOT_USER_ID" ]; then
+                echo "❌ Set QA_SLACK_TARGET_USER_ID or SLACK_BOT_TOKEN to identify the target bot"
+                exit 1
+            fi
+            SENDER_AUTH=$(curl -fsS --max-time 30 https://slack.com/api/auth.test \
+                -H "Authorization: Bearer $QA_SEND_TOKEN")
+            if ! printf '%s' "$SENDER_AUTH" | jq -e '.ok == true and (.user_id | type == "string")' >/dev/null; then
+                echo "❌ Sender auth.test failed: $(printf '%s' "$SENDER_AUTH" | jq -r '.error')"
+                exit 1
+            fi
+            if [ "$(printf '%s' "$SENDER_AUTH" | jq -r '.user_id')" = "$TARGET_BOT_USER_ID" ]; then
+                echo "❌ QA sender and target are the same Slack user; use a separate sender"
+                exit 1
+            fi
         fi
         ;;
     whatsapp)
@@ -350,7 +399,7 @@ case "$TEST_PLATFORM" in
         ;;
 esac
 
-if [ -z "$AUTH_TOKEN" ]; then
+if [ -z "$AUTH_TOKEN" ] && { [ "$TEST_PLATFORM" != "slack" ] || [ -z "$QA_SEND_TOKEN" ]; }; then
     echo "❌ Authentication token required. Set TEST_AUTH_TOKEN/LOBU_API_TOKEN or run \`lobu login\`."
     exit 1
 fi
@@ -409,10 +458,8 @@ for i in "${!MESSAGES[@]}"; do
     # Slack QA-sender path: post via chat.postMessage so the target bot sees a
     # genuine Slack event instead of a gateway-forged enqueue.
     #   - QA_SLACK_USER_TOKEN (xoxp-): posts as a real user.
-    #   - QA_SLACK_BOT_TOKEN  (xoxb-): posts as a *separate* QA bot. The target
-    #     bot's isMessageFromSelf only matches its own bot_id, so cross-app
-    #     bot posts are delivered normally.
-    QA_SEND_TOKEN="${QA_SLACK_USER_TOKEN:-${QA_SLACK_BOT_TOKEN:-}}"
+    #   - QA_SLACK_BOT_TOKEN  (xoxb-): posts an explicit target mention as a
+    #     separate QA bot.
     if [ "$TEST_PLATFORM" = "slack" ] && [ -z "$QA_SEND_TOKEN" ]; then
         echo "   ⚠️  No QA Slack token set — using gateway-forged send."
         echo "       The message is queued directly to the worker; nothing"
@@ -431,7 +478,7 @@ for i in "${!MESSAGES[@]}"; do
         if [ -n "$LAST_THREAD_ID" ]; then
             POST_BODY="$POST_BODY&thread_ts=$LAST_THREAD_ID"
         fi
-        POST_RESP=$(curl -s -X POST https://slack.com/api/chat.postMessage \
+        POST_RESP=$(curl -fsS --max-time 30 -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $QA_SEND_TOKEN" \
             -H "Content-Type: application/x-www-form-urlencoded" \
             -d "$POST_BODY")
@@ -449,22 +496,41 @@ for i in "${!MESSAGES[@]}"; do
         POLL_TOKEN="${SLACK_BOT_TOKEN:-$QA_SEND_TOKEN}"
         echo "   ⏳ Waiting for bot response..."
         START_TIME=$(date +%s)
+        BOT_RESPONSE=""
         while true; do
             CURRENT_TIME=$(date +%s)
             ELAPSED=$((CURRENT_TIME - START_TIME))
             if [ $ELAPSED -ge $TIMEOUT ]; then
-                echo "   ❌ Timeout: No bot response within ${TIMEOUT}s"
+                echo "   ❌ Timeout: No matching reply from $TARGET_BOT_USER_ID within ${TIMEOUT}s"
+                if [ -n "$BOT_RESPONSE" ]; then
+                    printf '      Last reply: %s\n' "$BOT_RESPONSE"
+                fi
                 exit 1
             fi
-            REPLIES=$(curl -s -X POST https://slack.com/api/conversations.replies \
+            REPLIES=$(curl -fsS --max-time 30 -X POST https://slack.com/api/conversations.replies \
                 -H "Authorization: Bearer $POLL_TOKEN" \
                 -H "Content-Type: application/x-www-form-urlencoded" \
-                -d "channel=$CHANNEL&ts=$LAST_THREAD_ID&limit=20")
-            BOT_RESPONSE=$(echo "$REPLIES" | jq -r '.messages[]? | select(.bot_id != null) | select(.ts > "'"$MESSAGE_ID"'") | .text' | head -1)
+                -d "channel=$CHANNEL&ts=$LAST_THREAD_ID&oldest=$MESSAGE_ID&limit=20")
+            if ! printf '%s' "$REPLIES" | jq -e '.ok == true' >/dev/null; then
+                echo "   ❌ Slack conversations.replies failed: $(printf '%s' "$REPLIES" | jq -r '.error')"
+                exit 1
+            fi
+            BOT_RESPONSE=$(printf '%s' "$REPLIES" | jq -r \
+                --arg user "$TARGET_BOT_USER_ID" --arg expected "${TEST_EXPECT_RESPONSE:-}" \
+                '([.messages[]? | select(.user == $user and .text != null) | .text]) as $responses
+                | if $expected != "" and any($responses[]; . == $expected)
+                  then $expected
+                  else ($responses | last // empty)
+                  end')
             if [ -n "$BOT_RESPONSE" ]; then
-                echo "   ✅ Bot responded:"
-                echo "      $(echo "$BOT_RESPONSE" | head -c 200)..."
-                break
+                if [ -z "${TEST_EXPECT_RESPONSE:-}" ] || [ "$BOT_RESPONSE" = "$TEST_EXPECT_RESPONSE" ]; then
+                    if [ -n "${TEST_EXPECT_RESPONSE:-}" ]; then
+                        printf '   ✅ Matched expected response: %s\n' "$BOT_RESPONSE"
+                    else
+                        printf '   ✅ Target bot responded: %s\n' "$BOT_RESPONSE"
+                    fi
+                    break
+                fi
             fi
             sleep 2
         done


### PR DESCRIPTION
## Summary

The Slack QA sender could report success for another app's reply or for Lobu's provider-connection error. It also required a Lobu login even when sending directly through Slack's API.

Add an exact-response smoke check to the existing runner. Resolve the target bot explicitly or through its token, reject self-sends, read only replies after the sent message, and surface Slack API failures. QA sends use Slack authentication directly. The QA user-app manifest includes the history scopes needed to read replies.

## Test plan

- [x] Reproduced the false-pass and unnecessary-login failures before changing the runner: 0 passed, 6 failed.
- [x] Focused shell-process regression suite: 9 passed, 0 failed. Covers QA user/bot sends, exact response and author matching, later status updates, authentication-error replies, Slack read failures, self-sends, and preserving normal platform detection.
- [x] Shell syntax and focused Biome checks pass.
- [x] `make review-fix` completed with the configured Codex reviewer after Claude reached its session limit. Its edits were inspected.
- [x] Final `make pre-pr` and commit hooks pass.
- [x] [GitHub CI](https://github.com/lobu-ai/lobu/actions/runs/34156552564) passed for `75daaffe9aa3641bfd2dfc0ef00a5b97888f2a8d`. All 10 required checks pass.
- [x] `make review`: correctness 88, simplicity 88, zero bugs or blockers. `make ui-review`: not applicable.
- [ ] Successful live Slack-to-Lobu reply and model trace.

Before:
```text
0 pass
6 fail
Expected exit code 1 for a provider error; received 0.
Another app's response was accepted as the bot response.
```

After:
```text
9 pass
0 fail
```

Live authentication checks:
```text
QA_SLACK_BOT_TOKEN: invalid_auth
SLACK_BOT_TOKEN: account_inactive
Runner: Target auth.test failed: account_inactive
```

The local tokens were rejected before any message was posted. Successful live verification needs an active QA sender token and a token with access to the test thread. A bot sender tests bot-message routing; testing personal ChatGPT credentials requires a linked human sender.

## Notes

Three files, +281/−22: runner +86/−20, QA manifest +8/−2, and one new regression file +187. No runtime, database, public API, or tenant configuration changes. Removed the unconditional Lobu-login requirement from the Slack QA path and acceptance of arbitrary bot replies.

The manifest change does not update an installed Slack app. A developer must reauthorize the QA user app to obtain the added history scopes. The existing Slack-to-Lobu user-identity resolution bug is outside this tooling change. Model selection must still be verified from the resulting gateway/worker trace; matching the Slack text alone does not prove which model ran.
