### PR TITLE
test(mcp): gate releases on workspace errors and rendered failures

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -298,6 +298,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
+      # Isolated exact-version browser driver; no workspace install or secrets.
+      # Ubuntu's runner image supplies Google Chrome.
+      - name: Install MCP smoke browser driver
+        run: |
+          mkdir -p "$RUNNER_TEMP/mcp-smoke"
+          echo '{"private":true}' > "$RUNNER_TEMP/mcp-smoke/package.json"
+          bun add --cwd "$RUNNER_TEMP/mcp-smoke" --exact playwright-core@1.60.0
+          echo "NODE_PATH=$RUNNER_TEMP/mcp-smoke/node_modules" >> "$GITHUB_ENV"
+
       - name: Smoke the candidate app digest
         run: |
           chmod +x scripts/app-image-smoke.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -722,6 +722,10 @@ jobs:
         if: steps.submodule.outputs.stubbed != 'true'
         run: cd packages/owletto && bun run smoke:boot
 
+      - name: MCP App failure smoke (built bundle in Chrome)
+        if: steps.submodule.outputs.stubbed != 'true'
+        run: node scripts/mcp-app-smoke.mjs --dist packages/owletto/dist-mcp-apps/interaction
+
   # Backend integration tests need a real Postgres + pgvector. The Vitest
   # files share a module graph and database within one process, so each shard
   # remains single-forked; the shards themselves get isolated runners and

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -66,6 +66,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
+      # Isolated exact-version browser driver; no workspace install or secrets.
+      # Ubuntu's runner image supplies Google Chrome.
+      - name: Install MCP smoke browser driver
+        run: |
+          mkdir -p "$RUNNER_TEMP/mcp-smoke"
+          echo '{"private":true}' > "$RUNNER_TEMP/mcp-smoke/package.json"
+          bun add --cwd "$RUNNER_TEMP/mcp-smoke" --exact playwright-core@1.60.0
+          echo "NODE_PATH=$RUNNER_TEMP/mcp-smoke/node_modules" >> "$GITHUB_ENV"
+
       - name: Smoke prod
         env:
           PROD_URL: ${{ inputs.url || 'https://app.lobu.ai' }}

--- a/scripts/app-image-smoke.sh
+++ b/scripts/app-image-smoke.sh
@@ -26,7 +26,7 @@
 # Keyless: needs only a Postgres with pgvector. No provider key, no secrets.
 #
 # Usage: app-image-smoke.sh <image-ref>
-# Env:   DATABASE_URL  postgres with pgvector (required)
+# Env:   DATABASE_URL  disposable local lobu_app_smoke DB with pgvector (required)
 #        APP_PORT      host port to bind (default 8787)
 
 set -uo pipefail
@@ -37,6 +37,7 @@ APP_PORT="${APP_PORT:-8787}"
 
 BASE="http://127.0.0.1:${APP_PORT}"
 CID=""
+MCP_FIXTURE=$(mktemp) || exit 1
 PASS=0
 FAIL=0
 
@@ -45,6 +46,7 @@ ok()   { echo "  ok   — $*"; PASS=$((PASS + 1)); }
 bad()  { echo "  FAIL — $*"; FAIL=$((FAIL + 1)); }
 
 cleanup() {
+  rm -f "$MCP_FIXTURE"
   if [ -n "$CID" ]; then
     echo ""
     echo "---- container logs (tail) ----"
@@ -202,7 +204,7 @@ case "$mcp_code" in
   404)     bad "/mcp returned 404 — the MCP handler is not mounted" ;;
   000)     bad "/mcp did not respond (connection failed)" ;;
   5*)      bad "/mcp returned HTTP ${mcp_code}" ;;
-  *)       ok "/mcp responded (HTTP ${mcp_code})" ;;
+  *)       bad "/mcp unexpected HTTP ${mcp_code} — expected an auth challenge" ;;
 esac
 
 # ---------------------------------------------------------------------------
@@ -220,6 +222,25 @@ if docker exec "$CID" lobu connector runtime-self-check --json >/tmp/app-image-s
 else
   bad "connector runtime self-check failed"
   tail -30 /tmp/app-image-selfcheck.json 2>/dev/null || true
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Authenticated MCP, end to end. The unauthenticated probe above only proves
+#    the route is mounted; this authenticates as a synthetic bare-account grant
+#    in the disposable database and fails promotion on a discovery, dispatch,
+#    audit, or widget regression. The wire smoke hands its real rejection and
+#    real served shell to the browser smoke through $MCP_FIXTURE.
+# ---------------------------------------------------------------------------
+note "authenticated MCP and rendered app"
+if node scripts/mcp-image-smoke.mjs "$BASE" "$MCP_FIXTURE"; then
+  ok "authenticated MCP discovery, dispatch, audit, and resources"
+  if node scripts/mcp-app-smoke.mjs "$BASE" "$MCP_FIXTURE"; then
+    ok "rendered MCP errors, deadlines, cancellation, and late recovery"
+  else
+    bad "rendered MCP App smoke failed"
+  fi
+else
+  bad "authenticated MCP smoke failed"
 fi
 
 echo ""

--- a/scripts/mcp-app-smoke.mjs
+++ b/scripts/mcp-app-smoke.mjs
@@ -1,0 +1,248 @@
+/** Render the shipped MCP App in Chromium with a synthetic MCP host.
+ * No tool requests leave the harness.
+ *
+ *   <url> [fixture.json]                  a deployed URL, or the candidate image
+ *   --dist <dist-mcp-apps/interaction>    the built bundle, in required CI
+ *
+ * The optional fixture is written by `mcp-image-smoke.mjs`: it threads that
+ * run's real served shell and real tool rejection in, so the rendered failure
+ * is the one the gateway actually returns rather than a copy of it.
+ */
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { resolve, extname } from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { chromium } = require("playwright-core");
+const args = process.argv.slice(2);
+const dist = args[0] === "--dist" ? resolve(args[1]) : null;
+const base = dist ? null : new URL(args[0] || "https://app.lobu.ai");
+const hasFixture = !dist && args[1] !== undefined;
+const fixture = hasFixture ? JSON.parse(await readFile(args[1], "utf8")) : null;
+if (hasFixture) {
+  assert(
+    fixture?.toolResult?.isError === true,
+    "fixture must contain the real tool rejection"
+  );
+  assert(
+    typeof fixture.html === "string" && fixture.html.trim(),
+    "fixture must contain the served MCP shell"
+  );
+}
+const toolResult = fixture
+  ? fixture.toolResult
+  : {
+      isError: true,
+      content: [
+        { type: "text", text: "Pass an explicit workspace target (org_slug)." },
+      ],
+    };
+const errors = [];
+const server = createServer(async (req, res) => {
+  try {
+    const pathname = new URL(req.url, "http://localhost").pathname;
+    if (pathname === "/favicon.ico") {
+      res.writeHead(204).end();
+      return;
+    }
+    if (pathname === "/") {
+      res.setHeader("Content-Type", "text/html");
+      res.end("<!doctype html><html><body></body></html>");
+      return;
+    }
+    // Only --dist serves local files, and only these two shapes: anything
+    // else (including a traversal) falls through to the 404 below.
+    assert(
+      dist && /^(?:\/assets\/[a-zA-Z0-9._-]+|\/index\.html)$/.test(pathname)
+    );
+    res.setHeader(
+      "Content-Type",
+      extname(pathname) === ".js"
+        ? "text/javascript"
+        : extname(pathname) === ".css"
+          ? "text/css"
+          : "text/html"
+    );
+    res.end(await readFile(resolve(dist, `.${pathname}`)));
+  } catch {
+    res.writeHead(404).end("missing smoke asset");
+  }
+});
+await new Promise((r) => server.listen(0, "127.0.0.1", r));
+const host = `http://127.0.0.1:${server.address().port}`;
+let browser;
+try {
+  browser = await chromium.launch({
+    channel: "chrome",
+    headless: true,
+    args: ["--no-sandbox", "--disable-dev-shm-usage"],
+  });
+  const shell = dist
+    ? `${host}/index.html`
+    : new URL("/mcp-apps/interaction/index.html", base).href;
+  const response = await fetch(shell, { signal: AbortSignal.timeout(20000) });
+  assert(
+    response.ok && response.headers.get("content-type")?.includes("text/html"),
+    "MCP shell must be HTML"
+  );
+  const fetched = await response.text();
+  // Only the raw built bundle still has relative `./assets/…`. Everything the
+  // gateway serves has already been rewritten to absolute URLs, precisely
+  // because a real MCP host's `base-uri 'self'` drops a `<base>` tag
+  // (`utils/mcp-app-bundle.ts`) — so the deployed paths must render without
+  // one, and only `--dist` gets a base to resolve against inside `srcdoc`.
+  const html =
+    fixture?.html ??
+    (dist
+      ? fetched.replace("<head>", `<head><base href="${shell}">`)
+      : fetched);
+  for (const scenario of [
+    "error",
+    "missing",
+    "cancelled",
+    "stalled-handshake",
+  ]) {
+    const page = await browser.newPage();
+    page.on("console", (msg) => {
+      if (msg.type() === "error") console.error(msg.text());
+    });
+    page.on("requestfailed", (request) =>
+      errors.push(`asset request failed: ${request.failure()?.errorText}`)
+    );
+    page.on("pageerror", (e) => errors.push(e.message));
+    page.on("response", (r) => {
+      if (r.status() >= 400)
+        errors.push(`asset HTTP ${r.status()} for ${r.url()}`);
+    });
+    await page.goto(host);
+    await page.evaluate(
+      ({ html, scenario }) => {
+        window.smokeCalls = [];
+        window.smokeReady = false;
+        const frame = document.createElement("iframe");
+        frame.style.cssText = "width:800px;height:600px";
+        window.addEventListener("message", (event) => {
+          if (event.source !== frame.contentWindow) return;
+          const msg = event.data;
+          if (
+            msg.method === "ui/initialize" &&
+            scenario !== "stalled-handshake"
+          ) {
+            frame.contentWindow.postMessage(
+              {
+                jsonrpc: "2.0",
+                id: msg.id,
+                result: {
+                  protocolVersion: msg.params.protocolVersion,
+                  hostInfo: { name: "smoke-host", version: "1.0.0" },
+                  hostCapabilities: {},
+                  hostContext: {
+                    theme: "light",
+                    toolInfo: {
+                      tool: {
+                        name: "save_memory",
+                        inputSchema: { type: "object" },
+                      },
+                    },
+                  },
+                },
+              },
+              "*"
+            );
+          } else if (msg.method === "ui/notifications/initialized") {
+            window.smokeReady = true;
+          } else if (
+            msg.method === "tools/call" ||
+            msg.method === "ui/message"
+          ) {
+            window.smokeCalls.push(msg.method);
+          }
+        });
+        window.smokeNotify = (method, params) =>
+          frame.contentWindow.postMessage(
+            { jsonrpc: "2.0", method, params },
+            "*"
+          );
+        frame.srcdoc = html;
+        document.body.append(frame);
+      },
+      { html, scenario }
+    );
+    const frame = page.frameLocator("iframe");
+    if (scenario !== "stalled-handshake")
+      await page.waitForFunction(() => window.smokeReady, null, {
+        timeout: 10000,
+      });
+    if (scenario === "error") {
+      await page.evaluate(
+        (result) => window.smokeNotify("ui/notifications/tool-result", result),
+        toolResult
+      );
+    } else if (scenario === "cancelled") {
+      await page.evaluate(() =>
+        window.smokeNotify("ui/notifications/tool-cancelled", {
+          reason: "cancelled",
+        })
+      );
+    }
+    // Real wall clock: proves the production deadline, without modifying timers.
+    const alert = frame.getByRole("alert");
+    await alert.waitFor({ state: "visible", timeout: 35000 });
+    assert.match(
+      await alert.innerText(),
+      scenario === "error"
+        ? /explicit workspace/
+        : scenario === "cancelled"
+          ? /cancelled/i
+          : /unavailable|could not connect/i,
+      `${scenario}: the notice must name what happened`
+    );
+    assert.equal(
+      await frame.locator("html").getAttribute("data-ready"),
+      "true",
+      `${scenario}: a terminal notice must still report the runtime ready`
+    );
+    assert.equal(
+      await frame.getByText("Loading…", { exact: true }).count(),
+      0,
+      `${scenario}: must not be left spinning`
+    );
+    if (scenario === "missing") {
+      await page.evaluate(() =>
+        window.smokeNotify("ui/notifications/tool-result", {
+          content: [],
+          structuredContent: {
+            version: 1,
+            title: "Recovered smoke result",
+            blocks: [{ type: "text", value: "Late result arrived" }],
+            actions: [],
+          },
+        })
+      );
+      await frame
+        .getByText("Late result arrived", { exact: true })
+        .waitFor({ state: "visible", timeout: 5000 });
+      assert.equal(
+        await alert.count(),
+        0,
+        "a late authoritative result must clear the notice"
+      );
+    }
+    assert.deepEqual(
+      await page.evaluate(() => window.smokeCalls),
+      [],
+      "the card must not retry a write or send a message"
+    );
+    console.log(
+      `ok — MCP App ${scenario}${scenario === "missing" ? " + late recovery" : ""}`
+    );
+    await page.close();
+  }
+  assert.deepEqual(errors, [], "browser runtime and asset failures");
+  console.log("MCP App smoke PASSED");
+} finally {
+  await browser?.close();
+  await new Promise((r) => server.close(r));
+}

--- a/scripts/mcp-image-smoke.mjs
+++ b/scripts/mcp-image-smoke.mjs
@@ -1,0 +1,202 @@
+/** Authenticated wire smoke for the disposable app-image database only.
+ * Credentials/fixtures never touch production; no provider calls are needed.
+ */
+import assert from "node:assert/strict";
+import { randomBytes, createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const base = new URL(process.argv[2]);
+const db = new URL(process.env.DATABASE_URL);
+assert(
+  ["127.0.0.1", "localhost"].includes(base.hostname),
+  "candidate must be local"
+);
+assert(
+  ["127.0.0.1", "localhost"].includes(db.hostname) &&
+    db.pathname === "/lobu_app_smoke",
+  "requires disposable lobu_app_smoke database"
+);
+const suffix = randomBytes(8).toString("hex");
+const user = `smoke_user_${suffix}`;
+const org = `smoke_org_${suffix}`;
+const denied = `smoke_denied_${suffix}`;
+const token = randomBytes(32).toString("hex");
+const hash = createHash("sha256").update(token).digest("hex");
+const sql = (query) =>
+  execFileSync("psql", [db.href, "-X", "-qAt", "-v", "ON_ERROR_STOP=1"], {
+    input: query,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+    timeout: 10000,
+    env: { ...process.env, PGOPTIONS: "-c statement_timeout=5000" },
+  }).trim();
+// Every value interpolated into a query in this file is either generated hex
+// with a fixed prefix or a literal from the loops below — never caller input.
+sql(`BEGIN;
+INSERT INTO organization (id, name, slug, visibility, "createdAt") VALUES
+('${org}', 'MCP smoke workspace', '${org}', 'private', now()),
+('${denied}', 'MCP smoke denied workspace', '${denied}', 'private', now());
+INSERT INTO "user" (id, name, email, username, "emailVerified", "createdAt", "updatedAt")
+VALUES ('${user}', 'MCP smoke', '${user}@example.test', '${user}', true, now(), now());
+INSERT INTO member (id, "userId", "organizationId", role, "createdAt") VALUES ('${suffix}', '${user}', '${org}', 'owner', now());
+INSERT INTO oauth_clients (id, redirect_uris, grant_types, response_types, token_endpoint_auth_method, client_name, created_at, updated_at)
+VALUES ('${suffix}', ARRAY['http://localhost/callback'], ARRAY['authorization_code'], ARRAY['code'], 'none', 'MCP image smoke', now(), now());
+INSERT INTO oauth_tokens (id, token_type, token_hash, client_id, user_id, organization_id, granted_organization_ids, scope, expires_at, created_at)
+VALUES ('${suffix}', 'access', '${hash}', '${suffix}', '${user}', NULL, ARRAY['${org}'], 'mcp:read mcp:write', now() + interval '10 minutes', now());
+COMMIT;`);
+// Matches @lobu/core's MCP_PROTOCOL_VERSION; this image job has no workspace
+// install. Subsequent requests use the version negotiated by the gateway.
+const PROTOCOL_VERSION = "2025-11-25";
+let session;
+let protocol;
+let id = 0;
+async function rpc(method, params, notification = false) {
+  const response = await fetch(new URL("/mcp", base), {
+    method: "POST",
+    signal: AbortSignal.timeout(20000),
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...(protocol ? { "MCP-Protocol-Version": protocol } : {}),
+      ...(session ? { "Mcp-Session-Id": session } : {}),
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      ...(notification ? {} : { id: ++id }),
+      method,
+      params,
+    }),
+  });
+  assert(response.ok, `${method}: HTTP ${response.status}`);
+  session = response.headers.get("mcp-session-id") || session;
+  if (notification) return;
+  const text = await response.text();
+  const body = response.headers
+    .get("content-type")
+    ?.includes("text/event-stream")
+    ? text
+        .split("\n")
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => JSON.parse(line.slice(5)))
+        .find((message) => message.id === id)
+    : JSON.parse(text);
+  assert(body && !body.error, `${method}: JSON-RPC error`);
+  return body.result;
+}
+const initialized = await rpc("initialize", {
+  protocolVersion: PROTOCOL_VERSION,
+  capabilities: {
+    extensions: {
+      "io.modelcontextprotocol/ui": {
+        mimeTypes: ["text/html;profile=mcp-app"],
+      },
+    },
+  },
+  clientInfo: { name: "mcp-image-smoke", version: "1.0.0" },
+});
+assert(session, "initialize must create a session");
+assert(
+  typeof initialized.protocolVersion === "string" &&
+    initialized.protocolVersion,
+  "initialize must negotiate a protocol version"
+);
+protocol = initialized.protocolVersion;
+await rpc("notifications/initialized", {}, true);
+const { tools } = await rpc("tools/list", {});
+for (const [name, target] of [
+  ["save_memory", "org_slug"],
+  ["query_sql", "org_slug"],
+  ["get_approval", "organization"],
+]) {
+  assert(
+    tools
+      .find((tool) => tool.name === name)
+      ?.inputSchema.required?.includes(target),
+    `${name} must advertise explicit ${target}`
+  );
+}
+console.log("ok — bare-account discovery requires explicit workspace targets");
+let saveError;
+for (const [title, name, args, code] of [
+  ["missing", "query_sql", { sql: "SELECT 1 AS ok" }, "VALIDATION"],
+  [
+    "missing-save",
+    "save_memory",
+    { content: "Synthetic smoke note" },
+    "VALIDATION",
+  ],
+  [
+    "denied",
+    "query_sql",
+    { sql: "SELECT 1 AS ok", org_slug: denied },
+    "PERMISSION",
+  ],
+]) {
+  const result = await rpc("tools/call", {
+    name,
+    arguments: { ...args, title },
+  });
+  if (name === "save_memory") saveError = result;
+  assert.equal(result.isError, true, `${title}: must return an MCP tool error`);
+  assert(
+    result.content?.some(
+      (item) => item.type === "text" && item.text.length > 10
+    ),
+    `${title}: actionable text`
+  );
+  assert.equal(result.structuredContent?.error?.code, code, `${title}: code`);
+  assert(result.structuredContent?.error?.call_id, `${title}: correlation ID`);
+  const count =
+    sql(`SELECT count(*) FROM events WHERE created_by = '${user}' AND organization_id IS NULL
+    AND origin_type = 'tool_invocation' AND payload_data->>'tool_name' = '${name}'
+    AND payload_data->>'success' = 'false'
+    ${name === "query_sql" ? `AND payload_data->'request'->>'title' = '${title}'` : ""};`);
+  assert.equal(
+    count,
+    "1",
+    `${title}: failure must be audited privately against caller`
+  );
+  console.log(
+    `ok — ${title} target returns ${code} and a private audit record`
+  );
+}
+const result = await rpc("tools/call", {
+  name: "query_sql",
+  arguments: { sql: "SELECT 1 AS ok", org_slug: org, title: "explicit" },
+});
+assert.notEqual(result.isError, true, "explicit target must dispatch");
+assert.deepEqual(
+  result.structuredContent?.rows,
+  [{ ok: 1 }],
+  "explicit target must return structured rows"
+);
+const uri = tools.find((tool) => tool.name === "save_memory")?._meta?.[
+  "openai/outputTemplate"
+];
+assert(uri, "tool must advertise its MCP App resource");
+const resource = await rpc("resources/read", { uri });
+const [shell] = resource.contents ?? [];
+assert(
+  shell?.mimeType?.startsWith("text/html") &&
+    /assets\/app\.js\?v=/.test(shell.text),
+  "resource must contain the versioned app bundle"
+);
+const staleResource = await rpc("resources/read", {
+  uri: "ui://lobu/interaction/v1.html",
+});
+assert.equal(
+  staleResource.contents?.[0]?.text,
+  shell.text,
+  "cached resource URIs must resolve the current shell"
+);
+console.log(
+  "ok — explicit target query succeeds; current and cached MCP App resources resolve"
+);
+if (process.argv[3])
+  writeFileSync(
+    process.argv[3],
+    JSON.stringify({ toolResult: saveError, html: shell.text })
+  );
+console.log("MCP image smoke PASSED");

--- a/scripts/prod-smoke.sh
+++ b/scripts/prod-smoke.sh
@@ -240,6 +240,18 @@ else
   fi
 fi
 
+# ---------------------------------------------------------------------------
+# 8. The delivered MCP widget, rendered against a synthetic host. Only its
+#    public shell and assets are fetched; every tool notification stays inside
+#    the local browser, so nothing is written to prod.
+# ---------------------------------------------------------------------------
+note "rendered MCP App"
+if node "$(dirname "$0")/mcp-app-smoke.mjs" "$BASE"; then
+  ok "MCP App failures are visible and late results recover without replay"
+else
+  bad "MCP App browser smoke failed"
+fi
+
 echo ""
 echo "  prod smoke: ${PASS} passed, ${FAIL} failed"
 if [ "$FAIL" -ne 0 ]; then


### PR DESCRIPTION
## Summary
The previous smoke accepted an MCP auth challenge without calling an authenticated tool or rendering its result, so it could pass while a missing workspace left ChatGPT stuck on Loading.

Add a candidate-image smoke that creates a synthetic bare-account OAuth grant in the disposable smoke database, checks required workspace targets, missing/denied target errors and private audit records, an explicitly targeted query, and current/historical MCP resource URLs. Feed the actual failed save result and resource HTML into Chromium.

Render the built MCP App in required frontend CI and the delivered App in the scheduled/post-rollout production smoke. Check visible tool errors, missing results, cancellation, a stalled handshake, late-result recovery, readiness, and no automatic tool replay. The candidate-image check remains a prerequisite for image promotion. Production checks only fetch public HTML/assets and simulate host messages locally.

## Test plan
- [x] `make pre-pr`
- [x] Authenticated smoke against a fresh local PostgreSQL database and real HTTP server
- [x] Actual failed-save response and resource rendered in Chromium
- [x] Browser smoke against the built artifact and deployed production artifact
- [x] Existing release ordering suite: 95 passed
- [x] Actionlint, shell syntax, and formatting
- [x] Required GitHub CI and exact-head semantic review (0 bugs, 0 blockers)

Red → green: the exact pre-fix bundle (`40f2967f890e171d…`) exits nonzero with `locator.waitFor: Timeout 35000ms exceeded` waiting for a visible error. The fixed bundle passes error, missing-result + late recovery, cancellation, and stalled-handshake scenarios. The expanded production smoke also passes.
