### PR TITLE
fix(mcp): align OAuth scopes and submission metadata

### DIFF
--- a/examples/lobu-team/lobu.config.ts
+++ b/examples/lobu-team/lobu.config.ts
@@ -275,7 +275,7 @@ const productOps = defineAgent({
     // Keep the headless lockdown (no native worker tools) and pre-approve the
     // one MCP write the Automation needs: run_sdk carries completeWindow, is not
     // read-only, and would otherwise stall an unattended run on an approval
-    // card. query_sdk is readOnlyHint and needs no grant.
+    // card. query_sdk is non-destructive and needs no grant.
     allowed: [],
     strict: true,
     preApproved: ["/mcp/lobu-memory/tools/run_sdk"],

--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -120,7 +120,7 @@ describe('MCP Authentication', () => {
 
       expect(response.status).toBe(401);
       expect(response.headers.get('WWW-Authenticate')).toBe(
-        'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/mcp", scope="mcp:read mcp:write"'
+        'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/mcp", scope="mcp:read mcp:write profile:read"'
       );
     });
 
@@ -536,7 +536,7 @@ describe('MCP Authentication', () => {
       });
       expect(response.status).toBe(401);
       expect(response.headers.get('WWW-Authenticate')).toBe(
-        `Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/mcp/${org2.slug}", scope="mcp:read mcp:write", error="invalid_token"`
+        `Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/mcp/${org2.slug}", scope="mcp:read mcp:write profile:read", error="invalid_token"`
       );
     });
 
@@ -1995,7 +1995,7 @@ describe('MCP Authentication', () => {
       const listed = await mcpListTools({ token, orgSlug: roleOrg.slug });
       const runSdk = listed.tools.find((tool: any) => tool.name === 'run_sdk');
       expect(runSdk?.securitySchemes).toEqual([
-        { type: 'oauth2', scopes: ['mcp:write', 'mcp:admin'] },
+        { type: 'oauth2', scopes: ['mcp:write', 'mcp:admin', 'profile:read'] },
       ]);
       expect(runSdk?._meta?.securitySchemes).toEqual(runSdk?.securitySchemes);
 
@@ -2028,7 +2028,7 @@ describe('MCP Authentication', () => {
         { path: 'connections.installConnector', access: 'admin', count: 1 },
       ]);
       expect(challenge).toContain('error="insufficient_scope"');
-      expect(challenge).toContain('scope="mcp:read mcp:write mcp:admin"');
+      expect(challenge).toContain('scope="mcp:read mcp:write mcp:admin profile:read"');
     });
 
     it('does not challenge when an owner catches a nested admin denial and run_sdk succeeds', async () => {
@@ -2109,7 +2109,7 @@ describe('MCP Authentication', () => {
       const listed = await mcpListTools({ token, orgSlug: roleOrg.slug });
       const runSdk = listed.tools.find((tool: any) => tool.name === 'run_sdk');
       expect(runSdk?.securitySchemes).toEqual([
-        { type: 'oauth2', scopes: ['mcp:write'] },
+        { type: 'oauth2', scopes: ['mcp:write', 'profile:read'] },
       ]);
 
       const discovery = await mcpToolsCall(
@@ -2206,7 +2206,9 @@ describe('MCP Authentication', () => {
       expect(toolNames).not.toContain('join_organization');
 
       const runSdk = (result.tools as any[]).find((tool) => tool.name === 'run_sdk');
-      expect(runSdk?.securitySchemes).toEqual([{ type: 'oauth2', scopes: ['mcp:write'] }]);
+      expect(runSdk?.securitySchemes).toEqual([
+        { type: 'oauth2', scopes: ['mcp:write', 'profile:read'] },
+      ]);
     });
 
     it('lists Automations through the consolidated internal admin tool', async () => {

--- a/packages/server/src/__tests__/integration/mcp/bare-oauth-federated-search-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/bare-oauth-federated-search-e2e.test.ts
@@ -1,6 +1,7 @@
 /**
  * Bare-OAuth federated search, through the real local wire:
- * DCR -> explicit PKCE consent -> token exchange -> `/mcp` initialize/call.
+ * DCR -> explicit PKCE consent -> token exchange -> `/oauth/userinfo` ->
+ * `/mcp` initialize/call.
  *
  * The only direct database mutation after setup is membership revocation,
  * which proves an already-established MCP session revalidates live membership
@@ -12,6 +13,7 @@ import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { createAuthorizationIntent } from '../../../auth/oauth/authorization-intent';
 import { hashToken } from '../../../auth/oauth/utils';
 import { parsePgTextArray } from '../../../db/client';
+import { getMcpTools } from '../../../tools/registry';
 import { initWorkspaceProvider } from '../../../workspace';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import {
@@ -21,7 +23,7 @@ import {
   createTestSession,
   createTestUser,
 } from '../../setup/test-fixtures';
-import { mcpToolsCall, post } from '../../setup/test-helpers';
+import { get, mcpToolsCall, post } from '../../setup/test-helpers';
 
 const ORIGIN = 'http://localhost';
 const SEARCH_NAME = 'Bare OAuth Federated Needle';
@@ -88,13 +90,20 @@ describe('bare OAuth /mcp federated search end to end', () => {
     expect(registration.status).toBe(201);
     const { client_id: clientId } = (await registration.json()) as { client_id: string };
 
+    // Request exactly what the published tool metadata advertises, as an MCP
+    // host does. Hardcoding the scope here would still pass if that metadata
+    // stopped asking for identity, which is the failure this covers.
+    const searchTool = getMcpTools().find((tool) => tool.name === 'search_memory');
+    const scope = (searchTool?.securitySchemes?.[0]?.scopes ?? []).join(' ');
+    expect(scope).toContain('mcp:read');
+
     const verifier = randomBytes(32).toString('base64url');
     const challenge = createHash('sha256').update(verifier).digest('base64url');
     const consent = await post('/oauth/authorize/consent', {
       body: {
         client_id: clientId,
         redirect_uri: redirectUri,
-        scope: 'mcp:read profile:read',
+        scope,
         code_challenge: challenge,
         code_challenge_method: 'S256',
         resource,
@@ -105,7 +114,7 @@ describe('bare OAuth /mcp federated search end to end', () => {
             client_id: clientId,
             redirect_uri: redirectUri,
             response_type: 'code',
-            scope: 'mcp:read profile:read',
+            scope,
             code_challenge: challenge,
             code_challenge_method: 'S256',
             resource,
@@ -135,10 +144,32 @@ describe('bare OAuth /mcp federated search end to end', () => {
       env: MULTI_GRANT_ENV,
     });
     expect(tokenResponse.status).toBe(200);
-    const { access_token: accessToken } = (await tokenResponse.json()) as {
-      access_token: string;
-    };
+    const { access_token: accessToken, refresh_token: refreshToken } =
+      (await tokenResponse.json()) as { access_token: string; refresh_token: string };
     expect(accessToken).toBeTruthy();
+
+    // The metadata-derived scope must actually unlock the identity call a host
+    // makes before it initializes MCP.
+    const identity = await get('/oauth/userinfo', { token: accessToken });
+    expect(identity.status).toBe(200);
+    expect(((await identity.json()) as { sub: string }).sub).toBe(user.id);
+
+    // Advertising `profile:read` only shapes the REQUEST: a token refreshed
+    // without it loses identity access instead of being silently widened.
+    const withoutIdentity = await post('/oauth/token', {
+      body: {
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: clientId,
+        resource,
+        scope: 'mcp:read',
+      },
+      env: MULTI_GRANT_ENV,
+    });
+    expect(withoutIdentity.status).toBe(200);
+    const mcpOnly = (await withoutIdentity.json()) as { access_token: string; scope: string };
+    expect(mcpOnly.scope).toBe('mcp:read');
+    expect((await get('/oauth/userinfo', { token: mcpOnly.access_token })).status).toBe(403);
 
     const tokenRows = await sql`
       SELECT organization_id, granted_organization_ids

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -484,7 +484,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(tool).toEqual(
       expect.objectContaining({
         annotations: expect.objectContaining({
-          readOnlyHint: true,
+          readOnlyHint: false,
           destructiveHint: false,
           openWorldHint: false,
           idempotentHint: false,

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -489,9 +489,9 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
           openWorldHint: false,
           idempotentHint: false,
         }),
-        securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
+        securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read', 'profile:read'] }],
         _meta: expect.objectContaining({
-          securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
+          securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read', 'profile:read'] }],
           ui: expect.objectContaining({
             resourceUri: 'ui://lobu/interaction/v44.html',
             visibility: ['model', 'app'],
@@ -507,9 +507,9 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(saveMemory).toEqual(
       expect.objectContaining({
-        securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write'] }],
+        securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write', 'profile:read'] }],
         _meta: expect.objectContaining({
-          securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write'] }],
+          securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write', 'profile:read'] }],
           ui: expect.objectContaining({
             resourceUri: 'ui://lobu/interaction/v44.html',
             visibility: ['model', 'app'],
@@ -551,7 +551,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
           idempotentHint: false,
         }),
         outputSchema: expect.objectContaining({ type: 'object' }),
-        securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write'] }],
+        securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write', 'profile:read'] }],
         _meta: expect.objectContaining({
           ui: {
             visibility: ['app'],
@@ -2454,7 +2454,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       `resource_metadata="https://mcp.public.example/.well-known/oauth-protected-resource/mcp/${org.slug}"`
     );
     expect(challenge).toContain('error="insufficient_scope"');
-    expect(challenge).toContain('scope="mcp:read"');
+    expect(challenge).toContain('scope="mcp:read profile:read"');
     expect(challenge).not.toContain('internal.service');
   });
 
@@ -2488,7 +2488,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     const challenge = body.result?._meta?.['mcp/www_authenticate']?.[0];
     expect(body.result?.isError).toBe(true);
     expect(challenge).toContain('error="insufficient_scope"');
-    expect(challenge).toContain('scope="mcp:read"');
+    expect(challenge).toContain('scope="mcp:read profile:read"');
     expect(body.result?._meta?.['lobu/member-role']).toBe('owner');
   });
 

--- a/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
@@ -60,15 +60,17 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
     expect(byName.has('execute')).toBe(false);
 
     const expectedSafetyHints = {
-      // Invocation audits are server bookkeeping, not mutations performed by
-      // these retrieval tools against workspace or external state.
-      search_memory: [true, false, false],
-      search_sdk: [true, false, false],
-      query_sdk: [true, false, false],
-      query_sql: [true, false, false],
+      // The retrieval tools mutate nothing in the workspace or in an external
+      // system, but every invocation appends an audit/activity record, so they
+      // are not `readOnlyHint`. Read ACCESS is pinned separately by
+      // `authorizationReadOnly` (see tool-registry-split.test.ts).
+      search_memory: [false, false, false],
+      search_sdk: [false, false, false],
+      query_sdk: [false, false, false],
+      query_sql: [false, false, false],
       save_memory: [false, false, false],
       run_sdk: [false, true, true],
-      get_approval: [true, false, false],
+      get_approval: [false, false, false],
     } as const;
 
     for (const [toolName, [readOnlyHint, openWorldHint, destructiveHint]] of Object.entries(

--- a/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
@@ -47,7 +47,7 @@ describe('MCP OAuth resource indicators', () => {
       'https://app.lobu.ai/.well-known/oauth-protected-resource/mcp/acme'
     );
     expect(buildMcpBearerChallenge(requestUrl, 'invalid_token')).toBe(
-      'Bearer resource_metadata="https://app.lobu.ai/.well-known/oauth-protected-resource/mcp/acme", scope="mcp:read mcp:write", error="invalid_token"'
+      'Bearer resource_metadata="https://app.lobu.ai/.well-known/oauth-protected-resource/mcp/acme", scope="mcp:read mcp:write profile:read", error="invalid_token"'
     );
   });
 
@@ -59,7 +59,7 @@ describe('MCP OAuth resource indicators', () => {
         scope: 'mcp:admin',
       })
     ).toBe(
-      'Bearer resource_metadata="https://app.lobu.ai/.well-known/oauth-protected-resource/mcp/acme", scope="mcp:admin", error="insufficient_scope", error_description="Expired \\"access\\" \\\\ token"'
+      'Bearer resource_metadata="https://app.lobu.ai/.well-known/oauth-protected-resource/mcp/acme", scope="mcp:admin profile:read", error="insufficient_scope", error_description="Expired \\"access\\" \\\\ token"'
     );
   });
 

--- a/packages/server/src/__tests__/unit/tool-registry-split.test.ts
+++ b/packages/server/src/__tests__/unit/tool-registry-split.test.ts
@@ -9,6 +9,7 @@ import {
 	getAllTools,
 	getMcpTools,
 	getTool,
+	isAuthorizationReadOnly,
 	isInternalDispatchTool,
 	isRestDispatchTool,
 } from "../../tools/registry";
@@ -88,6 +89,19 @@ describe("tool registry split", () => {
 		expect(isRestDispatchTool("get_approval")).toBe(false);
 		expect(isRestDispatchTool("resolve_approval")).toBe(false);
 		expect(isRestDispatchTool("manage_connections")).toBe(true);
+	});
+
+	it("discloses audit writes without requiring write access for data reads", () => {
+		const listed = getMcpTools({ maxAccessLevel: "read" });
+		for (const name of ["search_memory", "search_sdk", "query_sdk", "query_sql", "get_approval"]) {
+			const tool = listed.find((entry) => entry.name === name);
+			expect(tool).toBeDefined();
+			expect(tool?.annotations?.readOnlyHint).toBe(false);
+			expect(isAuthorizationReadOnly(getTool(name))).toBe(true);
+			expect(tool?.securitySchemes).toEqual([
+				{ type: "oauth2", scopes: ["mcp:read", "profile:read"] },
+			]);
+		}
 	});
 
 	it("advertises identity permission on every scoped tool", () => {

--- a/packages/server/src/__tests__/unit/tool-registry-split.test.ts
+++ b/packages/server/src/__tests__/unit/tool-registry-split.test.ts
@@ -90,6 +90,16 @@ describe("tool registry split", () => {
 		expect(isRestDispatchTool("manage_connections")).toBe(true);
 	});
 
+	it("advertises identity permission on every scoped tool", () => {
+		const scoped = getMcpTools().filter((tool) => tool.securitySchemes);
+		expect(scoped.length).toBeGreaterThan(0);
+		for (const tool of scoped) {
+			for (const scheme of tool.securitySchemes ?? []) {
+				expect(scheme.scopes).toContain("profile:read");
+			}
+		}
+	});
+
 	it("advertises progressive admin scope only to role-eligible MCP sessions", () => {
 		const eligibleRun = getMcpTools({
 			maxAccessLevel: "write",
@@ -101,10 +111,10 @@ describe("tool registry split", () => {
 		}).find((tool) => tool.name === "run_sdk");
 
 		expect(eligibleRun?.securitySchemes).toEqual([
-			{ type: "oauth2", scopes: ["mcp:write", "mcp:admin"] },
+			{ type: "oauth2", scopes: ["mcp:write", "mcp:admin", "profile:read"] },
 		]);
 		expect(memberRun?.securitySchemes).toEqual([
-			{ type: "oauth2", scopes: ["mcp:write"] },
+			{ type: "oauth2", scopes: ["mcp:write", "profile:read"] },
 		]);
 	});
 

--- a/packages/server/src/auth/oauth/resource-indicator.ts
+++ b/packages/server/src/auth/oauth/resource-indicator.ts
@@ -11,7 +11,7 @@ import {
   getConfiguredSubdomainZone,
 } from '../../utils/public-origin';
 import { resolveBaseUrl, safeParseUrl } from '../base-url';
-import { DEFAULT_SCOPES_STRING } from './scopes';
+import { DEFAULT_SCOPES_STRING, getMcpConnectionScopes } from './scopes';
 
 /**
  * The request URL as the client sees it: the serving/forwarded origin when it
@@ -181,9 +181,12 @@ export function buildMcpBearerChallenge(
 ): string {
   const options: McpBearerChallengeOptions =
     typeof errorOrOptions === 'string' ? { error: errorOrOptions } : (errorOrOptions ?? {});
+  const scopes = getMcpConnectionScopes(
+    (options.scope ?? DEFAULT_SCOPES_STRING).split(/\s+/).filter(Boolean)
+  );
   const params = [
     `resource_metadata=${quoteChallengeValue(getProtectedResourceMetadataUrl(requestUrl))}`,
-    `scope=${quoteChallengeValue(options.scope ?? DEFAULT_SCOPES_STRING)}`,
+    `scope=${quoteChallengeValue(scopes.join(' '))}`,
   ];
   if (options.error) params.push(`error=${quoteChallengeValue(options.error)}`);
   if (options.errorDescription) {

--- a/packages/server/src/auth/oauth/scopes.ts
+++ b/packages/server/src/auth/oauth/scopes.ts
@@ -87,6 +87,22 @@ export const AVAILABLE_PAT_SCOPES = [
  */
 export const CONNECTIONS_TOKEN_SCOPE = 'connections:token';
 
+/**
+ * The scopes an MCP host should ask for when it connects.
+ *
+ * A host may call /oauth/userinfo before it initializes MCP, so identity has
+ * to ride the connection request. Not every host builds that request from
+ * discovery — some ask only for what the resource states it needs — so
+ * `profile:read` is advertised on the bearer challenge and on published tool
+ * metadata too, not just in `scopes_supported`.
+ *
+ * This shapes the REQUEST only: consent and issuance still grant exactly the
+ * permissions that were explicitly requested, and no existing token is widened.
+ */
+export function getMcpConnectionScopes(scopes: readonly string[]): string[] {
+  return [...new Set([...scopes, 'profile:read'])];
+}
+
 /** Default scopes as a space-separated string (for OAuth params) */
 export const DEFAULT_SCOPES_STRING = DEFAULT_SCOPES.join(' ');
 

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -21,6 +21,7 @@
 
 import { SaveContentSchema } from '@lobu/core/contracts/tools/save-memory';
 import { type Static, Type } from '@sinclair/typebox';
+import { getMcpConnectionScopes } from '../auth/oauth/scopes';
 import { getPublicReadableActions, getRequiredAccessLevel } from '../auth/tool-access';
 import type { Env } from '../index';
 import { LOBU_INTERACTION_RESOURCE_URI } from '../mcp-app-resource-uris';
@@ -844,7 +845,9 @@ function computeListedTools(
         inputSchema,
         ...(tool.annotations && { annotations: tool.annotations }),
         ...(securityScopes && {
-          securitySchemes: [{ type: 'oauth2' as const, scopes: securityScopes }],
+          securitySchemes: [
+            { type: 'oauth2' as const, scopes: getMcpConnectionScopes(securityScopes) },
+          ],
         }),
         ...(tool.mcpMeta && { _meta: tool.mcpMeta }),
         // outputSchema keeps its discriminated variants (no flattening, no

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -238,11 +238,13 @@ const READ_ONLY = {
 // CHANGE public internet or third-party state. Live reads from a user's private
 // connectors remain closed-world even though they contact an external service.
 //
-// These tools only retrieve data. Their invocation audit is server bookkeeping,
-// not an operation on workspace or third-party state, so it does not make the
-// tool a write. Authorization stays separately pinned by `authorizationReadOnly`.
+// These operations retrieve data, but every OAuth and PAT invocation appends an
+// audit/activity record, and `readOnlyHint` asserts the tool "does not modify
+// its environment" — that append does, so the hint cannot be claimed. Access
+// enforcement stays separate through `authorizationReadOnly`, so a read grant
+// still invokes these tools while the SDK keeps rejecting data writes.
 const AUDITED_READ = {
-  readOnlyHint: true,
+  readOnlyHint: false,
   destructiveHint: false,
   openWorldHint: false,
   idempotentHint: false,


### PR DESCRIPTION
## Summary
ChatGPT completed OAuth token exchange but failed its next `/oauth/userinfo` request because published tool metadata and authentication challenges omitted the required `profile:read` scope. Include that permission in every OAuth tool scheme and MCP bearer challenge, while preserving explicit consent, exact token scopes, and workspace isolation.

The submission audit also found five retrieval tools advertising `readOnlyHint: true` despite writing audit/activity records. Mark those tools non-read-only under the submission rules, retain their independent read-only authorization classification, and correct the affected tests and example comment. No token is silently widened and no read grant gains write access.

## Validation
- [x] OAuth regression derives its requested scopes from published tool metadata and reproduces the original failure before the fix:
  ```text
  AssertionError: expected 403 to be 200
  expect(identity.status).toBe(200)
  ```
- [x] Annotation regression fails before the correction:
  ```text
  Expected: false
  Received: true
  tool.annotations.readOnlyHint
  ```
- [x] Focused tests after both fixes: 47 unit tests passed; 112 integration tests passed, with 2 existing skips.
- [x] Independent reviewer expanded verification: all 20 MCP integration suites (235 passed, 2 skipped), all 9 OAuth suites (55 passed), and 91 registry/resource/access unit tests passed.
- [x] Production preflight with explicit identity scope passed reviewer sign-in, PKCE exchange, workspace-scoped userinfo, MCP discovery, all five reviewer tool flows, save replay, and refresh. The final metadata assertion reproduced the old deployment's missing scope. All probe tokens were revoked; the dry-run note was not persisted.
- [x] Independent fixer reviews completed; driving agent inspected edits.
- [x] Final pre-PR checks, full GitHub CI, exact-head semantic review (0 bugs/blockers), and UI applicability gate passed.
- [x] Merged as `ed0abd181ded1039a60fe2fea812b501dc9a6578`; exact-SHA production smoke passed 8/8.
- [x] Deployed reviewer regression passed sign-in, DCR, PKCE, userinfo, every supplied tool flow, save replay, token refresh, and live tool scopes/annotations. All 8 probe tokens are revoked and the dry-run note count remains zero.

## Release notes
Refresh the submission's OAuth defaults and always-requested scopes, rescan tools after deployment, and import matching annotations/test instructions. Hosts holding older grants without `profile:read` may request reconnect/consent after refreshing metadata. Post-deployment verification passed. The OpenAI draft has corrected identity scopes and test cases; its browser OAuth handoff requests the correct scopes. The final OpenAI scan/import and submission remain pending user consent for the browser demo-workspace grant.

Annotation interpretation: https://developers.openai.com/plugins/deploy/app-review (writing logs counts as state-changing behavior).
