### PR TITLE
docs(connectors): document the agent-driven MCP authoring loop

### DIFF
--- a/docs/connector-authoring.md
+++ b/docs/connector-authoring.md
@@ -1,6 +1,6 @@
 # Connector authoring
 
-When to write a connector, the two authoring surfaces, and the SDK contract.
+When to write a connector, the three authoring surfaces, and the SDK contract.
 The full SDK reference is `packages/connectors/src/README.md` in the repo
 (`github.com/lobu-ai/lobu/blob/main/packages/connectors/src/README.md`); the
 seed example is `examples/lobu-crm/npm-downloads.connector.ts`.
@@ -10,9 +10,10 @@ seed example is `examples/lobu-crm/npm-downloads.connector.ts`.
 Search the catalog first: `client.catalog.listInstalled({ kinds: ["connectors"] })`,
 then `client.catalog.listCatalog(...)` if it is not installed. If a matching
 connector exists, connect to it. If none matches the data source, do **not**
-conclude "no integration exists" — author a custom connector in the project.
+conclude "no integration exists" — author a custom connector (in the project,
+or over MCP, below).
 
-## Two authoring surfaces
+## Authoring surfaces
 
 1. **Project-local custom connectors** (`connectors/<name>.connector.ts`) —
    registered in `lobu.config.ts` with
@@ -21,6 +22,30 @@ conclude "no integration exists" — author a custom connector in the project.
 2. **Bundled built-ins** (`packages/connectors/src/<name>.ts`) — compiled into
    the platform catalog and auto-installed per org on first use. Only for
    connectors shipped with the platform itself.
+3. **Over MCP, no CLI** — an agent drives the whole loop through
+   `manage_connections` tool actions (see below).
+
+### The MCP loop
+
+All of these are `manage_connections` actions available to agents:
+
+1. **`validate_connector_source`** — compile-checks raw `source_code` (or a
+   `source_url`) and returns diagnostics plus the extracted actions, scopes,
+   and feed keys. Nothing is installed; this is the dry run.
+2. **`install_connector`** — installs from exactly one of `connector_id`
+   (reviewed catalog), `source_code`, `source_url`, `source_uri`, or
+   `mcp_url` (proxy an external MCP server as a connector). Org-scoped;
+   compiled code is stored in `connector_versions` with prior versions
+   retained.
+3. **`test`** — live probe of the connection's auth.
+4. **Read/sync once** — a one-shot `read_feeds` source read (or a manual sync)
+   to watch the first events land before trusting it.
+5. **Iterate** — `get_connector_source` → `update_connector_source` (each
+   update re-validates), with `rollback_connector_version` to revert.
+
+Prefer validate → install → test → read over installing blind. Two gates are
+deliberately human-only: `connection.config.action_modes` (approval overrides)
+and connector-run approvals.
 
 ## The contract
 

--- a/packages/connectors/src/README.md
+++ b/packages/connectors/src/README.md
@@ -562,7 +562,7 @@ Connectors are **not** pre-installed globally. When an org first uses a connecto
 3. Stores the metadata in `connector_definitions` scoped to that org
 4. Stores a `source_path` reference (e.g. `github.ts`) in `connector_versions` — **compiled code is NOT stored**
 
-Connectors can also be installed manually via `client.connections.installConnector(...)` from inside an `execute` script (or the equivalent admin REST endpoint), passing a `source_url` or inline `source_code`. Manual installs store compiled code in the database as before.
+Connectors can also be installed manually via `client.connections.installConnector(...)` from inside an `execute` script (or the equivalent admin REST endpoint), passing a `connector_id`, `source_url`/`source_uri`, inline `source_code`, or `mcp_url`. Manual installs store compiled code in the database as before. Agents drive the full validate → install → test → iterate loop through `manage_connections`; see `docs/connector-authoring.md` ("The MCP loop").
 
 ### How connector code runs
 


### PR DESCRIPTION
## Summary
- `docs/connector-authoring.md` documented only the CLI (`lobu apply`) and bundled-built-in authoring paths; the in-product agent loop — `validate_connector_source` (compile dry-run) → `install_connector` (from `source_code`/`mcp_url`/…) → `test` → one-shot `read_feeds` → `update_connector_source`/`rollback_connector_version` — existed only inside tool-schema descriptions and server source. An agent (or contributor) reading the docs could wrongly conclude authoring requires the CLI.
- Adds a concise "The MCP loop" section listing the actions, their order, and the two deliberately human-only gates (`action_modes`, connector-run approvals).
- Fixes the stale one-liner in `packages/connectors/src/README.md` (`installConnector` sources now include `connector_id`/`source_uri`/`mcp_url`) and points it at the new section.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + biome + naming gates)
- [ ] Docs-only change: no runtime behavior touched; no tests added
- [x] Claims verified against source: `tools/admin/manage_connections/handlers/connector-management.ts`, `auth-actions.ts`, `catalog/connector-definitions.ts` (`updateInstalledConnectorSource` recompiles/validates), `tools/connector-discovery.ts`

## Notes
Pure docs change; discovered while comparing lobu's connector surface with executor.sh's MCP gateway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded connector authoring guidance to cover three authoring surfaces, including MCP without the CLI.
  - Documented the agent-driven connector workflow: validate, install, test, read, and iterate.
  - Added supported connector installation sources, including MCP URLs and source URIs.
  - Clarified approval requirements and version retention during connector installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->