### PR TITLE
fix(mcp): require explicit targets and surface rejected calls

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/account-dispatch.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/account-dispatch.test.ts
@@ -3,7 +3,7 @@ import { initWorkspaceProvider } from '../../../workspace';
 import { getDb } from '../../../db/client';
 import type { Env } from '../../../index';
 import { type AuthContext, executeTool } from '../../../tools/execute';
-import { get, post } from '../../setup/test-helpers';
+import { get, post, mcpRequest } from '../../setup/test-helpers';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import { addUserToOrganization, createTestAccessToken, createTestSession, createTestOAuthClient, createTestOrganization, createTestUser, seedSystemEntityTypes } from '../../setup/test-fixtures';
 
@@ -73,6 +73,58 @@ describe('account MCP dispatch', () => {
     const [audit] = await getDb()`SELECT organization_id FROM events WHERE client_id=${auth.clientId} AND payload_data->>'tool_name'='query_sql' ORDER BY id DESC LIMIT 1`;
     expect(audit.organization_id).toBe(second.id);
     await expect(call('save_memory', { org_slug: second.slug, content: 'Denied target' }, { ...auth, grantedOrganizationIds: [first.id] })).rejects.toThrow(/not available/);
+  });
+
+  it('advertises required workspace targets only on account MCP and returns actionable errors', async () => {
+    const token = await createTestAccessToken(auth.userId!, null, auth.clientId!, {
+      grantedOrganizationIds: [first.id, second.id], scope: 'mcp:read mcp:write',
+    });
+    for (const orgSlug of [undefined, first.slug, undefined]) {
+      const listed = await mcpRequest('tools/list', {}, { token: token.token, orgSlug });
+      for (const [name, field] of [['save_memory', 'org_slug'], ['query_sql', 'org_slug'], ['get_approval', 'organization']]) {
+        const tool = listed.result.tools.find((item: any) => item.name === name);
+        expect(tool, name).toBeDefined();
+        // A required key absent from `properties` is an invalid schema hosts reject.
+        expect(tool.inputSchema.properties?.[field!], name).toBeDefined();
+        expect(tool.inputSchema.required?.includes(field) ?? false, name).toBe(!orgSlug);
+      }
+    }
+    const failed = await mcpRequest('tools/call', {
+      name: 'save_memory', arguments: { content: 'Synthetic untargeted note', semantic_type: 'note' },
+    }, { token: token.token });
+    expect(failed.result.isError).toBe(true);
+    expect(failed.result.content[0].text).toMatch(/workspace|org_slug/i);
+    expect(failed.result.structuredContent.error).toMatchObject({
+      code: 'VALIDATION', retryable: false, call_id: expect.any(String),
+    });
+    // An ungranted target is a denial, not malformed input: it must carry the
+    // same correlated taxonomy rather than the SDK's untranslated typed error.
+    const denied = await mcpRequest('tools/call', {
+      name: 'save_memory',
+      arguments: { org_slug: 'unavailable-synthetic-workspace', content: 'Synthetic untargeted note', semantic_type: 'note' },
+    }, { token: token.token });
+    expect(denied.result.isError).toBe(true);
+    expect(denied.result.structuredContent.error).toMatchObject({
+      code: 'PERMISSION', retryable: false, call_id: expect.any(String),
+    });
+  });
+
+  it('audits early missing, invalid, and unauthorized targets privately without saving content', async () => {
+    for (const args of [
+      { content: 'Synthetic rejected note', semantic_type: 'note' },
+      { org_slug: '', content: 'Synthetic rejected note', semantic_type: 'note' },
+      { org_slug: 'unavailable-synthetic-workspace', content: 'Synthetic rejected note', semantic_type: 'note' },
+    ]) {
+      const [before] = await getDb()`SELECT count(*)::int AS n FROM events WHERE client_id=${auth.clientId} AND origin_type='tool_invocation'`;
+      await expect(call('save_memory', args)).rejects.toThrow();
+      const [after] = await getDb()`SELECT count(*)::int AS n FROM events WHERE client_id=${auth.clientId} AND origin_type='tool_invocation'`;
+      expect(after.n).toBe(before.n + 1);
+      const [audit] = await getDb()`SELECT organization_id, created_by, payload_data FROM events WHERE client_id=${auth.clientId} AND origin_type='tool_invocation' ORDER BY id DESC LIMIT 1`;
+      expect(audit.organization_id).toBeNull();
+      expect(audit.created_by).toBe(auth.userId);
+      expect(audit.payload_data.success).toBe(false);
+      expect(JSON.stringify(audit.payload_data)).not.toContain('Synthetic rejected note');
+    }
   });
 
   it('opens actor history through the account HTTP route without inheriting a token workspace', async () => {

--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -645,6 +645,44 @@ describe('tool invocation audit coverage', () => {
     ]);
   });
 
+  it('audits a pre-handler denial under the bound org without clearing the conversation workspace', async () => {
+    // Every throw before the handler runs — role/scope denial, deployment
+    // pause, an unresolvable workspace target — now reaches the audit/activity
+    // writers. A bound connection's org is already verified by auth, so it must
+    // survive: `mcp_client_conversations.organization_id` collapses to NULL the
+    // moment an upsert arrives with a different value, and that is permanent.
+    const conversationId = 'denied-call-session';
+    const ctx = {
+      ...authCtxFor('oauth'),
+      mcpSessionId: 'denied-call-transport',
+      mcpConversationId: conversationId,
+    };
+    await executeTool('list_organizations', {}, {} as Env, ctx);
+    await expect(
+      executeTool(
+        'manage_agents',
+        { action: 'create', name: 'denied-agent' },
+        {} as Env,
+        { ...ctx, memberRole: 'member' }
+      )
+    ).rejects.toThrow();
+
+    const row = await latestAuditRow(orgId, 'manage_agents');
+    expect(row).not.toBeNull();
+    expect(row!.payload_data.success).toBe(false);
+
+    const [conversation] = await getDb()`
+      SELECT organization_id, call_count::int AS call_count, failed_count::int AS failed_count
+      FROM mcp_client_conversations
+      WHERE client_identity = ${clientId} AND conversation_id = ${conversationId}
+    `;
+    expect(conversation).toMatchObject({
+      organization_id: orgId,
+      call_count: 2,
+      failed_count: 1,
+    });
+  });
+
   it('records resolved tool failures as failed', async () => {
     // A failure the HANDLER resolves, not one the arg validator throws:
     // manage_classifiers' per-action schema now supplies `classifier_id`'s

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -389,6 +389,7 @@ function createServerForContext(
     const publicOnly = !!authCtx.organizationId && !effectiveCrossOrg && !authCtx.memberRole;
     const maxAccessLevel = resolveMaxAccessLevel(authCtx.memberRole, authCtx.scopes, effectiveCrossOrg);
     const allTools = getMcpTools({
+      requireWorkspaceTarget: !authCtx.organizationId,
       publicOnly,
       maxAccessLevel,
       adminScopeEligible: effectiveCrossOrg || isAdminOrOwnerRole(authCtx.memberRole),
@@ -908,7 +909,7 @@ async function buildSessionInstructions(authCtx: AuthContext): Promise<string | 
   const grantLine =
     `Granted workspaces: ${labels.join(', ')}. ` +
     (authCtx.directSearchFederation
-      ? 'Unqualified search searches all granted workspaces. Select each SDK target with await client.org(workspace); direct writes and SQL require an explicit target.'
+      ? 'Unqualified search searches all granted workspaces. Select each SDK target with await client.org(workspace). Pass org_slug to save_memory and query_sql, and organization to get_approval. Never infer a target from entity IDs or a previous call.'
       : 'This connection operates in its explicitly bound workspace.');
   return [base, grantLine].filter(Boolean).join('\n\n');
 }

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -5,7 +5,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { resolveCrossOrgToolContext } from '../sandbox/client-sdk';
+import { CrossOrgAccessDenied, resolveCrossOrgToolContext } from '../sandbox/client-sdk';
 import { verifiedAutomationSource } from '../automations/automation-source';
 import { runWithActingAutomation } from '../utils/acting-automation-context';
 import type { Context } from 'hono';
@@ -206,7 +206,8 @@ export function checkToolAccess(
   if (!accountScope && !authCtx.organizationId) {
     throw new ToolUserError(
       'This connection has no workspace binding. Pass the tool’s explicit workspace target (for example org_slug), or run it through await client.org(target) in query_sdk/run_sdk.',
-      400
+      400,
+      'VALIDATION'
     );
   }
   if (accountScope && !authCtx.organizationId && (!authCtx.isAuthenticated || !authCtx.userId)) {
@@ -281,31 +282,6 @@ export async function executeTool(
   env: Env,
   authCtx: AuthContext
 ): Promise<unknown> {
-  const target = toolName === 'save_memory' || toolName === 'query_sql'
-    ? args.org_slug
-    : toolName === 'get_approval' ? args.organization : undefined;
-  if (target !== undefined) {
-    if (typeof target !== 'string' || !target.trim()) throw new ToolUserError('A workspace target is required.', 400);
-    const workspace = await resolveCrossOrgToolContext(target, toAccountToolContext(authCtx));
-    authCtx = { ...authCtx, organizationId: workspace.organizationId, memberRole: workspace.memberRole };
-  }
-  const requiredAccess = checkToolAccess(toolName, args, authCtx);
-
-  // Promotions pause, enforced where config is actually mutated. `lobu apply`
-  // writes through these tools, so this is the chokepoint that binds every
-  // caller — including a CI job posting straight at the API with a PAT, which
-  // the CLI-side check never could. Read-tier calls and non-apply traffic pass
-  // through untouched, which also covers the org-agnostic tools below (they
-  // are read-tier by construction); see `assertDeploymentsNotPaused`.
-  await assertDeploymentsNotPaused({
-    organizationId: authCtx.organizationId,
-    applyId: authCtx.applyId ?? null,
-    rollbackOf: authCtx.rollbackOf ?? null,
-    isReadOnly: requiredAccess === 'read',
-  });
-
-  const tool = getTool(toolName)!;
-  const toolContext = toAccountToolContext(authCtx);
   const startTime = Date.now();
 
   // Per-invocation correlation id (lobu#2051 Item 2). Distinct from the
@@ -313,46 +289,94 @@ export async function executeTool(
   // single tool call so a failure can be traced across logs/audit/response.
   const callId = randomUUID();
 
-  // Attribute every audit row this handler writes to the Automation driving the
-  // call. Resolution mirrors the one gated writes already use
-  // (`manage_entity.ts`): the server-set reaction identity first, then the
-  // caller-declared `automation_source` for an agent or device running a
-  // window. Setting it once here rather than at each audit writer is what keeps
-  // provenance from drifting as writers are added.
-  // A declared source is caller input. Verify it against this org before it can
-  // reach `events.automation_id` — an unowned id would misattribute the audit
-  // row (and inherit that Automation's causal chain), and a nonexistent one
-  // would fail the FK and DROP the audit row entirely, since audit writes are
-  // fire-and-forget. Same rule `notify.ts` already applies to this field.
-  // Skipped whenever a trusted reaction identity is present, and skipped
-  // entirely when nothing was declared, so ordinary tool calls pay nothing.
-  const declaredSource =
-    toolContext.actingAutomationId != null || !toolContext.organizationId
-      ? null
-      : await verifiedAutomationSource(
-          declaredAutomationSource(args),
-          toolContext.organizationId
-        );
-  const runHandler = () =>
-    runWithActingAutomation(
-      {
-        automationId:
-          toolContext.actingAutomationId ?? declaredSource?.automationId,
-        // The run is the causal identity for both trusted reaction sessions and
-        // verified declarations from agent/device lanes.
-        runId: toolContext.actingRunId ?? declaredSource?.runId ?? null,
-      },
-      () =>
-        trackMCPToolCall(toolName, args, () =>
-          isAccountContentRead(toolName, authCtx)
-            ? getAccountContent(args, env, authCtx)
-            : tool.scope === 'account'
-            ? tool.handler(args, env, toolContext)
-            : tool.handler(args, env, requireWorkspaceContext(toolContext))
-        )
-    );
-
+  // Snapshot the caller's own context BEFORE any requested target is resolved,
+  // so a rejected invocation is audited against the workspace this connection
+  // was already bound to (null on bare account MCP) and never against the
+  // requested target, which may be unauthorized or nonexistent.
+  let toolContext: AccountToolContext = toAccountToolContext(authCtx);
   try {
+    const field = getTool(toolName)?.workspaceTarget;
+    const target = field ? args[field] : undefined;
+    if (target !== undefined) {
+      if (typeof target !== 'string' || !target.trim()) {
+        throw new ToolUserError(
+          `${field} must be a workspace slug or id.`,
+          400,
+          'VALIDATION'
+        );
+      }
+      const workspace = await resolveCrossOrgToolContext(
+        target,
+        toAccountToolContext(authCtx)
+      ).catch((error: unknown) => {
+        // Denial arrives as the SDK's typed error, which only the sandbox
+        // translates; at this plain tool boundary it would surface as an
+        // uncoded 400. Re-raise so REST and MCP agree on 403 plus a correlated
+        // code — the same translation `mcp_app.ts` documents for its own
+        // approval-workspace resolution.
+        if (error instanceof CrossOrgAccessDenied) {
+          throw new ToolUserError(error.message, 403, 'PERMISSION');
+        }
+        throw error;
+      });
+      authCtx = { ...authCtx, organizationId: workspace.organizationId, memberRole: workspace.memberRole };
+    }
+    const requiredAccess = checkToolAccess(toolName, args, authCtx);
+    toolContext = toAccountToolContext(authCtx);
+
+    // Promotions pause, enforced where config is actually mutated. `lobu apply`
+    // writes through these tools, so this is the chokepoint that binds every
+    // caller — including a CI job posting straight at the API with a PAT, which
+    // the CLI-side check never could. Read-tier calls and non-apply traffic pass
+    // through untouched, which also covers the org-agnostic tools below (they
+    // are read-tier by construction); see `assertDeploymentsNotPaused`.
+    await assertDeploymentsNotPaused({
+      organizationId: authCtx.organizationId,
+      applyId: authCtx.applyId ?? null,
+      rollbackOf: authCtx.rollbackOf ?? null,
+      isReadOnly: requiredAccess === 'read',
+    });
+
+    const tool = getTool(toolName)!;
+
+    // Attribute every audit row this handler writes to the Automation driving the
+    // call. Resolution mirrors the one gated writes already use
+    // (`manage_entity.ts`): the server-set reaction identity first, then the
+    // caller-declared `automation_source` for an agent or device running a
+    // window. Setting it once here rather than at each audit writer is what keeps
+    // provenance from drifting as writers are added.
+    // A declared source is caller input. Verify it against this org before it can
+    // reach `events.automation_id` — an unowned id would misattribute the audit
+    // row (and inherit that Automation's causal chain), and a nonexistent one
+    // would fail the FK and DROP the audit row entirely, since audit writes are
+    // fire-and-forget. Same rule `notify.ts` already applies to this field.
+    // Skipped whenever a trusted reaction identity is present, and skipped
+    // entirely when nothing was declared, so ordinary tool calls pay nothing.
+    const declaredSource =
+      toolContext.actingAutomationId != null || !toolContext.organizationId
+        ? null
+        : await verifiedAutomationSource(
+            declaredAutomationSource(args),
+            toolContext.organizationId
+          );
+    const runHandler = () =>
+      runWithActingAutomation(
+        {
+          automationId:
+            toolContext.actingAutomationId ?? declaredSource?.automationId,
+          // The run is the causal identity for both trusted reaction sessions and
+          // verified declarations from agent/device lanes.
+          runId: toolContext.actingRunId ?? declaredSource?.runId ?? null,
+        },
+        () =>
+          trackMCPToolCall(toolName, args, () =>
+            isAccountContentRead(toolName, authCtx)
+              ? getAccountContent(args, env, authCtx)
+              : tool.scope === 'account'
+              ? tool.handler(args, env, toolContext)
+              : tool.handler(args, env, requireWorkspaceContext(toolContext))
+          )
+      );
     // Auto-retry (lobu#2051 Item 2): only transient thrown ToolErrors, and only
     // for read/test tools on the allowlist. Mutations and run_sdk are never
     // retried here — re-running them could double-write. Resolved failures from

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -189,6 +189,8 @@ interface ToolDefinitionMetadata {
   name: string;
   description: string;
   inputSchema: any; // JSON Schema
+  /** Explicit workspace selector shared by discovery and dispatch. */
+  workspaceTarget?: string;
   /**
    * Narrower schema advertised on `tools/list` when the tool accepts fields
    * that are server-internal (e.g. pre-computed embeddings, identity-bound
@@ -300,6 +302,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'save_memory',
+    workspaceTarget: 'org_slug',
     description:
       'Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The returned id is immediately readable with `client.knowledge.read`; the result also echoes the bounded saved payload for inline display. Semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Use a stable `idempotency_key` when a write may be retried. Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.',
     inputSchema: SaveMemorySchema,
@@ -340,6 +343,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
   },
   {
     name: 'query_sql',
+    workspaceTarget: 'org_slug',
     description:
       'Run a paginated, sortable, searchable read-only SQL query (member-safe). Table references auto-scope to the bound org, or pass `connection` to push read-only SQL fully into an external database connector. Source-backed feeds are queried explicitly with query_sdk client.feeds.readMany. Prefer client.metrics.query for declared measures; use client.query in query_sdk for simple one-shot SQL. Do NOT use positional parameters ($1, $2, …). `org_slug` selects a granted workspace on bare OAuth /mcp and is required when the connection has no workspace binding. The query does not change workspace content or external systems, but Lobu appends a private audit/activity record for the invocation.',
     inputSchema: QuerySqlSchema,
@@ -377,6 +381,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
 const MCP_APP_TOOLS: ToolDefinition[] = [
   {
     name: 'get_approval',
+    workspaceTarget: 'organization',
     scope: 'account',
     description:
       'Get the server-authored review card for one approval run returned by a pending action. On an unscoped OAuth session, pass organization with the target workspace slug or id. The card reads the canonical durable approval, exposes in-card controls only when this OAuth app context can resolve it, and always includes a review link while pending. Reading does not change workspace content or external systems. OAuth and PAT calls append a private audit/activity record.',
@@ -689,6 +694,8 @@ function filterSchemaForAccessLevel(
 const listedToolsCache = new Map<string, ReturnType<typeof computeListedTools>>();
 
 type ListedToolOptions = {
+  /** Bare account MCP has no implicit target. */
+  requireWorkspaceTarget?: boolean;
   publicOnly?: boolean;
   maxAccessLevel?: 'read' | 'write' | 'admin';
   /**
@@ -703,7 +710,21 @@ type ListedToolOptions = {
  * Agent-facing tools for MCP `tools/list` and external OpenAPI.
  */
 export function getMcpTools(options?: ListedToolOptions) {
-  return getListedTools(ALL_MCP_TOOLS, options);
+  const tools = getListedTools(ALL_MCP_TOOLS, options);
+  if (!options?.requireWorkspaceTarget) return tools;
+  // Never mutate cached schemas: a bound connection may list immediately after
+  // an account connection in the same process.
+  return tools.map((tool) => {
+    const field = getTool(tool.name)?.workspaceTarget;
+    if (!field) return tool;
+    return {
+      ...tool,
+      inputSchema: {
+        ...tool.inputSchema,
+        required: [...new Set([...(tool.inputSchema.required ?? []), field])],
+      },
+    };
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

An unscoped MCP connection could call `save_memory` without a workspace because discovery advertised the selector as optional. The server rejected it before audit recording, and the embedded card ignored ordinary tool errors, leaving “Loading…” indefinitely.

- Require `org_slug` for `save_memory`/`query_sql` and `organization` for `get_approval` in bare-account MCP discovery. Explicitly bound connections retain optional overrides; no default workspace or inference from entity IDs is introduced.
- Audit pre-handler rejections and retain typed validation/permission errors with call IDs. Preserve the caller's verified workspace association and keep denied target data private.
- Pin Owletto #1041: show initial errors, cancellation, connection failure, and bounded missing-result/action notices; retain late authoritative results, explicit approval targets, and safe mutation reconciliation.

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` and pre-commit checks passed.
- [x] Focused tests and broad independent review tests passed (details below).
- [x] Red → green reproduced on server and frontend.
- [x] GitHub CI full graph and exact-head semantic gate.

Red evidence: server regression tests initially had 2 failures; initial widget failure/timeout coverage had 3 failures. The final readiness and stalled follow-up/link tests had 4 failures before their fix.

Green evidence: frontend MCP suite 206 passed across 9 files; TypeScript and production MCP bundle checks passed. Independent fixer additionally ran 477 server MCP/tools/SDK integration tests and 1,460 unit tests, and mutation-proved both the conversation-association and permission-error guards.

## Notes

[Actual browser comparison](https://gist.githack.com/buremba/cb099b8aeda5ad80b2cabcbc82844ffc/raw/5ee43c91935fcd3a8aa5335ff5b4965bf0ba0571/mcp-failure-proof.html): deployed versus changed interaction bundles receiving identical synthetic host events. Captures show workspace error, missing result after 30 seconds, and late success recovery. No live tool writes, private workspace data, or credentials were used. This is browser rendering proof with a synthetic host; post-rollout checks remain separate.

CI also exposed a pre-existing 20 ms wall-clock race in the Chrome scraper deadline test. The test now drives the same deadline with fake timers, restored in finally. The 168 Chrome tool tests pass together with the 206 MCP app tests (374 total); no Chrome runtime changed.

Final recovery checks: empty/partial/rejected approval refreshes show a warning over cached data, and cached replays do not clear it. Viewer-role updates survive rejected refreshes. Connection, link, and approval notices clear when their own condition resolves; unrelated failures remain visible. Five targeted regression checks reproduced failures before this correction; the settled MCP + Chrome suite has 374 passing tests.

Action-specific regression coverage also proves that a different action or link succeeding cannot clear the original failure, while the same action succeeding does. A terminal approval clears its stale-refresh notice. Four assertions failed before this correction, then the complete 374-test MCP + Chrome suite passed.

Final parent head `6f142310495803d9609a6adf0818fd8cacb5fc6a`: all required CI contexts green; independent Opus gate passed with 0 bugs, 0 blockers, and adequate tests (88/100 confidence). Owletto content review also passed with 0 bugs and 0 blockers (93/100). The parent merge preserves upstream #3440 and pins Owletto squash `a213d581ab9df91abe7022078afde8ddc4a4cc3c`.
