### PR TITLE
fix(members): apply permission roles through entity hooks

### DIFF
--- a/db/migrations/20260909143000_member_permission_roles.sql
+++ b/db/migrations/20260909143000_member_permission_roles.sql
@@ -1,0 +1,44 @@
+-- migrate:up
+-- Quiesce writers: old servers treat role as editable profile text. Reconcile
+-- that projection from authentication before exposing the permission selector.
+UPDATE entity_types
+SET metadata_schema = jsonb_set(
+      jsonb_set(COALESCE(metadata_schema, '{"type":"object","properties":{}}'::jsonb),
+        '{properties}', COALESCE(metadata_schema->'properties', '{}'::jsonb)),
+      '{properties,role}', COALESCE(metadata_schema #> '{properties,role}', '{}'::jsonb)
+        || '{"type":"string","enum":["owner","admin","member"]}'::jsonb),
+    updated_at = current_timestamp
+WHERE slug = '$member' AND deleted_at IS NULL;
+
+-- Only authentication-owned claims can identify a permission-bearing member.
+UPDATE entities e
+SET metadata = COALESCE(e.metadata, '{}'::jsonb) || jsonb_build_object('role', m.role),
+    updated_at = current_timestamp
+FROM entity_types et, entity_identities ei, member m
+WHERE et.id = e.entity_type_id AND et.slug = '$member'
+  AND e.deleted_at IS NULL AND et.deleted_at IS NULL
+  AND ei.entity_id = e.id AND ei.organization_id = e.organization_id
+  AND ei.namespace = 'auth_user_id' AND ei.source_connector = 'auth:signup'
+  AND ei.deleted_at IS NULL
+  AND m."userId" = ei.identifier AND m."organizationId" = e.organization_id;
+
+-- Pending invitations have no auth identity yet. Use the schema's email field.
+UPDATE entities e
+SET metadata = COALESCE(e.metadata, '{}'::jsonb) || jsonb_build_object('role', i.role),
+    updated_at = current_timestamp
+FROM entity_types et, invitation i
+WHERE et.id = e.entity_type_id AND et.slug = '$member'
+  AND e.deleted_at IS NULL AND et.deleted_at IS NULL
+  AND i."organizationId" = e.organization_id AND i.status = 'pending'
+  AND i.email = e.metadata->>COALESCE(
+    (SELECT key FROM jsonb_each(et.metadata_schema->'properties')
+     WHERE value->>'x-email' = 'true' LIMIT 1), 'email')
+  AND NOT EXISTS (SELECT 1 FROM entity_identities ei WHERE ei.entity_id = e.id
+    AND ei.organization_id = e.organization_id AND ei.namespace = 'auth_user_id'
+    AND ei.source_connector = 'auth:signup' AND ei.deleted_at IS NULL);
+
+-- migrate:down
+-- Permission changes are intentionally not undone.
+UPDATE entity_types
+SET metadata_schema = metadata_schema #- '{properties,role,enum}', updated_at = current_timestamp
+WHERE slug = '$member' AND deleted_at IS NULL;

--- a/packages/server/src/__tests__/integration/entities/member-entity-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/entities/member-entity-lifecycle.test.ts
@@ -55,7 +55,7 @@ describe('$member entity lifecycle projections', () => {
     `;
 
     await updateMemberEntityStatus(organization.id, user.email, 'active');
-    await updateMemberEntityAccess(organization.id, user.email, { role: 'admin' });
+    await updateMemberEntityAccess(organization.id, user.id, { role: 'admin' });
 
     const updated = await memberRow(organization.id, user.email);
     expect(updated.metadata).toMatchObject({

--- a/packages/server/src/__tests__/integration/entities/member-role-hooks.test.ts
+++ b/packages/server/src/__tests__/integration/entities/member-role-hooks.test.ts
@@ -1,0 +1,205 @@
+import { createAuth } from '../../../auth';
+import { readFileSync } from 'node:fs';
+import { applyEntityFieldChangeProposal } from '../../../tools/admin/entity-field-approval';
+import { TestApiClient } from '../../setup/test-mcp-client';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ensureMemberEntity } from '../../../utils/member-entity';
+import { ensureMemberEntityType } from '../../../utils/member-entity-type';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { addUserToOrganization, createTestAccessToken, createTestOAuthClient, createTestOrganization, createTestSession, createTestUser } from '../../setup/test-fixtures';
+import { post } from '../../setup/test-helpers';
+
+describe('member roles through generic entity edits', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let owner: { userId: string; memberId: string; entityId: number; cookie: string };
+  let member: typeof owner;
+  async function person(role: 'owner' | 'admin' | 'member', name: string) {
+    const user = await createTestUser({ email: `${name}@roles.example.com` });
+    const memberId = await addUserToOrganization(user.id, org.id, role);
+    await ensureMemberEntity({ organizationId: org.id, userId: user.id, name, email: user.email, role, status: 'active' });
+    const sql = getTestDb();
+    const [entity] = await sql`SELECT entity_id FROM entity_identities WHERE organization_id = ${org.id} AND namespace = 'auth_user_id' AND identifier = ${user.id}`;
+    return { userId: user.id, memberId, entityId: Number(entity.entity_id), cookie: (await createTestSession(user.id)).cookieHeader };
+  }
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    org = await createTestOrganization({ name: 'Role hook test' });
+    owner = await person('owner', 'owner');
+    member = await person('member', 'member');
+  });
+  async function edit(actor: typeof owner, entityId: number, role: unknown) {
+    return post(`/api/${org.slug}/manage_entity`, { cookie: actor.cookie, body: { action: 'update', entity_id: entityId, metadata: { role } } });
+  }
+  async function roles(target: typeof owner) {
+    const sql = getTestDb();
+    const [row] = await sql`SELECT m.role, e.metadata->>'role' AS displayed FROM member m, entities e WHERE m.id = ${target.memberId} AND e.id = ${target.entityId}`;
+    return row;
+  }
+  it('renders the role as an enum in new and existing schemas', async () => {
+    const sql = getTestDb();
+    await sql`UPDATE entity_types SET metadata_schema = jsonb_set(metadata_schema, '{properties,role}', '{"type":"string"}') WHERE organization_id = ${org.id} AND slug = '$member'`;
+    await ensureMemberEntityType(org.id);
+    const [row] = await sql`SELECT metadata_schema FROM entity_types WHERE organization_id = ${org.id} AND slug = '$member'`;
+    expect(row.metadata_schema.properties.role.enum).toEqual(['owner', 'admin', 'member']);
+  });
+  it('promotes and demotes actual access through the generic form endpoint', async () => {
+    expect((await edit(owner, member.entityId, 'admin')).status).toBe(200);
+    expect(await roles(member)).toMatchObject({ role: 'admin', displayed: 'admin' });
+    expect((await edit(owner, member.entityId, 'member')).status).toBe(200);
+    expect(await roles(member)).toMatchObject({ role: 'member', displayed: 'member' });
+  });
+  it('rejects self promotion, invalid roles, and last owner demotion without changing metadata', async () => {
+    expect((await edit(member, member.entityId, 'admin')).status).toBeGreaterThanOrEqual(400);
+    expect((await edit(owner, member.entityId, 'superadmin')).status).toBeGreaterThanOrEqual(400);
+    expect((await edit(owner, owner.entityId, 'member')).status).toBeGreaterThanOrEqual(400);
+    expect(await roles(owner)).toMatchObject({ role: 'owner', displayed: 'owner' });
+    expect(await roles(member)).toMatchObject({ role: 'member', displayed: 'member' });
+  });
+  it('honors selected invitation roles and later edits', async () => {
+    const response = await post(`/api/${org.slug}/manage_entity`, { cookie: owner.cookie, body: { action: 'create', entity_type: '$member', name: 'Invited', metadata: { email: 'invited@roles.example.com', role: 'admin' } } });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const sql = getTestDb();
+    const pending = async () => (await sql`SELECT role FROM invitation WHERE "organizationId" = ${org.id} AND email = 'invited@roles.example.com' AND status = 'pending'`)[0].role;
+    expect(await pending()).toBe('admin');
+    expect((await edit(owner, Number(body.entity.id), 'member')).status).toBe(200);
+    expect(await pending()).toBe('member');
+  });
+  it('keeps the existing auth API and displayed role consistent', async () => {
+    const response = await post('/api/auth/organization/update-member-role', { cookie: owner.cookie, body: { organizationId: org.id, memberId: member.memberId, role: 'admin' } });
+    expect(response.status).toBe(200);
+    expect(await roles(member)).toMatchObject({ role: 'admin', displayed: 'admin' });
+  });
+  it('enforces ownership restrictions for admins', async () => {
+    const admin = await person('admin', 'admin');
+    expect((await edit(admin, member.entityId, 'admin')).status).toBe(200);
+    expect((await edit(admin, member.entityId, 'owner')).status).toBe(403);
+    expect((await edit(admin, owner.entityId, 'admin')).status).toBe(403);
+  });
+  it('serializes simultaneous owner demotions across entity and auth endpoints', async () => {
+    const otherOwner = await person('owner', 'other-owner');
+    const responses = await Promise.all([
+      edit(owner, owner.entityId, 'member'),
+      post('/api/auth/organization/update-member-role', { cookie: otherOwner.cookie, body: { organizationId: org.id, memberId: otherOwner.memberId, role: 'member' } }),
+    ]);
+    expect(responses.map(r => r.status).sort()).toEqual([200, 400]);
+    const sql = getTestDb();
+    expect(await sql`SELECT id FROM member WHERE "organizationId" = ${org.id} AND role = 'owner'`).toHaveLength(1);
+    for (const target of [owner, otherOwner]) {
+      const row = await roles(target);
+      expect(row.displayed).toBe(row.role);
+    }
+  });
+  it('does not let an edited email retarget a role change', async () => {
+    const result = await post(`/api/${org.slug}/manage_entity`, { cookie: owner.cookie, body: { action: 'update', entity_id: member.entityId, metadata: { email: 'owner@roles.example.com', role: 'admin' } } });
+    expect(result.status).toBe(400);
+    expect(await roles(owner)).toMatchObject({ role: 'owner', displayed: 'owner' });
+    expect(await roles(member)).toMatchObject({ role: 'member', displayed: 'member' });
+  });
+  it('rejects cross-workspace targets through both entrypoints', async () => {
+    const foreign = await createTestOrganization({ name: 'Foreign role org' });
+    const response = await post('/api/auth/organization/update-member-role', { cookie: owner.cookie, body: { organizationId: foreign.id, memberId: member.memberId, role: 'admin' } });
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect((await post(`/api/${foreign.slug}/manage_entity`, { cookie: owner.cookie, body: { action: 'update', entity_id: member.entityId, metadata: { role: 'admin' } } })).status).toBeGreaterThanOrEqual(400);
+    expect(await roles(member)).toMatchObject({ role: 'member', displayed: 'member' });
+  });
+  it('applies approved role edits through the same lifecycle', async () => {
+    await applyEntityFieldChangeProposal({ entity_id: member.entityId, fields: { role: 'admin' }, current: { role: 'member' } }, owner.userId);
+    expect(await roles(member)).toMatchObject({ role: 'admin', displayed: 'admin' });
+  });
+  it('updates roles through the SDK', async () => {
+    const client = await TestApiClient.for({ organizationId: org.id, userId: owner.userId, memberRole: 'owner' });
+    await client.entities.update({ entity_id: member.entityId, metadata: { role: 'admin' } });
+    expect(await roles(member)).toMatchObject({ role: 'admin', displayed: 'admin' });
+  });
+  it('rolls back permission and metadata when the audit insert fails', async () => {
+    const sql = getTestDb();
+    await sql.unsafe(`CREATE FUNCTION test_reject_role_audit() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN IF NEW.origin_type = 'workspace_member_updated' THEN RAISE EXCEPTION 'role audit test failure'; END IF; RETURN NEW; END $$`);
+    await sql.unsafe(`CREATE TRIGGER test_reject_role_audit BEFORE INSERT ON events FOR EACH ROW EXECUTE FUNCTION test_reject_role_audit()`);
+    try {
+      expect((await edit(owner, member.entityId, 'admin')).status).toBeGreaterThanOrEqual(400);
+      expect(await roles(member)).toMatchObject({ role: 'member', displayed: 'member' });
+      const response = await post('/api/auth/organization/update-member-role', { cookie: owner.cookie, body: { organizationId: org.id, memberId: member.memberId, role: 'admin' } });
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect(await roles(member)).toMatchObject({ role: 'member', displayed: 'member' });
+    } finally {
+      await sql.unsafe('DROP TRIGGER test_reject_role_audit ON events');
+      await sql.unsafe('DROP FUNCTION test_reject_role_audit()');
+    }
+  });
+  it('reconciles old display-only roles from auth during migration', async () => {
+    const sql = getTestDb();
+    await sql`UPDATE entities SET metadata = metadata || '{"role":"admin"}'::jsonb WHERE id = ${member.entityId}`;
+    const migration = readFileSync('../../db/migrations/20260909143000_member_permission_roles.sql', 'utf8').split('-- migrate:down')[0];
+    await sql.unsafe(migration);
+    expect(await roles(member)).toMatchObject({ role: 'member', displayed: 'member' });
+  });
+
+  it('requires admin scope even when the token belongs to an owner', async () => {
+    const client = await createTestOAuthClient();
+    const { token } = await createTestAccessToken(owner.userId, org.id, client.client_id, { scope: 'mcp:write profile:read' });
+    const response = await post(`/api/${org.slug}/manage_entity`, { token, body: { action: 'update', entity_id: member.entityId, metadata: { role: 'admin' } } });
+    expect(response.status).toBe(403);
+    expect(await roles(member)).toMatchObject({ role: 'member', displayed: 'member' });
+  });
+  it('accepts an invitation with the edited role', async () => {
+    const invited = await createTestUser({ email: 'accept@roles.example.com' });
+    const response = await post(`/api/${org.slug}/manage_entity`, { cookie: owner.cookie, body: { action: 'create', entity_type: '$member', name: 'Accept', metadata: { email: invited.email } } });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect((await edit(owner, Number(body.entity.id), 'admin')).status).toBe(200);
+    const sql = getTestDb();
+    const [invitation] = await sql`SELECT id FROM invitation WHERE "organizationId" = ${org.id} AND email = ${invited.email} AND status = 'pending'`;
+    const accepted = await post('/api/auth/organization/accept-invitation', { cookie: (await createTestSession(invited.id)).cookieHeader, body: { invitationId: invitation.id } });
+    expect(accepted.status).toBe(200);
+    const [membership] = await sql`SELECT role FROM member WHERE "organizationId" = ${org.id} AND "userId" = ${invited.id}`;
+    expect(membership.role).toBe('admin');
+  });
+
+  it('preserves email-only profile edits and targets later role changes by auth identity', async () => {
+    const response = await post(`/api/${org.slug}/manage_entity`, { cookie: owner.cookie, body: { action: 'update', entity_id: member.entityId, metadata: { email: 'corrected@roles.example.com' } } });
+    expect(response.status).toBe(200);
+    const changed = await post('/api/auth/organization/update-member-role', { cookie: owner.cookie, body: { organizationId: org.id, memberId: member.memberId, role: 'admin' } });
+    expect(changed.status).toBe(200);
+    expect(await roles(member)).toMatchObject({ role: 'admin', displayed: 'admin' });
+  });
+  it('rejects untrusted origins on the existing auth endpoint', async () => {
+    const auth = await createAuth({ ENVIRONMENT: 'test', BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only' });
+    const context = await auth.$context;
+    // Better Auth disables Origin checks under NODE_ENV=test. Exercise the
+    // production check explicitly instead of asserting against that bypass.
+    const previous = context.skipOriginCheck;
+    context.skipOriginCheck = false;
+    try {
+      const response = await post('/api/auth/organization/update-member-role', { cookie: owner.cookie, headers: { Origin: 'https://untrusted.roles.example.com' }, body: { organizationId: org.id, memberId: member.memberId, role: 'admin' } });
+      expect(response.status).toBe(403);
+      expect(await roles(member)).toMatchObject({ role: 'member', displayed: 'member' });
+    } finally {
+      context.skipOriginCheck = previous;
+    }
+  });
+  it('can edit an expired pending invitation without renewing its expiry', async () => {
+    const response = await post(`/api/${org.slug}/manage_entity`, { cookie: owner.cookie, body: { action: 'create', entity_type: '$member', name: 'Expired', metadata: { email: 'expired@roles.example.com' } } });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const sql = getTestDb();
+    await sql`UPDATE invitation SET "expiresAt" = now() - interval '1 day' WHERE "organizationId" = ${org.id} AND email = 'expired@roles.example.com'`;
+    expect((await edit(owner, Number(body.entity.id), 'admin')).status).toBe(200);
+    const [row] = await sql`SELECT role, "expiresAt" < now() AS expired FROM invitation WHERE "organizationId" = ${org.id} AND email = 'expired@roles.example.com'`;
+    expect(row).toMatchObject({ role: 'admin', expired: true });
+  });
+  it('requires admin scope for invitations and records API attribution', async () => {
+    const client = await createTestOAuthClient();
+    const { token: writeToken } = await createTestAccessToken(owner.userId, org.id, client.client_id, { scope: 'mcp:write profile:read' });
+    const { token: adminToken } = await createTestAccessToken(owner.userId, org.id, client.client_id, { scope: 'mcp:admin profile:read' });
+    const body = { action: 'create', entity_type: '$member', name: 'API invited', metadata: { email: 'api@roles.example.com', role: 'admin' } };
+    expect((await post(`/api/${org.slug}/manage_entity`, { token: writeToken, body })).status).toBe(403);
+    expect((await post(`/api/${org.slug}/manage_entity`, { token: adminToken, body })).status).toBe(200);
+    expect((await post(`/api/${org.slug}/manage_entity`, { token: adminToken, body: { action: 'update', entity_id: member.entityId, metadata: { role: 'admin' } } })).status).toBe(200);
+    const sql = getTestDb();
+    const rows = await sql`SELECT metadata->>'actor_source' AS actor_source, created_by FROM events WHERE organization_id = ${org.id} AND origin_type IN ('workspace_member_updated', 'workspace_invitation_created')`;
+    expect(rows).toHaveLength(2);
+    for (const row of rows) expect(row).toMatchObject({ actor_source: 'api', created_by: owner.userId });
+  });
+
+});

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -27,7 +27,6 @@ import logger from "../utils/logger";
 import {
 	deleteMemberEntity,
 	ensureMemberEntity,
-	updateMemberEntityAccess,
 	updateMemberEntityStatus,
 } from "../utils/member-entity";
 import {
@@ -44,6 +43,7 @@ import {
 	resolveLoginProviderCredentials,
 	resolveRequestOrganizationId,
 } from "./config";
+import { memberRoleAuthHook } from "./member-roles";
 import {
 	findExistingPersonalOrg,
 	isPersonalOrgDeletionBlocked,
@@ -529,39 +529,6 @@ export async function createAuth(
 							);
 						}
 					},
-					afterUpdateMemberRole: async ({
-						member,
-						user,
-						organization: org,
-					}) => {
-						// The role change is already committed. Audit first; `user` is
-						// the affected member (subject), not the acting session user.
-						recordWorkspaceChangeEvent({
-							organizationId: org.id,
-							resourceKind: "member",
-							resourceId: member.id,
-							op: "updated",
-							summary: `Member "${user.name || 'a member'}" role set to ${member.role}`,
-							state: {
-								id: member.id,
-								user_id: user.id,
-								role: member.role,
-							},
-							changedFields: ["role"],
-							actorSource: "ui",
-						});
-						try {
-							await updateMemberEntityAccess(org.id, user.email, {
-								role: member.role,
-								status: "active",
-							});
-						} catch (err) {
-							console.error(
-								"[Auth] Failed to update $member entity after updateMemberRole:",
-								err,
-							);
-						}
-					},
 					afterCreateInvitation: async ({
 						invitation,
 						inviter,
@@ -856,6 +823,8 @@ export async function createAuth(
 				origin: null,
 			}),
 		],
+
+		hooks: { before: memberRoleAuthHook },
 
 		databaseHooks: {
 			user: {

--- a/packages/server/src/auth/member-role-policy.ts
+++ b/packages/server/src/auth/member-role-policy.ts
@@ -1,0 +1,41 @@
+import { ToolUserError } from '../utils/errors';
+import type { DbClient } from '../db/client';
+
+export const MEMBER_ROLES = ['owner', 'admin', 'member'] as const;
+export type MemberRole = typeof MEMBER_ROLES[number];
+
+export function parseMemberRole(value: unknown): MemberRole {
+  if (typeof value !== 'string' || !MEMBER_ROLES.includes(value as MemberRole)) {
+    throw new ToolUserError(`Role must be one of: ${MEMBER_ROLES.join(', ')}`, 400);
+  }
+  return value as MemberRole;
+}
+
+// Every semantic membership-role write takes this lock BEFORE entity/member
+// rows. Serialize owner-count checks across replicas, including the auth API.
+export async function lockMemberRoleChanges(sql: DbClient, organizationId: string): Promise<void> {
+  const rows = await sql`SELECT id FROM organization WHERE id = ${organizationId} FOR UPDATE`;
+  if (!rows.length) throw new ToolUserError('Workspace not found', 404);
+}
+
+export async function authorizeMemberRole(
+  sql: DbClient,
+  organizationId: string,
+  actorId: string | null,
+  role: MemberRole,
+  previousRole?: string,
+  checkLastOwner = true,
+): Promise<void> {
+  const [actor] = await sql`SELECT role FROM member WHERE "organizationId" = ${organizationId} AND "userId" = ${actorId}`;
+  if (!actor || (actor.role !== 'owner' && actor.role !== 'admin')) {
+    throw new ToolUserError('Only workspace owners and admins can change member roles', 403);
+  }
+  if ((role === 'owner' || previousRole === 'owner') && actor.role !== 'owner') {
+    throw new ToolUserError('Only owners can grant or change ownership', 403);
+  }
+  if (checkLastOwner && previousRole === 'owner' && role !== 'owner') {
+    const owners = await sql`SELECT id FROM member WHERE "organizationId" = ${organizationId} AND role = 'owner'`;
+    if (owners.length <= 1) throw new ToolUserError('The workspace must retain at least one owner', 400);
+  }
+}
+

--- a/packages/server/src/auth/member-role-policy.ts
+++ b/packages/server/src/auth/member-role-policy.ts
@@ -24,7 +24,6 @@ export async function authorizeMemberRole(
   actorId: string | null,
   role: MemberRole,
   previousRole?: string,
-  checkLastOwner = true,
 ): Promise<void> {
   const [actor] = await sql`SELECT role FROM member WHERE "organizationId" = ${organizationId} AND "userId" = ${actorId}`;
   if (!actor || (actor.role !== 'owner' && actor.role !== 'admin')) {
@@ -33,9 +32,10 @@ export async function authorizeMemberRole(
   if ((role === 'owner' || previousRole === 'owner') && actor.role !== 'owner') {
     throw new ToolUserError('Only owners can grant or change ownership', 403);
   }
-  if (checkLastOwner && previousRole === 'owner' && role !== 'owner') {
-    const owners = await sql`SELECT id FROM member WHERE "organizationId" = ${organizationId} AND role = 'owner'`;
-    if (owners.length <= 1) throw new ToolUserError('The workspace must retain at least one owner', 400);
-  }
+}
+
+export async function assertWorkspaceRetainsOwner(sql: DbClient, organizationId: string): Promise<void> {
+  const owners = await sql`SELECT id FROM member WHERE "organizationId" = ${organizationId} AND role = 'owner'`;
+  if (owners.length <= 1) throw new ToolUserError('The workspace must retain at least one owner', 400);
 }
 

--- a/packages/server/src/auth/member-roles.ts
+++ b/packages/server/src/auth/member-roles.ts
@@ -7,7 +7,7 @@ import { insertWorkspaceChangeEventInTransaction } from '../utils/insert-event';
 import { updateMemberEntityAccess } from '../utils/member-entity';
 import { withEntityWriteTransaction } from '../utils/entity-management';
 
-import { authorizeMemberRole, lockMemberRoleChanges, parseMemberRole, type MemberRole } from './member-role-policy';
+import { assertWorkspaceRetainsOwner, authorizeMemberRole, lockMemberRoleChanges, parseMemberRole, type MemberRole } from './member-role-policy';
 
 export async function changeMemberRoleInTransaction(
   sql: DbClient,
@@ -17,6 +17,7 @@ export async function changeMemberRoleInTransaction(
   if (!member) throw new ToolUserError('Workspace member not found', 404);
   await authorizeMemberRole(sql, params.organizationId, params.actorId, params.role, member.role as string);
   if (member.role === params.role) return member;
+  if (member.role === 'owner') await assertWorkspaceRetainsOwner(sql, params.organizationId);
   await sql`UPDATE member SET role = ${params.role} WHERE id = ${member.id} AND "organizationId" = ${params.organizationId}`;
   await insertWorkspaceChangeEventInTransaction({
     organizationId: params.organizationId,
@@ -49,7 +50,7 @@ export const memberRoleAuthHook = createAuthMiddleware(async (ctx) => {
       const member = await changeMemberRoleInTransaction(sql, { organizationId, actorId: session.user.id, memberId: body.memberId, role, actorSource: 'ui' });
       // Target by the authentication claim, never by email: the displayed role
       // must follow the identity whose permission actually changed.
-      await updateMemberEntityAccess(organizationId, null, { role, status: 'active' }, sql, member.userId as string);
+      await updateMemberEntityAccess(organizationId, member.userId as string, { role, status: 'active' }, sql);
       return member;
     });
     return ctx.json(result);

--- a/packages/server/src/auth/member-roles.ts
+++ b/packages/server/src/auth/member-roles.ts
@@ -1,0 +1,63 @@
+import type { ConfigActorSource } from '../utils/apply-context';
+import { ToolUserError } from '../utils/errors';
+import { APIError } from 'better-auth';
+import { createAuthMiddleware, getSessionFromCtx } from 'better-auth/api';
+import { type DbClient, getDb } from '../db/client';
+import { insertWorkspaceChangeEventInTransaction } from '../utils/insert-event';
+import { updateMemberEntityAccess } from '../utils/member-entity';
+import { withEntityWriteTransaction } from '../utils/entity-management';
+
+import { authorizeMemberRole, lockMemberRoleChanges, parseMemberRole, type MemberRole } from './member-role-policy';
+
+export async function changeMemberRoleInTransaction(
+  sql: DbClient,
+  params: { organizationId: string; actorId: string | null; memberId: string; role: MemberRole; actorSource: ConfigActorSource },
+) {
+  const [member] = await sql`SELECT id, "userId", "organizationId", role, "createdAt" FROM member WHERE id = ${params.memberId} AND "organizationId" = ${params.organizationId}`;
+  if (!member) throw new ToolUserError('Workspace member not found', 404);
+  await authorizeMemberRole(sql, params.organizationId, params.actorId, params.role, member.role as string);
+  if (member.role === params.role) return member;
+  await sql`UPDATE member SET role = ${params.role} WHERE id = ${member.id} AND "organizationId" = ${params.organizationId}`;
+  await insertWorkspaceChangeEventInTransaction({
+    organizationId: params.organizationId,
+    resourceKind: 'member', resourceId: member.id as string, op: 'updated',
+    summary: `Member role set to ${params.role}`,
+    state: { id: member.id, user_id: member.userId, role: params.role },
+    changedFields: ['role'], actorSource: params.actorSource, createdBy: params.actorId,
+  }, sql);
+  return { ...member, role: params.role };
+}
+
+// Preserve Better Auth's existing endpoint and session checks, while routing
+// the write through the same transactional operation as entity hooks. Origin /
+// CSRF validation already ran: Better Auth registers `originCheckMiddleware` as
+// a router middleware on `/**`, which better-call runs before the endpoint this
+// hook short-circuits.
+export const memberRoleAuthHook = createAuthMiddleware(async (ctx) => {
+  if (ctx.path !== '/organization/update-member-role') return;
+  const session = await getSessionFromCtx(ctx);
+  if (!session) throw new APIError('UNAUTHORIZED', { message: 'Sign in to change member roles' });
+  const body = ctx.body;
+  const organizationId = body?.organizationId ?? session.session.activeOrganizationId;
+  if (typeof organizationId !== 'string' || typeof body?.memberId !== 'string') {
+    throw new APIError('BAD_REQUEST', { message: 'organizationId and memberId are required' });
+  }
+  try {
+    const role = parseMemberRole(body.role);
+    const result = await withEntityWriteTransaction(getDb(), async (sql) => {
+      await lockMemberRoleChanges(sql, organizationId);
+      const member = await changeMemberRoleInTransaction(sql, { organizationId, actorId: session.user.id, memberId: body.memberId, role, actorSource: 'ui' });
+      // Target by the authentication claim, never by email: the displayed role
+      // must follow the identity whose permission actually changed.
+      await updateMemberEntityAccess(organizationId, null, { role, status: 'active' }, sql, member.userId as string);
+      return member;
+    });
+    return ctx.json(result);
+  } catch (error) {
+    if (error instanceof ToolUserError) {
+      const status = error.httpStatus === 403 ? 'FORBIDDEN' : error.httpStatus === 404 ? 'NOT_FOUND' : 'BAD_REQUEST';
+      throw new APIError(status, { message: error.message });
+    }
+    throw error;
+  }
+});

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -7,10 +7,16 @@
  * lives in manage_operations next to `supersedeActionEvent`.
  */
 
+import { deriveToolActorSource } from '../../utils/apply-context';
 import {
 	RESERVED_COLUMN_NAMES,
 	validateEntityRowPatchGrantingApprovedFields,
 } from "../../authz/entity-row-validation";
+import { SCOPE_CHECK_NOT_APPLICABLE } from "../../auth/tool-access";
+import {
+	type EntityTransactionHookContext,
+	getEntityHooks,
+} from "../../utils/entity-hooks";
 import { createHash } from "node:crypto";
 import {
 	ApprovalAttribution,
@@ -1153,18 +1159,41 @@ export async function applyEntityFieldChangeProposal(
 		// the entity. The canonical event insert below takes the same FK lock, and
 		// this order avoids deadlocking with organization deletion's parent-first
 		// cascade.
-		const [scope] = await tx<{ organization_id: string }>`
-			SELECT organization_id FROM entities
-			WHERE id = ${proposal.entity_id} AND deleted_at IS NULL
+		const [scope] = await tx<{ organization_id: string; entity_type: string }>`
+			SELECT e.organization_id, et.slug AS entity_type FROM entities e JOIN entity_types et ON et.id = e.entity_type_id
+			WHERE e.id = ${proposal.entity_id} AND e.deleted_at IS NULL
 		`;
 		if (!scope) {
 			throw new ToolUserError(`Entity ${proposal.entity_id} not found`, 404);
 		}
+		const hooks = getEntityHooks(scope.entity_type);
+		// Applying a proposal is human-gated upstream (requireHumanApprovalContext),
+		// so the caller carries no MCP scope dimension — the same sentinel every
+		// session-authenticated path passes.
+		const hookContext: EntityTransactionHookContext = {
+			organizationId: scope.organization_id,
+			userId: approverUserId,
+			sql: tx,
+			scopes: SCOPE_CHECK_NOT_APPLICABLE,
+			actorSource: 'ui',
+		};
+		await hooks?.beforeUpdate?.(metadataFields, hookContext);
 		await tx`
 			SELECT 1 FROM organization
 			WHERE id = ${scope.organization_id}
 			FOR KEY SHARE
 		`;
+		// Only an afterUpdate hook needs the pre-image; entity types without one
+		// must not pay for a second lock on the row mergeEntityFields already locks.
+		const before = hooks?.afterUpdate
+			? (
+					await tx<{ metadata: Record<string, unknown> | null }>`
+						SELECT metadata FROM entities
+						WHERE id = ${proposal.entity_id}
+						FOR UPDATE
+					`
+				)[0]
+			: undefined;
 		const merge =
 			Object.keys(metadataFields).length > 0
 				? await mergeEntityFields({
@@ -1274,6 +1303,18 @@ export async function applyEntityFieldChangeProposal(
 			([field, value]) => ({ field, old: value.old, new: value.new }),
 		);
 		if (appliedChanges.length > 0) {
+			if (hooks?.afterUpdate && before) {
+				const [after] = await tx<{
+					metadata: Record<string, unknown> | null;
+				}>`
+					SELECT metadata FROM entities WHERE id = ${proposal.entity_id}
+				`;
+				await hooks.afterUpdate(
+					{ id: proposal.entity_id, metadata: before.metadata },
+					{ id: proposal.entity_id, metadata: after.metadata },
+					hookContext,
+				);
+			}
 			const [entity] = await tx<{ name: string }>`
 				SELECT name FROM entities
 				WHERE id = ${proposal.entity_id} AND deleted_at IS NULL
@@ -1410,6 +1451,8 @@ export async function applyEntityChangeProposal(
 				hookContext: {
 					organizationId: ctx.organizationId,
 					userId: ctx.userId,
+					scopes: ctx.scopes,
+					actorSource: deriveToolActorSource(ctx),
 					env,
 					deferAfterCommit: postCommitEffects
 						? (effect) => postCommitEffects.push(effect)

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -19,6 +19,7 @@
  * - unmerge: Reverse a ledger-backed merge when its after-state is unchanged
  */
 
+import { deriveToolActorSource } from '../../utils/apply-context';
 import { randomUUID } from "node:crypto";
 
 import {
@@ -500,6 +501,8 @@ async function handleCreate(
 			hookContext: {
 				organizationId: ctx.organizationId,
 				userId: ctx.userId,
+				scopes: ctx.scopes,
+				actorSource: deriveToolActorSource(ctx),
 				env,
 			},
 		});

--- a/packages/server/src/utils/entity-hooks.ts
+++ b/packages/server/src/utils/entity-hooks.ts
@@ -1,11 +1,16 @@
 /**
  * Generic entity lifecycle hook registry.
  *
- * Entity types can register hooks that fire during create/delete operations.
+ * Entity types can register hooks that fire during semantic create/update/delete operations.
  * Hooks are skipped when `skipHooks: true` is passed (used by auth callbacks
  * to prevent circular calls).
  */
 
+import type { ConfigActorSource } from './apply-context';
+import { ToolUserError } from './errors';
+import { hasRequiredMcpScope } from '../auth/tool-access';
+import { authorizeMemberRole, lockMemberRoleChanges, parseMemberRole } from '../auth/member-role-policy';
+import { changeMemberRoleInTransaction } from '../auth/member-roles';
 import { createElement } from 'react';
 import { sendTransactionalEmail } from '../email/send';
 import { InvitationEmail, invitationSubject } from '../email/templates/invitation';
@@ -25,17 +30,41 @@ export interface EntityHookContext {
   organizationId: string;
   userId: string | null;
   env?: Env;
+  scopes?: readonly string[] | null;
+  actorSource?: ConfigActorSource;
   /** Caller-owned transaction for hook database work. */
   sql?: DbClient;
   /** Register network side effects that may run only after the caller commits. */
   deferAfterCommit?: (effect: () => Promise<void>) => void;
 }
 
+/**
+ * Context for hooks that must run inside the caller's write transaction: their
+ * locks and writes are only meaningful on that connection, so `sql` is required
+ * rather than falling back to a fresh pool client.
+ */
+export type EntityTransactionHookContext = EntityHookContext & { sql: DbClient };
+
 interface EntityLifecycleHooks {
   /** Runs before INSERT. Can mutate data (e.g. set status). Throw to abort. */
   beforeCreate?: (data: EntityData, ctx: EntityHookContext) => Promise<EntityData>;
   /** Runs after INSERT. For side-effects (e.g. sending notifications). */
   afterCreate?: (entity: CreatedEntity, ctx: EntityHookContext) => Promise<void>;
+  /**
+   * Runs in the write transaction before any row lock, so a hook can claim a
+   * coarser lock first. `fields` is the proposed metadata patch, letting a hook
+   * skip work when the write cannot touch what it guards.
+   */
+  beforeUpdate?: (
+    fields: Record<string, unknown>,
+    ctx: EntityTransactionHookContext
+  ) => Promise<void>;
+  /** Runs after an applied update, in the same transaction. Throw to roll back. */
+  afterUpdate?: (
+    before: { id: number; metadata: Record<string, unknown> | null },
+    after: { id: number; metadata?: Record<string, unknown> | null },
+    ctx: EntityTransactionHookContext
+  ) => Promise<void>;
   /** Runs before soft/hard delete. For cleanup (e.g. cancelling invitations). */
   beforeDelete?: (
     entity: { id: number; entity_type: string; metadata: Record<string, unknown> | null },
@@ -106,9 +135,14 @@ async function sendMemberInvitationEmail(
 
 registerEntityHooks('$member', {
   async beforeCreate(data, ctx) {
+    if (!hasRequiredMcpScope('admin', ctx.scopes)) throw new ToolUserError('Changing membership requires mcp:admin scope', 403);
     const sql = ctx.sql ?? getDb();
     const { emailField } = await resolveMemberSchemaFields(ctx.organizationId, sql);
     const meta = { ...(data.metadata ?? {}) };
+    const role = parseMemberRole(meta.role ?? 'member');
+    await lockMemberRoleChanges(sql, ctx.organizationId);
+    await authorizeMemberRole(sql, ctx.organizationId, ctx.userId, role);
+    meta.role = role;
     const email = meta[emailField] as string | undefined;
 
     if (email) {
@@ -119,7 +153,7 @@ registerEntityHooks('$member', {
           gen_random_uuid()::text,
           ${ctx.organizationId},
           ${email},
-          'member',
+          ${role},
           'pending',
           ${new Date(Date.now() + 48 * 60 * 60 * 1000)},
           ${ctx.userId},
@@ -132,6 +166,13 @@ registerEntityHooks('$member', {
         )
         RETURNING id
       `) as unknown as Array<{ id: string }>;
+      if (inserted.length === 0) {
+        const [pending] = await sql`SELECT role FROM invitation
+          WHERE "organizationId" = ${ctx.organizationId} AND email = ${email} AND status = 'pending'`;
+        if (!pending || pending.role !== role) {
+          throw new ToolUserError('A pending invitation already exists; edit its member record to change the role', 400);
+        }
+      }
       if (inserted.length > 0) {
         const event: WorkspaceChangeEventParams = {
           organizationId: ctx.organizationId,
@@ -141,11 +182,11 @@ registerEntityHooks('$member', {
           summary: 'Invitation sent',
           state: {
             id: inserted[0].id,
-            role: 'member',
+            role,
             status: 'pending',
           },
           changedFields: ['role', 'status'],
-          actorSource: 'ui',
+          actorSource: ctx.actorSource,
           createdBy: ctx.userId ?? null,
         };
         if (ctx.sql) {
@@ -168,6 +209,65 @@ registerEntityHooks('$member', {
       return;
     }
     await sendMemberInvitationEmail(entity, ctx);
+  },
+
+  async beforeUpdate(fields, ctx) {
+    // Only a role write needs the org-wide serialization; taking it for every
+    // profile edit would block unrelated entity writes in the workspace.
+    if (!Object.hasOwn(fields, 'role')) return;
+    await lockMemberRoleChanges(ctx.sql, ctx.organizationId);
+  },
+
+  async afterUpdate(before, after, ctx) {
+    if (before.metadata?.role === after.metadata?.role) return;
+    const sql = ctx.sql;
+    const { emailField } = await resolveMemberSchemaFields(ctx.organizationId, sql);
+    const oldEmail = before.metadata?.[emailField];
+    const newEmail = after.metadata?.[emailField];
+    // An editable profile field must never retarget a permission mutation.
+    if (oldEmail !== newEmail) {
+      throw new ToolUserError('Change member email separately from its permission role', 400);
+    }
+    if (!hasRequiredMcpScope('admin', ctx.scopes)) throw new ToolUserError('Changing membership requires mcp:admin scope', 403);
+    const role = parseMemberRole(after.metadata?.role);
+    const members = await sql`
+      SELECT m.id FROM entity_identities ei JOIN member m
+        ON m."userId" = ei.identifier AND m."organizationId" = ei.organization_id
+      WHERE ei.organization_id = ${ctx.organizationId} AND ei.entity_id = ${before.id}
+        AND ei.namespace = 'auth_user_id' AND ei.source_connector = 'auth:signup'
+        AND ei.deleted_at IS NULL
+    `;
+    if (members.length === 1) {
+      await changeMemberRoleInTransaction(sql, {
+        organizationId: ctx.organizationId, actorId: ctx.userId,
+        memberId: members[0].id as string, role, actorSource: ctx.actorSource ?? 'api',
+      });
+      return;
+    }
+    if (members.length > 1) {
+      throw new ToolUserError('Member has more than one authentication identity', 400);
+    }
+    if (typeof oldEmail !== 'string') {
+      throw new ToolUserError('Member has no active membership or pending invitation', 400);
+    }
+    const invitations = await sql`
+      SELECT id, role FROM invitation WHERE "organizationId" = ${ctx.organizationId}
+        AND email = ${oldEmail} AND status = 'pending'
+      FOR UPDATE
+    `;
+    if (invitations.length !== 1) {
+      throw new ToolUserError('Member has no active membership or pending invitation', 400);
+    }
+    const invitation = invitations[0];
+    await authorizeMemberRole(sql, ctx.organizationId, ctx.userId, role,
+      invitation.role as string, false);
+    await sql`UPDATE invitation SET role = ${role} WHERE id = ${invitation.id}`;
+    await insertWorkspaceChangeEventInTransaction({
+      organizationId: ctx.organizationId, resourceKind: 'invitation',
+      resourceId: invitation.id as string, op: 'updated', summary: `Invitation role set to ${role}`,
+      state: { id: invitation.id, role, status: 'pending' }, changedFields: ['role'],
+      actorSource: ctx.actorSource, createdBy: ctx.userId,
+    }, sql);
   },
 
   async beforeDelete(entity, ctx) {
@@ -205,7 +305,7 @@ registerEntityHooks('$member', {
           status: inv.status ?? 'canceled',
         },
         changedFields: ['status'],
-        actorSource: 'ui',
+        actorSource: ctx.actorSource,
         createdBy: ctx.userId ?? null,
       };
       if (ctx.sql) {

--- a/packages/server/src/utils/entity-hooks.ts
+++ b/packages/server/src/utils/entity-hooks.ts
@@ -220,6 +220,7 @@ registerEntityHooks('$member', {
 
   async afterUpdate(before, after, ctx) {
     if (before.metadata?.role === after.metadata?.role) return;
+    if (!hasRequiredMcpScope('admin', ctx.scopes)) throw new ToolUserError('Changing membership requires mcp:admin scope', 403);
     const sql = ctx.sql;
     const { emailField } = await resolveMemberSchemaFields(ctx.organizationId, sql);
     const oldEmail = before.metadata?.[emailField];
@@ -228,7 +229,6 @@ registerEntityHooks('$member', {
     if (oldEmail !== newEmail) {
       throw new ToolUserError('Change member email separately from its permission role', 400);
     }
-    if (!hasRequiredMcpScope('admin', ctx.scopes)) throw new ToolUserError('Changing membership requires mcp:admin scope', 403);
     const role = parseMemberRole(after.metadata?.role);
     const members = await sql`
       SELECT m.id FROM entity_identities ei JOIN member m
@@ -260,7 +260,7 @@ registerEntityHooks('$member', {
     }
     const invitation = invitations[0];
     await authorizeMemberRole(sql, ctx.organizationId, ctx.userId, role,
-      invitation.role as string, false);
+      invitation.role as string);
     await sql`UPDATE invitation SET role = ${role} WHERE id = ${invitation.id}`;
     await insertWorkspaceChangeEventInTransaction({
       organizationId: ctx.organizationId, resourceKind: 'invitation',

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -6,6 +6,7 @@
  * Organization scoping ensures data isolation.
  */
 
+import { deriveToolActorSource } from './apply-context';
 import { slugify } from "@lobu/core";
 import { feedLinkedToBusinessEntitySql } from "../authz/channel-about";
 import type {
@@ -40,7 +41,11 @@ import {
 	type FieldMergeResult,
 	type FieldWriteSource,
 } from "./entity-field-merge";
-import { type EntityHookContext, getEntityHooks } from "./entity-hooks";
+import {
+	type EntityHookContext,
+	type EntityTransactionHookContext,
+	getEntityHooks,
+} from "./entity-hooks";
 import { ToolUserError } from "./errors";
 import { EntityPolicyDenialError } from "./entity-write-denial-audit";
 import logger from "./logger";
@@ -1085,6 +1090,26 @@ export async function updateEntity(
 	// updates to the same entity serialize on the row lock, fixing the pre-existing
 	// non-transactional read-modify-write race on entities.metadata.
 	const result = await withEntityWriteTransaction(sql, async (tx) => {
+		// Resolve the type before any lock: `beforeUpdate` exists so a hook can
+		// claim a coarser lock (e.g. the organization row) ahead of the entity
+		// row, which the `current` SELECT below takes.
+		const [type] = await tx`
+			SELECT et.slug FROM entities e
+			JOIN entity_types et ON et.id = e.entity_type_id
+			WHERE e.id = ${entityId}
+			  AND e.organization_id = ${ctx.organizationId}
+			  AND e.deleted_at IS NULL
+		`;
+		const hooks = type ? getEntityHooks(type.slug as string) : undefined;
+		const hookContext: EntityTransactionHookContext = {
+			organizationId: ctx.organizationId,
+			userId: ctx.userId,
+			env: _env,
+			sql: tx,
+			scopes: ctx.scopes,
+			actorSource: deriveToolActorSource(ctx),
+		};
+		await hooks?.beforeUpdate?.(metadataUpdates, hookContext);
 		// Canonical change events take an organization FK lock before commit. Claim
 		// it before the entity row so organization deletion cannot hold the parent
 		// while waiting on this row in the opposite order.
@@ -1423,6 +1448,13 @@ export async function updateEntity(
 			proposedFields: Record<string, unknown>;
 			proposedCurrent: Record<string, unknown>;
 		};
+		if (validated) {
+			await hooks?.afterUpdate?.(
+				{ id: entityId, metadata: existing },
+				updated,
+				hookContext,
+			);
+		}
 		await opts?.afterPersist?.(
 			{
 				name: (current[0].name as string | null) ?? null,
@@ -1645,7 +1677,7 @@ export async function deleteEntity(
           if (!beforeDelete) return;
           await beforeDelete(
             { id: entityId, ...entityRow },
-            { organizationId: ctx.organizationId, userId: ctx.userId, sql: tx }
+            { organizationId: ctx.organizationId, userId: ctx.userId, sql: tx, actorSource: deriveToolActorSource(ctx) }
           );
         }
       : null;

--- a/packages/server/src/utils/member-entity-type.ts
+++ b/packages/server/src/utils/member-entity-type.ts
@@ -2,6 +2,7 @@
  * Shared defaults and helpers for the built-in $member entity type.
  */
 
+import { MEMBER_ROLES } from '../auth/member-role-policy';
 import { getDb } from '../db/client';
 import { type EventKindDefinition, primeMemberEventKinds } from './event-kind-validation';
 import { GUIDANCE_SEMANTIC_TYPE } from './org-guidance';
@@ -117,6 +118,7 @@ const DEFAULT_MEMBER_METADATA_SCHEMA = {
     role: {
       type: 'string',
       description: 'Role',
+      enum: [...MEMBER_ROLES],
       'x-table-column': true,
     },
     status: {
@@ -209,7 +211,8 @@ function mergeMemberMetadataSchema(
   properties.role = properties.role
     ? {
         ...properties.role,
-        type: properties.role.type ?? 'string',
+        type: 'string',
+        enum: [...MEMBER_ROLES],
         description: properties.role.description ?? 'Role',
         'x-table-column': properties.role['x-table-column'] ?? true,
       }

--- a/packages/server/src/utils/member-entity.ts
+++ b/packages/server/src/utils/member-entity.ts
@@ -199,14 +199,22 @@ export async function updateMemberEntityStatus(
   });
 }
 
+/**
+ * Project role/status onto the $member entity. Targets by `authUserId` when
+ * given (the `auth:signup` identity claim), which is the only identifier a
+ * permission write may follow; `email` is used solely when no claim is passed
+ * and must then be non-null.
+ */
 export async function updateMemberEntityAccess(
   organizationId: string,
-  email: string,
-  updates: { role?: string; status?: 'active' | 'invited' }
+  email: string | null,
+  updates: { role?: string; status?: 'active' | 'invited' },
+  transaction?: DbClient,
+  authUserId?: string
 ): Promise<void> {
-  await ensureMemberEntityType(organizationId);
-  const { emailField } = await resolveMemberSchemaFields(organizationId);
-  const sql = getDb();
+  if (!transaction) await ensureMemberEntityType(organizationId);
+  const { emailField } = await resolveMemberSchemaFields(organizationId, transaction);
+  const sql = transaction ?? getDb();
   await withEntityWriteTransaction(sql, async (tx) => {
     const rows = await tx.unsafe<{ id: number; metadata: Record<string, unknown> | null }>(
       `SELECT e.id, e.metadata
@@ -216,12 +224,17 @@ export async function updateMemberEntityAccess(
          AND et.organization_id = $1
          AND et.deleted_at IS NULL
          AND e.organization_id = $1
-         AND e.metadata->>$2 = $3
+         AND (($4::text IS NULL AND e.metadata->>$2 = $3) OR EXISTS (
+           SELECT 1 FROM entity_identities ei WHERE ei.entity_id = e.id
+             AND ei.organization_id = e.organization_id AND ei.namespace = 'auth_user_id'
+             AND ei.source_connector = 'auth:signup' AND ei.deleted_at IS NULL
+             AND ei.identifier = $4
+         ))
          AND e.deleted_at IS NULL
        ORDER BY e.id
        LIMIT 1
        FOR UPDATE OF e`,
-      [organizationId, emailField, email]
+      [organizationId, emailField, email, authUserId ?? null]
     );
     if (rows.length === 0) return;
 

--- a/packages/server/src/utils/member-entity.ts
+++ b/packages/server/src/utils/member-entity.ts
@@ -199,21 +199,13 @@ export async function updateMemberEntityStatus(
   });
 }
 
-/**
- * Project role/status onto the $member entity. Targets by `authUserId` when
- * given (the `auth:signup` identity claim), which is the only identifier a
- * permission write may follow; `email` is used solely when no claim is passed
- * and must then be non-null.
- */
+/** Project role/status using the trusted authentication identity claim. */
 export async function updateMemberEntityAccess(
   organizationId: string,
-  email: string | null,
+  authUserId: string,
   updates: { role?: string; status?: 'active' | 'invited' },
   transaction?: DbClient,
-  authUserId?: string
 ): Promise<void> {
-  if (!transaction) await ensureMemberEntityType(organizationId);
-  const { emailField } = await resolveMemberSchemaFields(organizationId, transaction);
   const sql = transaction ?? getDb();
   await withEntityWriteTransaction(sql, async (tx) => {
     const rows = await tx.unsafe<{ id: number; metadata: Record<string, unknown> | null }>(
@@ -224,17 +216,17 @@ export async function updateMemberEntityAccess(
          AND et.organization_id = $1
          AND et.deleted_at IS NULL
          AND e.organization_id = $1
-         AND (($4::text IS NULL AND e.metadata->>$2 = $3) OR EXISTS (
+         AND EXISTS (
            SELECT 1 FROM entity_identities ei WHERE ei.entity_id = e.id
              AND ei.organization_id = e.organization_id AND ei.namespace = 'auth_user_id'
              AND ei.source_connector = 'auth:signup' AND ei.deleted_at IS NULL
-             AND ei.identifier = $4
-         ))
+             AND ei.identifier = $2
+         )
          AND e.deleted_at IS NULL
        ORDER BY e.id
        LIMIT 1
        FOR UPDATE OF e`,
-      [organizationId, emailField, email, authUserId ?? null]
+      [organizationId, authUserId]
     );
     if (rows.length === 0) return;
 


### PR DESCRIPTION
## Summary

Editing Role on Members previously changed only profile metadata: selecting or typing `admin` left actual access at `member`, and invitations always used `member`. Define the three supported roles in the schema and use generic transactional entity update hooks to apply permission changes, including approved edits and pending invitations. The existing auth role endpoint shares the same authorization and atomic audit/projection write.

Existing workspace schemas and displayed roles are reconciled from authentication during a quiesced migration. No frontend or Members-page-specific controls are added.

## Test plan

- [x] Focused PostgreSQL integration tests: role changes, owner restrictions, concurrent last-owner demotions, tenant isolation, SDK, approvals, scopes, invitation acceptance, migration repair, and audit rollback.
- [x] Bug reproduced before changes: 4 failed / 1 passed; promotion returned `displayed: admin, role: member`, and the admin invitation retained `member`.
- [x] After implementation: 150 tests passed across 14 integration suites, including 19 dedicated role regressions.
- [x] Real local UI with synthetic users: Role renders Owner/Admin/Member; saving Admin persisted `admin` in both membership and metadata and survived reload; last-owner demotion displayed the expected validation error.
- [x] `make pre-pr`, pre-commit checks, and Opus review-fix completed. Follow-up tests cover audit source, expired pending invitations, email-only edits, and production Origin validation.
- [x] Required GitHub CI passed on the final head.
- [x] Final exact-head Opus semantic review passed: zero bugs/blockers; confidence 87, simplicity 72, slop 8. All three cleanup suggestions from the prior review were applied; 21 affected integration tests passed again.

- [x] Production deployed squash `0ae20d52ca300451e07923c00574338fe18f1969`; exact-SHA smoke passed 9/9, and app/worker/embeddings deployments are ready.

## Notes

The migration requires writer quiescence because old servers allow arbitrary role metadata edits. Browser proof used an isolated local database and synthetic accounts; no live membership was changed.
