### PR TITLE
test(server): lock the browser group-title contract the extension enforces

### DIFF
--- a/packages/server/src/__tests__/unit/browser-action-context.test.ts
+++ b/packages/server/src/__tests__/unit/browser-action-context.test.ts
@@ -3,6 +3,7 @@ import {
   browserActionContextFromMetadata,
   deriveBrowserActionContext,
   deriveSdkBrowserActionContext,
+  runScopedBrowserActionContext,
   trustedChromeActionInput,
 } from '../../worker-api/browser-action-context';
 import type { ToolContext } from '../../tools/registry';
@@ -201,19 +202,26 @@ describe('SDK browser invocation', () => {
   });
 });
 
-// The Chrome extension enforces its own prefix and 64-code-point bound on every
-// group title it writes (packages/owletto/apps/chrome/tab-groups.js titleFor).
-// A server title that trips either one silently renders differently from what
-// this file says, so lock the shared shape here rather than discovering it in a
-// browser. Mirrors the extension's rule; it is not imported (separate runtime).
-const EXTENSION_TITLE_PREFIX = 'Lobu';
+// The extension normalizes titles outside this shape. Keep every fixed server
+// fallback within its pass-through contract; user-supplied subjects are
+// bounded by the extension.
+const EXTENSION_TITLE_PREFIX = 'Lobu · ';
 const EXTENSION_MAX_TITLE_POINTS = 64;
 
-describe('titles survive the extension title contract', () => {
+describe('extension title pass-through contract', () => {
   const titles = [
+    runScopedBrowserActionContext(Number.MAX_SAFE_INTEGER).title,
+    deriveSdkBrowserActionContext(
+      context({
+        sdkBrowserInvocation: { nonce: 'synthetic-default-title', title: '' },
+      })
+    )!.title,
     deriveBrowserActionContext(
-      context({ actingAutomationId: 12, actingRunId: 4821 })
-    )?.title,
+      context({
+        actingAutomationId: Number.MAX_SAFE_INTEGER,
+        actingRunId: Number.MAX_SAFE_INTEGER,
+      })
+    )!.title,
     deriveBrowserActionContext(
       context({
         sourceContext: {
@@ -222,20 +230,21 @@ describe('titles survive the extension title contract', () => {
           channelId: 'chan_1',
           conversationId: 'conv_1',
         },
-      } as Partial<ToolContext>)
-    )?.title,
+      })
+    )!.title,
+    deriveBrowserActionContext(
+      context({
+        tokenType: 'oauth',
+        clientId: 'synthetic-client',
+        mcpSessionId: 'synthetic-session',
+      })
+    )!.title,
   ];
 
-  it('prefixes every derived title so the extension keeps it verbatim', () => {
+  it('keeps fixed server titles unchanged by the extension', () => {
     for (const title of titles) {
-      expect(title).toBeTruthy();
-      expect(title?.startsWith(EXTENSION_TITLE_PREFIX)).toBe(true);
-    }
-  });
-
-  it('keeps derived titles inside the extension code-point bound', () => {
-    for (const title of titles) {
-      expect([...(title ?? '')].length).toBeLessThanOrEqual(
+      expect(title).toStartWith(EXTENSION_TITLE_PREFIX);
+      expect([...title].length).toBeLessThanOrEqual(
         EXTENSION_MAX_TITLE_POINTS
       );
     }

--- a/packages/server/src/__tests__/unit/browser-action-context.test.ts
+++ b/packages/server/src/__tests__/unit/browser-action-context.test.ts
@@ -200,3 +200,44 @@ describe('SDK browser invocation', () => {
     });
   });
 });
+
+// The Chrome extension enforces its own prefix and 64-code-point bound on every
+// group title it writes (packages/owletto/apps/chrome/tab-groups.js titleFor).
+// A server title that trips either one silently renders differently from what
+// this file says, so lock the shared shape here rather than discovering it in a
+// browser. Mirrors the extension's rule; it is not imported (separate runtime).
+const EXTENSION_TITLE_PREFIX = 'Lobu';
+const EXTENSION_MAX_TITLE_POINTS = 64;
+
+describe('titles survive the extension title contract', () => {
+  const titles = [
+    deriveBrowserActionContext(
+      context({ actingAutomationId: 12, actingRunId: 4821 })
+    )?.title,
+    deriveBrowserActionContext(
+      context({
+        sourceContext: {
+          platform: 'slack',
+          connectionId: 'conn_1',
+          channelId: 'chan_1',
+          conversationId: 'conv_1',
+        },
+      } as Partial<ToolContext>)
+    )?.title,
+  ];
+
+  it('prefixes every derived title so the extension keeps it verbatim', () => {
+    for (const title of titles) {
+      expect(title).toBeTruthy();
+      expect(title?.startsWith(EXTENSION_TITLE_PREFIX)).toBe(true);
+    }
+  });
+
+  it('keeps derived titles inside the extension code-point bound', () => {
+    for (const title of titles) {
+      expect([...(title ?? '')].length).toBeLessThanOrEqual(
+        EXTENSION_MAX_TITLE_POINTS
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Bumps the `packages/owletto` pointer to lobu-ai/owletto#1042, which makes the Chrome tab-group color a kind legend and enforces the group-title prefix + length bound where titles are written.
- Adds a server-side test locking the title shape the extension now enforces. The two live in separate runtimes, so the extension's bound cannot be imported — a server title that trips it would render differently from what `browser-action-context.ts` says, and nothing here would catch it.

Titles are derived in `deriveBrowserActionContext` / `runScopedBrowserActionContext`, persisted to `runs.run_metadata.browser_context`, and force-injected on every poll by `trustedChromeActionInput` (`poll.ts:1759`). All four kinds — automation, conversation, mcp, run — pass through the extension unchanged; the test pins that.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (local fallback; GitHub CI is the gate)
- [x] Tests run: targeted `bun test src/__tests__/unit/browser-action-context.test.ts`
- [ ] Bug fix: red→fix→green outputs pasted below — n/a, this side is a test + pointer bump; the red→green is in lobu-ai/owletto#1042
- [ ] If bot runtime changed: n/a

```
$ bun test src/__tests__/unit/browser-action-context.test.ts
 12 pass
 0 fail
 37 expect() calls
```

```
$ make pre-pr
✅ pre-pr gates clean.
```

## Notes
Companion PR: lobu-ai/owletto#1042 (must land first — this bumps the pointer to it).

Chrome offers no tab-group icon, so title + a nine-value color enum is the entire visual vocabulary; that's why both are worth pinning.

Not verified: no live-Chrome run on either side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation for browser-action titles to ensure they meet Chrome extension requirements, including the required prefix and maximum length.
  * Expanded coverage across automation and Slack conversation contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->