### PR TITLE
chore: keep ad-hoc .tmp-* probe scripts out of the index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,10 @@ examples/lobu-crm/evals/discovery-surface/last-run.json
 # visualizations (.codex). Local run artifacts, never project sources.
 .pi-subagents/
 .codex/
+
+# Ad-hoc `.tmp-<name>.<ext>` probe scripts written into the checkout root
+# during debugging. The existing `.tmp/*` rule only covers a directory, so
+# these stayed untracked-but-stageable, and `git add -A` would commit them.
+# They routinely hold live session material — Keychain-decrypted browser
+# cookies, tenant slugs, machine hostnames — so keep them unstageable.
+.tmp-*


### PR DESCRIPTION
## What

Adds `.tmp-*` to `.gitignore`.

## Why

The existing rule is `.tmp/*`, which only covers a *directory*. A
`.tmp-<name>.<ext>` script written into the checkout root was untracked but
still **stageable**, so a `git add -A` would commit it.

Three such files were sitting in the repo root (now deleted):

- `.tmp-create-film-postgres.mjs`
- `.tmp-inspect-crd.cjs`
- `.tmp-lobu-cookie-fetch.mjs`

All three decrypt Chrome's cookie database via the macOS Keychain
(`security find-generic-password -s "Chrome Safe Storage"` → PBKDF2 →
AES-128-CBC) to lift live `lobu.ai` session cookies. Two also carry a real
tenant slug and a machine hostname.

That is the exact class the staging rule exists to keep out of a commit, so
this ignores the *shape* instead of relying on someone spotting each instance.

## Testing

- `git check-ignore -v .tmp-probe.mjs` → matches at `.gitignore:115`
- `git check-ignore -v .tmpfile-should-not-match` → no match (hyphen is
  literal, so the glob does not over-reach)
- `git ls-files | grep -E '(^|/)\.tmp-'` → empty, so no tracked file is masked
- `make pre-pr` → all 5 gates clean