### PR TITLE
fix(chat): preserve native team identity in interaction tokens

### DIFF
--- a/packages/server/src/gateway/__tests__/chat-link-code-routing.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-link-code-routing.test.ts
@@ -1,6 +1,8 @@
 /** Link codes bind a chat without inventing a platform-user identity. */
 import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { CommandRegistry } from "@lobu/core";
+import { Chat } from "chat";
+import { createSlackAdapter } from "@chat-adapter/slack";
 import type { Context } from "hono";
 import { addUserToOrganization, createTestUser, linkSlackIdentityInGraph } from "../../__tests__/setup/test-fixtures.js";
 import { getDb } from "../../db/client.js";
@@ -12,10 +14,18 @@ import { registerBuiltInCommands } from "../commands/built-in-commands.js";
 import { CommandDispatcher } from "../commands/command-dispatcher.js";
 import { ConversationStateStore } from "../connections/conversation-state-store.js";
 import { MessageHandlerBridge } from "../connections/message-handler-bridge.js";
+import { registerInteractionBridge } from "../connections/interaction-bridge.js";
+import { readPendingSuggestion } from "../connections/pending-interaction-store.js";
 import { createConnectedGatewayStateAdapter } from "../connections/state-adapter.js";
 import type { PlatformConnection } from "../connections/types.js";
 import { QueueProducer } from "../infrastructure/queue/queue-producer.js";
 import { RunsQueue } from "../infrastructure/queue/runs-queue.js";
+import { InteractionService } from "../interactions.js";
+import { buildRunJobToken } from "../orchestration/message-consumer.js";
+import { buildDeploymentWorkerToken } from "../orchestration/deployment-manager.js";
+import { createInteractionRoutes } from "../routes/internal/interactions.js";
+import { InMemoryStateAdapter } from "./fixtures/in-memory-state-adapter.js";
+import { blockActionsPayload, buildSignedBlockActionsRequest } from "./fixtures/slack-signing.js";
 import { ensureDbForGatewayTests, resetTestDatabase, seedAgentRow } from "./helpers/db-setup.js";
 
 const SOURCE_ORG = "org-chat-installation";
@@ -45,6 +55,7 @@ describe("platform-neutral chat link-code routing", () => {
   let queue: RunsQueue;
   let producer: QueueProducer;
   let ownerId: string;
+  const disposeInteractions: Array<() => void> = [];
 
   beforeAll(ensureDbForGatewayTests);
   beforeEach(async () => {
@@ -59,7 +70,10 @@ describe("platform-neutral chat link-code routing", () => {
     producer = new QueueProducer(queue);
     await producer.start();
   });
-  afterEach(async () => { await queue?.stop(); });
+  afterEach(async () => {
+    for (const dispose of disposeInteractions.splice(0)) dispose();
+    await queue?.stop();
+  });
 
   async function install(platform: typeof PLATFORMS[number], organizationId: string, suffix = "") {
     const slug = `chat-code-${platform}${suffix}`;
@@ -78,6 +92,11 @@ describe("platform-neutral chat link-code routing", () => {
     registerBuiltInCommands(registry, { agentSettingsStore: { getSettings } as never, automationSubscriptionService: subscriptions });
     const dispatcher = new CommandDispatcher({ registry, automationSubscriptionService: subscriptions });
     const conversationState = new ConversationStateStore(await createConnectedGatewayStateAdapter());
+    const instance: any = { connection, conversationState };
+    const manager = {
+      has: (id: string) => id === slug,
+      getInstance: () => instance,
+    };
     const bridge = new MessageHandlerBridge(connection, {
       getArtifactStore: () => null,
       getPublicGatewayUrl: () => "https://gateway.example.test",
@@ -89,10 +108,8 @@ describe("platform-neutral chat link-code routing", () => {
       getDeclaredAgentRegistry: () => undefined,
       getProviderCatalogService: () => undefined,
       getQueueProducer: () => producer,
-    } as never, {
-      has: (id: string) => id === slug,
-      getInstance: () => ({ connection, conversationState }),
-    } as never, dispatcher);
+    } as never, manager as never, dispatcher);
+    instance.messageBridge = bridge;
     const channelId = `${platform}:123456`;
     const thread = { channelId, id: channelId, subscribe: mock(async () => {}), post: mock(async () => ({})) };
     let sequence = 0;
@@ -101,7 +118,117 @@ describe("platform-neutral chat link-code routing", () => {
       author: { userId: "provider-code-redeemer", isBot: false, isMe: false },
       raw: platform === "slack" ? { team_id: "T_CODE_WORKSPACE" } : {},
     }, source);
-    return { id: Number(row.id), slug, connection, thread, send, getSettings };
+    return { id: Number(row.id), slug, connection, thread, send, getSettings, instance, manager };
+  }
+
+  async function linkedChannel(platform: typeof PLATFORMS[number]) {
+    const installed = await install(platform, SOURCE_ORG);
+    installed.thread.id += ":1700000000.000100";
+    const response = await createPreviewClaim(claimContext({
+      platform, agent_id: AGENT_ID, connection_id: installed.id, surfaces: ["channel"],
+    }, ownerId));
+    expect(response.status).toBe(200);
+    await installed.send(`/link ${(await response.json()).code}`, "mention");
+    await installed.send("Handle this channel request", "mention");
+    const [run] = await getDb()`SELECT id, action_input FROM runs WHERE run_type = 'chat_message'`;
+    expect(run.action_input.organizationId).toBe(TARGET_ORG);
+    return { installed, run };
+  }
+
+  async function suggestionHarness(installed: Awaited<ReturnType<typeof install>>) {
+    const signingSecret = "test-chat-link-suggestions-secret";
+    const posted = mock(async () => ({ ts: "1700000000.000200" }));
+    let action: (event: any) => Promise<void> = async () => {};
+    let chat: any;
+    if (installed.connection.platform === "slack") {
+      const adapter = createSlackAdapter({ signingSecret, botToken: "xoxb-test", botUserId: "U_BOT" });
+      (adapter as any).postMessage = posted;
+      // The typing indicator is a live `assistant.threads.setStatus` call.
+      (adapter as any).startTyping = mock(async () => undefined);
+      chat = new Chat({ userName: "lobu", adapters: { slack: adapter }, state: new InMemoryStateAdapter() });
+    } else {
+      chat = {
+        onAction: (handler: typeof action) => { action = handler; },
+        channel: () => ({ post: posted }),
+      };
+    }
+    let actionsCompleted = 0;
+    const registerAction = chat.onAction.bind(chat);
+    chat.onAction = (handler: typeof action) => registerAction(async (event: any) => {
+      try { await handler(event); } finally { actionsCompleted += 1; }
+    });
+    installed.instance.chat = chat;
+    const service = new InteractionService();
+    disposeInteractions.push(registerInteractionBridge(service, installed.manager as never, installed.connection, chat));
+    const routes = createInteractionRoutes(service);
+    return {
+      async post(token: string) {
+        const response = await routes.request("/internal/suggestions/create", {
+          method: "POST", headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+          body: JSON.stringify({ prompts: [{ title: "Continue", message: "Continue this task" }], teamId: "T_UNTRUSTED_BODY" }),
+        });
+        expect(response.status).toBe(200);
+        const { id } = await response.json() as { id: string };
+        await waitFor(async () => { expect(await readPendingSuggestion(id, SOURCE_ORG, installed.slug)).not.toBeNull(); });
+        await waitFor(async () => { expect(posted.mock.calls.length).toBeGreaterThan(0); });
+        return id;
+      },
+      async click(id: string) {
+        const previous = actionsCompleted;
+        if (installed.connection.platform === "slack") {
+          const response = await chat.webhooks.slack(buildSignedBlockActionsRequest(signingSecret, blockActionsPayload({
+            teamId: "T_CODE_WORKSPACE", userId: "provider-code-redeemer", channelId: "123456",
+            messageTs: "1700000000.000200", actionId: `suggestion:${id}:0`, value: "",
+          })));
+          expect(response.status).toBe(200);
+        } else {
+          await action({ actionId: `suggestion:${id}:0`, user: { userId: "provider-code-redeemer" }, thread: installed.thread });
+        }
+        await waitFor(async () => { expect(actionsCompleted).toBe(previous + 1); });
+      },
+    };
+  }
+
+  for (const platform of PLATFORMS) {
+    for (const mint of ["run", "deployment"]) {
+      test(`${platform}: ${mint} token preserves native team through a persisted suggestion click and dispatch`, async () => {
+        const { installed, run } = await linkedChannel(platform);
+        const args = { ...run.action_input, deploymentName: "deployment-chat-code", runId: Number(run.id) };
+        const token = mint === "run" ? buildRunJobToken(args) : buildDeploymentWorkerToken(args);
+        const harness = await suggestionHarness(installed);
+        const id = await harness.post(token);
+        const stored = await readPendingSuggestion(id, SOURCE_ORG, installed.slug);
+        await harness.click(id);
+        await waitFor(async () => {
+          const rows = await getDb()`SELECT action_input FROM runs WHERE run_type = 'chat_message' ORDER BY id`;
+          expect(rows).toHaveLength(2);
+          expect(rows[1].action_input).toMatchObject({ agentId: AGENT_ID, organizationId: TARGET_ORG, messageText: "Continue this task", conversationId: installed.thread.id });
+        });
+        expect(stored?.suggestion.teamId).toBe(platform === "slack" ? "T_CODE_WORKSPACE" : undefined);
+      });
+    }
+
+    test.each(["foreign team", "other installation", "revoked authority", "legacy routing key"])(`${platform}: suggestion rejects %s`, async (boundary) => {
+      const { installed, run } = await linkedChannel(platform);
+      const metadata = { ...run.action_input.platformMetadata };
+      if (boundary === "foreign team") metadata.teamId = "T_OTHER_WORKSPACE";
+      if (boundary === "legacy routing key") delete metadata.teamId;
+      const token = buildRunJobToken({
+        ...run.action_input, platformMetadata: metadata,
+        deploymentName: "deployment-chat-code", runId: Number(run.id),
+      });
+      const harness = await suggestionHarness(installed);
+      const id = await harness.post(token);
+      if (boundary === "revoked authority") {
+        await getDb()`DELETE FROM member WHERE "userId" = ${ownerId} AND "organizationId" = ${SOURCE_ORG}`;
+      }
+      const clickHarness = boundary === "other installation"
+        ? await suggestionHarness(await install(platform, SOURCE_ORG, "-other"))
+        : harness;
+      await clickHarness.click(id);
+      const rows = await getDb()`SELECT id FROM runs WHERE run_type = 'chat_message'`;
+      expect(rows).toHaveLength(1);
+    });
   }
 
   for (const platform of PLATFORMS) {

--- a/packages/server/src/gateway/__tests__/worker-token-mint-parity.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-token-mint-parity.test.ts
@@ -132,6 +132,22 @@ describe("worker-token mint parity (real mint, not generateWorkerToken)", () => 
     }
   });
 
+  test.each(["T_NATIVE", null, 42])("native team metadata overrides the channel routing key: %s", (teamId) => {
+    const args = {
+      ...baseArgs,
+      teamId: "slack:C_CHANNEL",
+      platformMetadata: { ...baseArgs.platformMetadata, teamId },
+    };
+    for (const token of [
+      buildRunJobToken({ ...args, runId: 42, messageId: "message-team" }),
+      buildDeploymentWorkerToken(args),
+    ]) {
+      expect(verifyWorkerToken(token)?.teamId).toBe(
+        typeof teamId === "string" ? teamId : undefined,
+      );
+    }
+  });
+
   test("PARITY: both mints carry the egress allow AND deny claims", () => {
     const egressArgs = {
       ...baseArgs,

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -1623,7 +1623,9 @@ export class MessageHandlerBridge {
           senderId: userId,
           senderUsername,
           senderDisplayName,
-          teamId,
+          // Preserve known absence through queued JSON so token minting does
+          // not mistake the worker routing key for a native provider team.
+          teamId: teamId ?? null,
           conversationUrl,
           isGroup,
           connectionId: this.connection.id,

--- a/packages/server/src/gateway/connections/platform-metadata.ts
+++ b/packages/server/src/gateway/connections/platform-metadata.ts
@@ -30,8 +30,12 @@ export interface PlatformMetadata {
   senderId?: string;
   senderUsername?: string;
   senderDisplayName?: string;
-  /** Inbound: Slack workspace id (also used as `raw.team_id` shim). */
-  teamId?: string;
+  /**
+   * Inbound: Slack workspace id (also used as `raw.team_id` shim). Explicit
+   * `null` for a teamless chat so the queued JSON keeps the known absence and
+   * token minting does not fall back to the payload's routing `teamId`.
+   */
+  teamId?: string | null;
   /**
    * Inbound: a link back to the originating conversation/message on the source
    * platform (e.g. a Slack permalink). Surfaced to the agent in its per-run

--- a/packages/server/src/gateway/orchestration/worker-token-claims.ts
+++ b/packages/server/src/gateway/orchestration/worker-token-claims.ts
@@ -99,9 +99,15 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
 	// Provider comes solely from the conversation's pinned sandbox; there is
 	// no deployment-wide env-var fallback. Undefined → local just-bash.
 	const runtimeProviderId = args.runtimeProviderId;
+	// Chat payloads use top-level teamId as a worker routing key. Interactions
+	// need the provider-native team instead. Explicit null survives the queued
+	// JSON for teamless chats; callers without this metadata retain their team.
+	const teamId = args.platformMetadata && Object.hasOwn(args.platformMetadata, "teamId")
+		? args.platformMetadata.teamId
+		: args.teamId;
 	return {
 		channelId: args.channelId,
-		teamId: args.teamId,
+		teamId: typeof teamId === "string" ? teamId : undefined,
 		agentId: args.agentId,
 		organizationId: args.organizationId,
 		platform: args.platform,


### PR DESCRIPTION
## Summary

Suggestion clicks from a linked chat could return the unlinked-channel notice because worker tokens carried the internal channel routing key as the provider team ID. Preserve the native team from the queued platform metadata in both token mints, including explicit absence for teamless platforms.

The installation, channel, team, and cross-workspace authorization checks remain exact. Existing cards carrying a malformed routing key remain rejected; a new agent response must create new cards after deployment.

## Test plan

- [x] Five intended files staged explicitly; `make pre-pr` clean (build, typecheck, knip, naming, and runtime gates). Full Linux checks run in GitHub CI.
- [x] Required Fable pre-review fixer completed; its typing stub and internal metadata type correction were inspected and revalidated.
- [x] [Full GitHub CI](https://github.com/lobu-ai/lobu/actions/runs/34281815923) passed for commit `094446a66ff2ae22ae6266f162bbb59a7a06623f`; UI review is not applicable.
- [x] Exact-commit Fable review passed: zero bugs or blockers, confidence 88, simplicity 85, low runtime risk. Its independent mutation check made nine regression tests fail when the token correction was reverted.
- [x] Merged as `638b315fecd5a7b7d0065959cb7dbdac24b565ed`; image build and published-artifact smoke passed. Production reported that exact revision, and a fresh `EXPECT_SHA=638b315fecd5a7b7d0065959cb7dbdac24b565ed scripts/prod-smoke.sh` passed 8/8 checks.
- [x] Focused runtime regression suites: 190 tests pass across six files, including persisted interaction scoping and token refresh.
- [x] Six regression cases traverse authorized cross-workspace code redemption, the actual queued payload, both real token mints, the authenticated suggestion route, Postgres persistence, interaction handling, and actual planner dispatch. Slack uses a signed provider webhook; Telegram and WhatsApp enter at their normalized action boundary.
- [x] Twelve rejection cases cover foreign teams, other installations, revoked author authority, and malformed legacy cards across the three platforms. An untrusted request-body team does not override the signed claim.
- [x] Bug reproduced before the fix, including actual follow-up dispatch failure:

```text
Before: 0 pass, 6 fail. Each suggestion click left one chat run instead of the expected two.
After:  190 pass, 0 fail, 779 expect() calls across 6 files.
```

## Notes

No database, public API, SDK, or link lifecycle change. This corrects existing native-team metadata handling. Telegram and WhatsApp coverage proves the shared routing path; it does not claim live provider interaction testing. WhatsApp Web collection is outside this chat transport change.
