### PR TITLE
fix(browser): preserve SDK flows and recover extension failures

### DIFF
--- a/docs/plans/chrome-reliability.md
+++ b/docs/plans/chrome-reliability.md
@@ -1,0 +1,45 @@
+# Chrome reliability
+
+Design approved 2026-09-08. One Lobu PR with an Owletto source companion because the extension is a separate repository.
+
+## Target model
+
+A browser flow has one server-derived ownership identity throughout its actions. Titles are display data and never grant ownership. Keep the existing operation queue, run metadata, tab groups, leases, scheduler, and bootstrap route.
+
+- Each bare `run_sdk` invocation gets a server-generated nonce. At the operation boundary, derive its owner from the selected organization, authenticated user, and nonce. Actions within that invocation share an owner; separate invocations do not. Existing Automation, conversation, and MCP attribution retains priority and identity.
+- Persist ownership in the existing `runs.run_metadata.browser_context`. An SDK fallback is used only on fresh insertion. Keyed replay returns its original result without comparing, hydrating, or transferring the fallback owner. Attributed replay compares identity without its display title, in both TypeScript and the atomic SQL hydration guard.
+- Reuse `run_sdk.title`, normalized and bounded by code points, for `Lobu · <subject> · <diagnostic suffix>`. New tabs and targeted actions update titles through the existing group mutation path. An existing-tab title update requires the owning flow and preserves group identity and handoff metadata.
+- Propagate failed ownership-storage reads. A successful missing key may initialize an empty store; a rejected read must not erase leases. Delete title-based group adoption. If Chrome identity no longer resolves, do not adopt or clean up the old group.
+- Seed the existing integer document epoch per document, then increment it on snapshots. This prevents an old ref becoming valid on a new page merely because both snapshots used epoch 1. Uniqueness is probabilistic within the existing safe-integer field. Keep stale-ref and protected-URL checks; never retry click/type/submit after an ambiguous outcome.
+- Catch failures around the whole poll iteration and reuse its generation check and backoff. Bound polling and OAuth refresh requests, including response bodies. Record a healthy poll only after its body parses. Credential loss and explicit stop remain terminal; transient refresh failures retain credentials through the existing reconnect path.
+- Give bootstrap exchange a 15-second deadline with its existing Retry controls. Cancel the previous attempt and ignore late results. Preserve token-fragment stripping, session scoping, deep links, and pairing identity.
+
+## Scope and migration
+
+Server: `tools/sdk_run.ts`, `tools/registry.ts`, operation execution and queue creation, browser-action context derivation, and `auth/routes.ts` bootstrap. Extension: tab groups, targeted-action dispatch, polling/refresh, accessibility epochs, and generated cleanup guidance. Add focused regressions and a disposable-browser smoke script.
+
+Delete the rejection-to-empty-store path, title-only group recovery, duplicate startup credential precheck, rejection-leaking polling, and unbounded bootstrap waits. Scratch cleanup guidance must match the existing 5-minute idle lease; handoffs retain their separate 30-minute budget.
+
+No new database tables/columns, migrations, public arguments, endpoints, permission grants, aliases, credential paths, or server coordination service. New runs use existing metadata; old runs retain their ownership. User-owned and released tabs stay protected. Interactive drafts remain page-activated and never auto-submit.
+
+Slack/provider routing, the organization-wide Automation audit, a public resumable handle across bare CLI requests, and seamless full-browser restoration are out of scope. This is generic platform work, with no tenant, connector-slug, or entity-key special cases.
+
+The approved estimate was net-positive shipping code (+135 to +320 lines across repositories), with most growth expected in tests. Report actual shipping/test/document line counts at the PR checkpoint.
+
+## Acceptance and evidence
+
+- Shared SDK ownership is exercised through the actual sandbox and persisted PostgreSQL runs. Separate invocations, users and selected organizations derive distinct owners; forged ownership inputs remain stripped.
+- Keyed replay covers legacy absent metadata, existing owners, changed input/principal rejection, concurrent inserts, and title-only versus conflicting-identity hydration races. Existing parent connector-run attribution and token exchange remain covered.
+- Storage failures preserve leases; title writes report failures and reconcile on the next successful attempt. Same-title user groups are never adopted or disposed after stored identity disappears.
+- The installed-extension smoke asserts exact click counts and typed values, stale refs after navigation, same-title flow isolation, existing-tab title updates, closed/released/user-tab guards, and subsequent independent success.
+- Actual background dispatch is exercised against a synthetic local gateway: action failure, gateway 503, worker eviction, recovery, completion, and cleanup without duplicate completion. Missing-tab cleanup still reaches the tools' persisted-ownership checks.
+- Full Chromium process restart changed all synthetic tab/group/window IDs. The old flow could close neither restored scratch nor same-title user tab; fresh work created a new group and left the user tab untouched. Unverifiable restored scratch tabs remain for manual cleanup.
+- Actual bootstrap HTML in Chromium passed success, rejected-token/Retry, and stalled-request/Retry with fragment stripping and device deep links preserved. Unit tests cover obsolete late success and double retry.
+
+Reproduced failures and their red/green outputs, exact commands, final counts, and review verdicts belong in the PRs. Fable reviewed the design and the settled pre-commit change. A review verdict alone does not establish E2E health.
+
+## PR checkpoint and live checks
+
+Run focused regressions, the installed-extension smoke, `make pre-pr`, canonical GitHub CI, `make review`, and `make ui-review`. Open the paired PRs as one delivery, report their diffstats and unmet gates, then stop at the PR checkpoint. Release requires merging Owletto first and updating the parent to its squash commit before landing Lobu.
+
+After rollout, verify deployed squash ancestry and the installed extension build separately. Live checks still owed: the exact SDK-to-production-extension journey after reload, the paired sidebar's sync-status deep link, and recovery over a real idle/sleep interval. The original hidden-window first-click no-op remains unproven; no forced-focus or click-retry patch was added. Coincidental reuse of old numeric Chrome IDs is untested. Do not claim every extension path, connector, or Automation is healthy from these isolated checks.

--- a/packages/server/src/__tests__/integration/device-action-wait.test.ts
+++ b/packages/server/src/__tests__/integration/device-action-wait.test.ts
@@ -757,6 +757,8 @@ describe('createConnectorOperationRun — ephemeral expires_at semantics', () =>
       browser_context: browserContext,
     });
 
+    expect((await createConnectorOperationRun({ ...request, runMetadata: { browser_context: { ...browserContext, title: 'Lobu · Changed task' } } })).runId).toBe(first.runId);
+
     await expect(
       createConnectorOperationRun({
         ...request,
@@ -767,7 +769,51 @@ describe('createConnectorOperationRun — ephemeral expires_at semantics', () =>
     ).rejects.toThrow(/already bound to a different request/);
   });
 
-  it('rejects a conflicting browser-context hydration race atomically', async () => {
+  it.each([false, true])('replays a bare SDK operation without adopting its owner (legacy=%s)', async (legacy) => {
+    const org = await createTestOrganization();
+    await insertChromeConnector(org.id);
+    const connectionId = await insertChromeConnection(org.id);
+    const request = {
+      organizationId: org.id, connectionId, connectorKey: 'chrome',
+      operationKey: 'open_tab', operationInput: { url: 'about:blank' },
+      approvalMode: 'device' as const, idempotencyKey: 'synthetic-sdk-replay',
+    };
+    const owner = { id: 'run:sdk-first', flow_id: 'sdk-first', kind: 'run' as const, title: 'Lobu · Same task · first' };
+    const first = await createConnectorOperationRun({ ...request, sdkBrowserContext: legacy ? undefined : owner });
+    const sql = getTestDb();
+    await sql`UPDATE runs SET status = 'completed', action_output = '{"tab_id":123}'::jsonb WHERE id = ${first.runId}`;
+    const replay = await createConnectorOperationRun({
+      ...request, sdkBrowserContext: { ...owner, id: 'run:sdk-second', flow_id: 'sdk-second' },
+    });
+    expect(replay).toMatchObject({ runId: first.runId, created: false, status: 'completed', actionOutput: { tab_id: 123 } });
+    const [row] = await sql`SELECT run_metadata FROM runs WHERE id = ${first.runId}`;
+    expect(row.run_metadata?.browser_context ?? null).toEqual(legacy ? null : owner);
+    await expect(createConnectorOperationRun({ ...request, operationInput: { url: 'https://different.example' } })).rejects.toThrow(/different request/);
+    await expect(createConnectorOperationRun({ ...request, policyPrincipalKind: 'user', policyPrincipalId: 'synthetic-other-user' })).rejects.toThrow(/different request/);
+  });
+
+  it('keeps the winning invocation owner when two replicas insert the same SDK key', async () => {
+    const org = await createTestOrganization();
+    await insertChromeConnector(org.id);
+    const connectionId = await insertChromeConnection(org.id);
+    const request = {
+      organizationId: org.id, connectionId, connectorKey: 'chrome',
+      operationKey: 'open_tab', operationInput: {},
+      approvalMode: 'device' as const, idempotencyKey: 'synthetic-sdk-race',
+    };
+    const contexts = ['first', 'second'].map((suffix) => ({
+      id: `run:sdk-${suffix}`, flow_id: `sdk-${suffix}`, kind: 'run' as const, title: 'Lobu · Same task',
+    }));
+    const claims = await Promise.all(contexts.map((sdkBrowserContext) => createConnectorOperationRun({ ...request, sdkBrowserContext })));
+    expect(new Set(claims.map((claim) => claim.runId)).size).toBe(1);
+    const winner = claims.findIndex((claim) => claim.created);
+    expect(claims.filter((claim) => claim.created)).toHaveLength(1);
+    const sql = getTestDb();
+    const [row] = await sql`SELECT run_metadata FROM runs WHERE id = ${claims[0].runId}`;
+    expect(row.run_metadata.browser_context).toEqual(contexts[winner]);
+  });
+
+  it.each([false, true])('checks browser identity atomically during hydration (title-only=%s)', async (titleOnly) => {
     const org = await createTestOrganization();
     await insertChromeConnector(org.id);
     const connId = await insertChromeConnection(org.id);
@@ -820,7 +866,7 @@ describe('createConnectorOperationRun — ephemeral expires_at semantics', () =>
       flow_id: 'conversation:context-a',
       kind: 'conversation',
     };
-    const contextB = {
+    const contextB = titleOnly ? { ...contextA, title: 'Lobu · New task · context-a' } : {
       id: 'conversation:context-b',
       title: 'Owletto · Conversation context-b',
       flow_id: 'conversation:context-b',
@@ -839,8 +885,8 @@ describe('createConnectorOperationRun — ephemeral expires_at semantics', () =>
       }),
     ]);
 
-    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
-    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(titleOnly ? 2 : 1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(titleOnly ? 0 : 1);
     const [row] = await sql`
       SELECT run_metadata FROM runs
       WHERE organization_id = ${org.id}

--- a/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
+++ b/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { Env } from "../../index";
 import { createAutomationRun } from "../../runs/queue-service";
 import { manageOperations } from "../../tools/admin/manage_operations";
+import { runSdkScript } from "../../tools/sdk_run";
 import type { ToolContext } from "../../tools/registry";
 import { createAuthProfile } from "../../utils/auth-profiles";
 import { initWorkspaceProvider } from "../../workspace";
@@ -417,6 +418,33 @@ describe("operations.execute backend lifecycle", () => {
 		expect(Date.now() - started).toBeLessThan(10_000);
 	});
 
+	it("carries one SDK invocation owner through real sandbox calls without sharing across invocations", async () => {
+		const script = `export default async (ctx, client) => {
+			return await Promise.all(['first', 'second'].map(value => client.operations.execute({
+				connection_id: ${localConnectionId}, operation_key: 'echo',
+				input: { value: 'synthetic-sdk-owner-' + value }
+			})));
+		}`;
+		for (let i = 0; i < 2; i++) {
+			await runSdkScript({ script, title: "Check notifications" }, {} as Env, ctx);
+		}
+		const sql = getTestDb();
+		const rows = await sql`
+			SELECT run_metadata FROM runs
+			WHERE organization_id = ${orgId}
+				AND action_input->>'value' IN ('synthetic-sdk-owner-first', 'synthetic-sdk-owner-second')
+			ORDER BY id
+		`;
+		expect(rows).toHaveLength(4);
+		const owners = rows.map((row) => row.run_metadata.browser_context);
+		expect(owners[0]).toEqual(owners[1]);
+		expect(owners[2]).toEqual(owners[3]);
+		expect(owners[0].flow_id).not.toBe(owners[2].flow_id);
+		expect(owners[0].title).toMatch(
+			/^Lobu · Check notifications · [a-f0-9]{12}$/,
+		);
+	});
+
 	it("replays a completed action instead of executing an idempotency key twice", async () => {
 		const execute = () =>
 			manageOperations(
@@ -473,7 +501,7 @@ describe("operations.execute backend lifecycle", () => {
 		expect(run.run_metadata).toEqual({
 			browser_context: {
 				id: `automation:${sourceRunId}`,
-				title: `Owletto · Automation ${automationId} · Run ${sourceRunId}`,
+				title: `Lobu · Automation ${automationId} · Run ${sourceRunId}`,
 				flow_id: String(sourceRunId),
 				kind: "automation",
 			},

--- a/packages/server/src/__tests__/unit/browser-action-context.test.ts
+++ b/packages/server/src/__tests__/unit/browser-action-context.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { deriveBrowserActionContext } from '../../worker-api/browser-action-context';
+import {
+  browserActionContextFromMetadata,
+  deriveBrowserActionContext,
+  deriveSdkBrowserActionContext,
+  trustedChromeActionInput,
+} from '../../worker-api/browser-action-context';
 import type { ToolContext } from '../../tools/registry';
 
 function context(overrides: Partial<ToolContext> = {}): ToolContext {
@@ -27,7 +32,7 @@ describe('deriveBrowserActionContext', () => {
       )
     ).toEqual({
       id: 'automation:42',
-      title: 'Owletto · Automation 7 · Run 42',
+      title: 'Lobu · Automation 7 · Run 42',
       flow_id: '42',
       kind: 'automation',
     });
@@ -91,5 +96,107 @@ describe('deriveBrowserActionContext', () => {
     expect(fromHostA?.id).not.toBe(fromTransport?.id);
     expect(JSON.stringify(fromHostA)).not.toContain(rawHostConversationId);
     expect(fromHostA?.title).not.toContain(rawHostConversationId);
+  });
+});
+
+describe('SDK browser invocation', () => {
+  const invocation = {
+    nonce: 'synthetic-invocation-a',
+    title: 'Check notifications',
+  };
+
+  it('keeps one owner within the invocation and round-trips through stored metadata', () => {
+    const ctx = context({ sdkBrowserInvocation: invocation });
+    const first = deriveSdkBrowserActionContext(ctx);
+    expect(first).not.toBeNull();
+    expect(deriveSdkBrowserActionContext({ ...ctx })).toEqual(first);
+    expect(first?.id).toMatch(/^run:sdk-[a-f0-9]{64}$/);
+    expect(first?.title).toMatch(/^Lobu · Check notifications · [a-f0-9]{12}$/);
+    expect(browserActionContextFromMetadata({ browser_context: first })).toEqual(
+      first
+    );
+    expect(deriveBrowserActionContext(ctx)).toBeNull();
+  });
+
+  it('isolates invocations, selected workspaces and users even with the same title', () => {
+    const ctx = context({ sdkBrowserInvocation: invocation });
+    const owner = deriveSdkBrowserActionContext(ctx)?.flow_id;
+    for (const change of [
+      {
+        sdkBrowserInvocation: {
+          ...invocation,
+          nonce: 'synthetic-invocation-b',
+        },
+      },
+      { organizationId: 'org_browser_other' },
+      { userId: 'user_browser_other' },
+    ]) {
+      expect(
+        deriveSdkBrowserActionContext({ ...ctx, ...change })?.flow_id
+      ).not.toBe(owner);
+    }
+    expect(deriveSdkBrowserActionContext(context())).toBeNull();
+    expect(deriveSdkBrowserActionContext({ ...ctx, userId: null })).toBeNull();
+  });
+
+  it('normalizes and bounds Unicode subjects without changing ownership', () => {
+    const ctx = context({ sdkBrowserInvocation: invocation });
+    const original = deriveSdkBrowserActionContext(ctx)!;
+    const changed = deriveSdkBrowserActionContext({
+      ...ctx,
+      sdkBrowserInvocation: {
+        ...invocation,
+        title: ' A\nB\u0000 ' + '😀'.repeat(250),
+      },
+    })!;
+    expect(changed.flow_id).toBe(original.flow_id);
+    expect(changed.title).toStartWith('Lobu · A B 😀');
+    expect(changed.title).not.toMatch(/[\u0000-\u001f]/);
+    expect([...changed.title]).toHaveLength(
+      200 + 'Lobu · '.length + ' · '.length + 12
+    );
+  });
+
+  it('uses a human subject for untitled calls and strips forged ownership', () => {
+    const browser = deriveSdkBrowserActionContext(
+      context({
+        sdkBrowserInvocation: { nonce: invocation.nonce, title: '' },
+      })
+    )!;
+    expect(browser.title).toMatch(/^Lobu · Browser task · [a-f0-9]{12}$/);
+    expect(
+      trustedChromeActionInput(
+        {
+          tab_id: 123,
+          browser_context_id: 'forged',
+          browser_context_title: 'forged',
+          browser_flow_id: 'forged',
+          holder_run_id: 'forged',
+          parent_run_id: 999,
+        },
+        browser
+      )
+    ).toEqual({
+      tab_id: 123,
+      browser_context_id: browser.id,
+      browser_context_title: browser.title,
+      browser_flow_id: browser.flow_id,
+      holder_run_id: browser.flow_id,
+    });
+  });
+
+  it.each([
+    { actingAutomationId: 7, actingRunId: 42 },
+    { sourceContext: { platform: 'slack', conversationId: 'synthetic-thread' } },
+    { mcpSessionId: 'synthetic-mcp-session', clientId: 'synthetic-client' },
+  ])('changes the subject without changing attributed ownership: %j', (attribution) => {
+    const original = deriveBrowserActionContext(context(attribution))!;
+    const titled = deriveBrowserActionContext(
+      context({ ...attribution, sdkBrowserInvocation: invocation })
+    )!;
+    expect(titled).toEqual({
+      ...original,
+      title: expect.stringContaining('Lobu · Check notifications · '),
+    });
   });
 });

--- a/packages/server/src/__tests__/unit/extension-bootstrap.test.ts
+++ b/packages/server/src/__tests__/unit/extension-bootstrap.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import { describe, expect, it } from 'bun:test';
+
+const routes = readFileSync(new URL('../../auth/routes.ts', import.meta.url), 'utf8');
+const start = routes.indexOf("credentialRoutes.get('/extension-bootstrap'");
+let html = '';
+runInNewContext(routes.slice(start, routes.indexOf('\n/**', start)), {
+  credentialRoutes: { get: (_path: string, handler: Function) => handler({ header() {}, html(value: string) { html = value; } }) },
+});
+const script = html.match(/<script>([\s\S]*?)<\/script>/)![1];
+
+function harness(hash = '#token=synthetic-token&worker=synthetic-worker') {
+  const requests: Array<{ resolve: (value: unknown) => void; reject: (error: Error) => void; options: RequestInit }> = [];
+  const timers = new Map<number, () => void>();
+  const paragraphs = [{ textContent: '' }, { textContent: '' }];
+  const buttons: Record<string, { onclick?: () => void }> = {};
+  const body = {
+    textContent: '', markup: '',
+    set innerHTML(value: string) {
+      this.markup = value;
+      for (const id of ['owl-retry', 'owl-settings']) if (value.includes(id)) buttons[id] = {};
+    },
+  };
+  const redirects: string[] = [];
+  const stored: string[] = [];
+  let fragmentCleared = false;
+  let timerId = 0;
+  runInNewContext(script, {
+    URLSearchParams, AbortController,
+    location: { hash, pathname: '/api/extension-bootstrap', replace: (url: string) => redirects.push(url) },
+    history: { replaceState() { fragmentCleared = true; } },
+    document: { body, querySelectorAll: () => paragraphs, getElementById: (id: string) => buttons[id] },
+    sessionStorage: { setItem: (_key: string, value: string) => stored.push(value) },
+    setTimeout(callback: () => void) { timers.set(++timerId, callback); return timerId; },
+    clearTimeout(id: number) { timers.delete(id); },
+    fetch: (_url: string, options: RequestInit) => {
+      expect(fragmentCleared).toBe(true);
+      return new Promise((resolve, reject) => requests.push({ resolve, reject, options }));
+    },
+  });
+  return { requests, timers, paragraphs, buttons, redirects, stored, body, fragmentCleared };
+}
+
+async function flush() { for (let i = 0; i < 10; i++) await Promise.resolve(); }
+function success(request: ReturnType<typeof harness>['requests'][number]) {
+  request.resolve({ ok: true, json: async () => ({ session_token: 'synthetic-session' }) });
+}
+
+describe('extension bootstrap', () => {
+  it('bounds a stalled request, shows retry, and ignores its late success', async () => {
+    const h = harness();
+    expect(h.timers.size).toBe(1);
+    [...h.timers.values()][0]();
+    expect(h.requests[0].options.signal?.aborted).toBe(true);
+    expect(h.paragraphs[1].textContent).toContain('timed out');
+    expect(h.buttons['owl-retry']).toBeDefined();
+    success(h.requests[0]);
+    await flush();
+    expect(h.redirects).toEqual([]);
+    expect(h.stored).toEqual([]);
+  });
+
+  it('keeps only the latest retry active and preserves the deep link', async () => {
+    const h = harness('#token=synthetic-token&agent=synthetic-agent&thread=synthetic-thread&message=synthetic-message');
+    h.requests[0].reject(new Error('offline'));
+    await flush();
+    const retry = h.buttons['owl-retry'].onclick!;
+    retry();
+    retry();
+    expect(h.timers.size).toBe(1);
+    expect(h.requests[1].options.signal?.aborted).toBe(true);
+    success(h.requests[1]);
+    await flush();
+    expect(h.redirects).toEqual([]);
+    success(h.requests[2]);
+    await flush();
+    expect(h.redirects).toEqual(['/#agent=synthetic-agent&thread=synthetic-thread&message=synthetic-message']);
+    expect(h.stored).toEqual(['synthetic-session']);
+    expect(h.timers.size).toBe(0);
+  });
+
+  it.each(['network', 'token'])('offers recovery on %s failure', async (failure) => {
+    const h = harness();
+    if (failure === 'network') h.requests[0].reject(new Error('offline'));
+    else h.requests[0].resolve({ ok: false });
+    await flush();
+    expect(h.buttons['owl-retry']).toBeDefined();
+    expect(h.body.markup).toContain('Lobu');
+    expect(h.timers.size).toBe(0);
+    expect(h.redirects).toEqual([]);
+  });
+
+  it('opens the device after success and strips the fragment before exchange', async () => {
+    const h = harness();
+    success(h.requests[0]);
+    await flush();
+    expect(h.redirects).toEqual(['/#worker=synthetic-worker']);
+    expect(h.fragmentCleared).toBe(true);
+    expect(h.timers.size).toBe(0);
+  });
+});

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -558,7 +558,7 @@ credentialRoutes.get('/sse-ticket', async (c) => {
 });
 
 /**
- * Bootstrap page for the Owletto extension's side-panel iframe.
+ * Bootstrap page for the Lobu extension's side-panel iframe.
  *
  * The extension mounts the iframe at this route with the deep-link token in the
  * URL **fragment** (`#token=…&worker=…`) — fragments are never sent to a server
@@ -607,6 +607,7 @@ credentialRoutes.get('/extension-bootstrap', (c) => {
   }
   if (!token) { location.replace("/"); return; }
   var retried = false;
+  var activeAttempt = null;
   function fail(msg) {
     // Surface a real error instead of redirecting to a token-less app, which
     // would just render signed-out and hang on a spinner — the exact failure
@@ -616,7 +617,7 @@ credentialRoutes.get('/extension-bootstrap', (c) => {
     // re-pair) — the only path that recovers a token this page can't refresh.
     document.body.innerHTML =
       '<div style="font:14px/1.5 system-ui,sans-serif;color:#e7e5e4;padding:24px;max-width:24rem">' +
-      '<p style="margin:0 0 .5rem;font-weight:600">Could not connect to your Owletto.</p>' +
+      '<p style="margin:0 0 .5rem;font-weight:600">Could not connect to Lobu.</p>' +
       '<p style="margin:0 0 1rem;color:#a8a29e"></p>' +
       '<button id="owl-retry" style="font:inherit;padding:.4rem .9rem;border:1px solid #3f3f46;border-radius:.4rem;background:#18181b;color:inherit;cursor:pointer">Retry</button>' +
       (retried
@@ -635,16 +636,30 @@ credentialRoutes.get('/extension-bootstrap', (c) => {
     };
   }
   function attempt() {
+    if (activeAttempt) {
+      clearTimeout(activeAttempt.timer);
+      activeAttempt.controller.abort();
+    }
+    var current = { controller: new AbortController(), timer: null };
+    activeAttempt = current;
+    current.timer = setTimeout(function () {
+      if (activeAttempt !== current) return;
+      activeAttempt = null;
+      current.controller.abort();
+      fail("Connection timed out. Check your connection and retry.");
+    }, 15000);
     document.body.textContent = "Connecting\\u2026";
     var body = new URLSearchParams();
     body.set("token", token);
     fetch("/api/extension-session", {
+      signal: current.controller.signal,
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: body.toString(),
     })
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (data) {
+        if (activeAttempt !== current) return;
         if (data && data.session_token) {
           try { sessionStorage.setItem("owletto.session_token", data.session_token); } catch (e) {}
           location.replace(next);
@@ -652,7 +667,13 @@ credentialRoutes.get('/extension-bootstrap', (c) => {
           fail("Your session may have expired. Re-pair from the extension if this keeps happening.");
         }
       })
-      .catch(function () { fail("Network error reaching the gateway."); });
+      .catch(function () {
+        if (activeAttempt === current) fail("Network error reaching the gateway.");
+      })
+      .finally(function () {
+        clearTimeout(current.timer);
+        if (activeAttempt === current) activeAttempt = null;
+      });
   }
   attempt();
 })();

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -8,6 +8,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import type { BrowserActionContext } from '../worker-api/browser-action-context';
 
 import { type DbClient, parsePgTextArray, pgTextArray } from '../db/client';
 import {
@@ -1144,6 +1145,8 @@ export async function createConnectorOperationRun(params: {
   parentRunId?: number | null;
   /** Internal-only metadata persisted in the existing runs.run_metadata column. */
   runMetadata?: Record<string, unknown> | null;
+  /** Fresh-insert-only SDK ownership. Replaying an operation never adopts a new invocation. */
+  sdkBrowserContext?: BrowserActionContext | null;
   /**
    * Optional transaction handle. When passed, the run INSERT (and its
    * connector-version read) execute on the caller's transaction instead of the
@@ -1225,6 +1228,13 @@ export async function createConnectorOperationRun(params: {
     targetDeviceWorkerId = connRows[0]?.device_worker_id ?? null;
   }
 
+  const insertMetadata = params.sdkBrowserContext
+    ? {
+        ...params.runMetadata,
+        browser_context:
+          params.runMetadata?.browser_context ?? params.sdkBrowserContext,
+      }
+    : params.runMetadata;
   const inserted = await sql<{
     id: number;
     status: string;
@@ -1260,7 +1270,7 @@ export async function createConnectorOperationRun(params: {
       ${inlineOwner},
       ${params.activation?.kind ?? null},
       ${params.activation ? pgTextArray(params.activation.urls) : null}::text[],
-      ${params.runMetadata == null ? null : sql.json(params.runMetadata)},
+      ${insertMetadata == null ? null : sql.json(insertMetadata)},
       ${targetDeviceWorkerId == null ? null : sql`${targetDeviceWorkerId}::uuid`},
       current_timestamp
     )
@@ -1331,10 +1341,15 @@ export async function createConnectorOperationRun(params: {
         ? prior.run_metadata.browser_context
         : null;
     const requestedBrowserContext = params.runMetadata?.browser_context ?? null;
+    // Display titles are not identity: the same flow may re-request with a new subject.
+    const browserIdentity = (context: unknown) => {
+      const { title: _title, ...identity } = context as Record<string, unknown>;
+      return stableJson(identity);
+    };
     const compatibleBrowserContext =
       priorBrowserContext == null ||
       requestedBrowserContext == null ||
-      stableJson(priorBrowserContext) === stableJson(requestedBrowserContext);
+      browserIdentity(priorBrowserContext) === browserIdentity(requestedBrowserContext);
     const compatibleProvenance =
       (priorAutomationId == null || priorAutomationId === requestedAutomationId) &&
       (priorParentRunId == null || priorParentRunId === requestedParentRunId);
@@ -1358,7 +1373,7 @@ export async function createConnectorOperationRun(params: {
           ? sql`TRUE`
           : sql`(
               run_metadata->'browser_context' IS NULL
-              OR run_metadata->'browser_context' = ${sql.json(requestedBrowserContext)}::jsonb
+              OR ((run_metadata->'browser_context') - 'title') = (${sql.json(requestedBrowserContext)}::jsonb - 'title')
             )`;
       const hydrated = await sql`
         UPDATE runs

--- a/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
@@ -53,7 +53,10 @@ import { stripNul, stripNulDeep } from "../../../../utils/strip-nul";
 import { buildResourcePermalink } from "../../../../utils/url-builder";
 import { trackAutomationReaction } from "../../../../utils/automation-reactions";
 import { dispatchChromeActionToExtension } from "../../../../worker-api/dispatch-chrome-action";
-import { deriveBrowserActionContext } from "../../../../worker-api/browser-action-context";
+import {
+	deriveBrowserActionContext,
+	deriveSdkBrowserActionContext,
+} from "../../../../worker-api/browser-action-context";
 import { resolveRunInitiator } from "../../../initiator";
 import type { ToolContext } from "../../../registry";
 import { getOrgUrlContext } from "../../../view-urls";
@@ -489,6 +492,9 @@ export async function handleExecute(
 ): Promise<ManageOperationsResult> {
 	const sql = getDb();
 	const browserContext = deriveBrowserActionContext(ctx);
+	const sdkBrowserContext = browserContext
+		? undefined
+		: deriveSdkBrowserActionContext(ctx);
 	const runMetadata = browserContext
 		? { browser_context: browserContext }
 		: undefined;
@@ -767,6 +773,7 @@ export async function handleExecute(
 				automationId: ctx.actingAutomationId,
 				parentRunId: ctx.actingRunId,
 				runMetadata,
+				sdkBrowserContext,
 				idempotencyKey: args.idempotency_key,
 				db: tx,
 			});
@@ -905,6 +912,7 @@ export async function handleExecute(
 		automationId: ctx.actingAutomationId,
 		parentRunId: ctx.actingRunId,
 		runMetadata,
+		sdkBrowserContext,
 		idempotencyKey: args.idempotency_key,
 		activation,
 	});

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -118,6 +118,8 @@ export interface ToolContext {
   sourceContext?: ToolSourceContext | null;
   /** `x-lobu-apply-id` when this call belongs to a `lobu apply` run (REST proxy only). */
   applyId?: string | null;
+  /** Server-only seed shared by browser operations within one SDK invocation. */
+  sdkBrowserInvocation?: { nonce: string; title: string };
   /** Persistent MCP session id driving this call; null off the MCP transport. */
   mcpSessionId?: string | null;
   /** True only for an MCP session that negotiated the standard Apps UI extension. */

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { type Static, Type } from "@sinclair/typebox";
 import {
   isRetryable,
@@ -41,7 +42,7 @@ const SCRIPT_FIELDS = {
   title: Type.Optional(
     Type.String({
       description:
-        'Human-friendly heading for this result (e.g. "Companies missing a domain"). The UI renders it above the execution status; without it the result card has no subject line. Set it whenever a person will read the result.',
+        'Human-friendly heading for this result (e.g. "Companies missing a domain"). In run_sdk, it also labels browser tab groups opened by the script. The UI renders it above the execution status; without it the result card has no subject line. Set it whenever a person will read the result.',
       maxLength: 200,
     }),
   ),
@@ -406,9 +407,13 @@ async function runSandbox(
     sdkMode: mode,
     agentDryRun,
   });
+  const sdkContext = {
+    ...ctx,
+    sdkBrowserInvocation: { nonce: randomUUID(), title: args.title ?? "" },
+  };
   const result = await runScript({
     source: args.script,
-    sdk: (abortSignal) => buildClientSDK(ctx, env, { mode, allowCrossOrg, abortSignal }),
+    sdk: (abortSignal) => buildClientSDK(sdkContext, env, { mode, allowCrossOrg, abortSignal }),
     sdkMode: mode,
     allowCrossOrg,
     // Account scripts are scope-bounded; selected SDK clients enforce the

--- a/packages/server/src/worker-api/browser-action-context.ts
+++ b/packages/server/src/worker-api/browser-action-context.ts
@@ -1,8 +1,8 @@
 import { createHash } from 'node:crypto';
-import { currentMcpActivityAttribution } from '../lobu/stores/mcp-client-conversations';
+import { currentMcpActivityAttribution, normalizeMcpConversationTitle } from '../lobu/stores/mcp-client-conversations';
 import type { ToolContext } from '../tools/registry';
 
-type BrowserActionContext = {
+export type BrowserActionContext = {
   id: string;
   title: string;
   flow_id: string;
@@ -26,7 +26,7 @@ export function runScopedBrowserActionContext(runIdValue: unknown): BrowserActio
   if (runId == null) throw new Error('Browser action context requires a positive run id.');
   return {
     id: `run:${runId}`,
-    title: `Owletto · Run ${runId}`,
+    title: `Lobu · Browser task · ${runId}`,
     flow_id: String(runId),
     kind: 'run',
   };
@@ -67,13 +67,31 @@ export function browserActionContextFromMetadata(
   };
 }
 
+function browserTitle(ctx: ToolContext, fallback: string, suffix: string): string {
+  const subject = normalizeMcpConversationTitle(ctx.sdkBrowserInvocation?.title ?? '');
+  return `Lobu · ${subject || fallback} · ${suffix}`;
+}
+
+export function deriveSdkBrowserActionContext(ctx: ToolContext): BrowserActionContext | null {
+  if (!ctx.sdkBrowserInvocation || !ctx.userId || !ctx.isAuthenticated) return null;
+  const digest = createHash('sha256')
+    .update(JSON.stringify([ctx.organizationId, ctx.userId, ctx.sdkBrowserInvocation.nonce]))
+    .digest('hex');
+  return {
+    id: `run:sdk-${digest}`,
+    flow_id: `sdk-${digest}`,
+    title: browserTitle(ctx, 'Browser task', digest.slice(0, 12)),
+    kind: 'run',
+  };
+}
+
 export function deriveBrowserActionContext(ctx: ToolContext): BrowserActionContext | null {
   const automationId = positiveRunId(ctx.actingAutomationId);
   const actingRunId = positiveRunId(ctx.actingRunId);
   if (automationId != null && actingRunId != null) {
     return {
       id: `automation:${actingRunId}`,
-      title: `Owletto · Automation ${automationId} · Run ${actingRunId}`,
+      title: browserTitle(ctx, `Automation ${automationId}`, `Run ${actingRunId}`),
       flow_id: String(actingRunId),
       kind: 'automation',
     };
@@ -92,7 +110,7 @@ export function deriveBrowserActionContext(ctx: ToolContext): BrowserActionConte
     const id = `conversation:${digest}`;
     return {
       id,
-      title: `Owletto · Conversation ${digest}`,
+      title: browserTitle(ctx, 'Conversation', digest),
       flow_id: id,
       kind: 'conversation',
     };
@@ -109,7 +127,7 @@ export function deriveBrowserActionContext(ctx: ToolContext): BrowserActionConte
     const id = `mcp:${digest}`;
     return {
       id,
-      title: `Owletto · MCP ${digest}`,
+      title: browserTitle(ctx, 'MCP activity', digest),
       flow_id: id,
       kind: 'mcp',
     };


### PR DESCRIPTION
## Summary

Bare `run_sdk` browser actions had no shared browser context, so a close operation could fail its ownership check for a scratch tab opened earlier in the script. New SDK invocations now create one authenticated ownership seed, scope it to the selected organization/user at the operation boundary, and persist the existing browser metadata on fresh runs. Keyed replay retains its original result and ownership.

Reuse the existing SDK title for Lobu tab-group subjects without changing attributed flow identity. The companion extension change preserves leases on storage failure, removes title-based adoption, rejects references from a previous document, and recovers polling and OAuth refresh within bounded requests. The existing sidebar bootstrap now times out with Retry and ignores obsolete attempts.

## Test plan

- [x] Targeted server context/bootstrap tests: 15 passed.
- [x] Real Postgres integration: 81 passed across operation execution, idempotent replay/hydration races, parent Chrome attribution and token exchange. Includes actual SDK sandbox calls.
- [x] Chrome suite: 457 tests passed.
- [x] Installed Chromium smoke: exact click/type outcomes, navigation refs, same-title flow isolation, explicit-tab title updates, ownership guards, queued 503 recovery across worker eviction and cleanup without duplicate completion.
- [x] Actual bootstrap HTML in Chromium: success, expired-token/Retry and stalled-request/Retry; token fragment stripped, device deep link preserved, no page errors.
- [x] Full browser process restart with changed IDs: old flow did not adopt or close either restored scratch or same-title user tab. A fresh operation left the user tab untouched.
- [x] `make pre-pr` plus commit-hook Biome/root typecheck passed.
- [x] First canonical CI run passed (all unit, frontend, integration and SDK/CLI jobs).
- [x] Canonical CI on final commit `37ade774` passed. `make land N=3428 CHECK_ONLY=1` verified all 10 required checks are merge-satisfying.
- [x] Fable semantic verdict: 0 bugs, 0 blockers, confidence 85, simplicity 76, slop 8. UI review passed as unhosted extension/script changes.

Red → green evidence:

```text
Before: rejected ownership reads lost stored leases; poll preflight rejections left no next callback.
Before: all new documents used epoch 1; an old ref clicked the new page after its snapshot.
Before: 3 refresh deadline tests failed (no timeout), stalled poll body reported connected:true.
Before: targeted-action title stayed "Lobu · Old task" instead of "Lobu · New task".
Before: 2 missing-tab dispatch tests failed before their persisted-ownership check.
After: 457 Chrome tests, 15 server unit tests, 81 database integration tests passed.
PASS installed extension: click/type outcomes, navigation refs, flow isolation, titles, worker eviction, close/release guards
PASS background worker: poll -> dispatch -> failed action -> 503 -> worker eviction -> recovery -> completion -> cleanup; no duplicate completion
```

## Notes

One delivery with merged [Owletto #1037](https://github.com/lobu-ai/owletto/pull/1037), pinned at its squash commit `fd58c768`. No database tables/columns, migrations, public arguments, endpoints, permission grants or automatic action retries. Existing metadata is reused; fallback-only keyed replay never hydrates an older run.

Browser tests use disposable profiles and a synthetic local gateway. The exact SDK-to-production-extension journey, paired sidebar after rollout, hidden-window first-click scenario and coincidental numeric ID reuse remain production/verification limits. This does not claim that every automation or connector is healthy.

Fable completed the design and settled pre-commit review, including the Chrome suite and queue identity regressions.

Diff accounting across both repositories: shipping code +197/−134 (net +63), tests/smoke +1101/−29 (net +1072), design record +45. No API endpoint or DB schema changes.

A non-required CodeQL check flags the lowercase `<script>` extractor in `extension-bootstrap.test.ts:11`. The test extracts JavaScript from the fixed local bootstrap template; it does not filter untrusted HTML. This test-only scanner warning remains open at the PR checkpoint.

The extension companion is merged. The Lobu gateway PR remains open for the release checkpoint; production SDK → paired extension smoke, paired sidebar deep link and idle/sleep checks still need rollout/reload. The authored diff accounting above excludes the existing +1/−1 deployment-image update inherited when pinning the Owletto squash commit.


### Production verification — 2026-09-08

Production image build 34180454391 passed. The live health revision is the squash commit `4793677513536a1ce93b64a8c9b1429367ca96f7`; ancestry and deployment rollout were verified. The updated Chrome device advertised manifest hash `54c593485b26555f0bb82ba6df93499b291ea0fe86309003edf567c6ac1c80f4` after reload.

The live SDK smoke is **not green**:
- The gateway persisted one ownership identity across all seven operations in the first SDK invocation, with the requested human-readable title. A separate invocation received a different identity. Both flows closed their own scratch tabs successfully.
- Cross-flow close/release attempts were refused after the first tab had already closed. This verifies refusal for a missing foreign tab; it does not establish the live foreign-tab branch.
- Click reported success but the fixture recorded zero clicks; typing produced the exact expected value and the page was hidden. Inspection of `executed_by_device_worker_id` showed that this ran on the other, older Chrome device, so this is not evidence against the updated extension's click behavior.
- The intended device's connection lost its physical pin during mixed-manifest reconciliation. Both devices advertised connector version `0.2.3` with different hashes. The old hash wins the equal-version lexical tie-break; `device-reconcile.ts` clears a pin whose device does not advertise that winning hash. The newly unpinned connection was then served by the other device. This PR changed the manifest without advancing its connector version, exposing that existing routing flaw.

No tenant configuration or routing code was changed during this verification. Both scratch tabs were cleaned up. New-extension production stale-reference tests, live foreign-tab ownership, sidebar confirmation, and idle/sleep action recovery remain incomplete. A separate approved device-routing slice is required before claiming the requested production E2E passed.
