### PR TITLE
fix(runtime): forward configured tool grants to queued messages

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-member-use.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-member-use.test.ts
@@ -96,10 +96,12 @@ function makeApp(
   agentMetadataStore: AgentMetadataStore,
   ambientOrg: string,
   sessions = makeSessionManager(),
-  queueProducer = {} as never
+  queueProducer = {} as never,
+  agentSettingsStore?: Parameters<typeof createAgentApi>[0]["agentSettingsStore"]
 ) {
   const agentApi = createAgentApi({
     queueProducer,
+    agentSettingsStore,
     sessionManager: sessions.mgr,
     sseManager: { hasActiveConnection: () => false } as never,
     publicGatewayUrl: "http://localhost:8787",
@@ -222,6 +224,65 @@ describe("POST /api/v1/agents — org member using an agent they don't own", () 
     expect(stored?.conversationId).toBe(expectedKey);
     expect(sessions.store.get(expectedKey)).toBe(stored);
   });
+
+  for (const source of ["direct-api", "automation_run"] as const) {
+    for (const configuredTools of [["/mcp/test-memory/tools/*"], []]) {
+      test(`${source} forwards only the workspace agent's configured tool grants (${configuredTools.length})`, async () => {
+        const enqueued: Array<Record<string, unknown>> = [];
+        const reads: Array<unknown> = [];
+        setAuthProvider(() => sessionFor(MEMBER_ID));
+        const { app, sessions } = makeApp(
+          userAgentsStore,
+          agentMetadataStore,
+          CALLER_DEFAULT_ORG,
+          makeSessionManager(),
+          {
+            enqueueMessage: async (payload: Record<string, unknown>) => {
+              enqueued.push(payload);
+              return "tool-grants-job";
+            },
+          } as never,
+          {
+            getSettings: async (agentId: string, options: unknown) => {
+              reads.push({ agentId, options });
+              return { models: ["test-provider/test-model"], preApprovedTools: configuredTools };
+            },
+          } as never,
+        );
+        const created = await postCreate(app, { thread: "tool-grants" }, {
+          "x-lobu-org": AGENT_ORG,
+        });
+        expect(created.status).toBe(201);
+        const session = sessions.getStored();
+        if (!session) throw new Error("Missing tool grants session");
+        // Session creation separately verifies Automation intent. Exercise the
+        // message route with the resulting persisted intent here.
+        if (source === "automation_run") {
+          session.intent = { kind: "automation_run", runId: 123, automationId: 456 };
+        }
+        const sent = await app.request(
+          `/api/v1/agents/${encodeURIComponent(session.conversationId)}/messages`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-lobu-org": AGENT_ORG },
+            // A client-supplied grant is passthrough body noise: only the
+            // agent's configured grants may reach the worker.
+            body: JSON.stringify({
+              content: "Use the configured tools",
+              ephemeralContext: "Test context",
+              preApprovedTools: ["*"],
+            }),
+          },
+        );
+        expect(sent.status).toBe(200);
+        expect(reads).toContainEqual({ agentId: AGENT_ID, options: { organizationId: AGENT_ORG } });
+        expect(enqueued).toHaveLength(1);
+        expect(enqueued[0]?.preApprovedTools).toEqual(configuredTools.length ? configuredTools : undefined);
+        expect(enqueued[0]?.agentOptions).not.toHaveProperty("preApprovedTools");
+        expect(enqueued[0]?.organizationId).toBe(AGENT_ORG);
+      });
+    }
+  }
 
   test("device placement is owner-scoped, capability-checked, and retained on resume", async () => {
     const sql = getDb();

--- a/packages/server/src/gateway/__tests__/enqueue-nix-config.test.ts
+++ b/packages/server/src/gateway/__tests__/enqueue-nix-config.test.ts
@@ -27,6 +27,7 @@ const ORG_ID = "org-1";
 
 const AGENT_SETTINGS = {
   models: ["openai/gpt-5"],
+  preApprovedTools: ["/mcp/test-memory/tools/*"],
   nixConfig: { packages: ["agent-pkg"] },
   skillsConfig: {
     skills: [
@@ -89,6 +90,8 @@ describe("enqueued payload carries the resolved nixConfig", () => {
 
     expect(enqueued).toHaveLength(1);
     const payload = enqueued[0]!;
+    expect(payload.preApprovedTools).toEqual(AGENT_SETTINGS.preApprovedTools);
+    expect(payload.agentOptions).not.toHaveProperty("preApprovedTools");
     expect(payload.nixConfig?.packages).toEqual(["agent-pkg"]);
     // The worker reads the top-level field; a copy left in agentOptions would
     // mean the lift never happened.
@@ -152,6 +155,8 @@ describe("enqueued payload carries the resolved nixConfig", () => {
     expect(res.status).toBe(200);
     expect(enqueued).toHaveLength(1);
     const payload = enqueued[0]!;
+    expect(payload.preApprovedTools).toEqual(AGENT_SETTINGS.preApprovedTools);
+    expect(payload.agentOptions).not.toHaveProperty("preApprovedTools");
     expect(payload.nixConfig?.packages).toEqual(["request-pkg", "agent-pkg"]);
     expect(
       (payload.agentOptions as Record<string, unknown> | undefined)?.nixConfig,

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -2598,7 +2598,7 @@ export class ChatInstanceManager {
       agentSettingsStore,
       organizationId,
     );
-    const { nixConfig, ...remainingAgentOptions } = agentOptions;
+    const { nixConfig, preApprovedTools, ...remainingAgentOptions } = agentOptions;
 
     await sessionManager.setSession({
       conversationId: sessionId,
@@ -2640,6 +2640,7 @@ export class ChatInstanceManager {
       },
       agentOptions: remainingAgentOptions,
       nixConfig,
+      preApprovedTools,
     });
 
     logger.info(

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -1727,6 +1727,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
         networkConfig: settingsNetwork,
         guardrailsInline: settingsGuardrailsInline,
         nixConfig: resolvedNixConfig,
+        preApprovedTools,
         ...remainingOptions
       } = agentOptions;
 
@@ -1849,6 +1850,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
         networkConfig: session.networkConfig || settingsNetwork,
         guardrailsInline: settingsGuardrailsInline,
         nixConfig: resolvedNixConfig,
+        preApprovedTools,
       });
 
       rootSpan?.end();


### PR DESCRIPTION
## Summary
API messages, including managed Automation runs, resolved the agent's configured tool grants but left them inside `agentOptions`. Worker grant reconciliation reads the top-level `preApprovedTools`, so an already-authorized tool could still block a headless run on approval. Forward the existing field at both affected dispatch sites: direct API and platform CLI.

The settings lookup remains scoped to the agent's organization. Caller-supplied grants cannot change the queued authority; agents with no configured grants receive none.

## Test plan
- [x] Intended four files staged explicitly; `make pre-pr` passed.
- [x] Real API route tests cover direct and Automation sessions, correct organization lookup, configured/empty grants, and an attempted client-supplied wildcard.
- [x] Capturing-queue tests cover platform CLI and preserve existing Nix package forwarding.
- [x] Focused gateway tests: 35 passed, 0 failed across agent-member-use, enqueue-nix-config, and agent-session-create.
- [x] Independent Fable pre-review fixer re-ran red/green and server typecheck.

Red before the production fix:
```
agent-member-use: 14 pass, 2 fail (configured grants missing in direct API and Automation payloads)
enqueue-nix-config: 0 pass, 2 fail (configured grants missing in platform CLI and direct API payloads)
```
Green after the fix:
```
35 pass
0 fail
130 expect() calls
Ran 35 tests across 3 files.
```

## Notes
No new approval policy or grants. Live Automation execution will be verified after deployment; queue-shape tests alone do not establish production execution success.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent messages now consistently use the workspace agent’s approved tool permissions when queued.
  * Client-provided tool permissions are no longer used to override configured approvals.
  * Approved tools are correctly preserved for direct API and automated runs.
  * Queued messages now retain the associated agent organization and separate tool permissions from other agent options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->