### PR TITLE
fix(lobu-team): use claimed arrival windows for production digests

### DIFF
--- a/examples/lobu-team/__tests__/lobu-team.config.test.ts
+++ b/examples/lobu-team/__tests__/lobu-team.config.test.ts
@@ -101,7 +101,7 @@ describe("Lobu Team configuration", () => {
       },
     ]);
     expect(digest?.sources).toEqual({
-      reaction_window: "SELECT id FROM events WHERE FALSE",
+      reaction_window: "SELECT * FROM events WHERE FALSE",
     });
     expect(digest?.agent).toMatchObject({
       id: "product-ops",

--- a/examples/lobu-team/__tests__/lobu-team.config.test.ts
+++ b/examples/lobu-team/__tests__/lobu-team.config.test.ts
@@ -97,15 +97,15 @@ describe("Lobu Team configuration", () => {
       {
         kind: "schedule",
         cron: "5,25,45 * * * *",
-        skip_if_unchanged: true,
+        skip_if_unchanged: false,
       },
     ]);
     expect(digest?.sources).toEqual({
-      product_activity: "@connection:lobu-product-activity-db",
-      kubernetes_logs: "@connection:lobu-production-logs",
+      reaction_window: "SELECT id FROM events WHERE FALSE",
     });
     expect(digest?.agent).toMatchObject({
       id: "product-ops",
+      providers: [{ id: "gemini", model: "gemini-2.5-flash" }],
       tools: {
         allowed: [],
         strict: true,

--- a/examples/lobu-team/__tests__/product-activity-digest.reaction.test.ts
+++ b/examples/lobu-team/__tests__/product-activity-digest.reaction.test.ts
@@ -85,9 +85,7 @@ describe("Lobu Team product activity digest reaction", () => {
       },
     ];
     const send = mock().mockResolvedValue({ notified_count: 1 });
-    const query = mock()
-      .mockResolvedValueOnce([{ created_at: "2026-08-13T12:00:00.000Z" }])
-      .mockResolvedValueOnce(rows);
+    const query = mock().mockResolvedValueOnce(rows);
     const client = {
       query,
       notifications: { send },
@@ -114,11 +112,7 @@ describe("Lobu Team product activity digest reaction", () => {
     expect(serializedCard).toContain("pool exhausted");
     expect(serializedCard).toContain("Open production logs");
 
-    const cursorQuery = String(query.mock.calls[0]?.[0]);
-    expect(cursorQuery).toContain("automation_id = 42");
-    expect(cursorQuery).toContain("ORDER BY created_at DESC, id DESC");
-
-    const queryText = String(query.mock.calls[1]?.[0]);
+    const queryText = String(query.mock.calls[0]?.[0]);
     expect(queryText).not.toContain("superseded_by");
     expect(queryText).toContain("e.created_at");
     expect(queryText).toContain("FROM events e");
@@ -204,9 +198,7 @@ describe("Lobu Team product activity digest reaction", () => {
       },
     ];
     const send = mock();
-    const query = mock()
-      .mockResolvedValueOnce([{ created_at: "2026-08-13T12:00:00.000Z" }])
-      .mockResolvedValueOnce(rows);
+    const query = mock().mockResolvedValueOnce(rows);
     const client = {
       query,
       notifications: { send },
@@ -240,7 +232,6 @@ describe("Lobu Team product activity digest reaction", () => {
     ];
     const send = mock().mockResolvedValue({ notified_count: 1 });
     const query = mock()
-      .mockResolvedValueOnce([{ created_at: "2026-08-13T12:00:00.000Z" }])
       .mockResolvedValueOnce(excludedPage)
       .mockResolvedValueOnce(validRows);
     const client = {
@@ -251,10 +242,66 @@ describe("Lobu Team product activity digest reaction", () => {
 
     await productActivityDigest(context, client);
 
-    expect(query.mock.calls).toHaveLength(3);
+    expect(query.mock.calls).toHaveLength(2);
     const serializedCard = JSON.stringify(send.mock.calls[0]?.[0]?.card);
     expect(serializedCard).toContain("ada@example.com");
     expect(serializedCard).not.toContain("emrekabakci");
+  });
+
+  it("reads only the claimed arrival window, including its lower boundary", async () => {
+    const query = mock().mockResolvedValue([]);
+    await productActivityDigest(context, {
+      query,
+      notifications: { send: mock() },
+      log: mock(),
+    } as unknown as ReactionClient);
+    expect(query).toHaveBeenCalledTimes(1);
+    const statement = String(query.mock.calls[0]?.[0]);
+    expect(statement).toContain("e.created_at >= '2026-08-13T12:00:00.000Z'");
+    expect(statement).toContain("e.created_at < '2026-08-13T12:20:00.000Z'");
+  });
+
+  it("rejects invalid windows before reading or notifying", async () => {
+    const query = mock();
+    const send = mock();
+    for (const window_end of ["invalid", context.window.window_start]) {
+      await expect(
+        productActivityDigest(
+          {
+            ...context,
+            window: { ...context.window, window_end },
+          },
+          {
+            query,
+            notifications: { send },
+            log: mock(),
+          } as unknown as ReactionClient
+        )
+      ).rejects.toThrow("requires a valid arrival window");
+    }
+    expect(query).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("fails before notifying when the row budget would truncate activity", async () => {
+    const page = Array.from({ length: 1000 }, (_, i) => ({
+      connection_slug: "lobu-product-activity-db",
+      title: "New signup",
+      payload_text: "Ada · ada@example.com",
+      _created_at: "2026-08-13T12:01:00.000Z",
+      _id: i + 1,
+    }));
+    const query = mock().mockResolvedValue(page);
+    const send = mock();
+    await expect(
+      productActivityDigest(context, {
+        query,
+        notifications: { send },
+        log: mock(),
+      } as unknown as ReactionClient)
+    ).rejects.toThrow("exceeded its row budget");
+    expect(query).toHaveBeenCalledTimes(20);
+    expect(send).not.toHaveBeenCalled();
   });
 
   it("requires the run id used to deduplicate retries", async () => {

--- a/examples/lobu-team/lobu.config.ts
+++ b/examples/lobu-team/lobu.config.ts
@@ -445,7 +445,7 @@ const productActivityDigest = defineAutomation({
   // An empty source list falls back to all workspace content. This explicit
   // empty input lets the reaction own the windowed query without duplicating
   // the backlog in the model context or hitting non-pageable source limits.
-  sources: { reaction_window: "SELECT id FROM events WHERE FALSE" },
+  sources: { reaction_window: "SELECT * FROM events WHERE FALSE" },
   minCooldownSeconds: 60,
   tags: ["product-ops", "production", "slack"],
   prompt:

--- a/examples/lobu-team/lobu.config.ts
+++ b/examples/lobu-team/lobu.config.ts
@@ -3,21 +3,21 @@ import {
   defineAgent,
   defineAuthProfile,
   defineAutomation,
-  every,
   defineConfig,
   defineConnection,
   defineEntityType,
   defineRelationshipType,
   defineSkill,
+  every,
+  field,
   reactionFromFile,
   secret,
   skillFromFile,
-  field,
   Type,
 } from "@lobu/cli/config";
 import type DeliverooConnector from "./deliveroo.connector.ts";
-import type lunchDeliverooReaction from "./lunch-deliveroo.reaction.ts";
 import type LokiActivityConnector from "./loki-activity.connector.ts";
+import type lunchDeliverooReaction from "./lunch-deliveroo.reaction.ts";
 import type productActivityDigestReaction from "./product-activity-digest.reaction.ts";
 
 const lunchOpenSkill = defineSkill({
@@ -270,7 +270,7 @@ const productOps = defineAgent({
   name: "product-ops",
   description:
     "Summarizes Lobu production activity from organization-owned read-only feeds",
-  providers: [{ id: "qwen", model: "qwen3.8-max" }],
+  providers: [{ id: "gemini", model: "gemini-2.5-flash" }],
   tools: {
     // Keep the headless lockdown (no native worker tools) and pre-approve the
     // one MCP write the Automation needs: run_sdk carries completeWindow, is not
@@ -439,17 +439,17 @@ const productActivityDigest = defineAutomation({
     "Every 20 minutes, summarize new signups, logins, connections, MCP clients, and Kubernetes log activity; stay silent when nothing happened.",
   triggers: [
     every("5,25,45 * * * *", {
-      skip_if_unchanged: true,
+      skip_if_unchanged: false,
     }),
   ],
-  sources: {
-    product_activity: "@connection:lobu-product-activity-db",
-    kubernetes_logs: "@connection:lobu-production-logs",
-  },
+  // An empty source list falls back to all workspace content. This explicit
+  // empty input lets the reaction own the windowed query without duplicating
+  // the backlog in the model context or hitting non-pageable source limits.
+  sources: { reaction_window: "SELECT id FROM events WHERE FALSE" },
   minCooldownSeconds: 60,
   tags: ["product-ops", "production", "slack"],
   prompt:
-    'The reaction sends the exact activity rows for this window. Return exactly {"run":true,"exclude_email":"emrekabakci@gmail.com"} — the digest excludes this operator email from presence counts.',
+    'Read this Automation window to obtain its window_token, then call client.automations.completeWindow with extracted_data {"run":true,"exclude_email":"emrekabakci@gmail.com"} — the digest excludes this operator email from presence counts. The reaction queries and formats all activity itself; do not fetch activity rows, send a separate message, or stop after printing JSON.',
   reactionsGuidance:
     "Send one rich digest containing every user email and activity detail in the window. Send nothing when both sources are empty.",
   reaction: reactionFromFile<typeof productActivityDigestReaction>(

--- a/examples/lobu-team/product-activity-digest.reaction.ts
+++ b/examples/lobu-team/product-activity-digest.reaction.ts
@@ -31,10 +31,6 @@ interface ActivityRow {
   _id?: number | null;
 }
 
-interface PreviousDigestRow {
-  created_at: string;
-}
-
 interface LogActivity {
   errors?: number;
   warnings?: number;
@@ -300,24 +296,18 @@ export default async (
     throw new Error("Product activity digest requires a durable run id");
   }
 
-  // Sub-hour schedules share a daily analysis period. Use the last delivered
-  // digest as a durable cursor so every newly ingested row is reported once.
-  const previousRows = (await client.query(`
-    SELECT created_at
-    FROM events
-    WHERE automation_id = ${ctx.window.automation_id}
-      AND semantic_type = 'notification'
-      AND title = 'Lobu production activity digest'
-    ORDER BY created_at DESC, id DESC
-    LIMIT 1
-  `)) as PreviousDigestRow[];
-  const end = new Date();
-  const previous = previousRows[0]?.created_at
-    ? new Date(previousRows[0].created_at)
-    : new Date(end.getTime() - 20 * 60 * 1000);
-  const start = Number.isFinite(previous.getTime())
-    ? previous
-    : new Date(end.getTime() - 20 * 60 * 1000);
+  // The scheduler owns the durable arrival cursor. Read exactly the claimed
+  // half-open window so retries cannot skip activity based on a later inbox
+  // notification or include arrivals reserved for the next run.
+  const start = new Date(ctx.window.window_start);
+  const end = new Date(ctx.window.window_end);
+  if (
+    !Number.isFinite(start.getTime()) ||
+    !Number.isFinite(end.getTime()) ||
+    start >= end
+  ) {
+    throw new Error("Product activity digest requires a valid arrival window");
+  }
 
   const excludedEmail =
     ctx.extracted_data &&
@@ -333,15 +323,16 @@ export default async (
   // Read the window in bounded keyset pages ordered by (created_at, id) and
   // exclude the operator's presence rows in memory. No leading-wildcard LIKE
   // over events, and excluded rows cannot consume a fixed LIMIT budget: the
-  // cursor keeps advancing past them until the window is exhausted or the
-  // safety cap is hit, so later valid activity is never starved.
+  // cursor keeps advancing past them until the window is exhausted, so later
+  // valid activity is never starved. Hitting the safety cap fails the run
+  // instead of silently reporting a truncated digest.
   const rows: ActivityRow[] = [];
   let lastCreatedAt: string | null = null;
   let lastId = 0;
   const PAGE_SIZE = 1000;
   const MAX_ROWS = 20_000;
-  let sawPartialPage = true;
-  while (sawPartialPage && rows.length < MAX_ROWS) {
+  let pageWasFull = true;
+  while (pageWasFull && rows.length < MAX_ROWS) {
     const page = (await client.query(`
       SELECT
         c.slug AS connection_slug,
@@ -354,8 +345,8 @@ export default async (
       FROM events e
       JOIN connections c ON c.id = e.connection_id
       WHERE c.slug IN ('${PRODUCT_ACTIVITY_CONNECTION}', '${LOG_ACTIVITY_CONNECTION}')
-        AND e.created_at > '${start.toISOString()}'::timestamptz
-        AND e.created_at <= '${end.toISOString()}'::timestamptz
+        AND e.created_at >= '${start.toISOString()}'::timestamptz
+        AND e.created_at < '${end.toISOString()}'::timestamptz
         AND (
           ${
             lastCreatedAt == null
@@ -367,12 +358,17 @@ export default async (
       ORDER BY e.created_at ASC, e.id ASC
       LIMIT ${PAGE_SIZE}
     `)) as ActivityRow[];
-    sawPartialPage = page.length === PAGE_SIZE;
+    pageWasFull = page.length === PAGE_SIZE;
     for (const row of page) {
       rows.push(row);
       if (typeof row._created_at === "string") lastCreatedAt = row._created_at;
       if (typeof row._id === "number") lastId = row._id;
     }
+  }
+  if (pageWasFull) {
+    throw new Error(
+      "Product activity digest exceeded its row budget; narrow the arrival window before retrying"
+    );
   }
   const digest = collectProductActivityDigest(rows, excludedEmail);
   if (!hasProductActivity(digest)) {


### PR DESCRIPTION
## Summary

The production activity digest used notification creation time as its cursor, so retries could read beyond their claimed arrival window and couple coverage to notification timing. Read the scheduler's half-open arrival window, validate it, and fail before sending if the bounded query cannot cover it fully.

The example now uses an explicit empty model input and lets its reaction query the activity feeds. An empty source list defaults to all workspace content; the explicit query avoids that fallback and non-pageable model-source truncation. Keep the schedule running so the reaction decides whether there is activity, and select the workspace's working Gemini model. The prompt explicitly requires window completion.

Inspection showed the allegedly missing Slack connection was an existing, healthy shared preview bot in its owning workspace. Its original credential and private-channel membership remained valid. No duplicate installation, connection transfer, or lifecycle migration was needed. Existing soft-deletion, chat archival, and workspace routing behavior passed focused tests.

## Test plan

- [x] Full Lobu Team example suite: 25 passed (10 reaction tests), including window boundaries, invalid windows, pagination, silence, and refusing truncated digests.
- [x] Slack coordinator and connection-scoped chat lifecycle suites: 35 passed.
- [x] Local build, package typechecks, dead-code, naming, and write-funnel gates passed.
- [x] Red to green: the added claimed-window test initially failed (two reads, old cursor); after the fix all 10 reaction tests passed.
- [x] Live application: manual run completed, reaction completed, original Slack bot's message read back from the bound private channel. The next scheduled run completed, remained silent without new activity, and left the failure counter at zero.
- [x] Required GitHub CI and exact-head semantic review passed on `c3e1ea31791ef168a015f7df09d98dcb3331a41e`; final review: zero bugs or blockers.

## Notes

The first CI run exposed the configuration test's old source/skip expectations; they now assert the live-verified explicit empty source and reaction-owned silence behavior.

Hitting the 20,000-row safety budget intentionally fails instead of claiming complete delivery. The separately paused Kubernetes-log feed remains outside this repair; live proof covers PostgreSQL activity and Slack delivery.

Review caught an id-only empty-source projection missing `occurred_at`, which the paging wrapper requires. A read-only Postgres probe reproduced the missing-column error; the corrected full projection returned zero rows successfully. Live Automation version 5 carries this correction.
