### PR TITLE
fix(deploy): promote images only after candidate smoke passes

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -49,6 +49,9 @@ env:
   IMAGE_NAME_APP: lobu-ai/lobu-app
   IMAGE_NAME_WORKER: lobu-ai/lobu-worker
   IMAGE_NAME_EMBEDDINGS: lobu-ai/lobu-embeddings
+  # Excluded by Flux's timestamp-only ImagePolicy. Only promote-images may
+  # publish deployment, semver, or latest tags after the candidate passes.
+  CANDIDATE_TAG: candidate-${{ github.run_id }}-${{ github.run_attempt }}
   # Prod runs Hetzner cpx41 (x86_64 only — see project_hetzner_prod_cost
   # memory), so main-branch pushes build amd64 only. This dropped the
   # build-app step from ~25min to ~8min AND fixed the disk-full failure
@@ -134,13 +137,14 @@ jobs:
         run: node scripts/derive-image-tags.mjs
 
   # Connector-runtime parity smoke gate (main/deploy side). RUNS the built worker
-  # artifact's self-check before any image is pushed, so the packaging/parity
-  # drift that broke prod (worker image missing `COPY packages/core` → dangling
-  # transitive `@lobu/core` → every feed sync crashed, all CI green) can't ship.
-  # `build-worker` depends on this, and `build-app` depends on `build-worker`, so
-  # a failing smoke blocks BOTH worker and app pushes — critical because the chart
-  # applies one shared tag to app + worker and Flux's ImageUpdateAutomation would
-  # otherwise roll the app to a tag whose worker is broken.
+  # artifact's self-check before any deployable tag is published, so the
+  # packaging/parity drift that broke prod (worker image missing `COPY
+  # packages/core` → dangling transitive `@lobu/core` → every feed sync
+  # crashed, all CI green) can't ship.
+  # `build-worker` depends on this, and `build-app` depends on `build-worker`.
+  # Promotion waits for all three candidate builds and the app-image smoke
+  # before publishing the shared tag Flux deploys to app, worker, and
+  # embeddings.
   #
   # amd64-only (no QEMU/arm64): a smoke gate, not a release. Reuses the same GHA
   # buildx cache scope as `build-worker` so this doesn't double the build cost.
@@ -190,19 +194,9 @@ jobs:
   build-app:
     runs-on: ubuntu-24.04
     if: needs.generate-tag.outputs.should_publish == 'true'
-    # Push the app image LAST. Flux's ImageUpdateAutomation only watches
-    # the app image policy, but the chart applies one shared tag to app,
-    # worker, AND embeddings. If app pushed before worker or embeddings,
-    # Flux would roll the release to a tag whose sibling images don't yet
-    # exist (or never will, if a sibling build failed for an unrelated
-    # reason — disk pressure, registry hiccup, an unrelated Dockerfile
-    # regression). Earlier in this PR I tried parallelizing build-app for
-    # a ~7min critical-path win, but pi flagged the real (low-probability
-    # but not zero) failure window: a failed sibling build still lets
-    # build-app push the watched tag, and Flux rolls a half-existent
-    # tag. Reverted to the safe gate. The arm64-drop alone still cuts
-    # ~15-20min off the critical path, which is the bigger lever anyway.
     needs: [generate-tag, build-worker, build-embeddings-service]
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     permissions:
       contents: read
       packages: write
@@ -235,11 +229,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_APP }}
           tags: |
-            type=raw,value=${{ needs.generate-tag.outputs.tag }}
-            type=raw,value=${{ needs.generate-tag.outputs.semver }},enable=${{ needs.generate-tag.outputs.semver != '' }}
-            type=raw,value=latest,enable=${{ needs.generate-tag.outputs.is_stable == 'true' }}
+            type=raw,value=${{ env.CANDIDATE_TAG }}
 
-      - name: Build and push App image
+      - name: Build and push App candidate
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -267,19 +260,8 @@ jobs:
             https://api.github.com/user/packages/container/lobu-app/visibility \
             -d '{"visibility":"public"}' || true
 
-  # App-image smoke. Deliberately runs AFTER build-app has pushed, not before.
-  #
-  # `connector-parity-smoke` gates the push because a broken worker must never
-  # reach the registry. This one is the opposite shape on purpose: it needs the
-  # pushed tag to exist so it can smoke the EXACT artifact Flux will roll out,
-  # rather than a rebuild that could differ. So it cannot block the rollout —
-  # but it does fail the workflow, which reddens main and is what stops a
-  # release being cut on a broken image.
-  #
-  # Nothing else runs the app image. build-images only builds it, and CI's
-  # suites run from source. That gap shipped #2231 (no `lobu` on PATH in the
-  # image) and #2183 (app image serving 404s for its own assets) — both with
-  # every check green.
+  # Smoke the immutable candidate before any deployable app tag exists.
+  # Promotion re-tags this same digest; it never rebuilds the tested image.
   app-image-smoke:
     runs-on: ubuntu-24.04
     needs: [generate-tag, build-app]
@@ -316,11 +298,39 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Smoke the pushed app image
+      - name: Smoke the candidate app digest
         run: |
           chmod +x scripts/app-image-smoke.sh
           scripts/app-image-smoke.sh \
-            "${REGISTRY}/${IMAGE_NAME_APP}:${{ needs.generate-tag.outputs.tag }}"
+            "${REGISTRY}/${IMAGE_NAME_APP}@${{ needs.build-app.outputs.digest }}"
+
+  promote-images:
+    runs-on: ubuntu-24.04
+    needs: [generate-tag, build-app, build-worker, build-embeddings-service, app-image-smoke]
+    if: needs.generate-tag.outputs.should_publish == 'true'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish tested digests, app last for Flux
+        env:
+          APP_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_APP }}@${{ needs.build-app.outputs.digest }}
+          WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_WORKER }}@${{ needs.build-worker.outputs.digest }}
+          EMBEDDINGS_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_EMBEDDINGS }}@${{ needs.build-embeddings-service.outputs.digest }}
+          DEPLOY_TAG: ${{ needs.generate-tag.outputs.tag }}
+          SEMVER: ${{ needs.generate-tag.outputs.semver }}
+          IS_STABLE: ${{ needs.generate-tag.outputs.is_stable }}
+        run: bash scripts/promote-images.sh
 
   # Package publication belongs after the exact release artifact passes its
   # runtime smoke. Dispatch from current main so the hardened workflow policy
@@ -328,7 +338,7 @@ jobs:
   # ID so the downstream gate cannot select a different producer.
   trigger-package-publish:
     runs-on: ubuntu-24.04
-    needs: [generate-tag, app-image-smoke]
+    needs: [generate-tag, promote-images]
     if: >-
       github.event_name == 'release'
       && needs.generate-tag.outputs.should_publish == 'true'
@@ -354,6 +364,8 @@ jobs:
     # build-worker`) on the parity smoke passing.
     needs: [generate-tag, connector-parity-smoke]
     if: needs.generate-tag.outputs.should_publish == 'true'
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     permissions:
       contents: read
       packages: write
@@ -381,11 +393,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_WORKER }}
           tags: |
-            type=raw,value=${{ needs.generate-tag.outputs.tag }}
-            type=raw,value=${{ needs.generate-tag.outputs.semver }},enable=${{ needs.generate-tag.outputs.semver != '' }}
-            type=raw,value=latest,enable=${{ needs.generate-tag.outputs.is_stable == 'true' }}
+            type=raw,value=${{ env.CANDIDATE_TAG }}
 
-      - name: Build and push Worker image
+      - name: Build and push Worker candidate
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -412,6 +423,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [generate-tag]
     if: needs.generate-tag.outputs.should_publish == 'true'
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     permissions:
       contents: read
       packages: write
@@ -439,11 +452,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_EMBEDDINGS }}
           tags: |
-            type=raw,value=${{ needs.generate-tag.outputs.tag }}
-            type=raw,value=${{ needs.generate-tag.outputs.semver }},enable=${{ needs.generate-tag.outputs.semver != '' }}
-            type=raw,value=latest,enable=${{ needs.generate-tag.outputs.is_stable == 'true' }}
+            type=raw,value=${{ env.CANDIDATE_TAG }}
 
-      - name: Build and push Embeddings Service image
+      - name: Build and push Embeddings Service candidate
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -464,27 +476,12 @@ jobs:
             https://api.github.com/user/packages/container/lobu-embeddings/visibility \
             -d '{"visibility":"public"}' || true
 
-  # Failure notification. The chart applies one shared tag to app + worker +
-  # embeddings, so if any of the three build/push jobs fails on main or a Lobu
-  # release, sibling tags may be incomplete. On timestamped runs the next
-  # ImageUpdateAutomation cycle can either roll a tag that does not exist for
-  # one service (half-rolled prod) or — when app fails after worker/embeddings
-  # already pushed — silently leave prod on the previous app tag while the
-  # other two move forward. Both modes were caught only by manual inspection
-  # before this notifier existed (PR #1116 build-app disk-full incident).
-  #
-  # Posts to the same Slack webhook the Flux notification-controller's
-  # `slack-devops` Provider uses (devops channel) so cluster-side and CI-side
-  # deploy failures land in one place. Webhook lives in the SLACK_DEPLOY_WEBHOOK_URL
-  # repo secret; if unset the curl is skipped, never failing the job.
-  # app-image-smoke is in `needs` too: it runs after the tag is already pushed,
-  # so when it fails Flux may already be rolling a broken image — exactly the
-  # case that must ping, not just redden the workflow. trigger-package-publish
-  # is in `needs` for the same reason: nothing else watches that dispatch, so a
-  # failed one would otherwise surface only as a version missing from npm.
+  # A failed build, smoke, promotion, or package dispatch fails the workflow.
+  # Candidate build or smoke failures never publish the app timestamp tag Flux
+  # watches.
   notify-failure:
     runs-on: ubuntu-24.04
-    needs: [generate-tag, connector-parity-smoke, build-worker, build-embeddings-service, build-app, app-image-smoke, trigger-package-publish]
+    needs: [generate-tag, connector-parity-smoke, build-worker, build-embeddings-service, build-app, app-image-smoke, promote-images, trigger-package-publish]
     if: >-
       failure()
       && needs.generate-tag.outputs.should_publish == 'true'

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -22,7 +22,7 @@ permissions:
   actions: read
 
 env:
-  REQUIRED_IMAGE_JOBS: generate-tag connector-parity-smoke build-worker build-embeddings-service build-app app-image-smoke
+  REQUIRED_IMAGE_JOBS: generate-tag connector-parity-smoke build-worker build-embeddings-service build-app app-image-smoke promote-images
 
 jobs:
   attest-publish:
@@ -93,9 +93,9 @@ jobs:
           # names, so that run is still in_progress while this gate reads it --
           # asserting "completed" here strands the release off npm, which is
           # the defect this workflow exists to prevent. The per-job attestation
-          # below is stronger evidence anyway: it proves all six required image
+          # below is stronger evidence anyway: it proves all seven required image
           # jobs are completed-success, which an unfinished producer cannot
-          # fake, and none of the six is the job doing the dispatching.
+          # fake, and none of the seven is the job doing the dispatching.
 
           # Piped, never --argjson: filter=all returns the jobs of every rerun
           # attempt, so this payload grows without bound and dies with "jq:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ permissions:
   actions: read
 
 env:
-  REQUIRED_IMAGE_JOBS: generate-tag connector-parity-smoke build-worker build-embeddings-service build-app app-image-smoke
+  REQUIRED_IMAGE_JOBS: generate-tag connector-parity-smoke build-worker build-embeddings-service build-app app-image-smoke promote-images
 
 jobs:
   attest:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -5,12 +5,12 @@ The published packages ship as a synchronized release: `@lobu/core`, `@lobu/cli`
 ## Flow
 
 1. Merge feature PRs into `main` with conventional commit messages.
-2. The push to `main` starts `build-images.yml`. When it finishes, `release-please.yml` runs on its `workflow_run` and attests the producer before touching anything: the run must be a completed-success push to the current `main` tip, all six required image jobs must be completed-success, and there must be an exact successful `ci.yml` run for the same commit.
+2. The push to `main` starts `build-images.yml`. When it finishes, `release-please.yml` runs on its `workflow_run` and attests the producer before touching anything: the run must be a completed-success push to the current `main` tip, all seven required image jobs must be completed-success, and there must be an exact successful `ci.yml` run for the same commit.
 3. Against that attested commit, release-please opens a `chore(main): release lobu <version>` PR with bumped `package.json`s and a generated `CHANGELOG.md`. It runs with `skip-github-release: true`, so it never creates the tag or the release itself.
 4. Merging the release PR repeats steps 2–3 for the new commit. The workflow then asks whether the attested commit's manifest version already has a stable `lobu-v<version>` GitHub release; if it does not, it creates the tag and release bound to that exact attested SHA. The question is deliberately about the release list rather than about whether the attested commit is the one that bumped the manifest — keyed on a parent diff, the release could only be cut while the bump commit was still `main`'s tip, so anything merging behind the release PR stranded it permanently. Publishing the release starts `build-images.yml` again, now on a `release` event. One consequence of asking the release list rather than the parent commit: if the bump commit's own image build does not get to cut the release, the tag binds to a later `main` tip instead, and release-please computes the following changelog from that tag — so commits that landed in the gap do not appear in the next `CHANGELOG.md`. That is deliberate; a release that ships with a short changelog is strictly better than a release that never ships at all.
-5. Once that run's `app-image-smoke` boots the tagged app image, its `trigger-package-publish` job dispatches `publish-packages.yml` from `main` with the release tag and its own run id. Automated npm publication is therefore downstream of a green image smoke — a red or still-queued image build leaves the version unpublished rather than shipping an unverified tree.
+5. That release run pushes candidate image tags outside Flux's policy, boots the app candidate by immutable digest in `app-image-smoke`, then runs `promote-images` to publish the deployment and release tags from the tested digests. Only after promotion succeeds does `trigger-package-publish` dispatch `publish-packages.yml` from `main` with the release tag and its own run id. Automated npm publication is therefore downstream of a green image smoke and successful promotion — a red or still-queued image build leaves the version unpublished rather than shipping an unverified tree.
 
-Every gate in that chain is one subcommand of `scripts/release-provenance.mjs`, covered by `scripts/__tests__/release-publish-order.test.ts`. Change the policy there, not in the workflow YAML.
+Every provenance decision in that chain is one subcommand of `scripts/release-provenance.mjs`, covered by `scripts/__tests__/release-publish-order.test.ts`. Change the attestation policy there, not in the workflow YAML.
 
 To force a specific version, land a commit on `main` whose body contains `Release-As: 7.2.0`; release-please then opens or updates the release PR for that version.
 
@@ -49,7 +49,7 @@ BREAKING CHANGE: RuntimeProviderCredentialResolver now returns
 
 **Publish step fails after release PR merge** — re-running `release-please.yml` does NOT re-publish: the release already exists, so no new release event fires and nothing dispatches the publish. Recover from the artifact side instead:
 
-- **`build-images` failed or was evicted** — re-run that run (`gh run rerun <id>`). A green `app-image-smoke` re-fires `trigger-package-publish` on its own.
+- **`build-images` failed or was evicted** — re-run that run (`gh run rerun <id>`). A successful `app-image-smoke` and `promote-images` re-fire `trigger-package-publish` on their own.
 - **`build-images` is green but `publish-packages` failed** — re-dispatch it from `main`, naming the release tag and the exact producing run. Both inputs are required and there is no fallback that guesses either one:
   ```bash
   gh workflow run publish-packages.yml --ref main \

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -1,4 +1,13 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "bun:test";
 import {
@@ -63,6 +72,7 @@ const REQUIRED_IMAGE_JOBS = [
   "build-embeddings-service",
   "build-app",
   "app-image-smoke",
+  "promote-images",
 ];
 
 /** Run the helper the way the workflows do — over stdin, as a subprocess. */
@@ -372,6 +382,179 @@ describe("image builds refuse an off-main manual dispatch", () => {
     expect(dispatch).toContain('-f image_run_id="$GITHUB_RUN_ID"');
     // `skip` was the only accepted value, so the input was dead surface.
     expect(dispatch).not.toContain("bump");
+  });
+});
+
+describe("deployment images are published only after the candidate passes", () => {
+  const file = "build-images.yml";
+
+  it("builds only candidate tags and exposes immutable digests", () => {
+    const workflow = parse(file) as Workflow & { env: Record<string, string> };
+    expect(workflow.env.CANDIDATE_TAG).toBe(
+      "candidate-${{ github.run_id }}-${{ github.run_attempt }}"
+    );
+    for (const id of [
+      "build-app",
+      "build-worker",
+      "build-embeddings-service",
+    ]) {
+      const build = steps(file, id).find((step) =>
+        step.uses?.startsWith("docker/build-push-action@")
+      );
+      const metadata = steps(file, id).find((step) =>
+        step.uses?.startsWith("docker/metadata-action@")
+      );
+      expect(metadata?.with?.tags).toBe(
+        "type=raw,value=${{ env.CANDIDATE_TAG }}\n"
+      );
+      expect(build?.with?.tags).toBe("${{ steps.meta.outputs.tags }}");
+      expect(
+        (job(file, id) as Job & { outputs: Record<string, string> }).outputs
+          .digest
+      ).toBe("${{ steps.build.outputs.digest }}");
+    }
+  });
+
+  it("smokes the app digest and requires success before promotion", () => {
+    expect(shell(file, "app-image-smoke")).toContain(
+      "${REGISTRY}/${IMAGE_NAME_APP}@${{ needs.build-app.outputs.digest }}"
+    );
+    expect(job(file, "promote-images").needs).toEqual([
+      "generate-tag",
+      "build-app",
+      "build-worker",
+      "build-embeddings-service",
+      "app-image-smoke",
+    ]);
+    expect(job(file, "promote-images").if).not.toMatch(/always\(|!cancelled\(/);
+    expect(
+      steps(file, "promote-images").find(
+        (step) => step.name === "Publish tested digests, app last for Flux"
+      )
+    ).toMatchObject({
+      run: "bash scripts/promote-images.sh",
+      env: {
+        APP_IMAGE:
+          "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_APP }}@${{ needs.build-app.outputs.digest }}",
+        WORKER_IMAGE:
+          "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_WORKER }}@${{ needs.build-worker.outputs.digest }}",
+        EMBEDDINGS_IMAGE:
+          "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_EMBEDDINGS }}@${{ needs.build-embeddings-service.outputs.digest }}",
+      },
+    });
+    expect(job(file, "trigger-package-publish").needs).toContain(
+      "promote-images"
+    );
+    expect(job(file, "notify-failure").needs).toContain("promote-images");
+  });
+});
+
+describe("image promotion command", () => {
+  const images = {
+    WORKER_IMAGE: `registry.example.test/worker@sha256:${"a".repeat(64)}`,
+    EMBEDDINGS_IMAGE: `registry.example.test/embeddings@sha256:${"b".repeat(64)}`,
+    APP_IMAGE: `registry.example.test/app@sha256:${"c".repeat(64)}`,
+  };
+  const deployTag = "20990101-000000-000001";
+
+  function promote(overrides: Record<string, string> = {}) {
+    const temp = mkdtempSync(join(tmpdir(), "image-promotion-"));
+    const log = join(temp, "docker.jsonl");
+    writeFileSync(log, "");
+    writeFileSync(
+      join(temp, "docker"),
+      `#!/usr/bin/env node
+const { appendFileSync } = require("node:fs");
+const args = process.argv.slice(2);
+appendFileSync(process.env.DOCKER_LOG, JSON.stringify(args) + "\\n");
+if (args.includes(process.env.FAIL_IMAGE)) process.exit(23);
+`,
+      { mode: 0o755 }
+    );
+    try {
+      const result = spawnSync("bash", ["scripts/promote-images.sh"], {
+        cwd: root,
+        env: {
+          ...process.env,
+          ...images,
+          DEPLOY_TAG: deployTag,
+          SEMVER: "",
+          IS_STABLE: "false",
+          FAIL_IMAGE: "",
+          ...overrides,
+          PATH: `${temp}:${process.env.PATH}`,
+          DOCKER_LOG: log,
+        },
+        encoding: "utf8",
+      });
+      return {
+        code: result.status,
+        stderr: result.stderr,
+        calls: readFileSync(log, "utf8")
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => JSON.parse(line) as string[]),
+      };
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  }
+
+  it.each([
+    { SEMVER: "", IS_STABLE: "false", tags: [deployTag] },
+    {
+      SEMVER: "1.2.3-rc.1",
+      IS_STABLE: "false",
+      tags: [deployTag, "1.2.3-rc.1"],
+    },
+    {
+      SEMVER: "1.2.3",
+      IS_STABLE: "true",
+      tags: [deployTag, "1.2.3", "latest"],
+    },
+    {
+      SEMVER: "1.2.3-rc.1+build.7",
+      IS_STABLE: "false",
+      tags: [deployTag, "1.2.3-rc.1-build.7"],
+    },
+  ])("copies exact digests and promotes app last: %j", ({ tags, ...env }) => {
+    const result = promote(env);
+    expect(result.code, result.stderr).toBe(0);
+    expect(result.calls).toEqual(
+      Object.values(images).map((image) => [
+        "buildx",
+        "imagetools",
+        "create",
+        "--prefer-index=false",
+        ...tags.flatMap((tag) => ["--tag", `${image.split("@")[0]}:${tag}`]),
+        image,
+      ])
+    );
+  });
+
+  it.each([
+    images.WORKER_IMAGE,
+    images.EMBEDDINGS_IMAGE,
+  ])("never publishes the watched app tag after sibling promotion fails: %s", (FAIL_IMAGE) => {
+    const result = promote({ FAIL_IMAGE });
+    expect(result.code).toBe(23);
+    expect(result.calls.some((args) => args.includes(images.APP_IMAGE))).toBe(
+      false
+    );
+  });
+
+  it.each([
+    { APP_IMAGE: "registry.example.test/app:candidate-123-1" },
+    { WORKER_IMAGE: "" },
+    { EMBEDDINGS_IMAGE: "registry.example.test/embeddings@sha256:" },
+    { DEPLOY_TAG: "latest" },
+    { IS_STABLE: "unknown" },
+    { IS_STABLE: "true", SEMVER: "" },
+    { SEMVER: "1.2.3 invalid" },
+  ])("rejects invalid inputs before any publication: %j", (env) => {
+    const result = promote(env);
+    expect(result.code).not.toBe(0);
+    expect(result.calls).toEqual([]);
   });
 });
 

--- a/scripts/app-image-smoke.sh
+++ b/scripts/app-image-smoke.sh
@@ -20,9 +20,8 @@
 # `docker run`s the self-check rather than trusting the build). This is the same
 # move for the APP image, which is the one users and the browser talk to.
 #
-# It runs AFTER `build-app` has pushed, deliberately: a failure here must not
-# block the push or Flux's rollout, but it does fail the workflow — so main goes
-# red and a release cannot be cut on a broken image.
+# Runs against the candidate digest after `build-app`. Only a passing smoke
+# allows promote-images to publish the deployment tags Flux watches.
 #
 # Keyless: needs only a Postgres with pgvector. No provider key, no secrets.
 #

--- a/scripts/promote-images.sh
+++ b/scripts/promote-images.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Publish the exact candidate digests after their required image checks pass.
+# Flux watches only the app timestamp tag, so publish its siblings first.
+set -euo pipefail
+
+: "${APP_IMAGE:?APP_IMAGE must be an immutable image reference}"
+: "${WORKER_IMAGE:?WORKER_IMAGE must be an immutable image reference}"
+: "${EMBEDDINGS_IMAGE:?EMBEDDINGS_IMAGE must be an immutable image reference}"
+: "${DEPLOY_TAG:?DEPLOY_TAG is required}"
+: "${IS_STABLE:?IS_STABLE is required}"
+
+# Require digest-pinned refs and valid tag controls before publishing any tag.
+# A missing build-job output must never fall through to a mutable tag.
+for image in "$WORKER_IMAGE" "$EMBEDDINGS_IMAGE" "$APP_IMAGE"; do
+  if [[ ! "$image" =~ ^[^@[:space:]]+@sha256:[a-f0-9]{64}$ ]]; then
+    echo "ERROR: promotion requires an image pinned by sha256" >&2
+    exit 1
+  fi
+done
+if [[ ! "$DEPLOY_TAG" =~ ^[0-9]{8}-[0-9]{6}-[0-9]{6}$ ]]; then
+  echo "ERROR: invalid deployment tag" >&2
+  exit 1
+fi
+case "$IS_STABLE" in
+  true) : "${SEMVER:?a stable release requires SEMVER}" ;;
+  false) ;;
+  *) echo "ERROR: IS_STABLE must be true or false" >&2; exit 1 ;;
+esac
+
+# docker/metadata-action, which previously published these tags, replaces the
+# `+` in SemVer build metadata because it is not valid in a Docker tag.
+semver_tag=${SEMVER:-}
+semver_tag=${semver_tag//+/-}
+if [[ -n "$semver_tag" && ! "$semver_tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+  echo "ERROR: invalid semver image tag" >&2
+  exit 1
+fi
+
+for image in "$WORKER_IMAGE" "$EMBEDDINGS_IMAGE" "$APP_IMAGE"; do
+  repository=${image%@*}
+  tags=(--tag "$repository:$DEPLOY_TAG")
+  if [[ -n "$semver_tag" ]]; then
+    tags+=(--tag "$repository:$semver_tag")
+  fi
+  if [[ "$IS_STABLE" == true ]]; then
+    tags+=(--tag "$repository:latest")
+  fi
+  # A single source is copied, including its multi-platform index. For a
+  # single manifest, avoid wrapping it in a new index and changing its digest.
+  docker buildx imagetools create --prefer-index=false "${tags[@]}" "$image"
+done


### PR DESCRIPTION
## Summary

Flux could deploy an app image while its smoke test was still running. Build jobs now publish only candidate tags, the app smoke boots the exact candidate digest, and a separate promotion job publishes worker and embeddings before the shared app tag Flux watches. Release and package publication also require successful promotion.

The old direct deployment/semver/latest publication path is removed from all three build jobs. Promotion copies registry manifests without rebuilding, preserving multi-platform digests and existing SemVer tag sanitization.

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` passed.
- [x] Focused release-order and image-tag suites: 111 passed, 0 failed.
- [x] Repository Biome, commit-hook typecheck, shell syntax, and actionlint passed.
- [x] Real local registry: all 9 promoted deployment/semver/latest tags retained the exact candidate digest and both amd64/arm64 manifests. A missing sibling manifest failed promotion and left the watched app tag absent.
- [x] `make review-fix` completed; its edits were reviewed.
- [x] GitHub CI and required semantic/UI review statuses passed for `5e3063229772bc1684b1de3c058794933468619f` (review: 0 bugs, 0 blockers).

Red, against the previous workflow:
```text
FAIL builds only candidate tags and exposes immutable digests
  Expected candidate-${{ github.run_id }}-${{ github.run_attempt }}; received undefined
FAIL smokes the app digest and requires success before promotion
  Received the deployment-tag reference, not the immutable digest reference
0 pass, 2 fail
```

Green, after the fix:
```text
111 pass, 0 fail, 855 expect() calls
PASS: 9 promoted tags preserve the exact candidate digest and both architectures in a real local registry
PASS: missing sibling manifest fails promotion; watched app tag stays absent
```

## Notes

7 files, +308/-78: CI/scripts/docs net +47; tests net +183. One new file, `scripts/promote-images.sh`. No API, SDK, database schema, runtime, or GitOps configuration changes.

This gates the existing image smoke. A populated-database upgrade/rollback gate and blue-green traffic promotion are separate follow-up slices.

## Production verification

Merged as `4de75bd8fab5357ad0aeb1e1380281c61edcd491`. The [first build and promotion](https://github.com/lobu-ai/lobu/actions/runs/34162208585) passed: app smoke completed before promotion began, and all three deployment tags retained their candidate digests. The watched app tag was published last.

[Production smoke](https://github.com/lobu-ai/lobu/actions/runs/34162960323) passed all 8 checks and confirmed the squash commit live. A separate `/health` check plus `git merge-base --is-ancestor <squash> <deployed>` passed. Helm was Ready and app, worker, and embeddings were each 1/1 on `20260907-211138-002686`.
