### PR TITLE
fix(auth): explain missing permissions and disable unauthorized entity edits

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -531,6 +531,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "postgres@3.4.9": "patches/postgres@3.4.9.patch",
+  },
   "overrides": {
     "sharp": "^0.35.3",
   },

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
   },
   "engines": {
     "node": ">=22 <25 || >=26"
+  },
+  "patchedDependencies": {
+    "postgres@3.4.9": "patches/postgres@3.4.9.patch"
   }
 }

--- a/packages/server/src/__tests__/integration/automations/automations-crud.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automations-crud.test.ts
@@ -1091,7 +1091,7 @@ describe('automation CRUD', () => {
         prompt: 'should fail',
         managed_agent_id: agentId,
       })
-    ).rejects.toThrow(/organization|entity_id/i);
+    ).rejects.toThrow('Select a workspace before making changes.');
   });
 
   it('blocks cross-org reads and writes for org-scoped automations', async () => {

--- a/packages/server/src/__tests__/integration/automations/source-id-and-cross-org.test.ts
+++ b/packages/server/src/__tests__/integration/automations/source-id-and-cross-org.test.ts
@@ -312,7 +312,7 @@ describe("manage_automations source-id + cross-org guards", () => {
 				version_id: versionId,
 				entity_ids: [foreignEntityId],
 			})
-		).rejects.toThrow(new RegExp(String(foreignEntityId)));
+		).rejects.toThrow('This record was not found in this workspace, or you do not have access to it.');
 
 		// No automation leaked pointing at the foreign entity.
 		const leaked = await sql<{ id: number }[]>`

--- a/packages/server/src/__tests__/integration/entities/member-role-hooks.test.ts
+++ b/packages/server/src/__tests__/integration/entities/member-role-hooks.test.ts
@@ -76,6 +76,7 @@ describe('member roles through generic entity edits', () => {
       message: "You don't have permission to make changes in this workspace. Ask a workspace owner or admin.", httpStatus: 403,
     });
     await expect(requireOrgWriteAccess(sql, ownerToolContext(org.id, owner.userId))).resolves.toBeUndefined();
+    await expect(requireOrgReadAccess(sql, { ...ctx, organizationId: null })).rejects.toMatchObject({ message: 'Select a workspace to view its records.', httpStatus: 403 });
     const outsider = await createTestUser({ email: 'outside@roles.example.com' });
     await expect(requireOrgReadAccess(sql, ownerToolContext(org.id, outsider.id))).rejects.toMatchObject({
       message: "You don't have permission to view this workspace. Ask a workspace owner or admin for access.", httpStatus: 403,

--- a/packages/server/src/__tests__/integration/entities/member-role-hooks.test.ts
+++ b/packages/server/src/__tests__/integration/entities/member-role-hooks.test.ts
@@ -5,8 +5,9 @@ import { TestApiClient } from '../../setup/test-mcp-client';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { ensureMemberEntity } from '../../../utils/member-entity';
 import { ensureMemberEntityType } from '../../../utils/member-entity-type';
+import { requireOrgReadAccess, requireOrgWriteAccess, requireReadAccess, requireWriteAccess } from '../../../utils/organization-access';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
-import { addUserToOrganization, createTestAccessToken, createTestOAuthClient, createTestOrganization, createTestSession, createTestUser } from '../../setup/test-fixtures';
+import { addUserToOrganization, createTestAccessToken, createTestOAuthClient, createTestOrganization, createTestSession, createTestUser, ownerToolContext } from '../../setup/test-fixtures';
 import { post } from '../../setup/test-helpers';
 
 describe('member roles through generic entity edits', () => {
@@ -49,11 +50,46 @@ describe('member roles through generic entity edits', () => {
     expect(await roles(member)).toMatchObject({ role: 'member', displayed: 'member' });
   });
   it('rejects self promotion, invalid roles, and last owner demotion without changing metadata', async () => {
-    expect((await edit(member, member.entityId, 'admin')).status).toBeGreaterThanOrEqual(400);
+    const denied = await edit(member, member.entityId, 'admin');
+    expect(denied.status).toBe(403);
+    expect(await denied.text()).toContain("You don't have permission to edit records in this workspace. Ask a workspace owner or admin.");
     expect((await edit(owner, member.entityId, 'superadmin')).status).toBeGreaterThanOrEqual(400);
     expect((await edit(owner, owner.entityId, 'member')).status).toBeGreaterThanOrEqual(400);
     expect(await roles(owner)).toMatchObject({ role: 'owner', displayed: 'owner' });
     expect(await roles(member)).toMatchObject({ role: 'member', displayed: 'member' });
+  });
+  it('does not disclose whether an inaccessible record exists in another workspace', async () => {
+    const other = await createTestOrganization({ name: 'Other access workspace' });
+    const ctx = ownerToolContext(other.id, owner.userId);
+    const sql = getTestDb();
+    const message = 'This record was not found in this workspace, or you do not have access to it.';
+    for (const id of [member.entityId, 2147483647]) {
+      await expect(requireWriteAccess(sql, id, ctx)).rejects.toMatchObject({ message, httpStatus: 403 });
+      await expect(requireReadAccess(sql, id, ctx)).rejects.toMatchObject({ message, httpStatus: 403 });
+    }
+  });
+  it('explains workspace permissions without claiming the workspace belongs to someone else', async () => {
+    const sql = getTestDb();
+    const ctx = ownerToolContext(org.id, member.userId);
+    await expect(requireOrgReadAccess(sql, ctx)).resolves.toBeUndefined();
+    await expect(requireOrgWriteAccess(sql, ctx)).rejects.toMatchObject({
+      message: "You don't have permission to make changes in this workspace. Ask a workspace owner or admin.", httpStatus: 403,
+    });
+    await expect(requireOrgWriteAccess(sql, ownerToolContext(org.id, owner.userId))).resolves.toBeUndefined();
+    const outsider = await createTestUser({ email: 'outside@roles.example.com' });
+    await expect(requireOrgReadAccess(sql, ownerToolContext(org.id, outsider.id))).rejects.toMatchObject({
+      message: "You don't have permission to view this workspace. Ask a workspace owner or admin for access.", httpStatus: 403,
+    });
+  });
+  it('applies the same existing write permission to ordinary entities', async () => {
+    const client = await TestApiClient.for({ organizationId: org.id, userId: owner.userId, memberRole: 'owner' });
+    await client.entity_schema.createType({ slug: 'contact', name: 'Contact' });
+    const created = await client.entities.create({ type: 'contact', name: 'Example contact' }) as { entity: { id: number } };
+    const body = { action: 'update', entity_id: created.entity.id, name: 'Updated contact' };
+    const denied = await post(`/api/${org.slug}/manage_entity`, { cookie: member.cookie, body });
+    expect(denied.status).toBe(403);
+    expect(await denied.text()).toContain("You don't have permission to edit records in this workspace. Ask a workspace owner or admin.");
+    expect((await post(`/api/${org.slug}/manage_entity`, { cookie: owner.cookie, body })).status).toBe(200);
   });
   it('honors selected invitation roles and later edits', async () => {
     const response = await post(`/api/${org.slug}/manage_entity`, { cookie: owner.cookie, body: { action: 'create', entity_type: '$member', name: 'Invited', metadata: { email: 'invited@roles.example.com', role: 'admin' } } });

--- a/packages/server/src/__tests__/integration/entities/member-role-hooks.test.ts
+++ b/packages/server/src/__tests__/integration/entities/member-role-hooks.test.ts
@@ -63,13 +63,17 @@ describe('member roles through generic entity edits', () => {
     const ctx = ownerToolContext(other.id, owner.userId);
     const sql = getTestDb();
     const message = 'This record was not found in this workspace, or you do not have access to it.';
-    for (const id of [member.entityId, 2147483647]) {
+    const foreignEntityId = member.entityId;
+    const neverAllocatedEntityId = 2147483647;
+    for (const id of [foreignEntityId, neverAllocatedEntityId]) {
       await expect(requireWriteAccess(sql, id, ctx)).rejects.toMatchObject({ message, httpStatus: 403 });
       await expect(requireReadAccess(sql, id, ctx)).rejects.toMatchObject({ message, httpStatus: 403 });
     }
   });
   it('explains workspace permissions without claiming the workspace belongs to someone else', async () => {
     const sql = getTestDb();
+    // ownerToolContext claims memberRole 'owner'; the guards must still deny,
+    // because they read the member table rather than trusting the context.
     const ctx = ownerToolContext(org.id, member.userId);
     await expect(requireOrgReadAccess(sql, ctx)).resolves.toBeUndefined();
     await expect(requireOrgWriteAccess(sql, ctx)).rejects.toMatchObject({

--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -1974,7 +1974,7 @@ describe('MCP Authentication', () => {
       // what denies. A passing `success: false` alone would also match an
       // unrelated fault (bad agent id, missing device) and hide a regression.
       expect(denied.error?.message).toMatch(
-        /organization-level write access is required|requires admin or owner access/i
+        /permission to make changes in this workspace|requires admin or owner access/i
       );
 
       const rows = await getTestDb()`

--- a/packages/server/src/__tests__/integration/postgres-cold-reserve.test.ts
+++ b/packages/server/src/__tests__/integration/postgres-cold-reserve.test.ts
@@ -1,0 +1,45 @@
+import { createRequire } from 'node:module';
+import postgres from 'postgres';
+import { describe, expect, it } from 'vitest';
+import { PROD_PG_VALUE_OPTIONS } from '../../db/client';
+import { getTestDb } from '../setup/test-db';
+
+const require = createRequire(import.meta.url);
+const cjsPostgres: typeof postgres = require('postgres');
+
+describe('Postgres cold connection reservations', () => {
+  it.each([
+    ['ESM', postgres],
+    ['CommonJS', cjsPostgres],
+  ] as const)('%s reserves cold connections and returns them to the pool', async (_name, driver) => {
+    await getTestDb()`SELECT 1`;
+    const sql = driver(process.env.DATABASE_URL!, { max: 2, ...PROD_PG_VALUE_OPTIONS });
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      // Auth uses reserve() on the same pool as entity transactions. With
+      // fetch_types:false, cold reservations must finish without another query
+      // first warming the pool; otherwise auth silently exhausts its capacity.
+      await Promise.race([
+        (async () => {
+          const connections = await Promise.all([sql.reserve(), sql.reserve()]);
+          try {
+            const rows = await Promise.all(connections.map(conn => conn`SELECT pg_backend_pid() AS pid`));
+            expect(new Set(rows.map(result => result[0].pid)).size).toBe(2);
+          } finally {
+            for (const connection of connections) connection.release();
+          }
+          await sql.begin(async tx => {
+            expect((await tx`SELECT 1 AS value`)[0].value).toBe(1);
+            expect((await sql`SELECT 2 AS value`)[0].value).toBe(2);
+          });
+        })(),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error('Cold reservation stalled')), 5000);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+      await sql.end({ timeout: 0 });
+    }
+  });
+});

--- a/packages/server/src/utils/organization-access.ts
+++ b/packages/server/src/utils/organization-access.ts
@@ -7,6 +7,8 @@
  * Access Rules:
  * - Upstream routing enforces public/private workspace visibility.
  * - Workspace members can read; owners/admins can edit records.
+ * - No-user contexts: an anonymous public-workspace read passes, but a write
+ *   also needs `isAuthenticated` (system/internal calls like reaction scripts).
  */
 
 import { type DbClient, getDb } from '../db/client';

--- a/packages/server/src/utils/organization-access.ts
+++ b/packages/server/src/utils/organization-access.ts
@@ -5,13 +5,20 @@
  * public/private organization support.
  *
  * Access Rules:
- * - Public orgs: Anyone can READ, only members can WRITE
- * - Private orgs: Members only for READ and WRITE
+ * - Upstream routing enforces public/private workspace visibility.
+ * - Workspace members can read; owners/admins can edit records.
  */
 
 import { type DbClient, getDb } from '../db/client';
 import type { ToolContext } from '../tools/registry';
 import { ToolUserError } from './errors';
+
+/**
+ * Read and write denials on an entity must be byte-identical: a caller that is
+ * told "no access" for a record in another workspace must not be able to tell
+ * it apart from one that never existed.
+ */
+const NO_RECORD_ACCESS = 'This record was not found in this workspace, or you do not have access to it.';
 
 /**
  * Get the user's role in a workspace (organization).
@@ -52,37 +59,6 @@ async function canReadEntity(sql: DbClient, entityId: number, ctx: ToolContext):
 }
 
 /**
- * Check if user can write to an entity (must own it)
- * Only allowed if entity is in user's own organization
- */
-async function canWriteEntity(sql: DbClient, entityId: number, ctx: ToolContext): Promise<boolean> {
-  const entityRows = await getDb()`
-    SELECT organization_id
-    FROM entities
-    WHERE id = ${entityId}
-    LIMIT 1
-  `;
-  if (entityRows.length === 0) return false;
-
-  const entityOrgId = String(entityRows[0].organization_id);
-  if (entityOrgId !== ctx.organizationId) return false;
-
-  // System/internal calls (e.g. reaction scripts) — org match is sufficient
-  if (!ctx.userId && ctx.isAuthenticated) return true;
-  if (!ctx.userId) return false;
-
-  const membership = await sql`
-    SELECT 1
-    FROM "member"
-    WHERE "organizationId" = ${ctx.organizationId}
-      AND "userId" = ${ctx.userId}
-      AND role IN ('owner', 'admin')
-    LIMIT 1
-  `;
-  return membership.length > 0;
-}
-
-/**
  * Require read access or throw
  */
 export async function requireReadAccess(
@@ -92,7 +68,7 @@ export async function requireReadAccess(
 ): Promise<void> {
   const canRead = await canReadEntity(sql, entityId, ctx);
   if (!canRead) {
-    throw new ToolUserError(`Access denied: entity ${entityId} is not accessible to your organization`, 403);
+    throw new ToolUserError(NO_RECORD_ACCESS, 403);
   }
 }
 
@@ -104,9 +80,17 @@ export async function requireWriteAccess(
   entityId: number,
   ctx: ToolContext
 ): Promise<void> {
-  const canWrite = await canWriteEntity(sql, entityId, ctx);
+  const rows = await getDb()`
+    SELECT 1 FROM entities
+    WHERE id = ${entityId} AND organization_id = ${ctx.organizationId}
+    LIMIT 1
+  `;
+  if (rows.length === 0) {
+    throw new ToolUserError(NO_RECORD_ACCESS, 403);
+  }
+  const canWrite = await canWriteOrg(sql, ctx);
   if (!canWrite) {
-    throw new ToolUserError(`Access denied: entity ${entityId} does not belong to your organization`, 403);
+    throw new ToolUserError("You don't have permission to edit records in this workspace. Ask a workspace owner or admin.", 403);
   }
 }
 
@@ -151,7 +135,7 @@ async function canReadOrg(sql: DbClient, ctx: ToolContext): Promise<boolean> {
 export async function requireOrgReadAccess(sql: DbClient, ctx: ToolContext): Promise<void> {
   const ok = await canReadOrg(sql, ctx);
   if (!ok) {
-    throw new ToolUserError('Access denied: organization-level read access is required', 403);
+    throw new ToolUserError("You don't have permission to view this workspace. Ask a workspace owner or admin for access.", 403);
   }
 }
 
@@ -161,6 +145,6 @@ export async function requireOrgReadAccess(sql: DbClient, ctx: ToolContext): Pro
 export async function requireOrgWriteAccess(sql: DbClient, ctx: ToolContext): Promise<void> {
   const ok = await canWriteOrg(sql, ctx);
   if (!ok) {
-    throw new ToolUserError('Access denied: organization-level write access is required', 403);
+    throw new ToolUserError("You don't have permission to make changes in this workspace. Ask a workspace owner or admin.", 403);
   }
 }

--- a/packages/server/src/utils/organization-access.ts
+++ b/packages/server/src/utils/organization-access.ts
@@ -133,6 +133,7 @@ async function canReadOrg(sql: DbClient, ctx: ToolContext): Promise<boolean> {
  * Require organization-level read access or throw.
  */
 export async function requireOrgReadAccess(sql: DbClient, ctx: ToolContext): Promise<void> {
+  if (!ctx.organizationId) throw new ToolUserError('Select a workspace to view its records.', 403);
   const ok = await canReadOrg(sql, ctx);
   if (!ok) {
     throw new ToolUserError("You don't have permission to view this workspace. Ask a workspace owner or admin for access.", 403);
@@ -143,6 +144,7 @@ export async function requireOrgReadAccess(sql: DbClient, ctx: ToolContext): Pro
  * Require organization-level write access or throw.
  */
 export async function requireOrgWriteAccess(sql: DbClient, ctx: ToolContext): Promise<void> {
+  if (!ctx.organizationId) throw new ToolUserError('Select a workspace before making changes.', 403);
   const ok = await canWriteOrg(sql, ctx);
   if (!ok) {
     throw new ToolUserError("You don't have permission to make changes in this workspace. Ask a workspace owner or admin.", 403);

--- a/patches/postgres@3.4.9.patch
+++ b/patches/postgres@3.4.9.patch
@@ -1,0 +1,57 @@
+diff --git a/cf/src/connection.js b/cf/src/connection.js
+index 8e79170aeb13efe8c3c77ccede0cd3a115b5e1b5..de7da6a95b7cdb427e15cef3b75b69913f2d459f 100644
+--- a/cf/src/connection.js
++++ b/cf/src/connection.js
+@@ -566,9 +566,12 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
+         return fetchArrayTypes()
+       }
+ 
+-      initial && !initial.reserve && execute(initial)
+-      options.shared.retries = retries = 0
++      const pending = initial
+       initial = null
++      options.shared.retries = retries = 0
++      // A cold reserve is queued by the pool. Without a type-fetch query,
++      // no second ReadyForQuery arrives to hand this connection to it.
++      pending && !pending.reserve ? execute(pending) : onopen(connection)
+       return
+     }
+ 
+diff --git a/cjs/src/connection.js b/cjs/src/connection.js
+index 07f6716702ac888215c86ad6e0071aaf55ae519c..5c776aa77ad296fb7fdca592f7142b81dc31dfe2 100644
+--- a/cjs/src/connection.js
++++ b/cjs/src/connection.js
+@@ -564,9 +564,12 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
+         return fetchArrayTypes()
+       }
+ 
+-      initial && !initial.reserve && execute(initial)
+-      options.shared.retries = retries = 0
++      const pending = initial
+       initial = null
++      options.shared.retries = retries = 0
++      // A cold reserve is queued by the pool. Without a type-fetch query,
++      // no second ReadyForQuery arrives to hand this connection to it.
++      pending && !pending.reserve ? execute(pending) : onopen(connection)
+       return
+     }
+ 
+diff --git a/src/connection.js b/src/connection.js
+index 1b1cccde43b4570d5d071d6ffaab2669b3c2065a..ce4af910f5b8aebcb5766cbf1cd9cb9c4c5bcd47 100644
+--- a/src/connection.js
++++ b/src/connection.js
+@@ -564,9 +564,12 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
+         return fetchArrayTypes()
+       }
+ 
+-      initial && !initial.reserve && execute(initial)
+-      options.shared.retries = retries = 0
++      const pending = initial
+       initial = null
++      options.shared.retries = retries = 0
++      // A cold reserve is queued by the pool. Without a type-fetch query,
++      // no second ReadyForQuery arrives to hand this connection to it.
++      pending && !pending.reserve ? execute(pending) : onopen(connection)
+       return
+     }
+ 


### PR DESCRIPTION
## Summary

A member editing their own membership record received “entity does not belong to your organization” even when the record was in the correct workspace. Separate record availability from write authorization: permission failures explain that an owner or admin is needed, while unavailable records use the same neutral message for missing and cross-workspace IDs. Workspace-level read/write errors now explain the required access too.

The paired frontend fix (Owletto #1056, now also on parent main) uses the existing workspace membership hook to render read-only fields and an explanation for members. Save/Delete are available only after owner/admin access is confirmed. This covers all stored entity types, with no Members-specific UI or new API.

The role/auth integration sequence also exposed upstream [postgres.js #751](https://github.com/porsager/postgres/issues/751): with `fetch_types:false`, cold `reserve()` calls strand connections and exhaust the shared auth/entity pool. A pinned dependency patch completes the normal connection handoff in ESM, CommonJS and workerd builds. It preserves the existing pool size and serialization settings; Docker builds already include dependency patches.

## Test plan

- [x] Reproduced server error: 1 failed / 18 passed before fix.
- [x] Reproduced frontend gap: 3 failed / 1 passed before fix.
- [x] Server integration tests: 131 passed, 2 existing skips across member roles, cross-workspace isolation, MCP auth, and Automation access checks.
- [x] Frontend focused tests: 9 passed, covering member/ordinary entity types, loading, and admin save controls.
- [x] Real local browser with synthetic data: member editor is read-only; direct unauthorized POST returns the new 403 message; admin UI save persists.
- [x] Full frontend build and local gates.
- [x] Cold-reservation regressions: both ESM and CommonJS failed before the patch, then passed with simultaneous reservations and transaction/pool reuse.
- [x] Original failing CI order with `DB_POOL_MAX=5`: 42 passed. Full third shard with coverage: 1,603 passed.
- [x] Final pre-review fixer pass, including an independent cold-reservation red/green reproduction.
- [x] Frontend exact-head Opus review approved with zero bugs/blockers.
- [x] Required CI on `b20ef760` (all jobs passed, including all three integration shards and worker image parity).
- [x] Parent exact-head semantic review: bug-free confidence 88, simplicity 88, slop 5; zero bugs/blockers.
- [x] Production deployed squash `93869220502d20274cd40744c62f6dde3937f4ac`: exact deployed revision matched, 9/9 production smoke checks passed, application rollout complete, and Helm release v578 Ready=True.

## UI proof

[Before/after comparison](https://lobu-access-permission-proof.vercel.app) shows the actual local UI using an isolated database and synthetic users. No live membership was changed.

Frontend: [Owletto #1056](https://github.com/lobu-ai/owletto/pull/1056), merged as `00bac682` and already included on parent main through #3443. This PR completes the backend changes; it no longer changes the frontend gitlink relative to main.

Resource-specific cross-workspace errors remain where their ownership diagnosis is accurate, including relationship guidance about public-catalog targets. Existing 404 behavior for unavailable entity reads/deletes is preserved.
