### PR TITLE
fix(mcp): advertise read tools as readOnlyHint

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -484,7 +484,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(tool).toEqual(
       expect.objectContaining({
         annotations: expect.objectContaining({
-          readOnlyHint: false,
+          readOnlyHint: true,
           destructiveHint: false,
           openWorldHint: false,
           idempotentHint: false,

--- a/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
@@ -61,16 +61,17 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
 
     const expectedSafetyHints = {
       // The retrieval tools mutate nothing in the workspace or in an external
-      // system, but every invocation appends an audit/activity record, so they
-      // are not `readOnlyHint`. Read ACCESS is pinned separately by
-      // `authorizationReadOnly` (see tool-registry-split.test.ts).
-      search_memory: [false, false, false],
-      search_sdk: [false, false, false],
-      query_sdk: [false, false, false],
-      query_sql: [false, false, false],
+      // system, so they ARE `readOnlyHint`. The audit/activity record each
+      // invocation appends is server bookkeeping, not a change to the caller's
+      // environment. Read ACCESS is pinned separately by `authorizationReadOnly`
+      // (see tool-registry-split.test.ts).
+      search_memory: [true, false, false],
+      search_sdk: [true, false, false],
+      query_sdk: [true, false, false],
+      query_sql: [true, false, false],
       save_memory: [false, false, false],
       run_sdk: [false, true, true],
-      get_approval: [false, false, false],
+      get_approval: [true, false, false],
     } as const;
 
     for (const [toolName, [readOnlyHint, openWorldHint, destructiveHint]] of Object.entries(
@@ -292,5 +293,18 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
     expect(names).not.toContain('run_sdk');
     expect(names).not.toContain('query_sdk');
     expect(names).not.toContain('query_sql');
+
+    // The public path builds its own listing (publicOnly + read tier), so it
+    // needs its own annotation assertion: a regression here is invisible to the
+    // authenticated case above and reaches unauthenticated clients directly.
+    const publicTools = body.result?.tools as Array<{
+      name: string;
+      annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean };
+    }>;
+    for (const name of ['search_memory', 'search_sdk']) {
+      const annotations = publicTools.find((t) => t.name === name)?.annotations;
+      expect(annotations?.readOnlyHint, `public ${name}.readOnlyHint`).toBe(true);
+      expect(annotations?.destructiveHint, `public ${name}.destructiveHint`).toBe(false);
+    }
   });
 });

--- a/packages/server/src/__tests__/unit/tool-registry-split.test.ts
+++ b/packages/server/src/__tests__/unit/tool-registry-split.test.ts
@@ -91,12 +91,12 @@ describe("tool registry split", () => {
 		expect(isRestDispatchTool("manage_connections")).toBe(true);
 	});
 
-	it("discloses audit writes without requiring write access for data reads", () => {
+	it("advertises data reads as read-only without requiring write access", () => {
 		const listed = getMcpTools({ maxAccessLevel: "read" });
 		for (const name of ["search_memory", "search_sdk", "query_sdk", "query_sql", "get_approval"]) {
 			const tool = listed.find((entry) => entry.name === name);
 			expect(tool).toBeDefined();
-			expect(tool?.annotations?.readOnlyHint).toBe(false);
+			expect(tool?.annotations?.readOnlyHint).toBe(true);
 			expect(isAuthorizationReadOnly(getTool(name))).toBe(true);
 			expect(tool?.securitySchemes).toEqual([
 				{ type: "oauth2", scopes: ["mcp:read", "profile:read"] },

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -238,13 +238,21 @@ const READ_ONLY = {
 // CHANGE public internet or third-party state. Live reads from a user's private
 // connectors remain closed-world even though they contact an external service.
 //
-// These operations retrieve data, but every OAuth and PAT invocation appends an
-// audit/activity record, and `readOnlyHint` asserts the tool "does not modify
-// its environment" — that append does, so the hint cannot be claimed. Access
-// enforcement stays separate through `authorizationReadOnly`, so a read grant
-// still invokes these tools while the SDK keeps rejecting data writes.
+// These operations only retrieve data. Every OAuth and PAT invocation appends an
+// audit/activity record, but `readOnlyHint` describes the CALLER'S environment —
+// the workspace content and external systems a client prompts the user about —
+// and server-side bookkeeping is not part of it. Claiming `false` for the audit
+// row would make the hint unclaimable by any audited server and spends the
+// user's attention on confirmations that protect nothing, which in turn dulls
+// the prompts on `run_sdk`, where a write really can happen.
+//
+// Do not flip this back on the strength of the audit append alone. Access
+// enforcement is separate and explicit: each of these tools sets
+// `authorizationReadOnly: true` and `securityScopes: ['mcp:read']`, so the
+// `isAuthorizationReadOnly` fallback to `readOnlyHint` never fires for them and
+// this hint carries no access-control weight.
 const AUDITED_READ = {
-  readOnlyHint: false,
+  readOnlyHint: true,
   destructiveHint: false,
   openWorldHint: false,
   idempotentHint: false,


### PR DESCRIPTION
## Summary
- The five retrieval tools (`search_memory`, `search_sdk`, `query_sdk`, `query_sql`, `get_approval`) advertised `readOnlyHint: false` because every OAuth/PAT invocation appends an audit/activity record. That reading makes the hint unclaimable by any server that audits, and spends the user's attention on confirmations that protect nothing — dulling the prompt on `run_sdk`, where a write really can happen. The hint describes the caller's environment (workspace content, external systems), not server-side bookkeeping.
- Access control is untouched. Each of these tools sets `authorizationReadOnly: true` and `securityScopes: ['mcp:read']`, so the `isAuthorizationReadOnly` fallback to `readOnlyHint` never fires for them.
- Closes an assertion gap: the anonymous `/mcp/{slug}` listing checked tool *names* only, so an annotation regression on the public path was invisible to the authenticated case.

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean (build + typecheck + knip + biome + naming + gateway gates)
- [x] Tests run: targeted suites below

```
bun test packages/server/src/__tests__/unit/tool-registry-split.test.ts
  8 pass, 0 fail

bun run test -- run src/__tests__/integration/mcp/query-tool.test.ts \
                  src/__tests__/integration/mcp/mcp-app-resources.test.ts
  Test Files 2 passed (2) | Tests 49 passed (49)

bun run test -- run src/__tests__/integration/mcp/     # all MCP integration suites
  Test Files 20 passed (20) | Tests 235 passed | 2 skipped (237)
```

Runtime probe confirming access control is unchanged by the flip:

```
search_memory  annot.readOnlyHint=true   authorizationReadOnly=true   requiredAccess=read
search_sdk     annot.readOnlyHint=true   authorizationReadOnly=true   requiredAccess=read
query_sdk      annot.readOnlyHint=true   authorizationReadOnly=true   requiredAccess=read
query_sql      annot.readOnlyHint=true   authorizationReadOnly=true   requiredAccess=read
get_approval   annot.readOnlyHint=true   authorizationReadOnly=true   requiredAccess=read
save_memory    annot.readOnlyHint=false  authorizationReadOnly=undef  requiredAccess=write
run_sdk        annot.readOnlyHint=false  authorizationReadOnly=undef  requiredAccess=write
```

## Notes
- `resolve_approval` keeps `readOnlyHint: false, destructiveHint: true` — unchanged.
- `idempotentHint` left at `false`; deliberately out of scope.
- Not verified: no live MCP client exercised against the new annotations, and ChatGPT's client-side use of `readOnlyHint` is undocumented in what I could find. Expected effect either way is fewer redundant confirmations on tools that cannot write.
- The wider `bun test` sweep over `gateway`/`unit`/`auth` shows ~219 pre-existing failures on an unmodified baseline (60s timeouts, DB-bound `agent history routes` suites). None mention annotations, and the pass count is identical with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
