### PR TITLE
fix(gateway): scope SSE backlog replay to the session's own lifetime

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-events-backlog-scope.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-events-backlog-scope.test.ts
@@ -1,0 +1,109 @@
+/**
+ * GET /api/v1/agents/:id/events replays only THIS session's backlog.
+ *
+ * `conversationId` is deterministic (agent + user + org + thread), so
+ * `forceNew` mints a fresh session at the key the previous one used — while
+ * the SSE backlog ring, keyed on that same string, still holds the old turn
+ * for its 2-minute TTL. Replaying the whole ring answered `lobu chat --new`
+ * with the PREVIOUS turn's output, delivered before the new message had even
+ * been dispatched, so the CLI printed a stale answer and exited.
+ *
+ * The boundary is `session.createdAt`: a resumed session keeps its original
+ * value and still gets its own events back; a replacement session starts
+ * after everything the old one emitted.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { encrypt } from "@lobu/core";
+import { createAgentApi } from "../routes/public/agent.js";
+import { setAuthProvider } from "../routes/public/settings-auth.js";
+
+const TEST_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+const SESSION_KEY = "agent-1_user-1_org-1";
+const SESSION_CREATED_AT = 1_788_893_911_000;
+
+let savedKey: string | undefined;
+beforeEach(() => {
+  savedKey = process.env.ENCRYPTION_KEY;
+  process.env.ENCRYPTION_KEY = TEST_KEY;
+  setAuthProvider(null);
+});
+afterEach(() => {
+  if (savedKey === undefined) delete process.env.ENCRYPTION_KEY;
+  else process.env.ENCRYPTION_KEY = savedKey;
+  setAuthProvider(null);
+});
+
+/** Captures the `since` bound the route asks the backlog for. */
+function makeSseRecorder() {
+  const sinceArgs: Array<number | undefined> = [];
+  return {
+    sinceArgs,
+    manager: {
+      totalConnections: () => 0,
+      connectionCount: () => 0,
+      getRecentEvents(_key: string, since?: number) {
+        sinceArgs.push(since);
+        return [];
+      },
+      addConnection() {},
+      removeConnection() {},
+    },
+  };
+}
+
+function makeApp(sse: ReturnType<typeof makeSseRecorder>) {
+  return createAgentApi({
+    queueProducer: {} as never,
+    sessionManager: {
+      async getSession(id: string) {
+        if (id !== SESSION_KEY) return null;
+        return {
+          conversationId: SESSION_KEY,
+          channelId: "api_test",
+          userId: "user-1",
+          agentId: "agent-1",
+          lastActivity: SESSION_CREATED_AT,
+          createdAt: SESSION_CREATED_AT,
+        };
+      },
+    } as never,
+    sseManager: sse.manager as never,
+    publicGatewayUrl: "http://localhost:8787",
+    artifactStore: {} as never,
+    agentMetadataStore: {
+      async getMetadata() {
+        return { owner: { platform: "external", userId: "user-1" } };
+      },
+    } as never,
+  });
+}
+
+const ticket = (userId: string): string =>
+  encrypt(
+    JSON.stringify({ userId, platform: "external", exp: Date.now() + 60_000 }),
+  );
+
+describe("GET /api/v1/agents/:id/events — backlog is scoped to the session", () => {
+  test("replay is bounded by session.createdAt, not the whole ring", async () => {
+    const sse = makeSseRecorder();
+    const app = makeApp(sse);
+
+    // The handler holds the stream open for the life of the connection, so
+    // abort once the backlog snapshot has been taken rather than awaiting it.
+    const controller = new AbortController();
+    const request = app.request(
+      `/api/v1/agents/${SESSION_KEY}/events?token=${encodeURIComponent(ticket("user-1"))}`,
+      { method: "GET", signal: controller.signal },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    controller.abort();
+    await request.catch(() => undefined);
+
+    expect(sse.sinceArgs).toEqual([SESSION_CREATED_AT]);
+    // The regression this pins: an unbounded read returns the previous
+    // session's turn as well, because the ring key is the same string.
+    expect(sse.sinceArgs[0]).not.toBeUndefined();
+  });
+});

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -1378,7 +1378,17 @@ export function createAgentApi(config: AgentApiConfig): Hono {
       // broadcast landing during the `connected` write below would be delivered
       // live AND still be in the backlog we replay — duplicating it (and
       // possibly reordering it after later live events) for the client.
-      const backlog = sseManager.getRecentEvents(sseKey);
+      // Bounded to THIS session's lifetime. `conversationId` is deterministic
+      // (agent + user + org + thread), so `forceNew` mints a fresh session at
+      // the key the old one used — while the backlog ring, keyed on that same
+      // string, still holds the previous turn for its 2-minute TTL. Replaying
+      // the whole ring therefore answered `lobu chat --new` with the PREVIOUS
+      // turn's output, before the new message had even been dispatched.
+      //
+      // `createdAt` is the exact boundary: a resumed session keeps its
+      // original value and still gets its own events back, while a replacement
+      // session starts after everything the old one emitted.
+      const backlog = sseManager.getRecentEvents(sseKey, session.createdAt);
       sseManager.addConnection(sseKey, stream);
       connectionAdded = true;
 


### PR DESCRIPTION
## What

`lobu chat --new` answered with the **previous** turn's output — delivered before the new message had even been dispatched, so the CLI printed a stale answer and exited.

`conversationId` is deterministic (agent + user + org + thread), so `forceNew` mints a fresh session at the key the old one used. The SSE backlog ring is keyed on that same string with a 2-minute TTL, and connecting replayed the whole ring.

`getRecentEvents` already takes a `since` bound — nothing new was needed. The replay now passes `session.createdAt`: a resumed session keeps its original value and still gets its own events back, while a replacement session starts after everything the old one emitted.

The DELETE path already drops the backlog for exactly this reason, and its comment names the hazard — *"rare, but possible with deterministic conversationIds"*. This is the other way a session at a live key goes away.

## Red → green

```
# without the fix — the route asks for the whole ring
expect(sse.sinceArgs).toEqual([SESSION_CREATED_AT])
- Expected  - 1
+ Received  + 1
(fail) replay is bounded by session.createdAt, not the whole ring

# with the fix
1 pass  0 fail
```

Focused suites: `agent-session-create` + `sse-manager` → **30 pass, 0 fail**. `agent-routes` + `agent-ownership` + `agent-events-sse-ticket` → **13 pass, 0 fail**.

## A note on local verification

Running the full `gateway/__tests__` directory in one go on this machine produces ~150 `PostgresError: the database system is shutting down` failures from suites contending over the shared test database. That reproduces on an unmodified tree and is unrelated to this change; the per-suite runs above are clean. CI's `integration-bun` job is the real check here.

## Alternative considered

Purging the backlog at session-create time via `sseManager.closeAgent`. Rejected: it makes `closeAgent` a hard dependency of the create path, breaking four existing tests that stub `sseManager: {} as never`, and would have needed stub churn across three test files. Bounding the read is one line and semantically exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNbUaAAUbdLhAaxy3vi9Yi