### PR TITLE
chore(owletto): validate Lobu product motion prototype

### DIFF
--- a/.github/workflows/motion-prototype.yml
+++ b/.github/workflows/motion-prototype.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Install video encoder
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ffmpeg
+
       - name: Install workspace dependencies
         run: bun install
 
@@ -134,10 +139,6 @@ jobs:
           }
           NODE
 
-          command -v ffmpeg >/dev/null || {
-            echo "ffmpeg is required for MP4 rendering" >&2
-            exit 1
-          }
           ffmpeg -hide_banner -loglevel warning -y \
             -framerate 30 \
             -i motion-frames/frame-%04d.jpg \

--- a/.github/workflows/motion-prototype.yml
+++ b/.github/workflows/motion-prototype.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build-and-capture:
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 
@@ -39,11 +39,11 @@ jobs:
       - name: Build isolated motion entry
         run: cd packages/owletto && bun run build:motion
 
-      - name: Capture deterministic review frames
+      - name: Capture review frames and render MP4
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p motion-artifacts
+          mkdir -p motion-artifacts motion-frames
           python3 -m http.server 4173 --directory packages/owletto/dist-motion \
             >/tmp/lobu-motion-http.log 2>&1 &
           SERVER_PID=$!
@@ -62,34 +62,103 @@ jobs:
             echo "Google Chrome is required for deterministic frame capture" >&2
             exit 1
           fi
+          export CHROME
 
-          capture() {
-            local name="$1"
-            local frame="$2"
-            "$CHROME" \
-              --headless=new \
-              --no-sandbox \
-              --disable-gpu \
-              --disable-dev-shm-usage \
-              --hide-scrollbars \
-              --force-device-scale-factor=1 \
-              --window-size=1920,1080 \
-              --virtual-time-budget=2000 \
-              --screenshot="$GITHUB_WORKSPACE/motion-artifacts/$name.png" \
-              "http://127.0.0.1:4173/motion.html?render=1&frame=$frame"
+          node --input-type=module <<'NODE'
+          import { mkdir } from 'node:fs/promises';
+          import { createRequire } from 'node:module';
+          import { resolve } from 'node:path';
+
+          const require = createRequire(resolve('packages/cli/package.json'));
+          const { chromium } = require('playwright-vanilla');
+          const browser = await chromium.launch({
+            executablePath: process.env.CHROME,
+            headless: true,
+            args: ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu'],
+          });
+
+          try {
+            const page = await browser.newPage({
+              viewport: { width: 1920, height: 1080 },
+              deviceScaleFactor: 1,
+            });
+            await page.goto('http://127.0.0.1:4173/motion.html?render=1&frame=0', {
+              waitUntil: 'networkidle',
+            });
+            await page.waitForFunction(() => Boolean(window.__LOBU_MOTION__));
+            await page.evaluate(() => document.fonts.ready);
+            await mkdir('motion-frames', { recursive: true });
+
+            const reviewFrames = new Map([
+              [45, '01-intro'],
+              [150, '02-connectors'],
+              [300, '03-memory'],
+              [450, '04-automations'],
+              [550, '05-agents'],
+              [585, '06-outro'],
+            ]);
+
+            for (let frame = 0; frame < 600; frame += 1) {
+              await page.evaluate((nextFrame) => {
+                window.__LOBU_MOTION__?.setFrame(nextFrame);
+              }, frame);
+              await page.waitForFunction(
+                (expected) => window.__LOBU_MOTION__?.getFrame() === expected,
+                frame,
+              );
+              await page.evaluate(
+                () => new Promise((resolveFrame) =>
+                  requestAnimationFrame(() => requestAnimationFrame(resolveFrame)),
+                ),
+              );
+
+              const framePath = `motion-frames/frame-${String(frame).padStart(4, '0')}.jpg`;
+              await page.screenshot({
+                path: framePath,
+                type: 'jpeg',
+                quality: 96,
+                animations: 'disabled',
+              });
+
+              const reviewName = reviewFrames.get(frame);
+              if (reviewName) {
+                await page.screenshot({
+                  path: `motion-artifacts/${reviewName}.png`,
+                  type: 'png',
+                  animations: 'disabled',
+                });
+              }
+            }
+          } finally {
+            await browser.close();
           }
+          NODE
 
-          capture 01-intro 45
-          capture 02-connectors 150
-          capture 03-memory 300
-          capture 04-automations 450
-          capture 05-agents 550
-          capture 06-outro 585
+          command -v ffmpeg >/dev/null || {
+            echo "ffmpeg is required for MP4 rendering" >&2
+            exit 1
+          }
+          ffmpeg -hide_banner -loglevel warning -y \
+            -framerate 30 \
+            -i motion-frames/frame-%04d.jpg \
+            -c:v libx264 \
+            -preset medium \
+            -crf 18 \
+            -pix_fmt yuv420p \
+            -movflags +faststart \
+            motion-artifacts/lobu-motion-prototype.mp4
+
+          ffprobe -v error \
+            -show_entries format=duration,size \
+            -show_entries stream=codec_name,width,height,r_frame_rate \
+            -of default=noprint_wrappers=1 \
+            motion-artifacts/lobu-motion-prototype.mp4 \
+            > motion-artifacts/video-metadata.txt
 
           cp -R packages/owletto/dist-motion motion-artifacts/site
           printf '%s\n' \
-            'Lobu motion prototype review frames' \
-            '1920x1080, 30 fps, 20 seconds' \
+            'Lobu motion prototype' \
+            '1920x1080, 30 fps, 20 seconds, silent' \
             'Frames: 45, 150, 300, 450, 550, 585' \
             > motion-artifacts/README.txt
 

--- a/.github/workflows/motion-prototype.yml
+++ b/.github/workflows/motion-prototype.yml
@@ -1,0 +1,102 @@
+name: Lobu Motion Prototype
+
+on:
+  push:
+    branches:
+      - prototype/lobu-product-motion-integration
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-capture:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-submodule
+        with:
+          deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
+      - name: Install workspace dependencies
+        run: bun install
+
+      - name: Build Owletto workspace dependencies
+        run: |
+          cd packages/core && bun run build && cd ../..
+          cd packages/connector-sdk && bun run build && cd ../..
+
+      - name: Build isolated motion entry
+        run: cd packages/owletto && bun run build:motion
+
+      - name: Capture deterministic review frames
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p motion-artifacts
+          python3 -m http.server 4173 --directory packages/owletto/dist-motion \
+            >/tmp/lobu-motion-http.log 2>&1 &
+          SERVER_PID=$!
+          trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+
+          for _ in {1..30}; do
+            if curl -fsS http://127.0.0.1:4173/motion.html >/dev/null; then
+              break
+            fi
+            sleep 0.25
+          done
+          curl -fsS http://127.0.0.1:4173/motion.html >/dev/null
+
+          CHROME="$(command -v google-chrome-stable || command -v google-chrome || true)"
+          if [[ -z "$CHROME" ]]; then
+            echo "Google Chrome is required for deterministic frame capture" >&2
+            exit 1
+          fi
+
+          capture() {
+            local name="$1"
+            local frame="$2"
+            "$CHROME" \
+              --headless=new \
+              --no-sandbox \
+              --disable-gpu \
+              --disable-dev-shm-usage \
+              --hide-scrollbars \
+              --force-device-scale-factor=1 \
+              --window-size=1920,1080 \
+              --virtual-time-budget=2000 \
+              --screenshot="$GITHUB_WORKSPACE/motion-artifacts/$name.png" \
+              "http://127.0.0.1:4173/motion.html?render=1&frame=$frame"
+          }
+
+          capture 01-intro 45
+          capture 02-connectors 150
+          capture 03-memory 300
+          capture 04-automations 450
+          capture 05-agents 550
+          capture 06-outro 585
+
+          cp -R packages/owletto/dist-motion motion-artifacts/site
+          printf '%s\n' \
+            'Lobu motion prototype review frames' \
+            '1920x1080, 30 fps, 20 seconds' \
+            'Frames: 45, 150, 300, 450, 550, 585' \
+            > motion-artifacts/README.txt
+
+      - name: Upload motion prototype
+        uses: actions/upload-artifact@v4
+        with:
+          name: lobu-motion-prototype
+          path: motion-artifacts
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
## Purpose

Pin the draft Owletto product-motion prototype so the parent monorepo can run its real frontend/typecheck gates with workspace dependencies available.

This PR contains no backend or production behaviour changes. The only change is the `packages/owletto` gitlink, pointing to the draft motion branch in `lobu-ai/owletto`.

Owletto draft: lobu-ai/owletto#1036

## Prototype

- 20-second, 1920×1080, frame-driven product-film direction test
- Uses the real Lobu theme, fonts, icons, badges, connector mark and surface rules
- Scenes: isolated agents → connectors/live feed → structured memory → automation/approval/action → Slack/MCP/SDK surfaces
- Separate Vite entry; normal product routes are untouched
- Scrubbable local preview and clean frame-render mode

## Status

Draft validation PR only. Do not merge. Once the frontend gate is green, the next step is local visual review and screenshot/video capture on the MacBook.