### PR TITLE
fix(chat): route authorized links across workspaces

### DIFF
--- a/packages/server/src/automations/activation.ts
+++ b/packages/server/src/automations/activation.ts
@@ -6,6 +6,7 @@ import {
 } from "@lobu/core/contracts/tools/manage-automations";
 import type { DbClient } from "../db/client";
 import { getDb } from "../db/client";
+import { crossOrganizationChatLinkScope } from "../gateway/channels/chat-link-authorization";
 import { runtimeConnectionIdToSlug } from "../lobu/stores/connections-projection";
 import {
   type AutomationEventRunQueued,
@@ -94,7 +95,7 @@ export async function findMatchingAutomationActivations(
   organizationId: string,
   signal: ConnectorTriggerSignal,
   db: DbClient = getDb(),
-  options?: { crossOrganization?: boolean },
+  options?: { crossOrganization?: boolean; includeAuthorizedChatLinks?: boolean },
 ): Promise<MatchingAutomationActivation[]> {
   // Coarse GIN needle: kind + connector_key. When the signal carries a
   // connection_id, match that connection's triggers OR connector-wide triggers
@@ -105,9 +106,26 @@ export async function findMatchingAutomationActivations(
     kind: "event" as const,
     connector_key: signal.connector_key,
   };
+  const channelId = signal.attributes?.channel_id;
+  // The view normalizes an empty trigger team to NULL, so normalize the signal
+  // the same way: the SQL admission below and the per-trigger re-check further
+  // down must agree on what "no workspace" means.
+  const rawTeamId = signal.attributes?.team_id;
+  const teamId = typeof rawTeamId === "string" && rawTeamId !== "" ? rawTeamId : null;
+  const chatLinkFilter = options?.includeAuthorizedChatLinks &&
+    signal.event_type === "message.created" && signal.connection_id != null &&
+    typeof channelId === "string"
+    ? db`OR EXISTS (
+        SELECT 1 FROM automation_message_subscriptions s
+        WHERE s.automation_id = w.id
+          AND s.connection_id = ${signal.connection_id}
+          AND s.native_channel_id = ${channelId}
+          AND ${crossOrganizationChatLinkScope(db, organizationId, teamId)}
+      )`
+    : db``;
   const organizationFilter = options?.crossOrganization
     ? db``
-    : db`AND w.organization_id = ${organizationId}`;
+    : db`AND (w.organization_id = ${organizationId} ${chatLinkFilter})`;
   const connectionId = signal.connection_id;
   const triggerFilter =
     connectionId != null
@@ -146,7 +164,12 @@ export async function findMatchingAutomationActivations(
     const [trigger] = matchingAutomationTriggers(
       triggers.filter(
         (candidate): candidate is AutomationEventTrigger =>
-          candidate.kind === "event" && candidate.source !== "workspace",
+          candidate.kind === "event" && candidate.source !== "workspace" &&
+          (options?.crossOrganization || row.organization_id === organizationId || (
+            candidate.connection_id === signal.connection_id &&
+            candidate.match?.channel_id === channelId &&
+            (candidate.match?.team_id || null) === teamId
+          )),
       ),
       signal,
     );
@@ -203,7 +226,7 @@ export async function planAutomationActivationsForRuntimeConnection(
     args.connectionOrganizationId,
     signal,
     db,
-    { crossOrganization: args.crossOrganization },
+    { crossOrganization: args.crossOrganization, includeAuthorizedChatLinks: true },
   );
   return planAutomationActivations(signal, matches);
 }

--- a/packages/server/src/automations/activation.ts
+++ b/packages/server/src/automations/activation.ts
@@ -6,7 +6,7 @@ import {
 } from "@lobu/core/contracts/tools/manage-automations";
 import type { DbClient } from "../db/client";
 import { getDb } from "../db/client";
-import { crossOrganizationChatLinkScope } from "../gateway/channels/chat-link-authorization";
+import { authorizedChatLinkIds } from "../gateway/channels/chat-link-authorization";
 import { runtimeConnectionIdToSlug } from "../lobu/stores/connections-projection";
 import {
   type AutomationEventRunQueued,
@@ -115,13 +115,12 @@ export async function findMatchingAutomationActivations(
   const chatLinkFilter = options?.includeAuthorizedChatLinks &&
     signal.event_type === "message.created" && signal.connection_id != null &&
     typeof channelId === "string"
-    ? db`OR EXISTS (
-        SELECT 1 FROM automation_message_subscriptions s
-        WHERE s.automation_id = w.id
-          AND s.connection_id = ${signal.connection_id}
-          AND s.native_channel_id = ${channelId}
-          AND ${crossOrganizationChatLinkScope(db, organizationId, teamId)}
-      )`
+    ? db`OR w.id IN (${authorizedChatLinkIds(db, {
+        connectionOrganizationId: organizationId,
+        connection: { id: signal.connection_id },
+        channelId,
+        teamId,
+      })})`
     : db``;
   const organizationFilter = options?.crossOrganization
     ? db``

--- a/packages/server/src/gateway/__tests__/chat-link-code-routing.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-link-code-routing.test.ts
@@ -75,7 +75,7 @@ describe("platform-neutral chat link-code routing", () => {
     const subscriptions = new AutomationSubscriptionService();
     const registry = new CommandRegistry();
     const getSettings = mock(async () => undefined);
-    registerBuiltInCommands(registry, { agentSettingsStore: { getSettings } as never });
+    registerBuiltInCommands(registry, { agentSettingsStore: { getSettings } as never, automationSubscriptionService: subscriptions });
     const dispatcher = new CommandDispatcher({ registry, automationSubscriptionService: subscriptions });
     const conversationState = new ConversationStateStore(await createConnectedGatewayStateAdapter());
     const bridge = new MessageHandlerBridge(connection, {

--- a/packages/server/src/gateway/__tests__/chat-link-code-routing.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-link-code-routing.test.ts
@@ -1,0 +1,316 @@
+/** Link codes bind a chat without inventing a platform-user identity. */
+import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { CommandRegistry } from "@lobu/core";
+import type { Context } from "hono";
+import { addUserToOrganization, createTestUser, linkSlackIdentityInGraph } from "../../__tests__/setup/test-fixtures.js";
+import { getDb } from "../../db/client.js";
+import type { Env } from "../../index.js";
+import { createPreviewClaim } from "../../preview/slack.js";
+import { resolveChatUserIdentity } from "../../lobu/stores/chat-identity.js";
+import { AutomationSubscriptionService } from "../channels/automation-subscription-service.js";
+import { registerBuiltInCommands } from "../commands/built-in-commands.js";
+import { CommandDispatcher } from "../commands/command-dispatcher.js";
+import { ConversationStateStore } from "../connections/conversation-state-store.js";
+import { MessageHandlerBridge } from "../connections/message-handler-bridge.js";
+import { createConnectedGatewayStateAdapter } from "../connections/state-adapter.js";
+import type { PlatformConnection } from "../connections/types.js";
+import { QueueProducer } from "../infrastructure/queue/queue-producer.js";
+import { RunsQueue } from "../infrastructure/queue/runs-queue.js";
+import { ensureDbForGatewayTests, resetTestDatabase, seedAgentRow } from "./helpers/db-setup.js";
+
+const SOURCE_ORG = "org-chat-installation";
+const TARGET_ORG = "org-chat-agent";
+const AGENT_ID = "agent-chat-code";
+const PLATFORMS = ["slack", "telegram", "whatsapp"] as const;
+
+function claimContext(body: Record<string, unknown>, userId: string, authVariables: Record<string, unknown> = {}) {
+  return {
+    var: { organizationId: TARGET_ORG, session: { userId }, authSource: "session", ...authVariables },
+    req: { json: async () => body },
+    json: (value: unknown, status = 200) => new Response(JSON.stringify(value), { status }),
+  } as unknown as Context<{ Bindings: Env }>;
+}
+
+async function waitFor(check: () => Promise<void>) {
+  const deadline = Date.now() + 3_000;
+  let error: unknown;
+  while (Date.now() < deadline) {
+    try { await check(); return; } catch (caught) { error = caught; }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw error;
+}
+
+describe("platform-neutral chat link-code routing", () => {
+  let queue: RunsQueue;
+  let producer: QueueProducer;
+  let ownerId: string;
+
+  beforeAll(ensureDbForGatewayTests);
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedAgentRow(AGENT_ID, { organizationId: TARGET_ORG });
+    await seedAgentRow("installation-agent", { organizationId: SOURCE_ORG });
+    ownerId = (await createTestUser()).id;
+    await addUserToOrganization(ownerId, SOURCE_ORG, "owner");
+    await addUserToOrganization(ownerId, TARGET_ORG, "admin");
+    queue = new RunsQueue();
+    await queue.start();
+    producer = new QueueProducer(queue);
+    await producer.start();
+  });
+  afterEach(async () => { await queue?.stop(); });
+
+  async function install(platform: typeof PLATFORMS[number], organizationId: string, suffix = "") {
+    const slug = `chat-code-${platform}${suffix}`;
+    const [row] = await getDb()`
+      INSERT INTO connections (organization_id, connector_key, slug, display_name, status, credential_mode, config)
+      VALUES (${organizationId}, ${platform}, ${`agentconn-${slug}`}, 'Chat code fixture', 'active', 'managed', '{}')
+      RETURNING id
+    `;
+    const connection: PlatformConnection = {
+      id: slug, organizationId, platform, config: { platform } as never,
+      settings: { allowGroups: true }, status: "active", createdAt: 1, updatedAt: 1,
+    };
+    const subscriptions = new AutomationSubscriptionService();
+    const registry = new CommandRegistry();
+    const getSettings = mock(async () => undefined);
+    registerBuiltInCommands(registry, { agentSettingsStore: { getSettings } as never });
+    const dispatcher = new CommandDispatcher({ registry, automationSubscriptionService: subscriptions });
+    const conversationState = new ConversationStateStore(await createConnectedGatewayStateAdapter());
+    const bridge = new MessageHandlerBridge(connection, {
+      getArtifactStore: () => null,
+      getPublicGatewayUrl: () => "https://gateway.example.test",
+      getAutomationSubscriptionService: () => subscriptions,
+      getAgentMetadataStore: () => undefined,
+      getUserAgentsStore: () => undefined,
+      getTranscriptionService: () => undefined,
+      getAgentSettingsStore: () => undefined,
+      getDeclaredAgentRegistry: () => undefined,
+      getProviderCatalogService: () => undefined,
+      getQueueProducer: () => producer,
+    } as never, {
+      has: (id: string) => id === slug,
+      getInstance: () => ({ connection, conversationState }),
+    } as never, dispatcher);
+    const channelId = `${platform}:123456`;
+    const thread = { channelId, id: channelId, subscribe: mock(async () => {}), post: mock(async () => ({})) };
+    let sequence = 0;
+    const send = (text: string, source: "dm" | "mention" = "dm") => bridge.handleMessage(thread, {
+      id: `message-${++sequence}`, text,
+      author: { userId: "provider-code-redeemer", isBot: false, isMe: false },
+      raw: platform === "slack" ? { team_id: "T_CODE_WORKSPACE" } : {},
+    }, source);
+    return { id: Number(row.id), slug, connection, thread, send, getSettings };
+  }
+
+  for (const platform of PLATFORMS) {
+    for (const sourceOrg of [TARGET_ORG, SOURCE_ORG]) {
+      test(`${platform}: code links and dispatches from ${sourceOrg === TARGET_ORG ? "same" : "another administered"} workspace`, async () => {
+        const installed = await install(platform, sourceOrg);
+        const minted = await createPreviewClaim(claimContext({
+          platform, agent_id: AGENT_ID, connection_id: installed.id, surfaces: ["dm"],
+        }, ownerId));
+        expect(minted.status).toBe(200);
+        const { code } = await minted.json();
+        await installed.send(`/lobu link ${code}`);
+        expect(String(installed.thread.post.mock.calls[0]?.[0])).toContain("Linked this chat");
+        await installed.send("Handle this request");
+        await waitFor(async () => {
+          const rows = await getDb()`SELECT action_input FROM runs WHERE run_type = 'chat_message'`;
+          expect(rows).toHaveLength(1);
+          expect(rows[0].action_input).toMatchObject({ agentId: AGENT_ID, organizationId: TARGET_ORG });
+        });
+        expect(await resolveChatUserIdentity(platform, platform === "slack" ? "T_CODE_WORKSPACE" : undefined, "provider-code-redeemer")).toBeNull();
+      });
+    }
+
+    test(`${platform}: a channel code routes a mention and status to the linked workspace`, async () => {
+      const installed = await install(platform, SOURCE_ORG);
+      const response = await createPreviewClaim(claimContext({
+        platform, agent_id: AGENT_ID, connection_id: installed.id, surfaces: ["channel"],
+      }, ownerId));
+      expect(response.status).toBe(200);
+      await installed.send(`/link ${(await response.json()).code}`, "mention");
+      expect(String(installed.thread.post.mock.calls[0]?.[0])).toContain("Linked this chat");
+      await installed.send("Handle this channel request", "mention");
+      await waitFor(async () => {
+        const rows = await getDb()`SELECT action_input FROM runs WHERE run_type = 'chat_message'`;
+        expect(rows).toHaveLength(1);
+        expect(rows[0].action_input.organizationId).toBe(TARGET_ORG);
+      });
+      await installed.send("/status", "mention");
+      expect(installed.getSettings.mock.calls).toEqual([[AGENT_ID, { organizationId: TARGET_ORG }]]);
+    });
+
+    if (platform !== "whatsapp") {
+      test(`${platform}: hosted preview codes still dispatch without installation-admin membership`, async () => {
+        const installed = await install(platform, SOURCE_ORG);
+        installed.connection.settings = { allowGroups: true, previewMode: true };
+        const sql = getDb();
+        await sql`UPDATE connections SET config = ${sql.json({ settings: { previewMode: true } })} WHERE id = ${installed.id}`;
+        await sql`DELETE FROM member WHERE "userId" = ${ownerId} AND "organizationId" = ${SOURCE_ORG}`;
+        const response = await createPreviewClaim(claimContext({ platform, agent_id: AGENT_ID }, ownerId));
+        expect(response.status).toBe(200);
+        await installed.send(`/link ${(await response.json()).code}`);
+        expect(String(installed.thread.post.mock.calls[0]?.[0])).toContain("Linked this chat");
+        await installed.send("Handle this hosted preview request");
+        await waitFor(async () => {
+          const rows = await sql`SELECT action_input FROM runs WHERE run_type = 'chat_message'`;
+          expect(rows).toHaveLength(1);
+          expect(rows[0].action_input.organizationId).toBe(TARGET_ORG);
+        });
+      });
+    }
+
+    if (platform === "slack") {
+      test("slack: hosted preview retains verified codeless linking for a target-workspace member", async () => {
+        const installed = await install(platform, SOURCE_ORG);
+        installed.connection.settings = { allowGroups: true, previewMode: true };
+        const sql = getDb();
+        await sql`UPDATE connections SET config = ${sql.json({ settings: { previewMode: true } })} WHERE id = ${installed.id}`;
+        await sql`DELETE FROM member WHERE "userId" = ${ownerId} AND "organizationId" = ${SOURCE_ORG}`;
+        await linkSlackIdentityInGraph({
+          organizationId: TARGET_ORG, userId: ownerId,
+          teamId: "T_CODE_WORKSPACE", slackUserId: "provider-code-redeemer",
+        });
+        await installed.send(`/lobu link ${AGENT_ID}`);
+        expect(String(installed.thread.post.mock.calls[0]?.[0])).toContain("Linked this chat");
+        await installed.send("Handle the verified preview request");
+        await waitFor(async () => {
+          const rows = await sql`SELECT action_input FROM runs WHERE run_type = 'chat_message'`;
+          expect(rows).toHaveLength(1);
+          expect(rows[0].action_input.organizationId).toBe(TARGET_ORG);
+        });
+      });
+    }
+
+    test.each(["source member", "target member", "target-only OAuth", "source-only OAuth", "scoped PAT"])(`${platform}: rejects a code grant without both workspace permissions: %s`, async (boundary) => {
+      const installed = await install(platform, SOURCE_ORG);
+      const sql = getDb();
+      let authVariables: Record<string, unknown> = {};
+      if (boundary.endsWith("member")) {
+        const organizationId = boundary.startsWith("source") ? SOURCE_ORG : TARGET_ORG;
+        await sql`UPDATE member SET role = 'member' WHERE "userId" = ${ownerId} AND "organizationId" = ${organizationId}`;
+      } else {
+        const pat = boundary === "scoped PAT";
+        authVariables = {
+          authSource: pat ? "pat" : "oauth", session: null, user: { id: ownerId },
+          mcpAuthInfo: {
+            userId: ownerId, tokenType: pat ? "pat" : "access_token",
+            organizationId: pat ? TARGET_ORG : null,
+            grantedOrganizationIds: boundary === "source-only OAuth" ? [SOURCE_ORG] : [TARGET_ORG],
+          },
+        };
+      }
+      const response = await createPreviewClaim(claimContext({
+        platform, agent_id: AGENT_ID, connection_id: installed.id,
+      }, ownerId, authVariables));
+      expect(response.status).toBe(404);
+      expect(await sql`SELECT id FROM oauth_states`).toHaveLength(0);
+      expect(await sql`SELECT id FROM automations`).toHaveLength(0);
+    });
+
+    test.each(["both-workspace OAuth", "unscoped PAT"])(`${platform}: a credential with both workspace permissions can authorize a code: %s`, async (credential) => {
+      const installed = await install(platform, SOURCE_ORG);
+      const pat = credential === "unscoped PAT";
+      const response = await createPreviewClaim(claimContext({
+        platform, agent_id: AGENT_ID, connection_id: installed.id,
+      }, ownerId, {
+        authSource: pat ? "pat" : "oauth", session: null, user: { id: ownerId },
+        mcpAuthInfo: {
+          userId: ownerId, tokenType: pat ? "pat" : "access_token", organizationId: null,
+          grantedOrganizationIds: pat ? null : [SOURCE_ORG, TARGET_ORG],
+        },
+      }));
+      expect(response.status).toBe(200);
+      const { code } = await response.json();
+      await installed.send(`/link ${code}`);
+      expect(String(installed.thread.post.mock.calls[0]?.[0])).toContain("Linked this chat");
+      await installed.send("Handle the credential-authorized request");
+      await waitFor(async () => {
+        expect(await getDb()`SELECT id FROM runs WHERE run_type = 'chat_message'`).toHaveLength(1);
+      });
+    });
+
+    test.each(["source access revoked", "target access revoked", "wrong connection", "wrong platform", "installation moved", "expired code", "wrong surface"])(`${platform}: rejected redemption never links or dispatches: %s`, async (boundary) => {
+      const installed = await install(platform, SOURCE_ORG);
+      const response = await createPreviewClaim(claimContext({
+        platform, agent_id: AGENT_ID, connection_id: installed.id, surfaces: ["dm"],
+      }, ownerId));
+      expect(response.status).toBe(200);
+      const { code } = await response.json();
+      const sql = getDb();
+      const [claim] = await sql`SELECT payload FROM oauth_states`;
+      expect(claim.payload.connectionOrganizationId).toBe(SOURCE_ORG);
+      let destination = installed;
+      if (boundary.endsWith("access revoked")) {
+        const organizationId = boundary.startsWith("source") ? SOURCE_ORG : TARGET_ORG;
+        await sql`DELETE FROM member WHERE "userId" = ${ownerId} AND "organizationId" = ${organizationId}`;
+      } else if (boundary === "wrong connection") {
+        destination = await install(platform, SOURCE_ORG, "-other");
+      } else if (boundary === "wrong platform") {
+        destination = await install(platform === "slack" ? "telegram" : "slack", SOURCE_ORG);
+      } else if (boundary === "installation moved") {
+        await sql`UPDATE connections SET organization_id = ${TARGET_ORG} WHERE id = ${installed.id}`;
+      } else if (boundary === "expired code") {
+        await sql`UPDATE oauth_states SET expires_at = now() - interval '1 second'`;
+      }
+      await destination.send(`/lobu link ${code}`, boundary === "wrong surface" ? "mention" : "dm");
+      expect(String(destination.thread.post.mock.calls[0]?.[0])).not.toContain("Linked this chat");
+      expect(await sql`SELECT id FROM automations`).toHaveLength(0);
+      await destination.send("This must not create a turn");
+      expect(await sql`SELECT id FROM runs WHERE run_type = 'chat_message'`).toHaveLength(0);
+    });
+
+    test(`${platform}: re-link rejects a revoked author until the old link is retired`, async () => {
+      const installed = await install(platform, SOURCE_ORG);
+      const mint = async (userId: string) => {
+        const response = await createPreviewClaim(claimContext({
+          platform, agent_id: AGENT_ID, connection_id: installed.id,
+        }, userId));
+        expect(response.status).toBe(200);
+        return (await response.json()).code as string;
+      };
+      await installed.send(`/link ${await mint(ownerId)}`);
+      const sql = getDb();
+      const replacement = (await createTestUser()).id;
+      await addUserToOrganization(replacement, SOURCE_ORG, "admin");
+      await addUserToOrganization(replacement, TARGET_ORG, "admin");
+      await sql`DELETE FROM member WHERE "userId" = ${ownerId} AND "organizationId" = ${SOURCE_ORG}`;
+      const replacementCode = await mint(replacement);
+      await installed.send(`/link ${replacementCode}`);
+      expect(String(installed.thread.post.mock.calls[1]?.[0])).toContain("Retire its Automation");
+      const [existing] = await sql`SELECT id, created_by FROM automations`;
+      expect(existing.created_by).toBe(ownerId);
+      expect(await sql`SELECT id FROM oauth_states`).toHaveLength(1);
+      await installed.send("The old authorization must remain revoked");
+      expect(await sql`SELECT id FROM runs WHERE run_type = 'chat_message'`).toHaveLength(0);
+      await sql`UPDATE automations SET status = 'archived' WHERE id = ${existing.id}`;
+      await installed.send(`/link ${replacementCode}`);
+      expect(String(installed.thread.post.mock.calls.at(-1)?.[0])).toContain("Linked this chat");
+      await installed.send("A fresh link has a current authorized author");
+      await waitFor(async () => {
+        expect(await sql`SELECT id FROM runs WHERE run_type = 'chat_message'`).toHaveLength(1);
+      });
+    });
+
+    test(`${platform}: a code is single use and revoked admin access stops an existing link`, async () => {
+      const installed = await install(platform, SOURCE_ORG);
+      const response = await createPreviewClaim(claimContext({
+        platform, agent_id: AGENT_ID, connection_id: installed.id,
+      }, ownerId));
+      const { code } = await response.json();
+      await installed.send(`/link ${code}`);
+      const sql = getDb();
+      expect(await sql`SELECT id FROM oauth_states`).toHaveLength(0);
+      await installed.send(`/link ${code}`);
+      expect(String(installed.thread.post.mock.calls[1]?.[0])).toContain("invalid or expired");
+      expect(await sql`SELECT id FROM automations`).toHaveLength(1);
+      await sql`DELETE FROM member WHERE "userId" = ${ownerId} AND "organizationId" = ${SOURCE_ORG}`;
+      await installed.send("This must not run after access was revoked");
+      expect(await sql`SELECT id FROM runs WHERE run_type = 'chat_message'`).toHaveLength(0);
+      expect(await resolveChatUserIdentity(platform, platform === "slack" ? "T_CODE_WORKSPACE" : undefined, "provider-code-redeemer")).toBeNull();
+    });
+  }
+});

--- a/packages/server/src/gateway/__tests__/dm-link-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/dm-link-e2e.test.ts
@@ -90,6 +90,7 @@ describe("DM /lobu link <code> — real consume→bind chain", () => {
 			const registry = new CommandRegistry();
 			registerBuiltInCommands(registry, {
 				agentSettingsStore: {} as never,
+				automationSubscriptionService: {} as never,
 			});
 			const dispatcher = new CommandDispatcher({
 				registry,

--- a/packages/server/src/gateway/__tests__/dm-link-message-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/dm-link-message-e2e.test.ts
@@ -83,7 +83,7 @@ describe("DM bare-code message → real consume→bind (previewMode)", () => {
     try {
       // Real registry + real built-in `link` command + real dispatcher.
       const registry = new CommandRegistry();
-      registerBuiltInCommands(registry, { agentSettingsStore: {} as never });
+      registerBuiltInCommands(registry, { agentSettingsStore: {} as never, automationSubscriptionService: {} as never });
       const dispatcher = new CommandDispatcher({
         registry,
 				automationSubscriptionService: {

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -502,6 +502,7 @@ describe("registerMessageHandlers linked-channel ingress", () => {
       "slack:C0CHANNEL",
       "org-grid",
       false,
+      "T0WORKSPACE",
     );
     expect(handleMessage).toHaveBeenCalledWith(thread, message, "subscribed");
   });

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -501,8 +501,7 @@ describe("registerMessageHandlers linked-channel ingress", () => {
       "slackinst-grid",
       "slack:C0CHANNEL",
       "org-grid",
-      false,
-      "T0WORKSPACE",
+      { crossOrganization: false, teamId: "T0WORKSPACE" },
     );
     expect(handleMessage).toHaveBeenCalledWith(thread, message, "subscribed");
   });

--- a/packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts
@@ -19,6 +19,12 @@ import {
 import { createHmac } from "node:crypto";
 import { createSlackAdapter } from "@chat-adapter/slack";
 import { Chat, type StateAdapter } from "chat";
+import { CommandRegistry } from "@lobu/core";
+import { addUserToOrganization, createTestUser, linkSlackIdentityInGraph } from "../../__tests__/setup/test-fixtures.js";
+import { bindChatToAgentForOwner } from "../../preview/slack.js";
+import { planAutomationActivationsForRuntimeConnection } from "../../automations/activation.js";
+import { registerBuiltInCommands } from "../commands/built-in-commands.js";
+import { CommandDispatcher } from "../commands/command-dispatcher.js";
 import { createTestAutomationSubscription } from "../../__tests__/setup/automation-subscriptions.js";
 import { getDb } from "../../db/client.js";
 import { AutomationSubscriptionService } from "../channels/automation-subscription-service.js";
@@ -79,6 +85,7 @@ function slackEvent(options: {
   user?: string;
   botId?: string;
   channelType?: "channel" | "im";
+  eventType?: "message" | "app_mention";
 }) {
   return {
     token: "legacy-verification-token",
@@ -90,7 +97,7 @@ function slackEvent(options: {
     enterprise_id: ENTERPRISE_ID,
     is_enterprise_install: true,
     event: {
-      type: "message",
+      type: options.eventType ?? "message",
       team: WORKSPACE_TEAM_ID,
       team_id: WORKSPACE_TEAM_ID,
       channel: options.channel,
@@ -562,6 +569,195 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
     `;
     for (const row of runStamps) {
       expect(row.action_input.platformMetadata.teamId).toBe(WORKSPACE_TEAM_ID);
+    }
+  });
+
+  test("a verified admin links another Lobu workspace and signed Slack messages queue there", async () => {
+    const sourceOrg = "org-slack-grid-e2e";
+    const targetOrg = "org-slack-linked-workspace";
+    const targetAgent = "agent-slack-linked-workspace";
+    const channel = "C_CROSS_WORKSPACE";
+    await seedAgentRow(targetAgent, { organizationId: targetOrg });
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, sourceOrg, "owner");
+    await addUserToOrganization(user.id, targetOrg, "admin");
+    await linkSlackIdentityInGraph({
+      organizationId: sourceOrg, userId: user.id,
+      teamId: WORKSPACE_TEAM_ID, slackUserId: "U_LINK_ADMIN",
+    });
+    const subscriptions = new AutomationSubscriptionService();
+    const registry = new CommandRegistry();
+    registerBuiltInCommands(registry, { agentSettingsStore: {} as never });
+    const dispatcher = new CommandDispatcher({ registry, automationSubscriptionService: subscriptions });
+    const replies: string[] = [];
+    await dispatcher.tryHandleSlashText(`/lobu link ${targetAgent}`, {
+      platform: "slack", userId: "U_LINK_ADMIN", channelId: channel,
+      teamId: WORKSPACE_TEAM_ID, isGroup: true,
+      connectionId: RUNTIME_CONNECTION_ID, organizationId: sourceOrg,
+      reply: async (text) => { replies.push(String(text)); },
+    });
+    expect(replies).toEqual([`Linked this chat to agent \`${targetAgent}\`. Say hi — I'll reply here from now on.`]);
+
+    const response = await chat.webhooks.slack(signedEventRequest(slackEvent({
+      eventId: "Ev_CROSS_WORKSPACE", channel, ts: "1787292010.000001",
+      text: "Create the follow-up task", user: "U_LINK_ADMIN",
+    })));
+    expect(response.status).toBe(200);
+    await waitFor(async () => {
+      const rows = await getDb()`SELECT action_input FROM runs WHERE run_type = 'chat_message'`;
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.action_input).toMatchObject({
+        agentId: targetAgent, organizationId: targetOrg,
+        messageText: "Create the follow-up task",
+        platformMetadata: { teamId: WORKSPACE_TEAM_ID, connectionId: RUNTIME_CONNECTION_ID },
+      });
+    });
+    const linked = await subscriptions.resolveForConnection(
+      RUNTIME_CONNECTION_ID, channel, sourceOrg, false, WORKSPACE_TEAM_ID,
+    );
+    expect(linked?.organizationId).toBe(targetOrg);
+    const [automation] = await getDb()`SELECT created_by FROM automations WHERE organization_id = ${targetOrg}`;
+    expect(automation?.created_by).toBe(user.id);
+    const mentionResponse = await chat.webhooks.slack(signedEventRequest(slackEvent({
+      eventId: "Ev_CROSS_WORKSPACE_MENTION", channel, ts: "1787292011.000001",
+      eventType: "app_mention", text: `<@${BOT_USER_ID}> Follow up`, user: "U_LINK_ADMIN",
+    })));
+    expect(mentionResponse.status).toBe(200);
+    await waitFor(async () => {
+      const runs = await getDb()`SELECT action_input FROM runs WHERE run_type = 'chat_message'`;
+      expect(runs).toHaveLength(2);
+      for (const row of runs) expect(row.action_input.organizationId).toBe(targetOrg);
+    });
+    expect(slackPostMessage).not.toHaveBeenCalled();
+    const messages = await getDb()`SELECT organization_id, team_id FROM channel_messages WHERE channel_id = ${channel}`;
+    expect(messages).toHaveLength(2);
+    for (const message of messages) expect(message).toEqual({ organization_id: targetOrg, team_id: WORKSPACE_TEAM_ID });
+  });
+
+  test.each([
+    "no installation membership", "installation member", "agent member",
+    "missing team", "ambiguous agent",
+  ])("codeless linking rejects unauthorized or ambiguous targets: %s", async (boundary) => {
+    const targetOrg = "org-slack-untrusted-workspace";
+    await seedAgentRow("agent-slack-untrusted", { organizationId: targetOrg });
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, targetOrg, boundary === "agent member" ? "member" : "owner");
+    if (boundary !== "no installation membership") {
+      await addUserToOrganization(user.id, "org-slack-grid-e2e", boundary === "installation member" ? "member" : "owner");
+    }
+    if (boundary === "ambiguous agent") {
+      await seedAgentRow("agent-slack-untrusted", { organizationId: "org-slack-grid-e2e" });
+    }
+    const result = await bindChatToAgentForOwner({
+      platform: "slack", teamId: boundary === "missing team" ? undefined : WORKSPACE_TEAM_ID, channelId: "slack:C_UNAUTHORIZED",
+      agentId: "agent-slack-untrusted", lobuUserId: user.id,
+      connectionId: RUNTIME_CONNECTION_ID, connectionOrganizationId: "org-slack-grid-e2e",
+    });
+    expect(result).toEqual({ status: "forbidden" });
+    const rows = await getDb()`SELECT id FROM automations WHERE organization_id = ${targetOrg}`;
+    expect(rows).toHaveLength(0);
+  });
+
+  test.each([
+    "source membership revoked", "target membership revoked",
+    "source member is not admin", "target member is not admin",
+    "wrong team", "missing delivery team", "missing link team",
+    "wrong channel", "wrong connection", "wrong installation organization",
+    "inactive installation", "deleted installation", "untagged Automation",
+    "connector-wide trigger", "foreign agent",
+  ])("cross-workspace routing fails closed: %s", async (boundary) => {
+    const sourceOrg = "org-slack-grid-e2e";
+    const targetOrg = "org-slack-boundary";
+    const targetAgent = "agent-slack-boundary";
+    const channel = "C_BOUNDARY";
+    await seedAgentRow(targetAgent, { organizationId: targetOrg });
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, sourceOrg, "owner");
+    await addUserToOrganization(user.id, targetOrg, "admin");
+    await createTestAutomationSubscription({
+      organizationId: targetOrg, agentId: targetAgent, connectionId: connectionDbId,
+      channelId: channel, teamId: WORKSPACE_TEAM_ID, configuredBy: user.id,
+    });
+    const sql = getDb();
+    let deliveryTeam: string | undefined = WORKSPACE_TEAM_ID;
+    let deliveryChannel = channel;
+    let runtimeConnection = RUNTIME_CONNECTION_ID;
+    let installationOrg = sourceOrg;
+    if (boundary.endsWith("membership revoked") || boundary.endsWith("member is not admin")) {
+      const org = boundary.startsWith("source") ? sourceOrg : targetOrg;
+      if (boundary.endsWith("membership revoked")) {
+        await sql`DELETE FROM member WHERE "organizationId" = ${org} AND "userId" = ${user.id}`;
+      } else await sql`UPDATE member SET role = 'member' WHERE "organizationId" = ${org} AND "userId" = ${user.id}`;
+    } else if (boundary === "wrong team") deliveryTeam = "T_OTHER_WORKSPACE";
+    else if (boundary === "missing delivery team") deliveryTeam = undefined;
+    else if (boundary === "wrong channel") deliveryChannel = "C_OTHER_CHANNEL";
+    else if (boundary === "wrong installation organization") installationOrg = targetOrg;
+    else if (boundary === "wrong connection") {
+      runtimeConnection = "slackinst-unrelated";
+      await sql`INSERT INTO connections (organization_id, connector_key, slug, display_name, status, credential_mode, config)
+        VALUES (${sourceOrg}, 'slack', ${runtimeConnection}, 'Other install', 'active', 'managed', '{}')`;
+    } else if (boundary === "inactive installation") {
+      await sql`UPDATE connections SET status = 'error' WHERE id = ${connectionDbId}`;
+    } else if (boundary === "deleted installation") {
+      await sql`UPDATE connections SET deleted_at = now() WHERE id = ${connectionDbId}`;
+    } else if (boundary === "untagged Automation") {
+      await sql`UPDATE automations SET tags = '{}'::text[] WHERE organization_id = ${targetOrg}`;
+    } else if (boundary === "foreign agent") {
+      await sql`UPDATE automations SET managed_agent_id = 'agent-slack-grid-e2e' WHERE organization_id = ${targetOrg}`;
+    } else {
+      const [row] = await sql`SELECT triggers FROM automations WHERE organization_id = ${targetOrg}`;
+      const trigger = row.triggers[0];
+      if (boundary === "connector-wide trigger") delete trigger.connection_id;
+      else delete trigger.match.team_id;
+      await sql`UPDATE automations SET triggers = ${sql.json([trigger])} WHERE organization_id = ${targetOrg}`;
+    }
+    const plan = await planAutomationActivationsForRuntimeConnection({
+      connectionOrganizationId: installationOrg, runtimeConnectionId: runtimeConnection,
+      signal: {
+        connector_key: "slack", event_type: "message.created", delivery_id: "boundary-message",
+        resource_type: "channel", resource_ref: `slack:channel:${deliveryChannel}`,
+        attributes: { channel_id: deliveryChannel, ...(deliveryTeam ? { team_id: deliveryTeam } : {}) },
+      },
+    });
+    expect(plan.replyTargets).toHaveLength(0);
+    expect(plan.backgroundTargets).toHaveLength(0);
+    const subscriptions = new AutomationSubscriptionService();
+    expect(await subscriptions.resolveForConnection(runtimeConnection, deliveryChannel, installationOrg, false, deliveryTeam)).toBeNull();
+    expect(await subscriptions.channelHasMessageSubscription(runtimeConnection, deliveryChannel, installationOrg, false, deliveryTeam)).toBe(false);
+  });
+
+  test("foreign chat links only activate their exact trigger, preserving mention filters", async () => {
+    const sourceOrg = "org-slack-grid-e2e";
+    const targetOrg = "org-slack-trigger-scope";
+    const channel = "C_TRIGGER_SCOPE";
+    await seedAgentRow("agent-slack-trigger-scope", { organizationId: targetOrg });
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, sourceOrg, "owner");
+    await addUserToOrganization(user.id, targetOrg, "owner");
+    await createTestAutomationSubscription({
+      organizationId: targetOrg, agentId: "agent-slack-trigger-scope",
+      connectionId: connectionDbId, channelId: channel,
+      teamId: WORKSPACE_TEAM_ID, configuredBy: user.id,
+    });
+    const sql = getDb();
+    const [row] = await sql`SELECT triggers FROM automations WHERE organization_id = ${targetOrg}`;
+    const linkedTrigger = row.triggers[0];
+    linkedTrigger.match.mention_only = true;
+    await sql`UPDATE automations SET triggers = ${sql.json([
+      { ...linkedTrigger, connection_id: undefined, match: {}, output: "silent" },
+      linkedTrigger,
+    ])} WHERE organization_id = ${targetOrg}`;
+    for (const mention of [false, true]) {
+      const plan = await planAutomationActivationsForRuntimeConnection({
+        connectionOrganizationId: sourceOrg, runtimeConnectionId: RUNTIME_CONNECTION_ID,
+        signal: {
+          connector_key: "slack", event_type: "message.created", delivery_id: `mention-${mention}`,
+          resource_type: "channel", resource_ref: `slack:channel:${channel}`,
+          attributes: { channel_id: channel, team_id: WORKSPACE_TEAM_ID, mention_only: mention },
+        },
+      });
+      expect(plan.replyTargets).toHaveLength(mention ? 1 : 0);
+      expect(plan.backgroundTargets).toHaveLength(0);
     }
   });
 });

--- a/packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts
@@ -587,7 +587,7 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
     });
     const subscriptions = new AutomationSubscriptionService();
     const registry = new CommandRegistry();
-    registerBuiltInCommands(registry, { agentSettingsStore: {} as never });
+    registerBuiltInCommands(registry, { agentSettingsStore: {} as never, automationSubscriptionService: subscriptions });
     const dispatcher = new CommandDispatcher({ registry, automationSubscriptionService: subscriptions });
     const replies: string[] = [];
     await dispatcher.tryHandleSlashText(`/lobu link ${targetAgent}`, {

--- a/packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts
@@ -613,7 +613,7 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
       });
     });
     const linked = await subscriptions.resolveForConnection(
-      RUNTIME_CONNECTION_ID, channel, sourceOrg, false, WORKSPACE_TEAM_ID,
+      RUNTIME_CONNECTION_ID, channel, sourceOrg, { teamId: WORKSPACE_TEAM_ID },
     );
     expect(linked?.organizationId).toBe(targetOrg);
     const [automation] = await getDb()`SELECT created_by FROM automations WHERE organization_id = ${targetOrg}`;
@@ -722,8 +722,8 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
     expect(plan.replyTargets).toHaveLength(0);
     expect(plan.backgroundTargets).toHaveLength(0);
     const subscriptions = new AutomationSubscriptionService();
-    expect(await subscriptions.resolveForConnection(runtimeConnection, deliveryChannel, installationOrg, false, deliveryTeam)).toBeNull();
-    expect(await subscriptions.channelHasMessageSubscription(runtimeConnection, deliveryChannel, installationOrg, false, deliveryTeam)).toBe(false);
+    expect(await subscriptions.resolveForConnection(runtimeConnection, deliveryChannel, installationOrg, { teamId: deliveryTeam })).toBeNull();
+    expect(await subscriptions.channelHasMessageSubscription(runtimeConnection, deliveryChannel, installationOrg, { teamId: deliveryTeam })).toBe(false);
   });
 
   test("foreign chat links only activate their exact trigger, preserving mention filters", async () => {
@@ -745,8 +745,13 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
     linkedTrigger.match.mention_only = true;
     await sql`UPDATE automations SET triggers = ${sql.json([
       { ...linkedTrigger, connection_id: undefined, match: {}, output: "silent" },
+      { ...linkedTrigger, match: { channel_id: channel, team_id: "T_OTHER_WORKSPACE" }, output: "silent" },
       linkedTrigger,
     ])} WHERE organization_id = ${targetOrg}`;
+    const subscription = await new AutomationSubscriptionService().resolveForConnection(
+      RUNTIME_CONNECTION_ID, channel, sourceOrg, { teamId: WORKSPACE_TEAM_ID },
+    );
+    expect(subscription?.teamId).toBe(WORKSPACE_TEAM_ID);
     for (const mention of [false, true]) {
       const plan = await planAutomationActivationsForRuntimeConnection({
         connectionOrganizationId: sourceOrg, runtimeConnectionId: RUNTIME_CONNECTION_ID,

--- a/packages/server/src/gateway/channels/__tests__/automation-subscription-service-org-scope.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/automation-subscription-service-org-scope.test.ts
@@ -264,7 +264,7 @@ describe("AutomationSubscriptionService connection-scoped routing", () => {
 			"preview",
 			CHANNEL,
 			ORG_B,
-			true,
+			{ crossOrganization: true },
 		);
 		expect(binding?.agentId).toBe("agent-a");
 		expect(binding?.organizationId).toBe(ORG_A);

--- a/packages/server/src/gateway/channels/automation-subscription-service.ts
+++ b/packages/server/src/gateway/channels/automation-subscription-service.ts
@@ -14,6 +14,8 @@ import {
 	softDeleteChannelFeed,
 } from "./channel-feed.js";
 
+import { canLinkChatOrganizations, crossOrganizationChatLinkScope } from "./chat-link-authorization.js";
+
 const logger = createLogger("automation-channel-subscriptions");
 const CHAT_LINK_TAG = "system:chat-link";
 const CHAT_LINK_PROMPT = "Respond helpfully to the incoming message.";
@@ -157,6 +159,8 @@ async function loadChatAutomationSubscriptions(
 	sql: DbClient,
 	filters: {
 		automationOrganizationId?: string;
+		includeAuthorizedChatLinks?: boolean;
+		teamId?: string;
 		agentId?: string;
 		connectionId?: string;
 		connectionOrganizationId?: string;
@@ -169,8 +173,11 @@ async function loadChatAutomationSubscriptions(
 	const native = filters.channelId
 		? nativeChannelIdFromAny(filters.channelId)
 		: null;
+	const linkedOrgFilter = filters.includeAuthorizedChatLinks && filters.connectionOrganizationId
+		? sql`OR ${crossOrganizationChatLinkScope(sql, filters.connectionOrganizationId, filters.teamId)}`
+		: sql``;
 	const automationOrgFilter = filters.automationOrganizationId
-		? sql`AND s.organization_id = ${filters.automationOrganizationId}`
+		? sql`AND (s.organization_id = ${filters.automationOrganizationId} ${linkedOrgFilter})`
 		: sql``;
 	const agentFilter = filters.agentId
 		? sql`AND s.agent_id = ${filters.agentId}`
@@ -236,10 +243,13 @@ export class AutomationSubscriptionService {
 		channelId: string,
 		connectionOrganizationId: string,
 		crossOrg = false,
+		teamId?: string,
 	): Promise<ChatAutomationSubscription | null> {
 		const sql = getDb();
 		const rows = await loadChatAutomationSubscriptions(sql, {
 			automationOrganizationId: crossOrg ? undefined : connectionOrganizationId,
+			includeAuthorizedChatLinks: !crossOrg,
+			teamId,
 			connectionOrganizationId,
 			connectionSlug: runtimeConnectionIdToSlug(connectionId),
 			channelId,
@@ -260,10 +270,13 @@ export class AutomationSubscriptionService {
 		channelId: string,
 		connectionOrganizationId: string,
 		crossOrg = false,
+		teamId?: string,
 	): Promise<boolean> {
 		const sql = getDb();
 		const rows = await loadChatAutomationSubscriptions(sql, {
 			automationOrganizationId: crossOrg ? undefined : connectionOrganizationId,
+			includeAuthorizedChatLinks: !crossOrg,
+			teamId,
 			connectionOrganizationId,
 			connectionSlug: runtimeConnectionIdToSlug(connectionId),
 			channelId,
@@ -378,6 +391,8 @@ export class AutomationSubscriptionService {
 		teamId: string | undefined,
 		options: {
 			configuredBy?: string;
+			/** Preserve the original author when renewing a foreign installation grant. */
+			requireAuthorizedAuthor?: boolean;
 			organizationId?: string;
 			sql?: DbClient;
 			connectionId: number;
@@ -392,7 +407,7 @@ export class AutomationSubscriptionService {
 			 */
 			createOnly?: boolean;
 		},
-	): Promise<void> {
+	): Promise<boolean> {
 		if (!Number.isInteger(options.connectionId) || options.connectionId < 1) {
 			throw new Error("connectionId must be a positive integer");
 		}
@@ -409,7 +424,7 @@ export class AutomationSubscriptionService {
 			teamId,
 		});
 
-		const write = async (tx: DbClient): Promise<void> => {
+		const write = async (tx: DbClient): Promise<boolean> => {
 			// Serialize concurrent create/relink for the same org+connection+channel.
 			await tx`
 				SELECT pg_advisory_xact_lock(
@@ -418,7 +433,7 @@ export class AutomationSubscriptionService {
 				)
 			`;
 			const connectionRows = await tx`
-				SELECT 1
+				SELECT organization_id
 				FROM connections
 				WHERE id = ${options.connectionId}
 				  AND connector_key = ${platform}
@@ -431,8 +446,8 @@ export class AutomationSubscriptionService {
 				);
 			}
 
-			const existing = await tx<{ automation_id: number }>`
-				SELECT w.id AS automation_id
+			const existing = await tx<{ automation_id: number; created_by: string }>`
+				SELECT w.id AS automation_id, w.created_by
 				FROM automations w
 				CROSS JOIN LATERAL jsonb_array_elements(COALESCE(w.triggers, '[]'::jsonb)) trigger
 				WHERE w.status = 'active'
@@ -452,7 +467,12 @@ export class AutomationSubscriptionService {
 				// A chat-link already covers this connection+channel. Under
 				// create-only (the connection-owner fallback), leave it untouched —
 				// this is where a racing explicit `/lobu link` is preserved.
-				if (options.createOnly) return;
+				if (options.createOnly) return true;
+				// created_by is immutable audit attribution and the durable grant
+				// principal. A different caller cannot silently replace that authority.
+				if (options.requireAuthorizedAuthor && !(await canLinkChatOrganizations(
+					tx, existing[0].created_by, organizationId, connectionRows[0].organization_id,
+				))) return false;
 				// Relink must not wipe user-added triggers (schedule, extra events)
 				// on the same Automation — only replace the chat message.created
 				// trigger for this connection+channel.
@@ -493,7 +513,7 @@ export class AutomationSubscriptionService {
 						updated_at = current_timestamp
 					WHERE id = ${existing[0].automation_id}
 				`;
-				return;
+				return true;
 			}
 
 			const createdBy = await resolveCreatedBy(
@@ -535,9 +555,10 @@ export class AutomationSubscriptionService {
 				UPDATE automations SET current_version_id = ${versionId}
 				WHERE id = ${automationId}
 			`;
+			return true;
 		};
-		if (options.sql) await write(sql);
-		else await sql.begin(write);
+		const linked = options.sql ? await write(sql) : await sql.begin(write);
+		if (!linked) return false;
 
 		await resolveChannelFeedId({
 			connectionId: String(options.connectionId),
@@ -546,6 +567,7 @@ export class AutomationSubscriptionService {
 			sql,
 		});
 		logger.info(`Created chat Automation: ${platform}/${channelId} → ${agentId}`);
+		return true;
 	}
 
 	async archiveChatAutomation(

--- a/packages/server/src/gateway/channels/automation-subscription-service.ts
+++ b/packages/server/src/gateway/channels/automation-subscription-service.ts
@@ -14,7 +14,7 @@ import {
 	softDeleteChannelFeed,
 } from "./channel-feed.js";
 
-import { canLinkChatOrganizations, crossOrganizationChatLinkScope } from "./chat-link-authorization.js";
+import { authorizedChatLinkIds, canLinkChatOrganizations } from "./chat-link-authorization.js";
 
 const logger = createLogger("automation-channel-subscriptions");
 const CHAT_LINK_TAG = "system:chat-link";
@@ -33,6 +33,11 @@ interface ChatAutomationSubscription {
 	connectionId?: string;
 	model?: string;
 	createdAt: number;
+}
+
+interface ChatRoutingOptions {
+	crossOrganization?: boolean;
+	teamId?: string;
 }
 
 function rowToSubscription(
@@ -173,8 +178,19 @@ async function loadChatAutomationSubscriptions(
 	const native = filters.channelId
 		? nativeChannelIdFromAny(filters.channelId)
 		: null;
-	const linkedOrgFilter = filters.includeAuthorizedChatLinks && filters.connectionOrganizationId
-		? sql`OR ${crossOrganizationChatLinkScope(sql, filters.connectionOrganizationId, filters.teamId)}`
+	// An admitted Automation may also carry triggers for other workspaces on
+	// this channel; return only the trigger row that matches this chat's team.
+	const linkedOrgFilter = filters.includeAuthorizedChatLinks &&
+		filters.connectionOrganizationId && filters.connectionSlug && native
+		? sql`OR (
+			s.automation_id IN (${authorizedChatLinkIds(sql, {
+				connectionOrganizationId: filters.connectionOrganizationId,
+				connection: { slug: filters.connectionSlug },
+				channelId: native,
+				teamId: filters.teamId,
+			})})
+			AND s.trigger_team_id IS NOT DISTINCT FROM ${filters.teamId || null}
+		)`
 		: sql``;
 	const automationOrgFilter = filters.automationOrganizationId
 		? sql`AND (s.organization_id = ${filters.automationOrganizationId} ${linkedOrgFilter})`
@@ -242,14 +258,13 @@ export class AutomationSubscriptionService {
 		connectionId: string,
 		channelId: string,
 		connectionOrganizationId: string,
-		crossOrg = false,
-		teamId?: string,
+		options: ChatRoutingOptions = {},
 	): Promise<ChatAutomationSubscription | null> {
 		const sql = getDb();
 		const rows = await loadChatAutomationSubscriptions(sql, {
-			automationOrganizationId: crossOrg ? undefined : connectionOrganizationId,
-			includeAuthorizedChatLinks: !crossOrg,
-			teamId,
+			automationOrganizationId: options.crossOrganization ? undefined : connectionOrganizationId,
+			includeAuthorizedChatLinks: !options.crossOrganization,
+			teamId: options.teamId,
 			connectionOrganizationId,
 			connectionSlug: runtimeConnectionIdToSlug(connectionId),
 			channelId,
@@ -260,29 +275,19 @@ export class AutomationSubscriptionService {
 
 	/**
 	 * True when any active message.created Automation covers this connection+channel
-	 * (ignoring trigger match filters like mention_only/team). Used by the chat
-	 * bridge to distinguish "filters rejected a linked channel" from "channel is
-	 * unlinked" so we do not spam the "link your agent" notice on every
-	 * non-mention in a mention_only channel.
+	 * before message filters such as mention_only. Foreign links still require
+	 * their exact optional team identity. This keeps filtered messages from
+	 * receiving an incorrect "link your agent" notice.
 	 */
 	async channelHasMessageSubscription(
 		connectionId: string,
 		channelId: string,
 		connectionOrganizationId: string,
-		crossOrg = false,
-		teamId?: string,
+		options: ChatRoutingOptions = {},
 	): Promise<boolean> {
-		const sql = getDb();
-		const rows = await loadChatAutomationSubscriptions(sql, {
-			automationOrganizationId: crossOrg ? undefined : connectionOrganizationId,
-			includeAuthorizedChatLinks: !crossOrg,
-			teamId,
-			connectionOrganizationId,
-			connectionSlug: runtimeConnectionIdToSlug(connectionId),
-			channelId,
-			limit: 1,
-		});
-		return rows.length > 0;
+		return (await this.resolveForConnection(
+			connectionId, channelId, connectionOrganizationId, options,
+		)) !== null;
 	}
 
 	async healSubscriptionTeam(

--- a/packages/server/src/gateway/channels/chat-link-authorization.ts
+++ b/packages/server/src/gateway/channels/chat-link-authorization.ts
@@ -1,0 +1,64 @@
+import type { DbClient } from "../../db/client";
+import { isAdminOrOwnerRole } from "../../tools/access-control";
+import { getWorkspaceRole } from "../../utils/organization-access";
+
+/**
+ * Authorization for a chat-link outside the installation's organization.
+ * Callers bind `w` to automations and `s` to its exact message subscription.
+ * A tag or a foreign connection id alone is never a grant: the recorded author
+ * must still administer both workspaces. A provider's optional team identity
+ * must match the one captured when the channel was linked, including absence.
+ *
+ * The role predicate is the SQL twin of `isAdminOrOwnerRole`; a correlated read
+ * over `w.created_by` cannot call it, so keep the two definitions in step.
+ */
+export function crossOrganizationChatLinkScope(
+  sql: DbClient,
+  connectionOrganizationId: string,
+  teamId?: string | null,
+) {
+  return sql`(
+    w.tags @> ARRAY['system:chat-link']::text[]
+    AND s.connection_organization_id = ${connectionOrganizationId}
+    AND s.connection_status = 'active'
+    AND s.credential_mode IS NOT NULL
+    AND s.trigger_team_id IS NOT DISTINCT FROM ${teamId || null}
+    AND EXISTS (
+      SELECT 1 FROM agents a
+      WHERE a.id = w.managed_agent_id AND a.organization_id = w.organization_id
+    )
+    AND EXISTS (
+      SELECT 1 FROM member m
+      WHERE m."userId" = w.created_by
+        AND m."organizationId" = w.organization_id
+        AND m.role IN ('owner', 'admin')
+    )
+    AND EXISTS (
+      SELECT 1 FROM member m
+      WHERE m."userId" = w.created_by
+        AND m."organizationId" = ${connectionOrganizationId}
+        AND m.role IN ('owner', 'admin')
+    )
+  )`;
+}
+
+/**
+ * Live owner/admin authority in both organizations. Every write that creates or
+ * renews a cross-organization chat link checks it here; the read-side scope
+ * above re-checks the same pair on the recorded author at routing time, so
+ * revoking either membership retires the link without a cleanup job.
+ */
+export async function canLinkChatOrganizations(
+  sql: DbClient,
+  userId: string | null,
+  agentOrganizationId: string,
+  connectionOrganizationId: string,
+): Promise<boolean> {
+  if (!userId) return false;
+  if (!isAdminOrOwnerRole(await getWorkspaceRole(sql, agentOrganizationId, userId))) {
+    return false;
+  }
+  return isAdminOrOwnerRole(
+    await getWorkspaceRole(sql, connectionOrganizationId, userId),
+  );
+}

--- a/packages/server/src/gateway/channels/chat-link-authorization.ts
+++ b/packages/server/src/gateway/channels/chat-link-authorization.ts
@@ -3,48 +3,50 @@ import { isAdminOrOwnerRole } from "../../tools/access-control";
 import { getWorkspaceRole } from "../../utils/organization-access";
 
 /**
- * Authorization for a chat-link outside the installation's organization.
- * Callers bind `w` to automations and `s` to its exact message subscription.
- * A tag or a foreign connection id alone is never a grant: the recorded author
- * must still administer both workspaces. A provider's optional team identity
- * must match the one captured when the channel was linked, including absence.
- *
- * The role predicate is the SQL twin of `isAdminOrOwnerRole`; a correlated read
- * over `w.created_by` cannot call it, so keep the two definitions in step.
+ * Automation IDs authorized to handle one concrete incoming chat from outside
+ * the installation's organization. A tag or a foreign connection id alone is
+ * never a grant: the recorded author must still administer both workspaces.
+ * A provider's optional team identity must match the one captured when the
+ * channel was linked, including absence.
  */
-export function crossOrganizationChatLinkScope(
+export function authorizedChatLinkIds(
   sql: DbClient,
-  connectionOrganizationId: string,
-  teamId?: string | null,
+  chat: {
+    connectionOrganizationId: string;
+    connection: { id: number } | { slug: string };
+    channelId: string;
+    teamId?: string | null;
+  },
 ) {
-  return sql`(
-    w.tags @> ARRAY['system:chat-link']::text[]
-    AND s.connection_organization_id = ${connectionOrganizationId}
-    AND s.connection_status = 'active'
-    AND s.credential_mode IS NOT NULL
-    AND s.trigger_team_id IS NOT DISTINCT FROM ${teamId || null}
-    AND EXISTS (
-      SELECT 1 FROM agents a
-      WHERE a.id = w.managed_agent_id AND a.organization_id = w.organization_id
-    )
-    AND EXISTS (
-      SELECT 1 FROM member m
-      WHERE m."userId" = w.created_by
-        AND m."organizationId" = w.organization_id
-        AND m.role IN ('owner', 'admin')
-    )
-    AND EXISTS (
-      SELECT 1 FROM member m
-      WHERE m."userId" = w.created_by
-        AND m."organizationId" = ${connectionOrganizationId}
-        AND m.role IN ('owner', 'admin')
-    )
-  )`;
+  const connectionFilter = "id" in chat.connection
+    ? sql`s.connection_id = ${chat.connection.id}`
+    : sql`s.connection_slug = ${chat.connection.slug}`;
+  // These role predicates mirror isAdminOrOwnerRole. The query owns its SQL
+  // aliases; callers only match the returned IDs, then their specific trigger.
+  return sql`
+    SELECT s.automation_id
+    FROM automation_message_subscriptions s
+    JOIN automations w ON w.id = s.automation_id
+    JOIN agents a ON a.id = w.managed_agent_id AND a.organization_id = w.organization_id
+    JOIN member agent_admin ON agent_admin."userId" = w.created_by
+      AND agent_admin."organizationId" = w.organization_id
+      AND agent_admin.role IN ('owner', 'admin')
+    JOIN member installation_admin ON installation_admin."userId" = w.created_by
+      AND installation_admin."organizationId" = ${chat.connectionOrganizationId}
+      AND installation_admin.role IN ('owner', 'admin')
+    WHERE ${connectionFilter}
+      AND s.connection_organization_id = ${chat.connectionOrganizationId}
+      AND s.native_channel_id = ${chat.channelId}
+      AND s.trigger_team_id IS NOT DISTINCT FROM ${chat.teamId || null}
+      AND s.connection_status = 'active'
+      AND s.credential_mode IS NOT NULL
+      AND w.tags @> ARRAY['system:chat-link']::text[]
+  `;
 }
 
 /**
  * Live owner/admin authority in both organizations. Every write that creates or
- * renews a cross-organization chat link checks it here; the read-side scope
+ * renews a cross-organization chat link checks it here; the routing query
  * above re-checks the same pair on the recorded author at routing time, so
  * revoking either membership retires the link without a cleanup job.
  */

--- a/packages/server/src/gateway/commands/__tests__/built-in-commands.test.ts
+++ b/packages/server/src/gateway/commands/__tests__/built-in-commands.test.ts
@@ -58,7 +58,7 @@ describe("built-in status command", () => {
       reply: async () => {},
     });
     expect(resolveForConnection.mock.calls).toEqual([
-      ["test-installation", "telegram:123", "org-installation", false, undefined],
+      ["test-installation", "telegram:123", "org-installation", { teamId: undefined }],
     ]);
     expect(getSettings.mock.calls).toEqual([
       ["linked-agent", { organizationId: "org-linked-agent" }],

--- a/packages/server/src/gateway/commands/__tests__/built-in-commands.test.ts
+++ b/packages/server/src/gateway/commands/__tests__/built-in-commands.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { CommandRegistry } from "@lobu/core";
 import { registerBuiltInCommands } from "../built-in-commands.js";
 
 async function helpFor(platform: string): Promise<string> {
   const registry = new CommandRegistry();
-  registerBuiltInCommands(registry, { agentSettingsStore: {} as never });
+  registerBuiltInCommands(registry, { agentSettingsStore: {} as never, automationSubscriptionService: {} as never });
   const replies: string[] = [];
   await registry.tryHandle("help", {
     userId: "user-1",
@@ -35,5 +35,33 @@ describe("built-in command help", () => {
     const help = await helpFor("telegram");
     expect(help).toContain("/help - Show available commands");
     expect(help).not.toContain("/lobu help");
+  });
+});
+
+describe("built-in status command", () => {
+  test("reads agent settings from the workspace selected by the chat subscription", async () => {
+    const registry = new CommandRegistry();
+    const resolveForConnection = mock(async () => ({ organizationId: "org-linked-agent" }));
+    const getSettings = mock(async () => undefined);
+    registerBuiltInCommands(registry, {
+      agentSettingsStore: { getSettings } as never,
+      automationSubscriptionService: { resolveForConnection } as never,
+    });
+    await registry.tryHandle("status", {
+      platform: "telegram",
+      userId: "chat-user",
+      channelId: "telegram:123",
+      connectionId: "test-installation",
+      organizationId: "org-installation",
+      agentId: "linked-agent",
+      args: "",
+      reply: async () => {},
+    });
+    expect(resolveForConnection.mock.calls).toEqual([
+      ["test-installation", "telegram:123", "org-installation", false, undefined],
+    ]);
+    expect(getSettings.mock.calls).toEqual([
+      ["linked-agent", { organizationId: "org-linked-agent" }],
+    ]);
   });
 });

--- a/packages/server/src/gateway/commands/built-in-commands.ts
+++ b/packages/server/src/gateway/commands/built-in-commands.ts
@@ -8,11 +8,14 @@ import {
   previewAgentMenu,
 } from "../../preview/slack.js";
 import { resolveChatUserIdentity } from "../../lobu/stores/chat-identity.js";
+import { AutomationSubscriptionService } from "../channels/automation-subscription-service.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import {
   resolveEffectiveModelRef,
 } from "../auth/settings/model-selection.js";
 import { formatChatCommand } from "./command-spelling.js";
+
+const LINK_AUTHORITY_REVOKED_MESSAGE = "The existing chat link no longer has access to both workspaces. Retire its Automation in Lobu, then link this chat again.";
 
 interface BuiltInCommandDeps {
   agentSettingsStore: AgentSettingsStore;
@@ -67,8 +70,15 @@ export function registerBuiltInCommands(
         return;
       }
 
+      // Command context keeps the installation's organization for /link.
+      // Agent settings belong to the workspace selected by the chat subscription.
+      const subscription = ctx.connectionId && ctx.organizationId
+        ? await new AutomationSubscriptionService().resolveForConnection(
+            ctx.connectionId, ctx.channelId, ctx.organizationId, false, ctx.teamId,
+          )
+        : null;
       const settings = await deps.agentSettingsStore.getSettings(ctx.agentId, {
-        organizationId: ctx.organizationId,
+        organizationId: subscription?.organizationId ?? ctx.organizationId,
       });
 
       const effectiveModel = resolveEffectiveModelRef(settings);
@@ -208,20 +218,14 @@ export function registerBuiltInCommands(
 						`This code can't be used in a ${result.surfaceType === "dm" ? "DM" : "channel"}. Check the agent's \`preview.${ctx.platform}.surfaces\` setting.`,
 					);
 					return;
-				case "connection_mismatch": {
-					const allowedLocation =
-						ctx.platform === "slack"
-							? "Lobu's hosted Slack workspace or a Slack workspace"
-							: "Lobu's hosted preview bot or a chat connection";
-					const currentLocation =
-						ctx.platform === "slack"
-							? "this Slack workspace"
-							: "this chat connection";
+				case "connection_mismatch":
 					await ctx.reply(
-						`That code can only be used with ${allowedLocation} connected to the same Lobu organization as the agent. Open the preview link from \`lobu run\`, or connect ${currentLocation} to the agent's organization.`,
+						"That code isn't authorized for this chat connection. Use the selected installation or hosted preview bot, or create a fresh code with access to this connection.",
 					);
 					return;
-				}
+        case "link_authority_revoked":
+          await ctx.reply(LINK_AUTHORITY_REVOKED_MESSAGE);
+          return;
         case "not_found": {
           // Not a valid code — but if we already know who this chat user is,
           // treat the arg as an agent id and re-bind directly (no fresh code
@@ -243,6 +247,10 @@ export function registerBuiltInCommands(
 							connectionId: ctx.connectionId ?? "",
 							connectionOrganizationId: ctx.organizationId,
             });
+            if (bound.status === "link_authority_revoked") {
+              await ctx.reply(LINK_AUTHORITY_REVOKED_MESSAGE);
+              return;
+            }
             if (bound.status === "bound") {
               await ctx.reply(
 								`Linked this chat to agent \`${arg}\`. Say hi — I'll reply here from now on.`,

--- a/packages/server/src/gateway/commands/built-in-commands.ts
+++ b/packages/server/src/gateway/commands/built-in-commands.ts
@@ -8,7 +8,7 @@ import {
   previewAgentMenu,
 } from "../../preview/slack.js";
 import { resolveChatUserIdentity } from "../../lobu/stores/chat-identity.js";
-import { AutomationSubscriptionService } from "../channels/automation-subscription-service.js";
+import type { AutomationSubscriptionService } from "../channels/automation-subscription-service.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import {
   resolveEffectiveModelRef,
@@ -19,6 +19,7 @@ const LINK_AUTHORITY_REVOKED_MESSAGE = "The existing chat link no longer has acc
 
 interface BuiltInCommandDeps {
   agentSettingsStore: AgentSettingsStore;
+  automationSubscriptionService: AutomationSubscriptionService;
 }
 
 /**
@@ -73,7 +74,7 @@ export function registerBuiltInCommands(
       // Command context keeps the installation's organization for /link.
       // Agent settings belong to the workspace selected by the chat subscription.
       const subscription = ctx.connectionId && ctx.organizationId
-        ? await new AutomationSubscriptionService().resolveForConnection(
+        ? await deps.automationSubscriptionService.resolveForConnection(
             ctx.connectionId, ctx.channelId, ctx.organizationId, false, ctx.teamId,
           )
         : null;

--- a/packages/server/src/gateway/commands/built-in-commands.ts
+++ b/packages/server/src/gateway/commands/built-in-commands.ts
@@ -75,7 +75,7 @@ export function registerBuiltInCommands(
       // Agent settings belong to the workspace selected by the chat subscription.
       const subscription = ctx.connectionId && ctx.organizationId
         ? await deps.automationSubscriptionService.resolveForConnection(
-            ctx.connectionId, ctx.channelId, ctx.organizationId, false, ctx.teamId,
+            ctx.connectionId, ctx.channelId, ctx.organizationId, { teamId: ctx.teamId },
           )
         : null;
       const settings = await deps.agentSettingsStore.getSettings(ctx.agentId, {

--- a/packages/server/src/gateway/commands/command-dispatcher.ts
+++ b/packages/server/src/gateway/commands/command-dispatcher.ts
@@ -99,8 +99,7 @@ export class CommandDispatcher {
 						input.connectionId,
       input.channelId,
 						input.organizationId,
-						false,
-						input.teamId,
+						{ teamId: input.teamId },
 					)
 				: null;
     if (subscription?.agentId) {

--- a/packages/server/src/gateway/commands/command-dispatcher.ts
+++ b/packages/server/src/gateway/commands/command-dispatcher.ts
@@ -91,14 +91,16 @@ export class CommandDispatcher {
   }
 
   private async resolveAgentId(input: CommandDispatchInput): Promise<string> {
-    // Check message Automations first (Slack multi-tenant). Scope to the inbound
-    // org so an org-less read cannot match another tenant's subscription.
+    // Resolve through the concrete inbound installation so only its workspace
+    // and authorized linked workspaces can supply the command's agent.
 		const subscription =
 			input.connectionId && input.organizationId
 				? await this.automationSubscriptionService.resolveForConnection(
 						input.connectionId,
       input.channelId,
 						input.organizationId,
+						false,
+						input.teamId,
 					)
 				: null;
     if (subscription?.agentId) {

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -79,6 +79,17 @@ function sanitizeRefLabel(name: string): string {
   return name.replace(/[[\]()\r\n]+/g, " ").replace(/\s+/g, " ").trim() || "file";
 }
 
+/**
+ * Workspace id carried on the provider envelope (Slack `team_id`/`team`).
+ * Both admission checks and the routing planner must read it the same way, or
+ * a team-scoped chat link is admitted by one and rejected by the other.
+ */
+function teamIdFromRawMessage(raw: unknown): string | undefined {
+  const envelope = raw as Record<string, unknown> | undefined;
+  const teamId = envelope?.team_id ?? envelope?.team;
+  return typeof teamId === "string" ? teamId : undefined;
+}
+
 function parseProviderFromModelRef(modelRef: string): string | null {
   const trimmed = modelRef.trim();
   if (!trimmed) return null;
@@ -524,7 +535,7 @@ export class MessageHandlerBridge {
    */
   async handleUnmatchedChannelMessage(
     thread: { id: string; channelId: string },
-    message: { author?: { isBot?: boolean | "unknown"; isMe?: boolean } },
+    message: { author?: { isBot?: boolean | "unknown"; isMe?: boolean }; raw?: unknown },
   ): Promise<void> {
     // The catch-all pattern sees bot-authored channel events too. Chat SDK
     // already suppresses this installation's own posts before dispatch, but
@@ -546,6 +557,7 @@ export class MessageHandlerBridge {
       thread.channelId,
       organizationId,
       this.connection.settings?.previewMode === true,
+      teamIdFromRawMessage(message.raw),
     );
     if (!linked) return;
 
@@ -762,10 +774,7 @@ export class MessageHandlerBridge {
     // drop the message.
     const automationSubscriptionService =
       this.services.getAutomationSubscriptionService();
-    const rawTeamId =
-      (message.raw as Record<string, unknown> | undefined)?.team_id ??
-      (message.raw as Record<string, unknown> | undefined)?.team;
-    const teamId = typeof rawTeamId === "string" ? rawTeamId : undefined;
+    const teamId = teamIdFromRawMessage(message.raw);
 
     // Preview connections fan out to Automations in OTHER orgs (a
     // `/lobu link <code>` creates one under the claim's org, not this
@@ -872,7 +881,8 @@ export class MessageHandlerBridge {
           this.connection.id,
           channelId,
           this.connection.organizationId,
-          isPreview
+          isPreview,
+          teamId
         ))
       ) {
         logger.info(

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -556,8 +556,10 @@ export class MessageHandlerBridge {
       this.connection.id,
       thread.channelId,
       organizationId,
-      this.connection.settings?.previewMode === true,
-      teamIdFromRawMessage(message.raw),
+      {
+        crossOrganization: this.connection.settings?.previewMode === true,
+        teamId: teamIdFromRawMessage(message.raw),
+      },
     );
     if (!linked) return;
 
@@ -881,8 +883,7 @@ export class MessageHandlerBridge {
           this.connection.id,
           channelId,
           this.connection.organizationId,
-          isPreview,
-          teamId
+          { crossOrganization: isPreview, teamId }
         ))
       ) {
         logger.info(

--- a/packages/server/src/gateway/services/core-services.ts
+++ b/packages/server/src/gateway/services/core-services.ts
@@ -892,6 +892,7 @@ export class CoreServices {
 		this.commandRegistry = new CommandRegistry();
 		registerBuiltInCommands(this.commandRegistry, {
 			agentSettingsStore: this.agentSettingsStore,
+			automationSubscriptionService: this.getAutomationSubscriptionService(),
 		});
 		logger.debug("Command registry initialized with built-in commands");
 	}

--- a/packages/server/src/gateway/services/platform-helpers.ts
+++ b/packages/server/src/gateway/services/platform-helpers.ts
@@ -235,10 +235,9 @@ export async function resolveAgentId(params: {
   } = params;
 
   if (automationSubscriptionService) {
-    // Subscriptions are org-scoped (a channel can be handled independently by
-    // multiple tenants), so the read MUST be scoped to the inbound
-		// connection's org. Preview connections are the deliberate exception: they
-		// fan out across orgs, but still resolve through that concrete connection.
+    // Bind every read to the inbound installation. The subscription service
+    // admits its own workspace and authorized cross-workspace chat links;
+    // hosted preview installations retain their explicit cross-org routing.
 		const subscription =
 			connectionId && organizationId
 				? await automationSubscriptionService.resolveForConnection(
@@ -246,6 +245,7 @@ export async function resolveAgentId(params: {
           channelId,
 						organizationId,
 						crossOrg === true,
+						params.teamId,
 					)
 				: null;
     if (subscription) {

--- a/packages/server/src/gateway/services/platform-helpers.ts
+++ b/packages/server/src/gateway/services/platform-helpers.ts
@@ -244,8 +244,7 @@ export async function resolveAgentId(params: {
 						connectionId,
           channelId,
 						organizationId,
-						crossOrg === true,
-						params.teamId,
+						{ crossOrganization: crossOrg === true, teamId: params.teamId },
 					)
 				: null;
     if (subscription) {

--- a/packages/server/src/preview/__tests__/slack-preview.test.ts
+++ b/packages/server/src/preview/__tests__/slack-preview.test.ts
@@ -346,21 +346,17 @@ describe("Slack Preview claims + channel Automations", () => {
     });
   });
 
-  test("the link command explains the hosted-or-same-org boundary per platform", async () => {
+  test("the link command explains the authorized connection boundary per platform", async () => {
     const registry = new CommandRegistry();
     registerBuiltInCommands(registry, { agentSettingsStore: {} as never });
     for (const scenario of [
       {
         platform: "slack",
         connectionId: FOREIGN_SLACK_CONNECTION,
-        expectedHostedCopy: "Lobu's hosted Slack workspace",
-        expectedCurrentCopy: "this Slack workspace",
       },
       {
         platform: "telegram",
         connectionId: FOREIGN_TELEGRAM_CONNECTION,
-        expectedHostedCopy: "Lobu's hosted preview bot",
-        expectedCurrentCopy: "this chat connection",
       },
     ] as const) {
       const replies: string[] = [];
@@ -378,9 +374,8 @@ describe("Slack Preview claims + channel Automations", () => {
         },
       });
       const reply = replies.join("\n");
-      expect(reply).toContain(scenario.expectedHostedCopy);
-      expect(reply).toContain(scenario.expectedCurrentCopy);
-      expect(reply).toContain("same Lobu organization");
+      expect(reply).toContain("isn't authorized for this chat connection");
+      expect(reply).toContain("selected installation or hosted preview bot");
     }
   });
 

--- a/packages/server/src/preview/__tests__/slack-preview.test.ts
+++ b/packages/server/src/preview/__tests__/slack-preview.test.ts
@@ -348,7 +348,7 @@ describe("Slack Preview claims + channel Automations", () => {
 
   test("the link command explains the authorized connection boundary per platform", async () => {
     const registry = new CommandRegistry();
-    registerBuiltInCommands(registry, { agentSettingsStore: {} as never });
+    registerBuiltInCommands(registry, { agentSettingsStore: {} as never, automationSubscriptionService: {} as never });
     for (const scenario of [
       {
         platform: "slack",
@@ -448,10 +448,11 @@ describe("Slack Preview claims + channel Automations", () => {
   test("the /lobu link chat command redeems a code end to end", async () => {
     const code = await createClaim(AGENT_ID);
     const registry = new CommandRegistry();
-    // registerBuiltInCommands wires `status` against an agent settings store we
-    // don't need here; only `link` is exercised.
+    // registerBuiltInCommands wires `status` against an agent settings store and
+    // a subscription service we don't need here; only `link` is exercised.
     registerBuiltInCommands(registry, {
       agentSettingsStore: {} as never,
+      automationSubscriptionService: {} as never,
     });
 
     const replies: string[] = [];
@@ -630,7 +631,7 @@ describe("Public preview — /lobu try a demo agent", () => {
 
   test("the /lobu try chat command binds end to end", async () => {
     const registry = new CommandRegistry();
-    registerBuiltInCommands(registry, { agentSettingsStore: {} as never });
+    registerBuiltInCommands(registry, { agentSettingsStore: {} as never, automationSubscriptionService: {} as never });
 
     const replies: string[] = [];
     const handled = await registry.tryHandle("try", {
@@ -818,7 +819,7 @@ describe("chat-user identity + codeless re-link by agent id", () => {
     });
 
     const registry = new CommandRegistry();
-    registerBuiltInCommands(registry, { agentSettingsStore: {} as never });
+    registerBuiltInCommands(registry, { agentSettingsStore: {} as never, automationSubscriptionService: {} as never });
 
     const replies: string[] = [];
     await registry.tryHandle("link", {

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -14,6 +14,7 @@ import { getConfiguredPublicOrigin } from "../utils/public-origin";
 import { requireOrgUser } from "../utils/require-org-user";
 import { MANAGED_CHAT_PLATFORMS_SET } from "./managed-platforms";
 import { AutomationSubscriptionService } from "../gateway/channels/automation-subscription-service";
+import { canLinkChatOrganizations } from "../gateway/channels/chat-link-authorization";
 import { formatChatCommand } from "../gateway/commands/command-spelling";
 
 // Slack Preview lets people trying Lobu locally talk to their agent through the
@@ -63,6 +64,8 @@ interface ClaimPayload {
 	/** Unified chat connection this code may be redeemed through. Omitted only
 	 * for the hosted cross-org preview bot flow used by `lobu run`. */
 	connectionId?: number;
+	/** Freeze installation ownership so moving it invalidates outstanding codes. */
+	connectionOrganizationId?: string;
 	createdBy: string | null;
 	allowedSurfaces: SurfaceType[];
 	createdAt: number;
@@ -126,10 +129,27 @@ export function canonicalSlackChannelId(channelId: string): string {
 		: `${SLACK_PLATFORM}:${channelId}`;
 }
 
+/** The link endpoint must not widen the bearer credential's workspace grant. */
+function credentialAllowsChatLink(
+	c: Context<{ Bindings: Env }>,
+	organizationId: string,
+): boolean {
+	if (c.var.authSource === "session") return Boolean(c.var.session);
+	const token = c.var.mcpAuthInfo;
+	if (!token) return false;
+	if (c.var.authSource === "pat" && token.tokenType === "pat") {
+		return token.organizationId == null || token.organizationId === organizationId;
+	}
+	return c.var.authSource === "oauth" &&
+		(token.grantedOrganizationIds ?? []).includes(organizationId);
+}
+
 /**
  * POST /api/:orgSlug/preview/claims — called by `lobu run` (mcpAuth) to mint a
- * short-lived link code for one of the org's agents on a hosted preview platform.
- * Body: `{ agent_id, platform, surfaces?, ttl_minutes? }`.
+ * short-lived link code for a hosted preview bot or a selected installation.
+ * Cross-organization installations require both a credential grant and current
+ * admin authority in both workspaces.
+ * Body: `{ agent_id, platform, connection_id?, surfaces?, ttl_minutes? }`.
  */
 export async function createPreviewClaim(c: Context<{ Bindings: Env }>) {
 	const auth = requireOrgUser(c);
@@ -154,24 +174,30 @@ export async function createPreviewClaim(c: Context<{ Bindings: Env }>) {
 	const sql = getDb();
 	const requestedConnectionId = Number(body.connection_id);
 	let connectionId: number | undefined;
+	let connectionOrganizationId: string | undefined;
 	if (Number.isFinite(requestedConnectionId) && requestedConnectionId > 0) {
 		const rows = (await sql`
-			SELECT id, connector_key
+			SELECT id, connector_key, organization_id
 			FROM connections
 			WHERE id = ${requestedConnectionId}
-				AND organization_id = ${auth.organizationId}
 				AND credential_mode IS NOT NULL
 				AND status = 'active'
 				AND deleted_at IS NULL
 			LIMIT 1
-		`) as Array<{ id: number; connector_key: string }>;
+		`) as Array<{ id: number; connector_key: string; organization_id: string }>;
 		const connection = rows[0];
-		if (!connection)
-			return c.json({ error: "Active chat connection not found" }, 404);
+		if (!connection || (
+			connection.organization_id !== auth.organizationId && (
+				!credentialAllowsChatLink(c, auth.organizationId) ||
+				!credentialAllowsChatLink(c, connection.organization_id) ||
+				!(await canLinkChatOrganizations(sql, auth.userId, auth.organizationId, connection.organization_id))
+			)
+		)) return c.json({ error: "Active chat connection not found" }, 404);
 		if (connection.connector_key !== platform) {
 			return c.json({ error: "Connection platform does not match" }, 400);
 		}
 		connectionId = connection.id;
+		connectionOrganizationId = connection.organization_id;
 	} else if (!PREVIEW_PLATFORMS.has(platform)) {
 		return c.json(
 			{
@@ -207,7 +233,7 @@ export async function createPreviewClaim(c: Context<{ Bindings: Env }>) {
 		const payload: ClaimPayload = {
 			organizationId: auth.organizationId,
 			agentId,
-			...(connectionId ? { connectionId } : {}),
+			...(connectionId ? { connectionId, connectionOrganizationId } : {}),
 			createdBy: auth.userId,
 			allowedSurfaces: surfaces,
 			createdAt: Date.now(),
@@ -243,6 +269,7 @@ type ConsumeClaimResult =
 	| { status: "bound"; agentId: string; organizationId: string }
 	| { status: "not_found" }
 	| { status: "connection_mismatch" }
+	| { status: "link_authority_revoked" }
 	| { status: "surface_not_allowed"; surfaceType: SurfaceType };
 
 // Create/update the tagged chat-link Automation for this concrete connection and
@@ -256,8 +283,9 @@ async function upsertBinding(
 	organizationId: string,
 	connectionId: number,
 	configuredBy?: string | null,
-): Promise<void> {
-	await new AutomationSubscriptionService().createChatAutomation(
+	requireAuthorizedAuthor = false,
+): Promise<boolean> {
+	return new AutomationSubscriptionService().createChatAutomation(
 		agentId,
 		platform,
 		channelId,
@@ -266,6 +294,7 @@ async function upsertBinding(
 			organizationId,
 			connectionId,
 			configuredBy: configuredBy ?? undefined,
+			requireAuthorizedAuthor,
 			sql: tx,
 		},
 	);
@@ -319,10 +348,11 @@ export async function consumePreviewClaim(args: {
 		let bindingConnectionId = claim.connectionId;
 		if (bindingConnectionId != null) {
 			if (!connectionId) return { status: "connection_mismatch" as const };
+			const claimedConnectionOrg = claim.connectionOrganizationId ?? claim.organizationId;
 			const matched = await tx`
 				SELECT 1 FROM connections
 				WHERE id = ${claim.connectionId}
-					AND organization_id = ${claim.organizationId}
+					AND organization_id = ${claimedConnectionOrg}
 					AND slug = ${runtimeConnectionIdToSlug(connectionId)}
 					AND connector_key = ${platform}
 					AND credential_mode IS NOT NULL
@@ -330,14 +360,17 @@ export async function consumePreviewClaim(args: {
 					AND deleted_at IS NULL
 				LIMIT 1
 			`;
-			if (matched.length === 0)
-				return { status: "connection_mismatch" as const };
+			if (matched.length === 0 ||
+				(connectionOrganizationId && connectionOrganizationId !== claimedConnectionOrg) ||
+				(claimedConnectionOrg !== claim.organizationId &&
+					!(await canLinkChatOrganizations(tx, claim.createdBy, claim.organizationId, claimedConnectionOrg)))
+			) return { status: "connection_mismatch" as const };
 		} else {
 			// A hosted claim may cross organizations only through the deliberately
 			// shared preview connection for the workspace handling the command. A normal
-			// managed/BYO installation must belong to the claimed agent's org; otherwise
-			// the Automation would be written under the agent org but inbound messages
-			// would stay scoped to the connection org and could never fire.
+			// managed/BYO installation must belong to the claimed agent's org: a hosted
+			// code has no grant for a specific foreign installation. That requires an
+			// explicitly connection-scoped code minted with authority over both orgs.
 			if (!connectionId) return { status: "connection_mismatch" as const };
 			const matched = await tx<{ id: number }>`
 				SELECT id FROM connections
@@ -366,12 +399,7 @@ export async function consumePreviewClaim(args: {
 		if (!claim.allowedSurfaces.includes(surfaceType)) {
 			return { status: "surface_not_allowed" as const, surfaceType };
 		}
-		await tx`
-			DELETE FROM oauth_states
-			WHERE id = ${codeHash(code)} AND scope = ${CLAIM_SCOPE}
-		`;
-
-		await upsertBinding(
+		const linked = await upsertBinding(
 			tx,
 			platform,
 			channelId,
@@ -380,7 +408,13 @@ export async function consumePreviewClaim(args: {
 			claim.organizationId,
 			bindingConnectionId,
 			claim.createdBy,
+			claim.connectionOrganizationId != null && claim.connectionOrganizationId !== claim.organizationId,
 		);
+		if (!linked) return { status: "link_authority_revoked" as const };
+		await tx`
+			DELETE FROM oauth_states
+			WHERE id = ${codeHash(code)} AND scope = ${CLAIM_SCOPE}
+		`;
 
 		// Redemption binds the chat and NOTHING ELSE — deliberately no
 		// chat-platform → Lobu-user identity. A claim code is paste-able and does
@@ -744,12 +778,13 @@ export async function workspaceUnlinkedNotice(
 	return [header, "", cliLine].join("\n");
 }
 
-type BindForOwnerResult = { status: "bound" } | { status: "forbidden" };
+type BindForOwnerResult = { status: "bound" } | { status: "forbidden" } | { status: "link_authority_revoked" };
 
 /**
  * Re-bind a chat to one of the caller's agents by id, without a code — only
- * works after the caller has linked at least once (so we know their Lobu user)
- * and only for agents in an org they're a member of.
+ * works with a verified chat identity and an unambiguous agent in the caller's
+ * organizations. Non-preview installations also require admin authority in
+ * both workspaces when linking across organizations.
  */
 export async function bindChatToAgentForOwner(args: {
 	platform: string;
@@ -762,25 +797,41 @@ export async function bindChatToAgentForOwner(args: {
 }): Promise<BindForOwnerResult> {
 	const { platform, teamId, channelId, agentId, lobuUserId } = args;
 	const sql = getDb();
+	// `agents` is keyed on (organization_id, id), so one agent id can name a
+	// different agent in each org the caller belongs to. Refuse rather than let
+	// an arbitrary row decide which organization the chat is bound to.
 	const owned = await sql<{ organization_id: string }>`
     SELECT a.organization_id
     FROM agents a
     JOIN "member" m ON m."organizationId" = a.organization_id
     WHERE a.id = ${agentId} AND m."userId" = ${lobuUserId}
-    LIMIT 1
+    LIMIT 2
   `;
-	if (owned.length === 0) return { status: "forbidden" };
+	if (owned.length !== 1) return { status: "forbidden" };
 	const organizationId = owned[0].organization_id;
-	const connections = await sql<{ id: number }>`
-		SELECT id FROM connections
+	const connections = await sql<{ id: number; organization_id: string; is_preview: boolean }>`
+		SELECT id, organization_id,
+			COALESCE(config->'settings'->'previewMode' = 'true'::jsonb, false) AS is_preview
+		FROM connections
 		WHERE slug = ${runtimeConnectionIdToSlug(args.connectionId)}
 			AND connector_key = ${platform}
+			AND status = 'active'
+			AND credential_mode IS NOT NULL
 			AND deleted_at IS NULL
 			${args.connectionOrganizationId ? sql`AND organization_id = ${args.connectionOrganizationId}` : sql``}
 		LIMIT 2
 	`;
 	if (connections.length !== 1) return { status: "forbidden" };
-	await sql.begin((tx) =>
+	const requiresInstallationAuthority = connections[0].organization_id !== organizationId && !connections[0].is_preview;
+	if (requiresInstallationAuthority) {
+		// Codeless identity currently comes from verified Slack workspace identity.
+		// Platforms without that identity adapter use connection-scoped codes.
+		if (!teamId) return { status: "forbidden" };
+		if (!(await canLinkChatOrganizations(sql, lobuUserId, organizationId, connections[0].organization_id))) {
+			return { status: "forbidden" };
+		}
+	}
+	const linked = await sql.begin((tx) =>
 		upsertBinding(
 			tx,
 			platform,
@@ -789,7 +840,9 @@ export async function bindChatToAgentForOwner(args: {
 			agentId,
 			organizationId,
 			connections[0].id,
+			lobuUserId,
+			requiresInstallationAuthority,
 		),
 	);
-	return { status: "bound" };
+	return { status: linked ? "bound" : "link_authority_revoked" };
 }


### PR DESCRIPTION
## Summary

- A chat installation in one workspace could accept `/lobu link` for an agent in another workspace, then reject every incoming message as unlinked. Admit the exact linked installation/channel in both the subscription resolver and actual Automation planner only while the recorded author administers both workspaces; preserve ordinary tenant isolation and optional provider team identity.
- Apply the same authorization to the existing installation-scoped link-code flow for Slack, Telegram, and WhatsApp. Minting respects session/OAuth/PAT workspace grants; redemption rechecks current membership, installation identity and ownership, expiry, surface, and single use. Slack codeless linking retains its verified identity boundary and rejects ambiguous agent IDs.
- Preserve immutable Automation attribution. A revoked original author cannot be replaced by a successful-looking re-link: retire the stale Automation before redeeming a fresh authorized link. Keep the explicit hosted-preview linking paths intact and read `/status` from the linked agent workspace.

## Test plan

- [x] Intended files staged explicitly, then `make pre-pr` clean; canonical GitHub CI is the full graph per current AGENTS.md (`make pr-full` is optional).
- [x] 193 focused Bun tests: link-code dispatch, signed Slack Enterprise Grid delivery, bridge, subscriptions, command dispatch, channel mentions, cross-workspace status, hosted-preview compatibility, and multi-tenant neighbors.
- [x] 29 Vitest tests: preview claims and generic Automation activation. Server typecheck passes.
- [x] Bug fix: red→fix→green evidence below.
- [x] Bot-runtime coverage uses the real signed Slack adapter, command dispatcher, persisted subscriptions, default planner, and actual PostgreSQL `chat_message` queue. Telegram/WhatsApp enter at the Chat SDK bridge boundary.
- [x] Independent Claude Opus review-fix completed; 15 suites and mutation proof of the source-workspace admin guard. Fable validated the service injection and routing-query follow-ups; named routing options replace positional arguments, and the authorization subquery owns its SQL aliases. A multiple-team trigger regression proves both subscription selection and planner policy stay scoped.
- [x] Exact-head semantic review and all 10 required checks passed for `2414b4fad10bf164a129e3236ea63304e6c2e21e`: Fable confidence 88, simplicity 72, zero bugs/blockers. Full CI run: https://github.com/lobu-ai/lobu/actions/runs/34261874997. `CHECK_ONLY=1 make land N=3431` stopped before merge.

Red before the fix:

```text
Slack authorized cross-workspace link: expected 1 queued turn, received 0.
Slack target-only member link: expected status forbidden, received bound.
2 pass, 2 fail

Installation-scoped link codes (Slack / Telegram / WhatsApp):
Expected: 200
Received: 404
3 pass, 3 fail

Re-link after original author loses access:
Expected to not contain: "Linked this chat"
Received: "Linked this chat to agent ..."
0 pass, 3 fail

Hosted-preview codeless link and cross-workspace /status regressions:
2 pass, 4 fail
```

Green after the fix and expanded security coverage:

```text
193 pass, 0 fail (9 focused Bun files)
29 tests passed (2 Vitest files)
bun run typecheck: passed
```

## Notes

A channel explicitly linked in multiple administered workspaces currently queues a turn in each. Global cross-workspace retargeting/uniqueness is an open lifecycle design question; this PR preserves the existing per-workspace link storage and does not mutate another workspace's Automation during linking.

Foreign Slack links require the exact team identity captured at linking. Messages from Slack Connect authors whose provider payload reports a different team remain excluded; same-workspace routing is unchanged.

No public API, SDK, or schema addition. Existing link codes without an explicit foreign installation grant remain restricted to their own workspace or the configured hosted preview bot. Link redemption never establishes platform-user identity. The WhatsApp cases cover the existing chat transport, not the WhatsApp Web device collector. Provider delivery for Telegram/WhatsApp and the original live Slack channel still require post-deployment verification; this PR contains local integration proof only.
