### PR TITLE
fix(mcp): correct ChatGPT memory lookup and write authorization hints

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -11,7 +11,7 @@ export type SearchMemoryData = {
      */
     title?: string;
     /**
-     * Search query (entity name). Required unless entity_id is provided.
+     * Search saved memory by text or entity name. To open a known memory, event, or content ID, use query: "memory 1234" with include_content: true; do not pass that ID as entity_id. Required unless entity_id is provided.
      */
     query?: string;
     /**
@@ -19,7 +19,7 @@ export type SearchMemoryData = {
      */
     entity_type?: string;
     /**
-     * Entity ID for direct lookup. Can be used instead of query for exact fetch.
+     * Entity ID only, as returned in an entity result. Memory, event, and content IDs are different: use query: "memory 1234" with include_content: true to read those records.
      */
     entity_id?: number;
     /**

--- a/packages/core/src/contracts/tools/search-memory.ts
+++ b/packages/core/src/contracts/tools/search-memory.ts
@@ -23,7 +23,7 @@ export const SearchSchema = Type.Object({
   query: Type.Optional(
     Type.String({
       description:
-        "Search query (entity name). Required unless entity_id is provided.",
+        'Search saved memory by text or entity name. To open a known memory, event, or content ID, use query: "memory 1234" with include_content: true; do not pass that ID as entity_id. Required unless entity_id is provided.',
       minLength: 1,
     })
   ),
@@ -36,7 +36,7 @@ export const SearchSchema = Type.Object({
   entity_id: Type.Optional(
     Type.Number({
       description:
-        "Entity ID for direct lookup. Can be used instead of query for exact fetch.",
+        'Entity ID only, as returned in an entity result. Memory, event, and content IDs are different: use query: "memory 1234" with include_content: true to read those records.',
     })
   ),
   parent_id: Type.Optional(

--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -1995,6 +1995,7 @@ describe('MCP Authentication', () => {
       const listed = await mcpListTools({ token, orgSlug: roleOrg.slug });
       const runSdk = listed.tools.find((tool: any) => tool.name === 'run_sdk');
       expect(runSdk?.securitySchemes).toEqual([
+        { type: 'oauth2', scopes: ['mcp:write', 'profile:read'] },
         { type: 'oauth2', scopes: ['mcp:write', 'mcp:admin', 'profile:read'] },
       ]);
       expect(runSdk?._meta?.securitySchemes).toEqual(runSdk?.securitySchemes);

--- a/packages/server/src/__tests__/integration/tools/search-memory-federation.test.ts
+++ b/packages/server/src/__tests__/integration/tools/search-memory-federation.test.ts
@@ -238,6 +238,31 @@ describe('search_memory direct OAuth workspace federation', () => {
     expectValidSearchResult(partialHit);
   });
 
+  it('preserves entity-ID retry guidance across workspaces without hiding partial failures', async () => {
+    const args = { entity_id: 2147483647 };
+    const result = await search(args, {} as Env, context());
+    expect(result.discovery_status).toBe('not_found');
+    expect(result.coverage).toMatchObject({ scope: 'all_granted', status: 'complete' });
+    expect(result.suggestion).toContain('entity_id only accepts entity IDs');
+    expect(result.suggestion).toContain('query: "memory 2147483647"');
+    expect(result.suggestion).not.toContain('entities.create');
+    expectValidSearchResult(result);
+
+    const targets = [
+      { id: orgA.id, slug: orgA.slug, name: orgA.name, role: 'owner', personal: false },
+      { id: orgB.id, slug: orgB.slug, name: orgB.name, role: 'admin', personal: false },
+    ];
+    const shard = await search({ ...args, workspace: orgA.slug }, {} as Env, context());
+    const partial = mergeFederatedSearchResults(args, targets, [
+      { status: 'fulfilled', value: shard },
+      { status: 'rejected', reason: new Error('synthetic unavailable workspace') },
+    ]);
+    expect(partial.discovery_status).toBe('discovering');
+    expect(partial.suggestion).toContain('partial results');
+    expect(partial.suggestion).not.toContain('not found');
+    expectValidSearchResult(partial);
+  });
+
   // The federated arm of the empty-result guidance. `partialEmpty` above covers
   // the degraded case, which deliberately says "partial results" instead — this
   // is the HEALTHY all-granted miss, the one branch of the read guidance that

--- a/packages/server/src/__tests__/integration/tools/search-memory-recall-contract.test.ts
+++ b/packages/server/src/__tests__/integration/tools/search-memory-recall-contract.test.ts
@@ -195,6 +195,15 @@ describe('search_memory > recall contract', () => {
     );
   });
 
+  it('explains how to retry a memory id mistakenly supplied as an entity id', async () => {
+    const result = await search({ entity_id: 2147483647 }, env, ctx);
+
+    expect(result.discovery_status).toBe('not_found');
+    expect(result.suggestion).toContain('entity_id only accepts entity IDs');
+    expect(result.suggestion).toContain('query: "memory 2147483647"');
+    expect(result.content ?? []).toHaveLength(0);
+  });
+
   // ── ORDERING GUARD (never-broken semantics, pinned) ──────────────────────
   it('sorts content by similarity DESC so content_limit truncates the WORST, not the best', async () => {
     const result = await search(

--- a/packages/server/src/__tests__/unit/tool-registry-split.test.ts
+++ b/packages/server/src/__tests__/unit/tool-registry-split.test.ts
@@ -114,7 +114,7 @@ describe("tool registry split", () => {
 		}
 	});
 
-	it("advertises progressive admin scope only to role-eligible MCP sessions", () => {
+	it("allows ordinary writes without admin while advertising eligible elevation separately", () => {
 		const eligibleRun = getMcpTools({
 			maxAccessLevel: "write",
 			adminScopeEligible: true,
@@ -125,6 +125,7 @@ describe("tool registry split", () => {
 		}).find((tool) => tool.name === "run_sdk");
 
 		expect(eligibleRun?.securitySchemes).toEqual([
+			{ type: "oauth2", scopes: ["mcp:write", "profile:read"] },
 			{ type: "oauth2", scopes: ["mcp:write", "mcp:admin", "profile:read"] },
 		]);
 		expect(memberRun?.securitySchemes).toEqual([

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -291,7 +291,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
     name: 'search_memory',
     scope: 'account',
     description:
-      'Search local saved workspace memory: entities, facts, decisions, preferences, observations, notes, and authorized channel transcripts. Source-backed feeds are never queried implicitly; `coverage` reports local stores searched and visible source feeds with status `not_queried`, which agents can read explicitly through query_sdk client.feeds.readMany. A query such as `memory 1234` performs an exact permission-checked content read. Pair writes with `save_memory`. The search does not change workspace content or external systems. OAuth and PAT calls append a private audit/activity record.',
+      'Search local saved workspace memory: entities, facts, decisions, preferences, observations, notes, and authorized channel transcripts. To open a known memory, event, or content ID, pass query: "memory 1234" and include_content: true. entity_id is only for entity records, never memory IDs. Source-backed feeds are never queried implicitly; `coverage` reports local stores searched and visible source feeds with status `not_queried`, which agents can read explicitly through query_sdk client.feeds.readMany. Pair writes with `save_memory`. The search does not change workspace content or external systems. OAuth and PAT calls append a private audit/activity record.',
     inputSchema: SearchSchema,
     // Advertise the narrower public schema: query_embedding (server pre-compute
     // optimization) and agent_id (auth-bound) are server-internal, not client
@@ -814,16 +814,23 @@ function computeListedTools(
       }
       if (!inputSchema) return null;
 
-      // `run_sdk` is a write tool whose nested SDK surface also contains
-      // admin methods. OpenAI hosts require that possible elevation in the
-      // tool's securitySchemes before they will act on an insufficient-scope
-      // challenge. Keep it role-aware: advertising an ungrantable admin scope
-      // to regular members makes strict clients reject an otherwise valid
-      // read/write connection.
-      const securityScopes =
-        tool.name === 'run_sdk' && adminScopeEligible
-          ? Array.from(new Set([...(tool.securityScopes ?? []), 'mcp:admin']))
-          : tool.securityScopes;
+      // Each scheme is an alternative; scopes within a scheme are all required.
+      // Keep ordinary writes callable at write tier, while declaring optional
+      // elevation for nested admin methods only when the user's role allows it.
+      // The SDK dispatch still enforces each method's scope and membership role.
+      const securitySchemes = tool.securityScopes
+        ? [
+            { type: 'oauth2' as const, scopes: getMcpConnectionScopes(tool.securityScopes) },
+            ...(tool.name === 'run_sdk' && adminScopeEligible
+              ? [
+                  {
+                    type: 'oauth2' as const,
+                    scopes: getMcpConnectionScopes([...tool.securityScopes, 'mcp:admin']),
+                  },
+                ]
+              : []),
+          ]
+        : undefined;
 
       inputSchema = filterSchemaForAccessLevel(
         tool.name,
@@ -846,11 +853,7 @@ function computeListedTools(
         description: tool.description,
         inputSchema,
         ...(tool.annotations && { annotations: tool.annotations }),
-        ...(securityScopes && {
-          securitySchemes: [
-            { type: 'oauth2' as const, scopes: getMcpConnectionScopes(securityScopes) },
-          ],
-        }),
+        ...(securitySchemes && { securitySchemes }),
         ...(tool.mcpMeta && { _meta: tool.mcpMeta }),
         // outputSchema keeps its discriminated variants (no flattening, no
         // access-level filtering — those are input concerns) but the MCP spec

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -542,12 +542,22 @@ export function highestGrantedRole(
   return best;
 }
 
+function entityIdNotFoundSuggestion(entityId: number): string {
+  return (
+    `Entity with ID ${entityId} not found. entity_id only accepts entity IDs. ` +
+    `If this is a memory, event, or content ID, retry with query: "memory ${entityId}", ` +
+    'include_content: true, and no entity_id, keeping the same workspace scope.'
+  );
+}
+
 function buildEmptySearchSuggestion(
   query: string | null,
   args: SearchArgs,
   coverage?: SearchCoverage,
   callerMax?: ToolAccessLevel
 ): string {
+  if (args.entity_id) return entityIdNotFoundSuggestion(args.entity_id);
+
   const isFederated = coverage?.scope === 'all_granted';
   const queryLabel = !isFederated && query ? ` for "${query}"` : '';
   const scopeLabel = isFederated
@@ -1602,10 +1612,7 @@ async function searchWorkspaceImpl(
     return emptyResult({
       ...(title ? { title } : {}),
       entity_type: args.entity_type || null,
-      suggestion:
-        `Entity with ID ${args.entity_id} not found. entity_id only accepts entity IDs. ` +
-        `If this is a memory, event, or content ID, retry with query: "memory ${args.entity_id}", ` +
-        'include_content: true, and no entity_id, keeping the same workspace scope.',
+      suggestion: entityIdNotFoundSuggestion(args.entity_id),
     });
   }
 

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -1602,7 +1602,10 @@ async function searchWorkspaceImpl(
     return emptyResult({
       ...(title ? { title } : {}),
       entity_type: args.entity_type || null,
-      suggestion: `Entity with ID ${args.entity_id} not found`,
+      suggestion:
+        `Entity with ID ${args.entity_id} not found. entity_id only accepts entity IDs. ` +
+        `If this is a memory, event, or content ID, retry with query: "memory ${args.entity_id}", ` +
+        'include_content: true, and no entity_id, keeping the same workspace scope.',
     });
   }
 


### PR DESCRIPTION
## Summary
ChatGPT interpreted a known memory ID as an entity ID and reported a false miss. The published schema now distinguishes these IDs, and an unsuccessful entity lookup explains how to retry a memory read within the same workspace scope. This recovery guidance survives federated searches; an unavailable workspace still reports partial results instead of a false global miss.

`run_sdk` previously advertised administrator scope as mandatory for role-eligible users, causing ordinary read/write connections to show reconnect required. Advertise the ordinary write policy and eligible administrator elevation as separate OAuth alternatives. Runtime scope, role, workspace, and approval enforcement remain in place.

## Test plan
- [x] Regression tests reproduced both defects before the fixes: registry unit 7 passed / 1 failed; integration 73 passed / 2 failed / 2 existing skipped.
- [x] After fixes: registry unit 8 passed; auth and recall integration 75 passed / 2 existing skipped; MCP resources and bare OAuth federation 40 passed.
- [x] `make pre-pr`, pre-commit Biome and TypeScript checks passed.
- [x] Full server units: 1,461 passed / 2 existing skipped. Full MCP integration: 235 passed / 2 existing skipped.
- [x] Federation follow-up: 1 new regression failed before the fix; all 31 search/OAuth tests passed afterward, including partial failures.
- [x] Required CI and exact-head independent review passed on `cb6dc48906d36aa9e4a5b1aca637c11039d1e113` (zero bugs/blockers; low risk).
- [x] Deployed exact squash `8cf66edb9a9ea6669bc7ba2f9ccd9e7f9835b1f6`; local and GitHub production smoke passed, including all four rendered MCP App failure/recovery cases.
- [x] Fresh PKCE read/write/profile grant through the configured `https://lobu.ai/mcp` endpoint: fixture reads, SQL, idempotent replay, non-persisting dry-run, missing-workspace/empty-content validation, and scoped/federated wrong-ID guidance passed; temporary tokens revoked.
- [x] Actual ChatGPT developer app refreshed. Verified corrected memory-ID arguments, SDK discovery/read, SQL, idempotent save card, write-tier dry-run, and SQL preview_count=0.
- [x] Enabled developer-mode CSP enforcement and visually verified the saved card and the bounded unavailable-result fallback for a failing save. All three negative prompts avoided Lobu; image generation hit ChatGPT quota.
- [x] Correct submission metadata rescanned successfully. Portal now confirms "Lobu submitted for review" for app `asdk_app_6a73b856e4348191a97dc8e3a1e58a94`, version `asdk_app_v_6a73b868df1081918053b469172b2143`. Review is pending; this is not a claim of public publication.

The initial actual ChatGPT SDK-discovery attempt reported a host safety block; the user's retry succeeded through `search_sdk` and `query_sdk` and returned the expected fixture. The underlying host safety reason is unavailable, and this change does not claim to fix it. Actual ChatGPT run_sdk dry-run succeeded using the existing read/write grant after refresh. The developer settings page still shows a misleading reconnect-needed label, which did not block execution.

<details><summary>Focused red-to-green evidence</summary>

Before the fix:
```text
FAIL allows ordinary writes without admin while advertising eligible elevation separately
Expected: write/profile OAuth alternative followed by write/admin/profile
Received: only write/admin/profile
Unit: 7 pass, 1 fail

FAIL explains how to retry a memory id mistakenly supplied as an entity id
Expected suggestion to contain: entity_id only accepts entity IDs
Received: Entity with ID 2147483647 not found
Integration: 73 passed, 2 failed, 2 existing skipped

Federation follow-up: 13 passed, 1 failed
Expected entity-ID retry guidance; received generic empty-search guidance.
```

After the fix:
```text
Unit registry: 8 pass, 0 fail
Auth and recall integration: 75 passed, 2 existing skipped
Full server units: 1461 pass, 2 existing skipped, 0 fail
Full MCP integration: 235 passed, 2 existing skipped
Federation, recall and bare OAuth follow-up: 31 passed
```
</details>
