### PR TITLE
feat(server): group standalone browser actions instead of one group per run

### DIFF
--- a/packages/server/src/__tests__/integration/browser-affinity-poll-claim.test.ts
+++ b/packages/server/src/__tests__/integration/browser-affinity-poll-claim.test.ts
@@ -558,7 +558,20 @@ describe('browser-affinity poll claim', () => {
   // ten groups. Helper-level coverage cannot see the poll wiring that decides
   // this, which is the only place the fallback chain is actually exercised.
   it('gives unparented chrome actions a shared standalone context with per-run flows', async () => {
-    const { orgId, userId, workerId, deviceWorkerId } = await seedWorker();
+    const { userId, orgId } = await seedOrg();
+    await createTestConnectorDefinition({
+      key: 'chrome',
+      name: 'Chrome',
+      organization_id: orgId,
+    });
+    const sql = getTestDb();
+    await sql`
+      UPDATE connector_versions
+      SET compiled_code = 'export class ConnectorRuntime {}',
+          compile_config_hash = ${COMPILE_CONFIG_HASH}
+      WHERE connector_key = 'chrome'
+    `;
+    const { deviceWorkerId, workerId } = await seedExtWorker(userId, orgId);
     const connId = await seedConnection({
       orgId,
       userId,
@@ -566,6 +579,8 @@ describe('browser-affinity poll claim', () => {
       deviceWorkerId,
     });
 
+    // No runMetadata and no parent run: the SDK shape the fallback chain
+    // handles. Poll one at a time, since a poll claims a single run.
     const pollOne = async (url: string) => {
       const runId = await seedPendingAction({
         orgId,
@@ -588,7 +603,8 @@ describe('browser-affinity poll claim', () => {
     const first = await pollOne('https://a.example/');
     const second = await pollOne('https://b.example/');
 
-    // One group: same context id, and it is the standalone shape, not run:<id>.
+    // One visible group: same context id, in the standalone shape (not run:<id>,
+    // which would mint a group per run — ten SDK navigates, ten groups).
     expect(first.input.browser_context_id).toBe(second.input.browser_context_id);
     expect(String(first.input.browser_context_id)).toMatch(/^run:standalone-/);
     expect(first.input.browser_context_title).toBe(second.input.browser_context_title);

--- a/packages/server/src/__tests__/integration/browser-affinity-poll-claim.test.ts
+++ b/packages/server/src/__tests__/integration/browser-affinity-poll-claim.test.ts
@@ -550,4 +550,53 @@ describe('browser-affinity poll claim', () => {
     });
     expect(body).not.toHaveProperty('run_metadata');
   });
+
+  // Two unparented chrome actions with no stored browser_context: the SDK
+  // path. They must share one visible group (one standalone context id per
+  // organization+connection) while keeping separate per-run flow ids, so ten
+  // SDK navigates are one group with ten independently leased tabs rather than
+  // ten groups. Helper-level coverage cannot see the poll wiring that decides
+  // this, which is the only place the fallback chain is actually exercised.
+  it('gives unparented chrome actions a shared standalone context with per-run flows', async () => {
+    const { orgId, userId, workerId, deviceWorkerId } = await seedWorker();
+    const connId = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'chrome',
+      deviceWorkerId,
+    });
+
+    const pollOne = async (url: string) => {
+      const runId = await seedPendingAction({
+        orgId,
+        connectionId: connId,
+        connectorKey: 'chrome',
+        connectorVersion: '1.0.0',
+        actionInput: { url },
+        expiresAtAgoSeconds: -60,
+      });
+      const res = await pollExtension(workerId);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        run_id?: number;
+        action_input?: Record<string, unknown>;
+      };
+      expect(body.run_id).toBe(runId);
+      return { runId, input: body.action_input ?? {} };
+    };
+
+    const first = await pollOne('https://a.example/');
+    const second = await pollOne('https://b.example/');
+
+    // One group: same context id, and it is the standalone shape, not run:<id>.
+    expect(first.input.browser_context_id).toBe(second.input.browser_context_id);
+    expect(String(first.input.browser_context_id)).toMatch(/^run:standalone-/);
+    expect(first.input.browser_context_title).toBe(second.input.browser_context_title);
+
+    // Unshared ownership: each run leases its own tabs under its own flow.
+    expect(first.input.browser_flow_id).toBe(String(first.runId));
+    expect(second.input.browser_flow_id).toBe(String(second.runId));
+    expect(first.input.browser_flow_id).not.toBe(second.input.browser_flow_id);
+    expect(first.input.holder_run_id).toBe(String(first.runId));
+  });
 });

--- a/packages/server/src/__tests__/integration/browser-affinity-poll-claim.test.ts
+++ b/packages/server/src/__tests__/integration/browser-affinity-poll-claim.test.ts
@@ -110,13 +110,14 @@ async function seedPendingAction(opts: {
   actionInput?: Record<string, unknown>;
   approvedInput?: Record<string, unknown> | null;
   runMetadata?: Record<string, unknown> | null;
+  parentRunId?: number | null;
 }): Promise<number> {
   const sql = getTestDb();
   const [row] = (await sql`
     INSERT INTO runs (
       organization_id, run_type, connection_id, connector_key, connector_version,
       action_key, action_input, approved_input, run_metadata,
-      approval_status, status, created_at, expires_at
+      approval_status, status, created_at, expires_at, parent_run_id
     ) VALUES (
       ${opts.orgId}, 'action', ${opts.connectionId}, ${opts.connectorKey},
       ${opts.connectorVersion ?? null},
@@ -126,7 +127,8 @@ async function seedPendingAction(opts: {
       'auto', 'pending', current_timestamp,
       ${opts.expiresAtAgoSeconds == null
         ? null
-        : sql`current_timestamp - make_interval(secs => ${opts.expiresAtAgoSeconds})`}
+        : sql`current_timestamp - make_interval(secs => ${opts.expiresAtAgoSeconds})`},
+      ${opts.parentRunId ?? null}
     )
     RETURNING id
   `) as unknown as Array<{ id: number }>;
@@ -549,6 +551,139 @@ describe('browser-affinity poll claim', () => {
       holder_run_id: 'conversation:abc123def456',
     });
     expect(body).not.toHaveProperty('run_metadata');
+  });
+
+  // END-TO-END for page activation. x.prepare_reply navigates with
+  // require_page_activation, which the server answers itself — it never reaches
+  // the extension. Every mutating call AFTER that does, carrying a tab the user
+  // owns: no lease, no site entry, no container. The extension's ownership guard
+  // therefore refuses it unless the server hands down which tab the human
+  // opened. This asserts the whole seam, because the two halves passing
+  // separately is exactly how the regression shipped.
+  it('hands a page-activated parent tab down to the extension, ignoring forgery', async () => {
+    const { userId, orgId } = await seedOrg();
+    await createTestConnectorDefinition({
+      key: 'chrome',
+      name: 'Chrome',
+      organization_id: orgId,
+    });
+    const sql = getTestDb();
+    await sql`
+      UPDATE connector_versions
+      SET compiled_code = 'export class ConnectorRuntime {}',
+          compile_config_hash = ${COMPILE_CONFIG_HASH}
+      WHERE connector_key = 'chrome'
+    `;
+    const { deviceWorkerId, workerId } = await seedExtWorker(userId, orgId);
+    const connId = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'chrome',
+      deviceWorkerId,
+    });
+
+    // The parent: a draft the human activated by visiting the page. Tab 23 is
+    // the user's own tab, recorded when they opened it.
+    const [parent] = (await sql`
+      INSERT INTO runs (
+        organization_id, run_type, connection_id, connector_key, action_key,
+        action_input, approval_status, status, created_at, expires_at,
+        activation_kind, activation_target_urls, activated_at,
+        activated_by_device_worker_id, activation_tab_id, created_by_user_id
+      ) VALUES (
+        ${orgId}, 'action', ${connId}, 'chrome', 'prepare_reply',
+        ${sql.json({ body: 'draft' })}, 'auto', 'running',
+        current_timestamp, current_timestamp + interval '1 day',
+        'page_visit', ARRAY['https://x.example/status/1']::text[],
+        current_timestamp, ${deviceWorkerId}::uuid, 23, ${userId}
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+
+    // The child: the mutating step. It forges the ownership fields, including
+    // the activation tab, which is precisely why the gateway strips them.
+    const runId = await seedPendingAction({
+      orgId,
+      connectionId: connId,
+      connectorKey: 'chrome',
+      connectorVersion: '1.0.0',
+      parentRunId: Number(parent.id),
+      actionInput: {
+        tab_id: 23,
+        expression: '1',
+        activation_tab_id: 9999,
+        browser_flow_id: 'forged-flow',
+      },
+      expiresAtAgoSeconds: -60,
+    });
+
+    const res = await pollExtension(workerId);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      run_id?: number;
+      action_input?: Record<string, unknown>;
+    };
+    expect(body.run_id).toBe(runId);
+    // The server's resolution reached the worker, so the guard can authorize
+    // the one tab the human opened...
+    expect(body.action_input?.activation_tab_id).toBe(23);
+    // ...and neither forged field survived.
+    expect(body.action_input?.browser_flow_id).not.toBe('forged-flow');
+  });
+
+  // A child whose parent was never page-activated must carry no stamp at all —
+  // otherwise the field becomes a way to launder any tab into user-owned
+  // authority.
+  it('sends no activation stamp when the parent was never activated', async () => {
+    const { userId, orgId } = await seedOrg();
+    await createTestConnectorDefinition({
+      key: 'chrome',
+      name: 'Chrome',
+      organization_id: orgId,
+    });
+    const sql = getTestDb();
+    await sql`
+      UPDATE connector_versions
+      SET compiled_code = 'export class ConnectorRuntime {}',
+          compile_config_hash = ${COMPILE_CONFIG_HASH}
+      WHERE connector_key = 'chrome'
+    `;
+    const { deviceWorkerId, workerId } = await seedExtWorker(userId, orgId);
+    const connId = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'chrome',
+      deviceWorkerId,
+    });
+    const [parent] = (await sql`
+      INSERT INTO runs (
+        organization_id, run_type, connection_id, connector_key, action_key,
+        action_input, approval_status, status, created_at, expires_at,
+        created_by_user_id
+      ) VALUES (
+        ${orgId}, 'action', ${connId}, 'chrome', 'scrape',
+        ${sql.json({})}, 'auto', 'running',
+        current_timestamp, current_timestamp + interval '1 day', ${userId}
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+    const runId = await seedPendingAction({
+      orgId,
+      connectionId: connId,
+      connectorKey: 'chrome',
+      connectorVersion: '1.0.0',
+      parentRunId: Number(parent.id),
+      actionInput: { tab_id: 5, expression: '1', activation_tab_id: 5 },
+      expiresAtAgoSeconds: -60,
+    });
+
+    const res = await pollExtension(workerId);
+    const body = (await res.json()) as {
+      run_id?: number;
+      action_input?: Record<string, unknown>;
+    };
+    expect(body.run_id).toBe(runId);
+    expect(body.action_input).not.toHaveProperty('activation_tab_id');
   });
 
   // Two unparented chrome actions with no stored browser_context: the SDK

--- a/packages/server/src/__tests__/unit/browser-action-context.test.ts
+++ b/packages/server/src/__tests__/unit/browser-action-context.test.ts
@@ -203,6 +203,41 @@ describe('SDK browser invocation', () => {
   });
 });
 
+describe('page-activation trust stamp', () => {
+  const browser = runScopedBrowserActionContext(4242);
+
+  it('stamps the tab the server resolved and strips the caller\'s copy', () => {
+    expect(
+      trustedChromeActionInput(
+        { tab_id: 23, activation_tab_id: 999 },
+        browser,
+        23
+      )
+    ).toMatchObject({ tab_id: 23, activation_tab_id: 23 });
+  });
+
+  it('omits the stamp entirely when the run was never page-activated', () => {
+    // A caller-supplied id must not survive into a non-activated run — that
+    // would be a way to launder any tab into user-owned authority.
+    for (const activation of [null, undefined]) {
+      const out = trustedChromeActionInput(
+        { tab_id: 7, activation_tab_id: 7 },
+        browser,
+        activation
+      );
+      expect(out).not.toHaveProperty('activation_tab_id');
+    }
+  });
+
+  it('refuses a non-positive or non-integer resolved id', () => {
+    for (const bad of [0, -1, 1.5, Number.NaN]) {
+      expect(
+        trustedChromeActionInput({ tab_id: 7 }, browser, bad)
+      ).not.toHaveProperty('activation_tab_id');
+    }
+  });
+});
+
 // The extension normalizes titles outside this shape. Keep every fixed server
 // fallback within its pass-through contract; user-supplied subjects are
 // bounded by the extension.

--- a/packages/server/src/__tests__/unit/browser-action-context.test.ts
+++ b/packages/server/src/__tests__/unit/browser-action-context.test.ts
@@ -4,6 +4,7 @@ import {
   deriveBrowserActionContext,
   deriveSdkBrowserActionContext,
   runScopedBrowserActionContext,
+  standaloneBrowserActionContext,
   trustedChromeActionInput,
 } from '../../worker-api/browser-action-context';
 import type { ToolContext } from '../../tools/registry';
@@ -248,5 +249,43 @@ describe('extension title pass-through contract', () => {
         EXTENSION_MAX_TITLE_POINTS
       );
     }
+  });
+});
+
+describe('standaloneBrowserActionContext', () => {
+  it('shares one group across unrelated actions on the same browser connection', () => {
+    const first = standaloneBrowserActionContext('org_1', 432, 1001);
+    const second = standaloneBrowserActionContext('org_1', 432, 1002);
+    // Same visible container...
+    expect(first?.id).toBe(second?.id);
+    expect(first?.title).toBe('Lobu · Browser actions');
+    // ...but each run keeps its own flow lease, so neither owns the other's tab.
+    expect(first?.flow_id).toBe('1001');
+    expect(second?.flow_id).toBe('1002');
+  });
+
+  it('separates organizations and connections', () => {
+    const a = standaloneBrowserActionContext('org_1', 432, 1);
+    const b = standaloneBrowserActionContext('org_2', 432, 1);
+    const c = standaloneBrowserActionContext('org_1', 999, 1);
+    expect(new Set([a?.id, b?.id, c?.id]).size).toBe(3);
+  });
+
+  it('carries no raw identifier in the group key', () => {
+    const ctxId = standaloneBrowserActionContext('org_secret', 432, 1)?.id ?? '';
+    expect(ctxId).not.toContain('org_secret');
+    expect(ctxId).toMatch(/^run:standalone-[0-9a-f]{12}$/);
+  });
+
+  it('declines when provenance is missing, so the caller falls back to run scope', () => {
+    expect(standaloneBrowserActionContext(null, 432, 1)).toBeNull();
+    expect(standaloneBrowserActionContext('org_1', null, 1)).toBeNull();
+    expect(standaloneBrowserActionContext('org_1', 432, 0)).toBeNull();
+  });
+
+  it('stays inside the extension title contract', () => {
+    const title = standaloneBrowserActionContext('org_1', 432, 1)?.title ?? '';
+    expect(title.startsWith(EXTENSION_TITLE_PREFIX)).toBe(true);
+    expect([...title].length).toBeLessThanOrEqual(EXTENSION_MAX_TITLE_POINTS);
   });
 });

--- a/packages/server/src/worker-api/browser-action-context.ts
+++ b/packages/server/src/worker-api/browser-action-context.ts
@@ -32,6 +32,35 @@ export function runScopedBrowserActionContext(runIdValue: unknown): BrowserActio
   };
 }
 
+/**
+ * Shared container for standalone Chrome actions that belong to no richer
+ * context. Without this, every unparented action fell back to its own run id as
+ * the context key, so ten SDK navigates produced ten visible tab groups.
+ *
+ * The key is derived from server-held provenance (organization + browser
+ * connection) — never from caller input, which `trustedChromeActionInput`
+ * strips precisely so an agent cannot address another flow's group. Two
+ * unrelated actions therefore share the visible GROUP while each tab keeps its
+ * own per-run flow lease, so they display together without either being able
+ * to close or drive the other's tab.
+ */
+export function standaloneBrowserActionContext(
+  organizationId: string | null,
+  connectionId: number | null,
+  runIdValue: unknown
+): BrowserActionContext | null {
+  const runId = positiveRunId(runIdValue);
+  if (runId == null || !organizationId || connectionId == null) return null;
+  const digest = shortDigest([organizationId, String(connectionId)]);
+  return {
+    id: `run:standalone-${digest}`,
+    title: 'Lobu · Browser actions',
+    // The flow stays per-run: shared group, unshared ownership.
+    flow_id: String(runId),
+    kind: 'run',
+  };
+}
+
 export function browserContextWithFlow(
   context: BrowserActionContext,
   runIdValue: unknown

--- a/packages/server/src/worker-api/browser-action-context.ts
+++ b/packages/server/src/worker-api/browser-action-context.ts
@@ -167,7 +167,8 @@ export function deriveBrowserActionContext(ctx: ToolContext): BrowserActionConte
 
 export function trustedChromeActionInput(
   input: Record<string, unknown>,
-  context: BrowserActionContext
+  context: BrowserActionContext,
+  activationTabId?: number | null
 ): Record<string, unknown> {
   const trusted = { ...input };
   delete trusted.browser_context_id;
@@ -175,11 +176,20 @@ export function trustedChromeActionInput(
   delete trusted.browser_flow_id;
   delete trusted.holder_run_id;
   delete trusted.parent_run_id;
+  // Always deleted, then re-added only from the server's own resolution below.
+  // A connector that names an activated tab itself must never be believed: this
+  // field is what lets the extension mutate a tab the USER owns, so a
+  // caller-supplied copy would be a way to launder any tab id into that
+  // authority.
+  delete trusted.activation_tab_id;
   return {
     ...trusted,
     browser_context_id: context.id,
     browser_context_title: context.title,
     browser_flow_id: context.flow_id,
     holder_run_id: context.flow_id,
+    ...(Number.isInteger(activationTabId) && (activationTabId as number) > 0
+      ? { activation_tab_id: activationTabId as number }
+      : {}),
   };
 }

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -79,6 +79,7 @@ import {
 import {
   browserActionContextFromMetadata,
   runScopedBrowserActionContext,
+  standaloneBrowserActionContext,
   trustedChromeActionInput,
 } from './browser-action-context';
 import { runLeaseFence } from '../runs/run-lease';
@@ -1758,8 +1759,19 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   const actionInput = isChromeAction
     ? trustedChromeActionInput(
         selectedActionInput ?? {},
+        // Stored context first (a conversation/Automation/MCP container decided
+        // at dispatch), then the parent run for a connector child. An action
+        // with neither is standalone: group those together per
+        // organization+connection instead of minting a group per run, which
+        // turned ten SDK navigates into ten visible groups.
         browserActionContextFromMetadata(row.run_metadata) ??
-          runScopedBrowserActionContext(row.parent_run_id ?? row.run_id)
+          (row.parent_run_id != null
+            ? runScopedBrowserActionContext(row.parent_run_id)
+            : (standaloneBrowserActionContext(
+                row.organization_id,
+                row.connection_id,
+                row.run_id
+              ) ?? runScopedBrowserActionContext(row.run_id)))
       )
     : selectedActionInput;
 

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -993,7 +993,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         chat_agent.name AS chat_agent_name,
         chat_agent.identity_md AS chat_agent_identity_md,
         chat_agent.soul_md AS chat_agent_soul_md,
-        chat_agent.user_md AS chat_agent_user_md
+        chat_agent.user_md AS chat_agent_user_md,
+        parent.activation_tab_id AS parent_activation_tab_id
       FROM runs r
       LEFT JOIN organization org ON org.id = r.organization_id
       LEFT JOIN feeds f ON f.id = r.feed_id
@@ -1023,6 +1024,13 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       LEFT JOIN agents chat_agent
         ON chat_agent.organization_id = r.organization_id
         AND chat_agent.id = r.action_input->>'agentId'
+      -- A page-activated parent already resolved WHICH user tab the human
+      -- opened. The extension's ownership guard cannot see that decision, so
+      -- carry it down to the child action; scoped to the same organization for
+      -- the same reason dispatch-chrome-action.ts scopes its own read.
+      LEFT JOIN runs parent
+        ON parent.id = r.parent_run_id
+        AND parent.organization_id = r.organization_id
       WHERE r.id = ${runId}
       LIMIT 1
     `;
@@ -1128,6 +1136,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     app_auth_profile_id: number | null;
     connection_config: Record<string, unknown> | null;
     connection_device_worker_id: string | null;
+    parent_activation_tab_id: number | string | null;
     connector_version_row_id: number | null;
     artifact_organization_id: string | null;
     artifact_row_count: number;
@@ -1771,7 +1780,13 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
                 row.organization_id,
                 row.connection_id,
                 row.run_id
-              ) ?? runScopedBrowserActionContext(row.run_id)))
+              ) ?? runScopedBrowserActionContext(row.run_id))),
+        // The extension's ownership guard has no way to know the human opened
+        // this exact tab, so the server hands down the tab it already resolved
+        // for the page-activated parent. Set here, never from action_input.
+        row.parent_activation_tab_id == null
+          ? null
+          : Number(row.parent_activation_tab_id)
       )
     : selectedActionInput;
 

--- a/scripts/__tests__/ui-review-proof.test.ts
+++ b/scripts/__tests__/ui-review-proof.test.ts
@@ -173,10 +173,20 @@ describe("UI review proof", () => {
       ])
     ).toBe(false);
 
-    // `deploy/` is a path prefix, not a substring.
+    // Markdown design notes have no hosted surface: not referenced by
+    // vite.config.ts, never bundled into the SPA.
+    expect(
+      isUnhostedRange([
+        { filename: "docs/tab-group-model.md" },
+        { filename: "apps/chrome/tab-groups.js" },
+      ])
+    ).toBe(true);
+
+    // `deploy/` is a path prefix, not a substring — and so is `docs/`.
     expect(isUnhostedRange([{ filename: "src/deploy/widget.tsx" }])).toBe(
       false
     );
+    expect(isUnhostedRange([{ filename: "src/docs/viewer.tsx" }])).toBe(false);
     expect(
       isUnhostedRange([
         {

--- a/scripts/lib/ui-review-proof.ts
+++ b/scripts/lib/ui-review-proof.ts
@@ -247,6 +247,9 @@ export const UNHOSTED_PREFIXES = [
   "apps/chrome/",
   "apps/mac/",
   "scripts/",
+  // Markdown design notes. Not referenced by vite.config.ts and never enter the
+  // hosted SPA, so a docs-only pointer change has no UI to screenshot.
+  "docs/",
 ];
 
 const isUnhostedPath = (path: string) =>


### PR DESCRIPTION
## Summary
- Standalone Chrome actions now share one visible tab group per organization+browser-connection, instead of each dispatch minting its own.
- Bumps `packages/owletto` to lobu-ai/owletto#1044 (per-flow mutation guard with shared reads, exclusive persistent-anchor claims, live group state in the `open_tabs` feed).

**Reproduced live** against the paired extension before fixing: three `operations.execute` navigates produced three separate groups (`run:1392746`, `run:1392811`, `run:1393051`). Ten SDK navigates would produce ten — the grouping feature did nothing for the most common case, because an action with no parent run and no stored `browser_context` fell back to its own run id as the context key.

**Shared group, unshared ownership.** The context id is per organization+connection while `flow_id` stays the run id, so unrelated actions display together but neither can close or drive the other's tab. Derived from server-held provenance already projected in poll's row — no schema or projection change — and never caller-supplied: `trustedChromeActionInput` strips those fields precisely so an agent cannot address another flow's group, and a hashed caller-supplied id would not be authorization either.

Ordering is unchanged where it matters: stored metadata first, then the parent run for a connector child, and the standalone container only for the genuinely-unparented case, falling back to run scope when provenance is absent.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `bun test src/__tests__/unit/browser-action-context.test.ts` (16 pass); submodule `npx vitest run apps/chrome/` (476 pass) at the merged pin
- [x] Bug fix: red→green below
- [ ] If bot runtime changed: n/a

```
$ bun test src/__tests__/unit/browser-action-context.test.ts
 16 pass   0 fail   53 expect() calls

$ npx vitest run apps/chrome/     # submodule at e441f2d5
 Test Files  30 passed (30)
      Tests  476 passed (476)
```

Mutation-verified rather than trusted green — adding `runId` back into the digest fails exactly the group-sharing test:

```
(fail) standaloneBrowserActionContext > shares one group across unrelated actions
```

## Notes
Companion: lobu-ai/owletto#1044 (already merged; this pins its squash commit).

The submodule half also closes a real isolation hole: `click_ref`, `type_ref`, `upload_file`, `evaluate` and `scroll` had **no** ownership check, and `navigate` called `navigateTab()` before its own. Reads (`screenshot`, accessibility tree, the `open_tabs` feed) stay deliberately shared so every agent can see all tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standalone Chrome actions are now grouped consistently by organization and browser connection.
  * Separate runs retain independent flow tracking while sharing the appropriate browser-action context.
  * Context identifiers no longer expose raw organization or connection details.
  * Incomplete or invalid run, organization, or connection information is handled safely.
  * Browser-action titles remain consistent across related standalone actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->