### PR TITLE
fix(device): preserve physical pins and fail incompatible runs promptly

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/device-feed-read.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/device-feed-read.test.ts
@@ -251,6 +251,10 @@ describe('device-backed source feed read', () => {
     await setDeviceCapabilities(['local_directory']);
     const sql = getTestDb();
     await sql`UPDATE device_workers SET connector_manifests = ${sql.json(DIRECTORY_INVENTORY)} WHERE id = ${deviceWorkerId}::uuid`;
+    await sql`
+      UPDATE connector_versions SET compiled_code_hash = ${DIRECTORY_MANIFEST_HASH}
+      WHERE connector_key = ${CONNECTOR_KEY} AND version = ${CONNECTOR_VERSION}
+    `;
     await getTestDb()`UPDATE feeds SET status = 'active' WHERE id = ${feedId}`;
     await getTestDb()`DELETE FROM runs WHERE organization_id = ${orgId}`;
   });
@@ -458,7 +462,7 @@ describe('device-backed source feed read', () => {
       connectionId,
       connectorKey: CONNECTOR_KEY,
       connectorVersion: CONNECTOR_VERSION,
-      manifestHash: null,
+      manifestHash: DIRECTORY_MANIFEST_HASH,
       deviceOwnerUserId: userId,
       deviceWorkerId: foreign[0].id,
       feedStatus: 'active',
@@ -497,7 +501,17 @@ describe('device-backed source feed read', () => {
         },
       })} WHERE id = ${deviceWorkerId}::uuid
     `;
-    await expect(readSourceFeed({ scope: scope(), feedId })).rejects.toThrow(/selected connector manifest.*assigned device/i);
+    await expect(readSourceFeed({ scope: scope(), feedId })).rejects.toThrow(/selected connector manifest.*eligible device/i);
+    expect(await readRunRows()).toHaveLength(0);
+  });
+
+  it('refuses a manifest-backed read whose selected artifact has no hash', async () => {
+    const sql = getTestDb();
+    await sql`
+      UPDATE connector_versions SET compiled_code_hash = NULL
+      WHERE connector_key = ${CONNECTOR_KEY} AND version = ${CONNECTOR_VERSION}
+    `;
+    await expect(readSourceFeed({ scope: scope(), feedId })).rejects.toThrow(/selected connector manifest.*eligible device/i);
     expect(await readRunRows()).toHaveLength(0);
   });
 
@@ -1077,7 +1091,7 @@ describe('device source-feed read lifecycle — deadlines and orphan sweeping', 
       connectionId: lifecycleConnectionId,
       connectorKey: CONNECTOR_KEY,
       connectorVersion: CONNECTOR_VERSION,
-      manifestHash: null,
+      manifestHash: DIRECTORY_MANIFEST_HASH,
       deviceOwnerUserId: lifecycleUserId,
       deviceWorkerId: lifecycleDeviceId,
       feedStatus: 'active',
@@ -1122,7 +1136,7 @@ describe('device source-feed read lifecycle — deadlines and orphan sweeping', 
       connectionId: lifecycleConnectionId,
       connectorKey: CONNECTOR_KEY,
       connectorVersion: CONNECTOR_VERSION,
-      manifestHash: null,
+      manifestHash: DIRECTORY_MANIFEST_HASH,
       deviceOwnerUserId: lifecycleUserId,
       deviceWorkerId: lifecycleDeviceId,
       feedStatus: 'active',

--- a/packages/server/src/__tests__/integration/connectors/device-feed-read.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/device-feed-read.test.ts
@@ -463,6 +463,7 @@ describe('device-backed source feed read', () => {
       connectorKey: CONNECTOR_KEY,
       connectorVersion: CONNECTOR_VERSION,
       manifestHash: DIRECTORY_MANIFEST_HASH,
+      connectorRuntime: { platforms: ['macos'] },
       deviceOwnerUserId: userId,
       deviceWorkerId: foreign[0].id,
       feedStatus: 'active',
@@ -505,15 +506,26 @@ describe('device-backed source feed read', () => {
     expect(await readRunRows()).toHaveLength(0);
   });
 
-  it('refuses a manifest-backed read whose selected artifact has no hash', async () => {
+  it('serves a pre-attestation hashless artifact through the legacy capability poll', async () => {
     const sql = getTestDb();
     await sql`
       UPDATE connector_versions SET compiled_code_hash = NULL
       WHERE connector_key = ${CONNECTOR_KEY} AND version = ${CONNECTOR_VERSION}
     `;
-    await expect(readSourceFeed({ scope: scope(), feedId })).rejects.toThrow(/selected connector manifest.*eligible device/i);
-    expect(await readRunRows()).toHaveLength(0);
-  });
+    await sql`UPDATE device_workers SET connector_manifests = '{}'::jsonb WHERE id = ${deviceWorkerId}::uuid`;
+    const reading = readSourceFeed({ scope: scope(), feedId });
+    const result = reading.then(value => ({ value }), error => ({ error }));
+    await respondAsDevice({
+      status: 'success',
+      action_output: { rows: DEVICE_ROWS, columns: DEVICE_COLUMNS },
+    });
+    expect(await result).toMatchObject({ value: { rows: DEVICE_ROWS } });
+    const runs = await readRunRows();
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({ status: 'completed', action_output: null });
+    expect(runs[0].action_input).toEqual({ scrubbed: true, feed_key: FEED_KEY });
+    expect(await countPersistence()).toEqual({ events: 0, checkpointed: 0 });
+  }, 30_000);
 
   it('keeps an offline execution pin authoritative over another device\'s setup state', async () => {
     await setDeviceLastSeen('30 minutes');
@@ -1092,6 +1104,7 @@ describe('device source-feed read lifecycle — deadlines and orphan sweeping', 
       connectorKey: CONNECTOR_KEY,
       connectorVersion: CONNECTOR_VERSION,
       manifestHash: DIRECTORY_MANIFEST_HASH,
+      connectorRuntime: { platforms: ['macos'] },
       deviceOwnerUserId: lifecycleUserId,
       deviceWorkerId: lifecycleDeviceId,
       feedStatus: 'active',
@@ -1137,6 +1150,7 @@ describe('device source-feed read lifecycle — deadlines and orphan sweeping', 
       connectorKey: CONNECTOR_KEY,
       connectorVersion: CONNECTOR_VERSION,
       manifestHash: DIRECTORY_MANIFEST_HASH,
+      connectorRuntime: { platforms: ['macos'] },
       deviceOwnerUserId: lifecycleUserId,
       deviceWorkerId: lifecycleDeviceId,
       feedStatus: 'active',

--- a/packages/server/src/__tests__/integration/connectors/device-feed-read.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/device-feed-read.test.ts
@@ -55,6 +55,23 @@ const CONNECTOR_KEY = 'local.directory';
 const CONNECTOR_VERSION = '0.3.0';
 const FEED_KEY = 'files';
 const WORKER_ID = 'wk-dir-source-read';
+const DIRECTORY_MANIFEST: DeviceConnectorManifest = {
+  key: CONNECTOR_KEY,
+  version: CONNECTOR_VERSION,
+  name: 'Local Folder',
+  required_capability: 'local_directory',
+  runtime: { platforms: ['macos'] },
+  auth_schema: { methods: [{ type: 'none' }] },
+  feeds_schema: { [FEED_KEY]: { key: FEED_KEY, operations: ['read'] } },
+};
+const DIRECTORY_MANIFEST_HASH = deviceManifestHash(DIRECTORY_MANIFEST);
+const DIRECTORY_INVENTORY = {
+  [CONNECTOR_KEY]: {
+    manifest: DIRECTORY_MANIFEST,
+    manifest_hash: DIRECTORY_MANIFEST_HASH,
+    received_at: new Date().toISOString(),
+  },
+};
 
 const DEVICE_ROWS = [
   {
@@ -200,9 +217,9 @@ describe('device-backed source feed read', () => {
               ${sql.json({ methods: [{ type: 'none' }] })}, NOW(), NOW())
     `;
     await sql`
-      INSERT INTO connector_versions (connector_key, version, compiled_code, source_path, created_at)
+      INSERT INTO connector_versions (connector_key, version, compiled_code, source_path, compiled_code_hash, created_at)
       VALUES (${CONNECTOR_KEY}, ${CONNECTOR_VERSION}, NULL,
-              ${`device-manifest://macos/${CONNECTOR_KEY}@${CONNECTOR_VERSION}`}, NOW())
+              ${`device-manifest://macos/${CONNECTOR_KEY}@${CONNECTOR_VERSION}`}, ${DIRECTORY_MANIFEST_HASH}, NOW())
     `;
     const connection = (await sql`
       INSERT INTO connections
@@ -232,7 +249,8 @@ describe('device-backed source feed read', () => {
     __setDeviceActionWaiterForTest(null);
     await setDeviceLastSeen('5 seconds');
     await setDeviceCapabilities(['local_directory']);
-    await getTestDb()`UPDATE device_workers SET connector_manifests = '{}'::jsonb WHERE id = ${deviceWorkerId}::uuid`;
+    const sql = getTestDb();
+    await sql`UPDATE device_workers SET connector_manifests = ${sql.json(DIRECTORY_INVENTORY)} WHERE id = ${deviceWorkerId}::uuid`;
     await getTestDb()`UPDATE feeds SET status = 'active' WHERE id = ${feedId}`;
     await getTestDb()`DELETE FROM runs WHERE organization_id = ${orgId}`;
   });
@@ -464,6 +482,22 @@ describe('device-backed source feed read', () => {
       /is unavailable: device "Test Mac" is offline \(last polled 30m ago\)/
     );
     // No run parked for the 60s queue budget — the server already knew.
+    expect(await readRunRows()).toHaveLength(0);
+  });
+
+  it('refuses an online device with a different manifest before queuing a source read', async () => {
+    const sql = getTestDb();
+    const otherManifest = { ...DIRECTORY_MANIFEST, name: 'Different build' };
+    await sql`
+      UPDATE device_workers SET connector_manifests = ${sql.json({
+        [CONNECTOR_KEY]: {
+          manifest: otherManifest,
+          manifest_hash: deviceManifestHash(otherManifest),
+          received_at: new Date().toISOString(),
+        },
+      })} WHERE id = ${deviceWorkerId}::uuid
+    `;
+    await expect(readSourceFeed({ scope: scope(), feedId })).rejects.toThrow(/selected connector manifest.*assigned device/i);
     expect(await readRunRows()).toHaveLength(0);
   });
 
@@ -748,9 +782,9 @@ describe('unpinned device source-feed reads are a personal-org lane', () => {
     personalDeviceWorkerId = device[0].id;
 
     await sql`
-      INSERT INTO connector_versions (connector_key, version, compiled_code, source_path, created_at)
+      INSERT INTO connector_versions (connector_key, version, compiled_code, source_path, compiled_code_hash, created_at)
       VALUES (${CONNECTOR_KEY}, ${CONNECTOR_VERSION}, NULL,
-              ${`device-manifest://macos/${CONNECTOR_KEY}@${CONNECTOR_VERSION}`}, NOW())
+              ${`device-manifest://macos/${CONNECTOR_KEY}@${CONNECTOR_VERSION}`}, ${DIRECTORY_MANIFEST_HASH}, NOW())
     `;
     personalFeedId = (await seedPersonalLaneConnection(personalOrgId, 'folder-personal')).feedId;
     const teamSeed = await seedPersonalLaneConnection(teamOrgId, 'folder-team');
@@ -767,7 +801,8 @@ describe('unpinned device source-feed reads are a personal-org lane', () => {
     await sql`DELETE FROM runs WHERE organization_id IN (${personalOrgId}, ${teamOrgId})`;
     await sql`
       UPDATE device_workers
-      SET last_seen_at = now(), capabilities = ${sql.json([CAPABILITY])}
+      SET last_seen_at = now(), capabilities = ${sql.json([CAPABILITY])},
+          connector_manifests = ${sql.json(DIRECTORY_INVENTORY)}
       WHERE id = ${personalDeviceWorkerId}::uuid
     `;
     await sql`
@@ -984,9 +1019,9 @@ describe('device source-feed read lifecycle — deadlines and orphan sweeping', 
               ${sql.json({ methods: [{ type: 'none' }] })}, NOW(), NOW())
     `;
     await sql`
-      INSERT INTO connector_versions (connector_key, version, compiled_code, source_path, created_at)
+      INSERT INTO connector_versions (connector_key, version, compiled_code, source_path, compiled_code_hash, created_at)
       VALUES (${CONNECTOR_KEY}, ${CONNECTOR_VERSION}, NULL,
-              ${`device-manifest://macos/${CONNECTOR_KEY}@${CONNECTOR_VERSION}`}, NOW())
+              ${`device-manifest://macos/${CONNECTOR_KEY}@${CONNECTOR_VERSION}`}, ${DIRECTORY_MANIFEST_HASH}, NOW())
     `;
     const connection = (await sql`
       INSERT INTO connections
@@ -1019,7 +1054,8 @@ describe('device source-feed read lifecycle — deadlines and orphan sweeping', 
     await sql`DELETE FROM runs WHERE organization_id = ${lifecycleOrgId}`;
     await sql`
       UPDATE device_workers
-      SET last_seen_at = now(), capabilities = ${sql.json([CAPABILITY])}
+      SET last_seen_at = now(), capabilities = ${sql.json([CAPABILITY])},
+          connector_manifests = ${sql.json(DIRECTORY_INVENTORY)}
       WHERE id = ${lifecycleDeviceId}::uuid
     `;
   });

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -1799,7 +1799,7 @@ describe('device connector manifests', () => {
     expect((await readDefinition(orgId, CHROME_MANIFEST_KEY))?.version).toBe('1.0.0');
 
     const v2WorkerId = `chrome-wa-v2-setup-${generateSecureToken(4)}`;
-    const v2DeviceId = await seedAdditionalDevice({
+    await seedAdditionalDevice({
       userId,
       orgId,
       workerId: v2WorkerId,
@@ -1849,7 +1849,7 @@ describe('device connector manifests', () => {
     ).toBe(200);
     const upgraded = await readChromeConnectorRows(orgId);
     expect(upgraded.feeds[0]?.status).toBe('active');
-    expect(upgraded.connections[0]?.device_worker_id).toBe(v2DeviceId);
+    expect(upgraded.connections[0]?.device_worker_id).toBe(before.connections[0]?.device_worker_id);
     expect((await readDefinition(orgId, CHROME_MANIFEST_KEY))?.version).toBe('2.0.0');
   });
 

--- a/packages/server/src/__tests__/integration/device-pin-admission.test.ts
+++ b/packages/server/src/__tests__/integration/device-pin-admission.test.ts
@@ -1,0 +1,295 @@
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../index';
+import { createConnectorOperationRun, createSyncRun } from '../../runs/queue-service';
+import { manageOperations } from '../../tools/admin/manage_operations';
+import type { ToolContext } from '../../tools/registry';
+import {
+  deviceManifestHash,
+  type DeviceConnectorManifest,
+} from '../../worker-api/device-manifests';
+import { initWorkspaceProvider } from '../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import {
+  createTestConnection,
+  createTestConnectorDefinition,
+  seedOwnerContext,
+} from '../setup/test-fixtures';
+import { post } from '../setup/test-helpers';
+
+const KEY = 'chrome.test_admission';
+const CAPABILITY = 'browser.scripting';
+
+function manifest(version = '1.0.0', name = 'Admission test browser'): DeviceConnectorManifest {
+  return {
+    key: KEY,
+    version,
+    name,
+    description: 'Synthetic device admission test connector.',
+    required_capability: CAPABILITY,
+    runtime: { platforms: ['chrome-extension'] },
+    auth_schema: { methods: [{ type: 'none' }] },
+    actions_schema: {
+      echo: {
+        name: 'Echo',
+        kind: 'read',
+        input_schema: { type: 'object', properties: {} },
+      },
+    },
+    feeds_schema: {
+      default: { key: 'default', name: 'Snapshots', operations: ['sync'] },
+    },
+  };
+}
+
+async function seedDevice(userId: string, orgId: string, advertised: DeviceConnectorManifest) {
+  const sql = getTestDb();
+  const workerId = `admission-test-${randomUUID()}`;
+  const [device] = await sql<{ id: string }[]>`
+    INSERT INTO device_workers (
+      user_id, worker_id, platform, capabilities, connector_manifests,
+      label, organization_id, last_seen_at
+    ) VALUES (
+      ${userId}, ${workerId}, 'chrome-extension', ${sql.json([CAPABILITY])},
+      ${sql.json({
+        [KEY]: {
+          manifest: advertised,
+          manifest_hash: deviceManifestHash(advertised),
+          received_at: new Date().toISOString(),
+        },
+      })}, 'Synthetic admission device', ${orgId}, NOW()
+    ) RETURNING id
+  `;
+  return { id: device.id, workerId };
+}
+
+async function seedFixture(advertised = manifest(), selected = manifest()) {
+  const { org, user, ctx } = await seedOwnerContext();
+  ctx.baseUrl = 'https://gateway.test/lobu';
+  const sql = getTestDb();
+  await sql`
+    UPDATE organization SET metadata = ${sql.json({ personal_org_for_user_id: user.id })}
+    WHERE id = ${org.id}
+  `;
+  await createTestConnectorDefinition({
+    organization_id: org.id,
+    key: KEY,
+    name: selected.name,
+    version: selected.version,
+    auth_schema: selected.auth_schema,
+    feeds_schema: selected.feeds_schema,
+  });
+  await sql`
+    UPDATE connector_definitions
+    SET required_capability = ${CAPABILITY}, runtime = ${sql.json(selected.runtime)},
+        actions_schema = ${sql.json(selected.actions_schema!)}
+    WHERE organization_id = ${org.id} AND key = ${KEY}
+  `;
+  await sql`
+    UPDATE connector_versions
+    SET source_path = ${`device-manifest://chrome-extension/${KEY}@${selected.version}`},
+        compiled_code = NULL, compile_config_hash = NULL, source_code = NULL,
+        compiled_code_hash = ${deviceManifestHash(selected)}
+    WHERE connector_key = ${KEY} AND version = ${selected.version}
+  `;
+  const device = await seedDevice(user.id, org.id, advertised);
+  const connection = await createTestConnection({
+    organization_id: org.id,
+    connector_key: KEY,
+    created_by: user.id,
+    visibility: 'private',
+  });
+  await sql`UPDATE connections SET device_worker_id = ${device.id}::uuid WHERE id = ${connection.id}`;
+  await sql`UPDATE feeds SET next_run_at = '2099-01-01' WHERE connection_id = ${connection.id}`;
+  return { org, user, ctx, connection, device, selected, advertised };
+}
+
+type Fixture = Awaited<ReturnType<typeof seedFixture>>;
+
+function queueOperation(fixture: Fixture, idempotencyKey?: string) {
+  return createConnectorOperationRun({
+    organizationId: fixture.org.id,
+    connectionId: fixture.connection.id,
+    connectorKey: KEY,
+    operationKey: 'echo',
+    operationInput: {},
+    approvalMode: 'device',
+    createdByUserId: fixture.user.id,
+    idempotencyKey,
+  });
+}
+
+async function readiness(connectionId: number, ctx: ToolContext) {
+  const result = await manageOperations(
+    { action: 'list_available', connection_id: connectionId },
+    {} as Env,
+    ctx,
+  ) as {
+    operations: Array<{
+      operation_key: string;
+      executable: boolean;
+      execution_targets: Array<{ executable: boolean; reason: string }>;
+    }>;
+  };
+  const operation = result.operations.find((candidate) => candidate.operation_key === 'echo');
+  expect(operation).toBeDefined();
+  return operation!;
+}
+
+async function pollDevice(device: { workerId: string }, advertised: DeviceConnectorManifest) {
+  const response = await post('/api/workers/poll', {
+    body: {
+      worker_id: device.workerId,
+      platform: 'chrome-extension',
+      app_version: '1.0.0',
+      capabilities: { [CAPABILITY]: true },
+      connector_manifests: [advertised],
+      capacity_available: 1,
+    },
+  });
+  expect(response.status).toBe(200);
+  return response.json() as Promise<{ run_id?: number }>;
+}
+
+describe('manifest-backed device pin admission', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    delete process.env.LOBU_CLOUD_MODE;
+    delete process.env.WORKER_API_TOKEN;
+  });
+
+  afterEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it.each([
+    ['different version', manifest('0.9.0')],
+    ['different hash at the same version', manifest('1.0.0', 'Other implementation')],
+  ])('blocks a pin advertising a %s even when another device matches', async (_case, advertised) => {
+    const fixture = await seedFixture(advertised as DeviceConnectorManifest);
+    await seedDevice(fixture.user.id, fixture.org.id, fixture.selected);
+    const available = await readiness(fixture.connection.id, fixture.ctx);
+    expect(available.executable).toBe(false);
+    expect(available.execution_targets[0]).toMatchObject({ executable: false });
+    expect(available.execution_targets[0].reason).toMatch(/manifest|setup|implementation|version/i);
+
+    const result = await queueOperation(fixture);
+    expect(result.status).toBe('failed');
+    expect(result.errorMessage).toMatch(/device|manifest|setup|implementation|version/i);
+    const rows = await getTestDb()`
+      SELECT id FROM runs WHERE connection_id = ${fixture.connection.id}
+        AND status IN ('pending', 'claimed', 'running')
+    `;
+    expect(rows).toHaveLength(0);
+  });
+
+  it('does not report ready when no device advertises the selected exact artifact', async () => {
+    const fixture = await seedFixture(manifest('0.9.0'));
+    const available = await readiness(fixture.connection.id, fixture.ctx);
+    expect(available.executable).toBe(false);
+    expect(available.execution_targets[0].reason).toMatch(/manifest|setup|implementation|version/i);
+    const result = await queueOperation(fixture);
+    expect(result.status).toBe('failed');
+    expect(result.errorMessage).toMatch(/device|manifest|setup|implementation|version/i);
+  });
+
+  it('returns the admission failure through operations.execute without waiting for a worker', async () => {
+    const fixture = await seedFixture(manifest('0.9.0'));
+    const controller = new AbortController();
+    const deadline = setTimeout(() => controller.abort(), 3_000);
+    try {
+      const result = await manageOperations(
+        { action: 'execute', connection_id: fixture.connection.id, operation_key: 'echo', input: {} },
+        {} as Env,
+        { ...fixture.ctx, abortSignal: controller.signal },
+      ) as { status?: string; error_message?: string };
+      expect(controller.signal.aborted).toBe(false);
+      expect(result.status).toBe('failed');
+      expect(result.error_message).toMatch(/device|manifest|setup|implementation|version/i);
+      const runnable = await getTestDb()`
+        SELECT id FROM runs WHERE connection_id = ${fixture.connection.id}
+          AND status IN ('pending', 'claimed', 'running')
+      `;
+      expect(runnable).toHaveLength(0);
+    } finally {
+      clearTimeout(deadline);
+    }
+  });
+
+  it('returns a completed keyed result unchanged after its device goes offline', async () => {
+    const fixture = await seedFixture();
+    const first = await queueOperation(fixture, 'admission-completed-replay');
+    expect(first.status).toBe('pending');
+    const sql = getTestDb();
+    await sql`
+      UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json({ original: true })}
+      WHERE id = ${first.runId}
+    `;
+    await sql`UPDATE device_workers SET last_seen_at = NOW() - INTERVAL '10 minutes' WHERE id = ${fixture.device.id}::uuid`;
+
+    const replay = await queueOperation(fixture, 'admission-completed-replay');
+    expect(replay).toMatchObject({
+      created: false,
+      runId: first.runId,
+      status: 'completed',
+      actionOutput: { original: true },
+      errorMessage: null,
+    });
+    const fresh = await queueOperation(fixture, 'admission-after-offline');
+    expect(fresh.status).toBe('failed');
+  });
+
+  it('admits a compatible operation only to the exact pinned device', async () => {
+    const fixture = await seedFixture();
+    const other = await seedDevice(fixture.user.id, fixture.org.id, fixture.selected);
+    expect((await readiness(fixture.connection.id, fixture.ctx)).executable).toBe(true);
+    const run = await queueOperation(fixture);
+    expect(run.status).toBe('pending');
+    const [stored] = await getTestDb()`SELECT target_device_worker_id FROM runs WHERE id = ${run.runId}`;
+    expect(stored.target_device_worker_id).toBe(fixture.device.id);
+    expect((await pollDevice(other, fixture.selected)).run_id).toBeUndefined();
+    expect((await pollDevice(fixture.device, fixture.selected)).run_id).toBe(run.runId);
+  });
+
+  it('rejects a manual sync whose selected artifact cannot run on its pinned device', async () => {
+    const fixture = await seedFixture(manifest('0.9.0'));
+    const [feed] = await getTestDb()`SELECT id FROM feeds WHERE connection_id = ${fixture.connection.id}`;
+    await expect(createSyncRun(Number(feed.id), {} as Env)).rejects.toThrow(/device|manifest|setup|implementation|version/i);
+    const runs = await getTestDb()`SELECT id FROM runs WHERE connection_id = ${fixture.connection.id}`;
+    expect(runs).toHaveLength(0);
+  });
+
+  it('admits a retained pinned_version sync despite an incompatible newer active definition', async () => {
+    const oldManifest = manifest('0.9.0');
+    const fixture = await seedFixture(oldManifest);
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO connector_versions (
+        organization_id, connector_key, version, source_path, compiled_code_hash, created_at
+      ) VALUES (
+        ${fixture.org.id}, ${KEY}, ${oldManifest.version},
+        ${`device-manifest://chrome-extension/${KEY}@${oldManifest.version}`},
+        ${deviceManifestHash(oldManifest)}, NOW()
+      )
+    `;
+    const [feed] = await sql`
+      UPDATE feeds SET pinned_version = ${oldManifest.version}
+      WHERE connection_id = ${fixture.connection.id} RETURNING id
+    `;
+    const result = await createSyncRun(Number(feed.id), {} as Env);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(`Sync was skipped: ${result.reason}`);
+    const [run] = await sql`
+      SELECT connector_version, target_device_worker_id, status FROM runs WHERE id = ${result.runId}
+    `;
+    expect(run).toMatchObject({
+      connector_version: oldManifest.version,
+      target_device_worker_id: fixture.device.id,
+      status: 'pending',
+    });
+  });
+});

--- a/packages/server/src/__tests__/integration/device-pin-admission.test.ts
+++ b/packages/server/src/__tests__/integration/device-pin-admission.test.ts
@@ -50,9 +50,9 @@ async function seedDevice(userId: string, orgId: string, advertised: DeviceConne
       user_id, worker_id, platform, capabilities, connector_manifests,
       label, organization_id, last_seen_at
     ) VALUES (
-      ${userId}, ${workerId}, 'chrome-extension', ${sql.json([CAPABILITY])},
+      ${userId}, ${workerId}, ${advertised.runtime.platforms[0]}, ${sql.json([advertised.required_capability])},
       ${sql.json({
-        [KEY]: {
+        [advertised.key]: {
           manifest: advertised,
           manifest_hash: deviceManifestHash(advertised),
           received_at: new Date().toISOString(),
@@ -73,7 +73,7 @@ async function seedFixture(advertised = manifest(), selected = manifest()) {
   `;
   await createTestConnectorDefinition({
     organization_id: org.id,
-    key: KEY,
+    key: selected.key,
     name: selected.name,
     version: selected.version,
     auth_schema: selected.auth_schema,
@@ -81,21 +81,21 @@ async function seedFixture(advertised = manifest(), selected = manifest()) {
   });
   await sql`
     UPDATE connector_definitions
-    SET required_capability = ${CAPABILITY}, runtime = ${sql.json(selected.runtime)},
+    SET required_capability = ${selected.required_capability!}, runtime = ${sql.json(selected.runtime)},
         actions_schema = ${sql.json(selected.actions_schema!)}
-    WHERE organization_id = ${org.id} AND key = ${KEY}
+    WHERE organization_id = ${org.id} AND key = ${selected.key}
   `;
   await sql`
     UPDATE connector_versions
-    SET source_path = ${`device-manifest://chrome-extension/${KEY}@${selected.version}`},
+    SET source_path = ${`device-manifest://${selected.runtime.platforms[0]}/${selected.key}@${selected.version}`},
         compiled_code = NULL, compile_config_hash = NULL, source_code = NULL,
         compiled_code_hash = ${deviceManifestHash(selected)}
-    WHERE connector_key = ${KEY} AND version = ${selected.version}
+    WHERE connector_key = ${selected.key} AND version = ${selected.version}
   `;
   const device = await seedDevice(user.id, org.id, advertised);
   const connection = await createTestConnection({
     organization_id: org.id,
-    connector_key: KEY,
+    connector_key: selected.key,
     created_by: user.id,
     visibility: 'private',
   });
@@ -110,7 +110,7 @@ function queueOperation(fixture: Fixture, idempotencyKey?: string) {
   return createConnectorOperationRun({
     organizationId: fixture.org.id,
     connectionId: fixture.connection.id,
-    connectorKey: KEY,
+    connectorKey: fixture.selected.key,
     operationKey: 'echo',
     operationInput: {},
     approvalMode: 'device',
@@ -270,6 +270,63 @@ describe('manifest-backed device pin admission', () => {
     expect(stored.target_device_worker_id).toBe(fixture.device.id);
     expect((await pollDevice(other, fixture.selected)).run_id).toBeUndefined();
     expect((await pollDevice(fixture.device, fixture.selected)).run_id).toBe(run.runId);
+  });
+
+  it('admits native capability-only actions and manual sync without a manifest hash', async () => {
+    const native = {
+      ...manifest(),
+      key: 'local.test_admission',
+      required_capability: 'local_directory',
+      runtime: { platforms: ['macos'] },
+    };
+    const fixture = await seedFixture(native, native);
+    const sql = getTestDb();
+    await sql`
+      UPDATE connector_versions SET compiled_code_hash = NULL
+      WHERE connector_key = ${native.key} AND version = ${native.version}
+    `;
+    await sql`UPDATE device_workers SET connector_manifests = '{}'::jsonb WHERE id = ${fixture.device.id}::uuid`;
+    expect((await readiness(fixture.connection.id, fixture.ctx)).executable).toBe(true);
+    const run = await queueOperation(fixture);
+    expect(run.status).toBe('pending');
+    const response = await post('/api/workers/poll', {
+      body: {
+        worker_id: fixture.device.workerId,
+        platform: 'macos',
+        capabilities: { local_directory: true },
+        capacity_available: 1,
+      },
+    });
+    expect(response.status).toBe(200);
+    expect((await response.json()).run_id).toBe(run.runId);
+    const [feed] = await sql`SELECT id FROM feeds WHERE connection_id = ${fixture.connection.id}`;
+    expect((await createSyncRun(Number(feed.id), {} as Env)).ok).toBe(true);
+  });
+
+  it('rejects a hashless artifact whose platform cannot use the legacy capability lane', async () => {
+    // `headless` and `chrome-extension` are excluded from
+    // `legacyHashlessManifestAuthorization`, so a hashless artifact confined to
+    // them is unclaimable — admitting it would park a run nothing can pick up.
+    const shell = {
+      ...manifest(),
+      key: 'local.test_headless_admission',
+      required_capability: 'local_directory',
+      runtime: { platforms: ['headless'] },
+    };
+    const fixture = await seedFixture(shell, shell);
+    const sql = getTestDb();
+    await sql`
+      UPDATE connector_versions SET compiled_code_hash = NULL
+      WHERE connector_key = ${shell.key} AND version = ${shell.version}
+    `;
+    await sql`UPDATE device_workers SET connector_manifests = '{}'::jsonb WHERE id = ${fixture.device.id}::uuid`;
+    expect((await readiness(fixture.connection.id, fixture.ctx)).executable).toBe(false);
+    const run = await queueOperation(fixture);
+    expect(run.status).toBe('failed');
+    const [stored] = await sql`SELECT error_message FROM runs WHERE id = ${run.runId}`;
+    expect(String(stored.error_message)).toMatch(/selected connector manifest.*eligible device/i);
+    const [feed] = await sql`SELECT id FROM feeds WHERE connection_id = ${fixture.connection.id}`;
+    await expect(createSyncRun(Number(feed.id), {} as Env)).rejects.toThrow(/selected connector manifest.*eligible device/i);
   });
 
   it('rejects a manual sync whose selected artifact cannot run on its pinned device', async () => {

--- a/packages/server/src/__tests__/integration/device-pin-admission.test.ts
+++ b/packages/server/src/__tests__/integration/device-pin-admission.test.ts
@@ -197,6 +197,23 @@ describe('manifest-backed device pin admission', () => {
     expect(result.errorMessage).toMatch(/device|manifest|setup|implementation|version/i);
   });
 
+  it.each([true, false])('rejects a manifest artifact without a hash (pinned=%s)', async (pinned) => {
+    const fixture = await seedFixture(manifest('1.0.0', 'Unverified build'));
+    const sql = getTestDb();
+    await sql`
+      UPDATE connector_versions SET compiled_code_hash = NULL
+      WHERE connector_key = ${KEY} AND version = ${fixture.selected.version}
+    `;
+    if (!pinned) {
+      await sql`UPDATE connections SET device_worker_id = NULL WHERE id = ${fixture.connection.id}`;
+    }
+
+    expect((await queueOperation(fixture)).status).toBe('failed');
+    expect((await readiness(fixture.connection.id, fixture.ctx)).executable).toBe(false);
+    const [feed] = await sql`SELECT id FROM feeds WHERE connection_id = ${fixture.connection.id}`;
+    await expect(createSyncRun(Number(feed.id), {} as Env)).rejects.toThrow(/manifest/i);
+  });
+
   it('returns the admission failure through operations.execute without waiting for a worker', async () => {
     const fixture = await seedFixture(manifest('0.9.0'));
     const controller = new AbortController();

--- a/packages/server/src/__tests__/integration/device-pin-owner-guard.test.ts
+++ b/packages/server/src/__tests__/integration/device-pin-owner-guard.test.ts
@@ -8,15 +8,9 @@
  * PER DEVICE, the same shape `idx_connections_org_connector_account_live` gives
  * OAuth accounts.
  *
- * Retiring a Mac leaves its connection pinned to the now-stale device while the
- * replacement Mac's connection holds the only fresh one. The fast path resolves
- * a connection for the (org, connector) with no ORDER BY, hands it to
- * `reconcilePin`, and the pin UPDATE targets a device the OTHER row owns — 23505,
- * the whole wire transaction aborts, and the poll retries forever.
- *
- * Observed on prod 2026-07-29: org 8dc12bdd, apple.computer_use, rows 397
- * (MacBook Pro, last seen 10d) and 447 (Mac mini, last seen 2h), ~8 errors/min
- * across two replicas.
+ * An offline device's connection retains its placement even when another
+ * device can serve the connector. Initial binding must still respect the
+ * unique device ownership constraint.
  */
 
 import { afterAll, beforeEach, describe, expect, it } from 'vitest';
@@ -139,7 +133,7 @@ describe('device pin owner guard', () => {
     await cleanupTestDatabase();
   });
 
-  it('does not steal a pin held by another live connection, and clears the dead one', async () => {
+  it('preserves both pins when only one device is online', async () => {
     const staleDevice = await seedWorker(userId, orgId, false);
     const freshDevice = await seedWorker(userId, orgId, true);
 
@@ -150,21 +144,19 @@ describe('device pin owner guard', () => {
     // aborts, and the error is swallowed by the catch.
     await reconcileDeviceCapabilities(userId);
 
-    // The live row keeps its device; the retired row is unpinned (claimable by
-    // any future device) rather than left pointing at a vanished one.
+    // Offline placement is retained; it must not become a fleet-wide grant.
     expect(await pinOf(current)).toBe(freshDevice);
-    expect(await pinOf(retired)).toBeNull();
+    expect(await pinOf(retired)).toBe(staleDevice);
   });
 
-  it('still repairs a stale pin to the sole fresh device when nothing else holds it', async () => {
+  it('does not move an offline pin to the sole fresh device', async () => {
     const staleDevice = await seedWorker(userId, orgId, false);
-    const freshDevice = await seedWorker(userId, orgId, true);
+    await seedWorker(userId, orgId, true);
     const only = await seedConn(orgId, userId, staleDevice);
 
     await reconcileDeviceCapabilities(userId);
 
-    // The documented repair must survive the guard.
-    expect(await pinOf(only)).toBe(freshDevice);
+    expect(await pinOf(only)).toBe(staleDevice);
   });
 
   it('leaves a pin that is already a fresh device untouched', async () => {
@@ -174,5 +166,25 @@ describe('device pin owner guard', () => {
     await reconcileDeviceCapabilities(userId);
 
     expect(await pinOf(only)).toBe(freshDevice);
+  });
+
+  it('initially binds an unpinned connection to its sole advertiser', async () => {
+    const device = await seedWorker(userId, orgId, true);
+    const connection = await seedConn(orgId, userId, null);
+
+    await reconcileDeviceCapabilities(userId);
+
+    expect(await pinOf(connection)).toBe(device);
+  });
+
+  it('leaves an unpinned connection alone when a sibling owns the sole advertiser', async () => {
+    const device = await seedWorker(userId, orgId, true);
+    const unpinned = await seedConn(orgId, userId, null);
+    const owner = await seedConn(orgId, userId, device);
+
+    await reconcileDeviceCapabilities(userId);
+
+    expect(await pinOf(unpinned)).toBeNull();
+    expect(await pinOf(owner)).toBe(device);
   });
 });

--- a/packages/server/src/__tests__/integration/device-pin-owner-guard.test.ts
+++ b/packages/server/src/__tests__/integration/device-pin-owner-guard.test.ts
@@ -140,8 +140,8 @@ describe('device pin owner guard', () => {
     const retired = await seedConn(orgId, userId, staleDevice); // old MacBook's row
     const current = await seedConn(orgId, userId, freshDevice); // new Mac mini's row
 
-    // Before the guard this throws 23505 inside the wire pass, the transaction
-    // aborts, and the error is swallowed by the catch.
+    // Both rows are already pinned, so the wire pass must leave both alone —
+    // it may neither repoint the retired row nor contend for the fresh device.
     await reconcileDeviceCapabilities(userId);
 
     // Offline placement is retained; it must not become a fleet-wide grant.

--- a/packages/server/src/__tests__/integration/device-pin-preservation.test.ts
+++ b/packages/server/src/__tests__/integration/device-pin-preservation.test.ts
@@ -23,7 +23,7 @@ const CAPABILITY = 'test_pin_preservation';
 const MANIFEST = {
   key: CONNECTOR,
   version: '1.0.0',
-  name: 'Test Pin Sweep',
+  name: 'Test Pin Preservation',
   required_capability: CAPABILITY,
   runtime: { platforms: ['macos'] },
   feeds_schema: {},
@@ -35,7 +35,7 @@ async function seedDefinition(orgId: string) {
       organization_id, key, name, version, status, required_capability,
       runtime, feeds_schema, auth_schema, actions_schema, options_schema
     ) VALUES (
-      ${orgId}, ${CONNECTOR}, 'Test Pin Sweep', '1.0.0', 'active', ${CAPABILITY},
+      ${orgId}, ${CONNECTOR}, 'Test Pin Preservation', '1.0.0', 'active', ${CAPABILITY},
       ${sql.json({ kind: 'device' })}, ${sql.json({})}, ${sql.json({})},
       ${sql.json({})}, ${sql.json({})}
     )
@@ -78,7 +78,7 @@ async function seedConn(orgId: string, userId: string, device: string | null): P
       organization_id, connector_key, slug, display_name, status,
       auth_profile_id, created_by, visibility, device_worker_id
     ) VALUES (
-      ${orgId}, ${CONNECTOR}, ${slug}, 'Test Pin Sweep', 'active',
+      ${orgId}, ${CONNECTOR}, ${slug}, 'Test Pin Preservation', 'active',
       NULL, ${userId}, 'private', ${device}::uuid
     )
     RETURNING id

--- a/packages/server/src/__tests__/integration/device-pin-preservation.test.ts
+++ b/packages/server/src/__tests__/integration/device-pin-preservation.test.ts
@@ -1,16 +1,7 @@
 /**
- * reconcileDeviceCapabilities — a retired connection must not stay pinned to a
- * device that has dropped out of the fleet. Integration test, real Postgres.
- *
- * An org holds one connection PER DEVICE
- * (`idx_connections_org_connector_device_live`), but the fast path resolves only
- * ONE of them (`GROUP BY … LIMIT 1`, no ORDER BY) and pins that one. When it
- * returns the row that is already correctly pinned, the pin UPDATE no-ops — its
- * WHERE requires `device_worker_id IS DISTINCT FROM target` — and the sibling
- * stays bound to a worker that will never poll again. Nothing revisits it.
- *
- * Silent since #2286 stopped the 23505 crash: no error, just a connection
- * pointing at a vanished Mac, claimable by nobody.
+ * Reconciliation preserves device placement through upgrades, permission loss,
+ * and offline intervals. Availability never authorizes another device to take
+ * over an existing pin. Integration tests against real Postgres.
  */
 
 import { afterAll, beforeEach, describe, expect, it } from 'vitest';
@@ -24,8 +15,8 @@ import { createTestOrganization, createTestUser } from '../setup/test-fixtures';
 
 const sql = getTestDb();
 
-const CONNECTOR = 'test.pin_sweep';
-const CAPABILITY = 'test_pin_sweep';
+const CONNECTOR = 'test.pin_preservation';
+const CAPABILITY = 'test_pin_preservation';
 
 /** Bundled connectors come from the on-disk catalog (empty in tests), so the
  * connector must arrive as a device manifest to reach the wire pass at all. */
@@ -171,7 +162,7 @@ async function waitForAutowireLockWaiter(lockKey: string): Promise<void> {
   throw new Error(`reconcile never blocked on the autowire advisory lock for ${lockKey}`);
 }
 
-describe('device pin stale sweep', () => {
+describe('device pin preservation', () => {
   let orgId: string;
   let userId: string;
 
@@ -192,11 +183,7 @@ describe('device pin stale sweep', () => {
     await cleanupTestDatabase();
   });
 
-  it('clears EVERY retired pin, which one selected row never could', async () => {
-    // Deterministic by construction, not by scan order: with TWO stale
-    // connections the single-row path can clear at most the one row the
-    // unordered `GROUP BY … LIMIT 1` happened to return, so without the sweep
-    // at least one stale pin survives no matter which row that is.
+  it('preserves every offline pin while another device is available', async () => {
     const staleA = await seedWorker(userId, orgId, false);
     const staleB = await seedWorker(userId, orgId, false);
     const freshDevice = await seedWorker(userId, orgId, true);
@@ -208,14 +195,12 @@ describe('device pin stale sweep', () => {
     await reconcileDeviceCapabilities(userId);
 
     expect(await pinOf(current)).toBe(freshDevice);
-    expect(await pinOf(retiredA)).toBeNull();
-    expect(await pinOf(retiredB)).toBeNull();
+    expect(await pinOf(retiredA)).toBe(staleA);
+    expect(await pinOf(retiredB)).toBe(staleB);
   });
 
   it('leaves every pin alone when several devices are fresh', async () => {
-    // Two fresh devices means `matchingDeviceIds.length !== 1`, so nothing is
-    // auto-pinned and BOTH existing pins are deliberate — the sweep must not
-    // treat either as stale.
+    // Neither device may take over the other connection.
     const deviceA = await seedWorker(userId, orgId, true);
     const deviceB = await seedWorker(userId, orgId, true);
     const connA = await seedConn(orgId, userId, deviceA);
@@ -227,10 +212,10 @@ describe('device pin stale sweep', () => {
     expect(await pinOf(connB)).toBe(deviceB);
   });
 
-  it('unpins a fresh device whose manifest hash is older than the selected active winner', async () => {
+  it.each(['0.9.0', '1.0.0'])('preserves both pins with different manifests (other version %s)', async (otherVersion) => {
     const olderDevice = await seedWorker(userId, orgId, true);
     const newerDevice = await seedWorker(userId, orgId, true);
-    const olderManifest = { ...MANIFEST, version: '0.9.0' };
+    const olderManifest = { ...MANIFEST, version: otherVersion, description: 'Other device build' };
     const newerManifest = { ...MANIFEST, version: '1.0.0' };
     await sql`
       UPDATE device_workers
@@ -261,14 +246,10 @@ describe('device pin stale sweep', () => {
     await reconcileDeviceCapabilities(userId);
 
     expect(await pinOf(newerConn)).toBe(newerDevice);
-    expect(await pinOf(olderConn)).toBeNull();
+    expect(await pinOf(olderConn)).toBe(olderDevice);
   });
 
-  it('unpins a device that is alive but no longer advertises the capability', async () => {
-    // Freshness alone is not "still serving". A device can keep heartbeating
-    // after an app update or a revoked permission drops the capability; polling
-    // is capability-gated, so leaving that pin in place strands the connection
-    // on a worker that will never claim its runs.
+  it('preserves placement when a live device loses its capability', async () => {
     const serving = await seedWorker(userId, orgId, true);
     const lapsed = await seedWorker(userId, orgId, true);
     await sql`
@@ -280,26 +261,17 @@ describe('device pin stale sweep', () => {
     await reconcileDeviceCapabilities(userId);
 
     expect(await pinOf(servingConn)).toBe(serving);
-    expect(await pinOf(lapsedConn)).toBeNull();
+    expect(await pinOf(lapsedConn)).toBe(lapsed);
   });
 
-  it('clears a pin whose device is in the snapshot but has lost the capability', async () => {
-    // `matchingDeviceIds` is captured before the advisory lock. A device present
-    // in it can drop the capability before the sweep runs — an app update or a
-    // revoked permission on another replica. Gating the sweep on that snapshot
-    // would let such a pin survive, because the snapshot still says "serving"
-    // and short-circuits the mutation-time check. Only the NOT EXISTS decides.
+  it('preserves placement when another replica observes capability loss during reconciliation', async () => {
     const serving = await seedWorker(userId, orgId, true);
     const lapsing = await seedWorker(userId, orgId, true);
     const servingConn = await seedConn(orgId, userId, serving);
     const lapsingConn = await seedConn(orgId, userId, lapsing);
 
-    // The interleave has to happen INSIDE reconcile — between its fleet read
-    // and the sweep — or the snapshot never contains the stale-positive entry
-    // and the test proves nothing. Hold the per-(user, connector) autowire lock
-    // so reconcile snapshots BOTH devices as capable, then parks; drop the
-    // capability while it waits; release. Its snapshot is now wrong in exactly
-    // the way the blocker described.
+    // Hold the autowire lock after the fleet read, then revoke the capability
+    // before reconciliation can commit. Neither snapshot may change placement.
     let release!: () => void;
     const held = new Promise<void>((r) => {
       release = r;
@@ -319,7 +291,7 @@ describe('device pin stale sweep', () => {
     await Promise.all([reconciling, holder]);
 
     expect(await pinOf(servingConn)).toBe(serving);
-    expect(await pinOf(lapsingConn)).toBeNull();
+    expect(await pinOf(lapsingConn)).toBe(lapsing);
   });
 
   it('pauses only auth-free feeds when the fleet stops serving the capability', async () => {
@@ -455,17 +427,10 @@ describe('device pin stale sweep', () => {
     expect(await pinOf(appAuthBacked)).toBe(dead);
   });
 
-  it('keeps a pin whose device came back between the fleet snapshot and the sweep', async () => {
-    // `matchingDeviceIds` is snapshotted BEFORE the advisory lock, so on another
-    // replica a device can heartbeat back into the fleet while this pass is
-    // still parked on the lock holding a snapshot that says it is gone. Sweeping
-    // from that snapshot would unpin a device that is live again; the sweep's
-    // NOT EXISTS re-checks `device_workers` at mutation time instead.
+  it('keeps a pin whose device comes back during reconciliation', async () => {
     const fresh = await seedWorker(userId, orgId, true);
     const revived = await seedWorker(userId, orgId, false);
-    // Lowest id — the row the wire pass resolves (`ORDER BY id ASC LIMIT 1`), so
-    // the single-row repair lands here and the revived row is decided purely by
-    // the sweep. Its pin is already correct, so that repair is a no-op.
+    // Exercise the sibling row as well as the first connection selected.
     const currentConn = await seedConn(orgId, userId, fresh);
     const revivedConn = await seedConn(orgId, userId, revived);
 
@@ -478,7 +443,7 @@ describe('device pin stale sweep', () => {
       running = reconcileDeviceCapabilities(userId);
       await waitForAutowireLockWaiter(lockKey);
       // The device comes back while the pass is parked, exactly the window the
-      // mutation-time re-check exists for.
+      // reconciliation must preserve.
       await sql`UPDATE device_workers SET last_seen_at = now() WHERE id = ${revived}::uuid`;
     });
     await running;

--- a/packages/server/src/__tests__/integration/operation-device-routing-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/operation-device-routing-lifecycle.test.ts
@@ -609,7 +609,7 @@ describe("connection-to-device operation routing lifecycle", () => {
 		);
 		expect(manifestDemoResult).toMatchObject({
 			status: "failed",
-			error_message: expect.stringMatching(/selected connector manifest.*assigned device/i),
+			error_message: expect.stringMatching(/selected connector manifest.*eligible device/i),
 		});
 		const [manifestDemoRun] = (await sql`
 			SELECT status, claimed_by

--- a/packages/server/src/__tests__/integration/operation-device-routing-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/operation-device-routing-lifecycle.test.ts
@@ -574,9 +574,8 @@ describe("connection-to-device operation routing lifecycle", () => {
 		expect(unpinnedCompiledDemoRun).toEqual({ status: "timeout", claimed_by: null });
 
 		// The same key becomes device-native when the selected artifact is
-		// metadata-only. With no physical pin, its runtime still queues the action
-		// for any device advertising the exact manifest rather than attempting to
-		// resolve nonexistent connector code inline.
+		// metadata-only. No device advertises this manifest, so admission fails
+		// before waiting for a device or attempting to resolve connector code inline.
 		await sql`
 			UPDATE connector_versions
 			SET compiled_code = NULL,
@@ -609,7 +608,8 @@ describe("connection-to-device operation routing lifecycle", () => {
 			{ ...ctx, abortSignal: aborted.signal },
 		);
 		expect(manifestDemoResult).toMatchObject({
-			status: "timeout",
+			status: "failed",
+			error_message: expect.stringMatching(/selected connector manifest.*assigned device/i),
 		});
 		const [manifestDemoRun] = (await sql`
 			SELECT status, claimed_by
@@ -617,7 +617,7 @@ describe("connection-to-device operation routing lifecycle", () => {
 			WHERE connection_id = ${compiledDemoConnection.id}
 			  AND action_idempotency_key = ${manifestDemoKey}
 		`) as unknown as Array<{ status: string; claimed_by: string | null }>;
-		expect(manifestDemoRun).toEqual({ status: "timeout", claimed_by: null });
+		expect(manifestDemoRun).toEqual({ status: "failed", claimed_by: null });
 
 		// Intrinsic connector runtime remains authoritative even without a pin.
 		await sql`

--- a/packages/server/src/lib/connector-pushdown.ts
+++ b/packages/server/src/lib/connector-pushdown.ts
@@ -409,6 +409,7 @@ export async function readSourceFeed(p: ReadSourceFeedParams): Promise<ReadSourc
       connectorKey: feed.connector_key,
       connectorVersion: feed.pinned_version ?? feed.definition_version,
       manifestHash: feed.selected_artifact_hash,
+      connectorRuntime: feed.runtime,
       deviceOwnerUserId: feed.device_owner_user_id,
       deviceWorkerId: feed.device_worker_id,
       feedStatus: feed.feed_status,

--- a/packages/server/src/lib/device-feed-read.ts
+++ b/packages/server/src/lib/device-feed-read.ts
@@ -266,13 +266,12 @@ async function describeUnservableDevice(
       )}`
     );
   }
-  // A selected hash absent from the inventory is unavailable. Prefer the
-  // specific pin, heartbeat, and permission diagnostics below when present.
+  // This path serves only metadata-only device artifacts. Require an exact hash,
+  // while preferring the specific pin and liveness diagnostics below.
   const manifestError =
-    connectorReadiness?.state === 'device_offline' ||
-    (!connectorReadiness && p.manifestHash != null)
-      ? DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE
-      : null;
+    p.manifestHash != null && connectorReadiness?.state === 'ready'
+      ? null
+      : DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE;
 
   if (p.deviceWorkerId) {
     // Reached THROUGH the connection, not by device id alone. The id comes off

--- a/packages/server/src/lib/device-feed-read.ts
+++ b/packages/server/src/lib/device-feed-read.ts
@@ -43,6 +43,7 @@ import { waitForDeviceActionRun } from '../tools/admin/device-action-wait';
 import { DEVICE_ONLINE_WINDOW_SECONDS, describeDeviceLastSeen } from '../utils/device-liveness';
 import logger from '../utils/logger';
 import {
+  DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE,
   describeDeviceConnectorSetupRequired,
   findDeviceConnectorReadiness,
   loadDeviceConnectorReadiness,
@@ -265,6 +266,13 @@ async function describeUnservableDevice(
       )}`
     );
   }
+  // A selected hash absent from the inventory is unavailable. Prefer the
+  // specific pin, heartbeat, and permission diagnostics below when present.
+  const manifestError =
+    connectorReadiness?.state === 'device_offline' ||
+    (!connectorReadiness && p.manifestHash != null)
+      ? DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE
+      : null;
 
   if (p.deviceWorkerId) {
     // Reached THROUGH the connection, not by device id alone. The id comes off
@@ -300,7 +308,7 @@ async function describeUnservableDevice(
     if (p.requiredCapability && !capabilities.includes(p.requiredCapability)) {
       return `${name} no longer grants '${p.requiredCapability}'`;
     }
-    return null;
+    return manifestError;
   }
 
   // Unpinned. The question is which org a device may serve WITHOUT a pin, and
@@ -359,7 +367,7 @@ async function describeUnservableDevice(
       ? `no online device is serving '${p.requiredCapability}'`
       : 'no online device can serve this connection';
   }
-  return null;
+  return manifestError;
 }
 
 /**

--- a/packages/server/src/lib/device-feed-read.ts
+++ b/packages/server/src/lib/device-feed-read.ts
@@ -40,6 +40,7 @@ import { getDb, pgTextArray } from '../db/client';
 import { createConnectorOperationRun } from '../runs/queue-service';
 import { classifyRunOutcome } from '../runs/run-outcome';
 import { waitForDeviceActionRun } from '../tools/admin/device-action-wait';
+import { hashlessManifestArtifactMayBeClaimed } from '../utils/connector-execution-placement';
 import { DEVICE_ONLINE_WINDOW_SECONDS, describeDeviceLastSeen } from '../utils/device-liveness';
 import logger from '../utils/logger';
 import {
@@ -102,6 +103,8 @@ export interface DeviceFeedReadParams {
   /** Exact connector artifact selected for this read. */
   connectorVersion: string | null;
   manifestHash: string | null;
+  /** `connector_definitions.runtime` — declares which device platforms may serve it. */
+  connectorRuntime: Record<string, unknown> | null;
   /** User whose device fleet is authorized to serve this connection. */
   deviceOwnerUserId: string | null;
   /** `connections.device_worker_id` — the execution pin, or null when unpinned. */
@@ -251,7 +254,9 @@ async function describeUnservableDevice(
       },
     ],
   });
-  const connectorReadiness = findDeviceConnectorReadiness(readinessIndex, {
+  const capabilityOnly = p.manifestHash == null &&
+    hashlessManifestArtifactMayBeClaimed(p.connectorKey, p.connectorRuntime);
+  const connectorReadiness = capabilityOnly ? undefined : findDeviceConnectorReadiness(readinessIndex, {
     ownerUserId: p.deviceOwnerUserId,
     connectorKey: p.connectorKey,
     connectorVersion: p.connectorVersion,
@@ -266,12 +271,10 @@ async function describeUnservableDevice(
       )}`
     );
   }
-  // This path serves only metadata-only device artifacts. Require an exact hash,
-  // while preferring the specific pin and liveness diagnostics below.
+  // Prefer the specific pin and liveness diagnostics below.
   const manifestError =
-    p.manifestHash != null && connectorReadiness?.state === 'ready'
-      ? null
-      : DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE;
+    capabilityOnly || (p.manifestHash != null && connectorReadiness?.state === 'ready')
+      ? null : DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE;
 
   if (p.deviceWorkerId) {
     // Reached THROUGH the connection, not by device id alone. The id comes off

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -32,6 +32,13 @@ import { getDb } from '../db/client';
 import { DEVICE_ACTION_QUEUE_BUDGET_MS } from '../config/intervals';
 import type { Env } from '../index';
 import { findBundledConnectorFile } from '../utils/connector-catalog';
+import { selectedConnectorVersionArtifactSql } from '../utils/connector-execution-placement';
+import {
+  DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE,
+  describeDeviceConnectorSetupRequired,
+  findDeviceConnectorReadiness,
+  loadDeviceConnectorReadiness,
+} from '../worker-api/device-connector-readiness';
 import { nextRunAt as nextRunAtFromCron } from '../utils/cron';
 import { ToolUserError } from '../utils/errors';
 import { stableJson } from '../utils/insert-event';
@@ -294,6 +301,48 @@ async function resolveActiveConnectorVersion(
 }
 
 /**
+ * Reject an unavailable manifest on the exact execution pin before queuing.
+ * Reuse worker-claim readiness; compiled and bundled artifacts bypass this gate.
+ */
+async function deviceManifestAdmissionError(
+  sql: DbClient,
+  organizationId: string,
+  connectionId: number,
+  connectorKey: string,
+  connectorVersion: string,
+  deviceWorkerId: string | null
+): Promise<string | null> {
+  const [row] = await sql<{ owner_user_id: string | null; manifest_hash: string | null }>`
+    SELECT COALESCE(c.created_by, dw.user_id) AS owner_user_id, cv.artifact_hash AS manifest_hash
+    FROM connections c
+    LEFT JOIN device_workers dw ON dw.id = c.device_worker_id
+    JOIN LATERAL (
+      ${selectedConnectorVersionArtifactSql(sql, {
+        connectorKey: sql`${connectorKey}`,
+        version: sql`${connectorVersion}`,
+        organizationId: sql`${organizationId}`,
+      })}
+    ) cv ON cv.manifest_backed
+    WHERE c.id = ${connectionId} AND c.organization_id = ${organizationId}
+    LIMIT 1
+  `;
+  if (!row) return null;
+  const target = {
+    ownerUserId: row.owner_user_id,
+    connectorKey,
+    connectorVersion,
+    manifestHash: row.manifest_hash,
+    deviceWorkerId,
+  };
+  const index = await loadDeviceConnectorReadiness({ sql, targets: [target] });
+  const readiness = findDeviceConnectorReadiness(index, target);
+  if (readiness?.state === 'ready') return null;
+  return readiness?.state === 'setup_required'
+    ? describeDeviceConnectorSetupRequired(readiness)
+    : DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE;
+}
+
+/**
  * Why no sync run was queued. The reasons differ in remedy — `already_active`
  * resolves itself when the current run finishes, while the others never will
  * (the two connector reasons also retire the feed) — so callers that surface
@@ -460,6 +509,11 @@ async function createSyncRunWithClient(
     return { ok: false, reason: 'connector_version_unrunnable' };
   }
   const connectorVersion = resolved.version;
+  const admissionError = await deviceManifestAdmissionError(
+    sql, feed.organization_id, feed.connection_id, feed.connector_key,
+    connectorVersion, feed.device_worker_id
+  );
+  if (admissionError) throw new ToolUserError(admissionError, 409);
 
   // Manual feeds (schedule null) keep next_run_at null after enqueue so they
   // are not re-picked by the due-feed scheduler.
@@ -1228,6 +1282,15 @@ export async function createConnectorOperationRun(params: {
     targetDeviceWorkerId = connRows[0]?.device_worker_id ?? null;
   }
 
+  // Record a new unavailable action as terminal. Keeping the existing INSERT
+  // conflict path preserves a completed idempotent result when its device is offline.
+  const admissionError = params.approvalMode === 'device'
+    ? await deviceManifestAdmissionError(
+        sql, params.organizationId, params.connectionId, params.connectorKey,
+        connectorVersion, targetDeviceWorkerId
+      )
+    : null;
+
   const insertMetadata = params.sdkBrowserContext
     ? {
         ...params.runMetadata,
@@ -1251,13 +1314,13 @@ export async function createConnectorOperationRun(params: {
       action_idempotency_key, expires_at, claimed_at, last_heartbeat_at, claimed_by,
       activation_kind, activation_target_urls,
       run_metadata,
-      target_device_worker_id,
+      target_device_worker_id, error_message, completed_at,
       created_at
     ) VALUES (
       ${params.organizationId}, 'action', ${params.connectionId},
       ${params.connectorKey}, ${connectorVersion},
       ${params.operationKey}, ${sql.json(params.operationInput)},
-      ${approvalStatus}, ${status},
+      ${approvalStatus}, ${admissionError ? 'failed' : status},
       ${params.automationId ?? null}, ${params.parentRunId ?? null},
       ${params.policyPrincipalKind ?? null}, ${params.policyPrincipalId ?? null},
       ${params.createdByUserId ?? null},
@@ -1272,6 +1335,7 @@ export async function createConnectorOperationRun(params: {
       ${params.activation ? pgTextArray(params.activation.urls) : null}::text[],
       ${insertMetadata == null ? null : sql.json(insertMetadata)},
       ${targetDeviceWorkerId == null ? null : sql`${targetDeviceWorkerId}::uuid`},
+      ${admissionError}, ${admissionError ? sql`current_timestamp` : null},
       current_timestamp
     )
     ON CONFLICT (organization_id, action_idempotency_key)

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -32,7 +32,10 @@ import { getDb } from '../db/client';
 import { DEVICE_ACTION_QUEUE_BUDGET_MS } from '../config/intervals';
 import type { Env } from '../index';
 import { findBundledConnectorFile } from '../utils/connector-catalog';
-import { selectedConnectorVersionArtifactSql } from '../utils/connector-execution-placement';
+import {
+  hashlessManifestArtifactMayBeClaimed,
+  selectedConnectorVersionArtifactSql,
+} from '../utils/connector-execution-placement';
 import {
   DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE,
   describeDeviceConnectorSetupRequired,
@@ -302,7 +305,7 @@ async function resolveActiveConnectorVersion(
 
 /**
  * Reject an unavailable manifest on the exact execution pin before queuing.
- * Reuse worker-claim readiness; compiled and bundled artifacts bypass this gate.
+ * Compiled artifacts bypass this check; native hashless artifacts retain capability claims.
  */
 async function deviceManifestAdmissionError(
   sql: DbClient,
@@ -312,10 +315,18 @@ async function deviceManifestAdmissionError(
   connectorVersion: string,
   deviceWorkerId: string | null
 ): Promise<string | null> {
-  const [row] = await sql<{ owner_user_id: string | null; manifest_hash: string | null }>`
-    SELECT COALESCE(c.created_by, dw.user_id) AS owner_user_id, cv.artifact_hash AS manifest_hash
+  const [row] = await sql<{
+    owner_user_id: string | null;
+    manifest_hash: string | null;
+    runtime: Record<string, unknown> | null;
+  }>`
+    SELECT COALESCE(c.created_by, dw.user_id) AS owner_user_id, cv.artifact_hash AS manifest_hash,
+           cd.runtime
     FROM connections c
     LEFT JOIN device_workers dw ON dw.id = c.device_worker_id
+    LEFT JOIN connector_definitions cd
+      ON cd.organization_id = c.organization_id AND cd.key = c.connector_key
+      AND cd.status = 'active'
     JOIN LATERAL (
       ${selectedConnectorVersionArtifactSql(sql, {
         connectorKey: sql`${connectorKey}`,
@@ -327,7 +338,10 @@ async function deviceManifestAdmissionError(
     LIMIT 1
   `;
   if (!row) return null;
-  if (row.manifest_hash == null) return DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE;
+  if (row.manifest_hash == null) {
+    return hashlessManifestArtifactMayBeClaimed(connectorKey, row.runtime)
+      ? null : DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE;
+  }
   const target = {
     ownerUserId: row.owner_user_id,
     connectorKey,

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -327,6 +327,7 @@ async function deviceManifestAdmissionError(
     LIMIT 1
   `;
   if (!row) return null;
+  if (row.manifest_hash == null) return DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE;
   const target = {
     ownerUserId: row.owner_user_id,
     connectorKey,

--- a/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
@@ -28,6 +28,7 @@ import {
 } from "../../../../utils/device-liveness";
 import { buildConnectionsUrl } from "../../../../utils/url-builder";
 import {
+	DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE,
 	describeDeviceConnectorSetupRequired,
 	findDeviceConnectorReadiness,
 	loadDeviceConnectorReadiness,
@@ -111,12 +112,15 @@ function executionTargetFromRow(
 			)}).`,
 		};
 	}
-	if (row.connector_manifest_backed && !deviceReadiness) {
+	if (
+		row.connector_manifest_backed &&
+		(row.connector_manifest_hash == null || !deviceReadiness)
+	) {
 		return {
 			...base,
 			status: "setup_required",
 			executable: false,
-			reason: "The selected connector implementation is not advertised by the assigned device. Update the device app and finish setup, then retry.",
+			reason: DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE,
 		};
 	}
 	if (deviceReadiness?.state === "setup_required") {

--- a/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
@@ -111,6 +111,14 @@ function executionTargetFromRow(
 			)}).`,
 		};
 	}
+	if (row.connector_manifest_backed && !deviceReadiness) {
+		return {
+			...base,
+			status: "setup_required",
+			executable: false,
+			reason: "The selected connector implementation is not advertised by the assigned device. Update the device app and finish setup, then retry.",
+		};
+	}
 	if (deviceReadiness?.state === "setup_required") {
 		return {
 			...base,
@@ -132,7 +140,9 @@ function executionTargetFromRow(
 			...base,
 			status: "device_offline",
 			executable: false,
-			reason: "No online device is advertising the connector's selected manifest.",
+			reason: row.device_worker_id
+				? "The paired device is not advertising the connector's selected manifest. Update or reconnect that device."
+				: "No online device is advertising the connector's selected manifest.",
 		};
 	}
 	if (row.device_bound && !row.device_online) {

--- a/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
@@ -21,7 +21,10 @@ import {
 import { listOperations } from "../../../../operations/connector-operations";
 import { getMissingKnownOAuthScopes } from "../../../../operations/oauth-scope-readiness";
 import type { AvailableOperation, OperationDescriptor } from "../../../../operations/types";
-import { isChromeNamespaceConnectorKey } from "../../../../utils/connector-execution-placement";
+import {
+	hashlessManifestArtifactMayBeClaimed,
+	isChromeNamespaceConnectorKey,
+} from "../../../../utils/connector-execution-placement";
 import {
 	DEVICE_ONLINE_WINDOW_SECONDS,
 	describeDeviceLastSeen,
@@ -73,6 +76,7 @@ type OperationTargetRow = {
 	connector_version: string | null;
 	connector_manifest_backed: boolean;
 	connector_manifest_hash: string | null;
+	connector_runtime: Record<string, unknown> | null;
 	auth_profile_kind: string | null;
 	auth_profile_slug: string | null;
 	auth_data: Record<string, unknown> | null;
@@ -81,6 +85,9 @@ function executionTargetFromRow(
 	row: OperationTargetRow,
 	deviceReadiness?: DeviceConnectorReadiness,
 ): InternalExecutionTarget {
+	const capabilityOnly = row.connector_manifest_hash == null &&
+		hashlessManifestArtifactMayBeClaimed(row.connector_key, row.connector_runtime);
+	if (capabilityOnly) deviceReadiness = undefined;
 	const base = {
 		connection_id: Number(row.id),
 		slug: row.slug,
@@ -113,7 +120,7 @@ function executionTargetFromRow(
 		};
 	}
 	if (
-		row.connector_manifest_backed &&
+		row.connector_manifest_backed && !capabilityOnly &&
 		(row.connector_manifest_hash == null || !deviceReadiness)
 	) {
 		return {
@@ -602,6 +609,7 @@ async function loadVisibleOperationTargets(
 		        latest.version AS connector_version,
 		        COALESCE(latest.manifest_backed, false) AS connector_manifest_backed,
 		        latest.artifact_hash AS connector_manifest_hash,
+		        latest.runtime AS connector_runtime,
 		        ap.profile_kind AS auth_profile_kind,
 		        ap.slug AS auth_profile_slug,
 		        ap.auth_data AS auth_data,

--- a/packages/server/src/utils/connector-execution-placement.ts
+++ b/packages/server/src/utils/connector-execution-placement.ts
@@ -145,3 +145,14 @@ export function selectedConnectorVersionArtifactSql<TFragment>(
     LIMIT 1
   `;
 }
+
+/** Hashless native artifacts defer final authorization to the capability claim lane. */
+export function hashlessManifestArtifactMayBeClaimed(
+  connectorKey: string,
+  runtime: { platforms?: unknown; execution?: unknown } | null | undefined
+): boolean {
+  if (isChromeNamespaceConnectorKey(connectorKey) || runtime?.execution === 'bridge') return false;
+  return Array.isArray(runtime?.platforms) && runtime.platforms.some(
+    (platform) => typeof platform === 'string' && platform !== 'headless' && platform !== 'chrome-extension'
+  );
+}

--- a/packages/server/src/worker-api/device-connector-readiness.ts
+++ b/packages/server/src/worker-api/device-connector-readiness.ts
@@ -156,5 +156,5 @@ export function describeDeviceConnectorSetupRequired(
 }
 
 export const DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE =
-  'The selected connector manifest is not available on the assigned device. ' +
-  'Update or reconnect that device, then retry.';
+  'The selected connector manifest is not available on an eligible device. ' +
+  'Update or reconnect your device, then retry.';

--- a/packages/server/src/worker-api/device-connector-readiness.ts
+++ b/packages/server/src/worker-api/device-connector-readiness.ts
@@ -154,3 +154,7 @@ export function describeDeviceConnectorSetupRequired(
     'Open the paired device app, finish setup, then retry.'
   );
 }
+
+export const DEVICE_CONNECTOR_MANIFEST_UNAVAILABLE =
+  'The selected connector manifest is not available on the assigned device. ' +
+  'Update or reconnect that device, then retry.';

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -65,13 +65,9 @@ const DEVICE_WORKER_FRESH_INTERVAL = '7 days';
  * devices so they don't race past the existence checks and create duplicates.
  * Best-effort: failures are logged but never surface to the poll response.
  *
- * Device pin (`connections.device_worker_id`): when exactly one of the user's
- * fresh devices advertises the implementation, the connection is auto-pinned to it
- * (a deterministic 1:1 binding the Devices page can show); when several qualify
- * it's left unpinned ("any of my fresh devices that advertise the implementation").
- * A pin to a device that's still in the fresh set is treated as deliberate and
- * never overridden; a pin to a device that has dropped out is repaired (to the
- * sole remaining fresh device, or NULL) so the connection keeps running.
+ * Existing device pins are execution placement, not a freshness hint. Initial
+ * wiring may bind an unpinned connection to its sole advertiser; later polls
+ * must preserve that placement through upgrades, permission loss, and sleep.
  */
 async function ensureDeviceConnectorWired(
   userId: string,
@@ -79,125 +75,35 @@ async function ensureDeviceConnectorWired(
   connectorKey: string,
   declaredFeedKeys: string[],
   matchingDeviceIds: string[],
-  requiredCapability: string,
   source?: DeviceConnectorSource,
   pollingDeviceId?: string | null
 ): Promise<ManifestClaimAuthorization | null> {
   const sql = getDb();
 
-  // Self-heal the device pin against the user's current fleet. Cheap, idempotent
-  // (the WHERE matches nothing when the pin is already a valid fresh device), and
-  // runs even on the fast path so a stale pin doesn't silently strand the feeds.
-  const reconcilePin = async (
+  const initializePin = async (
     db: typeof sql,
     connectionId: number,
-    currentMatchingDeviceIds = matchingDeviceIds,
-    currentRequiredCapability = requiredCapability,
-    currentSource = source
+    currentMatchingDeviceIds = matchingDeviceIds
   ) => {
-    let target = currentMatchingDeviceIds.length === 1 ? currentMatchingDeviceIds[0] : null;
-    // `idx_connections_org_connector_device_live` is UNIQUE on
-    // (organization_id, connector_key, device_worker_id) for live rows, and an
-    // org legitimately holds one connection PER DEVICE (same shape as
-    // `idx_connections_org_connector_account_live` for OAuth accounts). So the
-    // row we were handed is not necessarily the one that owns `target`: retiring
-    // a Mac leaves its connection pinned to the stale device while the new Mac's
-    // connection holds the only fresh one, and pinning the former to the latter's
-    // device violates the index, aborts the whole wire transaction, and retries
-    // forever (~8/min in prod for apple.computer_use).
-    //
-    // Never steal a pin another live connection holds — the same guard
-    // `resolveOnlineChromeConnection` already carries for this index (see
-    // `findOwnerOf` in dispatch-chrome-action.ts, where it used to 500 the
-    // dispatcher). Fall back to NULL rather than skipping the UPDATE: NULL still
-    // clears the dead pin (a connection pinned to a vanished device is claimable
-    // by nobody, while an unpinned one is claimable by any polling device), so
-    // the documented stale-pin repair survives.
+    const target = currentMatchingDeviceIds.length === 1 ? currentMatchingDeviceIds[0] : null;
     if (target) {
-      const owner = (await db`
-        SELECT id FROM connections
-        WHERE organization_id = ${organizationId}
-          AND connector_key = ${connectorKey}
-          AND device_worker_id = ${target}::uuid
-          AND deleted_at IS NULL
-        LIMIT 1
-      `) as unknown as Array<{ id: number }>;
-      const ownerId = owner[0]?.id;
-      if (ownerId != null && Number(ownerId) !== connectionId) {
-        logger.warn(
-          { userId, connectorKey, connectionId, ownerConnectionId: ownerId, deviceWorkerId: target },
-          '[device-connectors] Device already pinned to another connection — unpinning instead'
-        );
-        target = null;
-      }
+      // Preserve existing pins and respect idx_connections_org_connector_device_live.
+      // Callers hold the autowire lock so concurrent replicas cannot both pass
+      // NOT EXISTS before either transaction commits.
+      await db`
+        UPDATE connections c
+        SET device_worker_id = ${target}::uuid, updated_at = NOW()
+        WHERE c.id = ${connectionId}
+          AND c.device_worker_id IS NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM connections other
+            WHERE other.organization_id = ${organizationId}
+              AND other.connector_key = ${connectorKey}
+              AND other.device_worker_id = ${target}::uuid
+              AND other.deleted_at IS NULL
+          )
+      `;
     }
-    // Compare via text on both sides — passing a `pgTextArray(...)` literal
-    // through a `::uuid[]` cast trips a postgres "malformed array literal"
-    // failure under the extended-protocol path postgres.js uses (the bound
-    // text parameter never gets re-parsed as an array before the uuid[] cast
-    // runs). `device_worker_id::text = ANY(text[])` sidesteps the cast
-    // entirely; UUIDs are canonical lowercase so text equality matches the
-    // uuid form 1:1.
-    await db`
-      UPDATE connections
-      SET device_worker_id = ${target}::uuid, updated_at = NOW()
-      WHERE id = ${connectionId}
-        AND device_worker_id IS DISTINCT FROM ${target}::uuid
-        AND (device_worker_id IS NULL OR NOT (device_worker_id::text = ANY(${pgTextArray(currentMatchingDeviceIds)}::text[])))
-    `;
-    // The statement above repairs only the row we were handed, but an org holds
-    // one connection PER DEVICE and the fast path resolves just one of them
-    // (`GROUP BY … LIMIT 1`, no ORDER BY). When it returns the row that is
-    // already correctly pinned, the UPDATE no-ops — and a sibling left pinned to
-    // a device that has dropped out is never revisited, so it stays bound to a
-    // worker that will never poll again. Sweep every live row instead: a pin
-    // outside the fresh set is stale by definition, and NULL is strictly better
-    // than a dead pin (unpinned is claimable by any polling device; a vanished
-    // device is claimable by nobody).
-    //
-    // Safe for the multi-fresh case — pins INSIDE the fresh set are deliberate
-    // and untouched — and the empty-fleet case never reaches here, because
-    // `reconcileDeviceCapabilities` only calls this connector's wire pass when
-    // `matchingDeviceIds.length > 0` (an offline fleet routes to
-    // `pauseStaleDeviceFeeds`, which must not unpin anything).
-    // Re-check freshness against `device_workers` AT MUTATION TIME rather than
-    // trusting `matchingDeviceIds`, which is snapshotted before the advisory
-    // lock is taken (see `reconcileDeviceCapabilities`). A concurrent poll on
-    // another replica can refresh a device's heartbeat between this pass's
-    // snapshot and its commit; sweeping from the stale list would unpin a
-    // device that is live again. The NOT EXISTS makes the sweep self-verifying:
-    // a row is cleared only if its worker is genuinely absent, stale, or no
-    // longer advertising the implementation as of this statement. Manifest
-    // sources require the exact winning hash as well as their capability;
-    // capability-only bundled sources retain their existing matching semantics.
-    await db`
-      UPDATE connections c
-      SET device_worker_id = NULL, updated_at = NOW()
-      WHERE c.organization_id = ${organizationId}
-        AND c.connector_key = ${connectorKey}
-        AND c.deleted_at IS NULL
-        -- The device-connector identity: auto-wire's own INSERT writes NULL to
-        -- BOTH profile columns, so anything with either set is credential-backed
-        -- and user-created. Unpinning one would hand it to any capable device
-        -- while the poll withholds credentials from unpinned connections —
-        -- breaking a connection this pass never created.
-        AND c.auth_profile_id IS NULL
-        AND c.app_auth_profile_id IS NULL
-        AND c.device_worker_id IS NOT NULL
-        -- Deliberately NOT also gated on matchingDeviceIds: ANDing the stale
-        -- snapshot in would let a device that has since dropped the capability
-        -- survive, by short-circuiting this check.
-        AND NOT EXISTS (
-          SELECT 1 FROM device_workers dw
-          WHERE dw.id = c.device_worker_id
-            AND dw.user_id = ${userId}
-            AND dw.last_seen_at > now() - ${DEVICE_WORKER_FRESH_INTERVAL}::interval
-            AND dw.capabilities @> ${db.json([currentRequiredCapability])}
-            ${currentSource ? db`AND (dw.connector_manifests -> ${connectorKey}) ->> 'manifest_hash' = ${currentSource.manifestHash}` : db``}
-        )
-    `;
-    // Pin restore (or already-valid pin): drop DELETE/move tombstones so the
-    // connection is not stuck as active + red "Device was removed".
     await clearDevicePinTombstoneIfPinned(db, {
       connectionId,
       matchingDeviceIds: currentMatchingDeviceIds,
@@ -439,25 +345,21 @@ async function ensureDeviceConnectorWired(
           await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
           const currentSource = await lockedManifestWinner(tx);
           if (!currentSource || !(await selectedArtifactMatches(tx, currentSource))) return null;
-          await reconcilePin(
+          await initializePin(
             tx,
             readyConnectionId,
-            currentSource.advertiserDeviceIds,
-            currentSource.requiredCapability,
-            currentSource
+            currentSource.advertiserDeviceIds
           );
           return claimAuthorization(currentSource);
         });
       } else {
-        // Same advisory lock as the `source` branch above: reconcilePin's owner
-        // check is read-then-write, so two replicas polling concurrently could
-        // both observe "nobody owns this device" and race into the unique index.
+        // Keep initial binding serialized, as in the manifest branch above.
         // (No bundled device connectors ship today, so this branch is currently
         // unreachable — keep it serialized anyway rather than leave the race
         // armed for the first one that does.)
         await sql.begin(async (tx) => {
           await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
-          await reconcilePin(tx, readyConnectionId);
+          await initializePin(tx, readyConnectionId);
         });
       }
       return null;
@@ -501,7 +403,7 @@ async function ensureDeviceConnectorWired(
       await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
       // Winner selection before this lock is only a scheduling hint. Recompute
       // the deterministic winner while serialized so a stale waiter can never
-      // downgrade metadata or repin after a newer manifest has arrived.
+      // downgrade metadata after a newer manifest has arrived.
       const currentSource = source ? await lockedManifestWinner(tx) : null;
       if (source && !currentSource) return null;
 
@@ -720,14 +622,11 @@ async function ensureDeviceConnectorWired(
         }
       }
 
-      // Pin the (possibly just-created) connection to the sole fresh device
-      // serving the capability, or leave it unpinned when several do.
-      await reconcilePin(
+      // Bind an unpinned connection only when there is a sole advertiser.
+      await initializePin(
         tx,
         connectionId,
-        currentSource?.advertiserDeviceIds ?? matchingDeviceIds,
-        currentSource?.requiredCapability ?? requiredCapability,
-        currentSource ?? source
+        currentSource?.advertiserDeviceIds ?? matchingDeviceIds
       );
       if (currentSource && !(await selectedArtifactMatches(tx, currentSource))) return null;
       return claimAuthorization(currentSource);
@@ -1070,7 +969,6 @@ export async function reconcileDeviceCapabilities(
             dc.key,
             dc.feedKeys,
             matchingDeviceIds,
-            dc.requiredCapability,
             'source' in dc && dc.source === 'device-manifest'
               ? dc
               : undefined,


### PR DESCRIPTION
## Summary

A connection pinned to one physical device could silently become unpinned or move when another device advertised a newer or different connector manifest. In production, a MacBook-labeled Chrome connection lost its pin and browser actions ran on a different machine. Two Chrome builds also advertised version 0.2.3 with different hashes.

- Preserve existing physical pins through sleep, permission loss, and manifest changes. Delete automatic stale-pin reassignment and sweeping; initial binding still respects device ownership.
- Reuse exact-manifest readiness at operation and manual-sync admission. New unavailable device actions fail immediately; completed idempotent calls retain their original result. Operation discovery and source reads report incompatible devices instead of presenting them as executable.
- Companion manifest release: https://github.com/lobu-ai/owletto/pull/1038 bumps Chrome to 0.2.4 and regenerates its hash.

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` passed (build, typechecks, lint, knip, naming, runtime funnel gates).
- [x] Seven focused Postgres-backed integration suites passed: pin preservation, pin ownership, manifest reconciliation, operation availability, source reads, action waiting, and admission.
- [x] Chrome generated-manifest hash suite passed all 8 tests.
- [x] After pre-review edits: 45 affected integration tests and `make pre-pr` passed again.
- [x] Red → green evidence:

```text
Baseline pin preservation regressions:
Tests  7 failed | 6 passed (13)

Baseline new admission suite:
Tests  6 failed | 2 passed (8)
Mismatched version/hash: expected pending to be failed.
Missing exact manifest: discovery incorrectly reported executable.
Public operations.execute: three-second abort fired instead of admission failure.
Fresh offline operation: expected pending to be failed.
Incompatible manual sync: resolved instead of rejecting.

Final combined run:
Test Files  7 passed (7)
Tests       133 passed (133)
Duration    44.28s
```

Run from `packages/server` with Node 22:

```sh
bun run test -- run \
  src/__tests__/integration/device-pin-preservation.test.ts \
  src/__tests__/integration/device-pin-owner-guard.test.ts \
  src/__tests__/integration/device-connector-manifests.test.ts \
  src/__tests__/integration/operations-list-available-lifecycle.test.ts \
  src/__tests__/integration/connectors/device-feed-read.test.ts \
  src/__tests__/integration/device-action-wait.test.ts \
  src/__tests__/integration/device-pin-admission.test.ts
```

The first full CI run caught one obsolete expectation in `operation-device-routing-lifecycle.test.ts`: an unavailable manifest was expected to time out. The result is now correctly asserted as `failed` with an actionable manifest error. The neighboring compiled-connector timeout case is unchanged. That lifecycle plus admission suite then passed 9/9, and `make pre-pr` passed again.

Source-read fixtures now advertise the exact selected manifest, matching a real paired device. Coverage includes refusal before queuing on manifest mismatch, successful device poll/complete responses, payload scrubbing, and cancellation.

## Notes

Root diff: 14 files, +673/-238; shipping TypeScript +164/-139 (net +25), tests +508/-98, submodule pointer +1/-1. One new regression file and one renamed regression file. The submodule advances through its merged release plus an existing image-tag update (+5/-5).

No API endpoints, DB tables/columns, migrations, tenant identifiers, or permission changes. Existing worker claim predicates remain authoritative and unchanged. Auth-run placement and unrelated Automation/Slack cleanup are outside this slice.

Requested Fable pre-review could not run because its CLI reported a usage limit; Opus, an accepted repository reviewer, completed `make review-fix`; its changes were inspected and the affected checks rerun.

Merged as `f0c931170461c4c5584d8bf9d663c96bac284856`. [Production image build and smoke](https://github.com/lobu-ai/lobu/actions/runs/34226911803) passed. Production health reports that exact squash commit, `git merge-base --is-ancestor` passed, and Kubernetes reports the deployment fully rolled out.

Restored the affected Chrome connection's physical pin through the existing connection API after rollout. Configuration, credentials, auth profiles, visibility, and ownership were unchanged; subsequent device polls retained the pin. A real SDK navigate attempt against the older incompatible extension returned the selected-manifest error in 23 ms. The persisted action was immediately terminal, targeted the intended device, and had no worker claimant. No browser tab was created.

Full browser-interaction E2E remains pending extension 0.2.4 reload. The paired browser still advertises 0.2.3. The earlier background click no-op occurred on the older extension on the wrong device; this PR does not claim that behavior is fixed.

Final HEAD `7817de6bbee4fcd7fabf31650f192697e4a9eb57` passed all 10 required checks. [GitHub CI](https://github.com/lobu-ai/lobu/actions/runs/34225671699) is green. Posted Opus review: confidence 86, zero bugs, zero blockers; it independently reran 90 relevant integration tests. Final `make pre-pr`, 111 combined integration tests, and 32 source-read unit tests passed. Working tree clean before merge.

Reviewed the nonblocking scheduler suggestion against committed `origin/main`: the sole production caller of `materializeDueFeeds` is `worker-api/poll.ts:1072`, and it supplies `claimContext`. `check-due-feeds.ts` applies the exact connector claim predicate before `createSyncRun`, so a persistently stale manifest is filtered before admission; the suggested recurring unscoped scheduler error path is not the production call path. A device changing readiness during admission can still fail that individual attempt. The bounded extra artifact lookup for non-device sync admission remains a potential performance follow-up; no additional readiness state or skip enum was introduced.


Inline review fixes: Chrome manifest artifacts without a stored hash fail operation discovery, execution, and manual sync. Artifacts with a stored hash require an exact eligible advertiser across discovery, execution, sync, and source reads. The common error names an eligible device so it also applies to unpinned connections. Regression reproduced as `2 failed | 8 skipped` (both pinned and unpinned rows incorrectly returned pending). Final retained diff passed 94 integration tests, 32 source-read unit tests, and `make pre-pr`. No new sync status or API contract was introduced.


The posted review caught a native capability-only regression in the hashless case. Reproduced before fixing: `2 failed | 32 skipped`, with native discovery incorrectly non-executable and the source read never reaching the polling device. The final correction preserves the existing native capability claim lane. It rejects hashless Chrome and headless-only artifacts and excludes bridge execution; it adds no claim lane or persisted protocol flag. One small TypeScript predicate is shared by the three admission surfaces. The proposed duplicate SQL predicate and claim-path refactor were removed after pre-review.

Final local validation of the retained diff: `7 files passed, 111 tests passed`, 33.45s. Tests cover successful native action polling, native manual sync, source-read poll/complete and payload scrubbing, plus immediate refusal for hashless Chrome and headless-only artifacts. Existing pin-preservation, owner isolation, exact hash/version, availability, and routing lifecycle suites passed together.

Hashless native admission intentionally remains provisional: whether a device omits `connector_manifests` is a per-poll fact that is not persisted. The existing worker claim predicate still performs final authorization. This PR does not invent a second legacy protocol or claim to eliminate every native queue timeout.

Pre-review also questioned the intervening Owletto image-tag commit. The pointer is a complete forward-only range confined to `apps/chrome/` and `deploy/`; the repository's UI gate classifies that exact range as not applicable. No hosted frontend changes are included.
