### PR TITLE
ci(frontend): run the Chrome extension smoke in real Chromium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
     outputs:
       packages: ${{ steps.filter.outputs.packages }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      chromeExt: ${{ steps.filter.outputs.chromeExt }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -111,6 +112,7 @@ jobs:
           if [ -z "${BASE_SHA:-}" ]; then
             echo "packages=true" >> "$GITHUB_OUTPUT"
             echo "frontend=true" >> "$GITHUB_OUTPUT"
+            echo "chromeExt=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           changed=$(git diff --name-only "$BASE_SHA"...HEAD)
@@ -125,6 +127,17 @@ jobs:
           else
             echo "frontend=false" >> "$GITHUB_OUTPUT"
             echo "::notice::No frontend paths changed - skipping frontend."
+          fi
+          # The extension smoke downloads a Playwright Chromium build, so it is
+          # gated separately from the rest of the frontend job (which runs for any
+          # `packages` change). `packages/owletto` is a submodule POINTER file, so
+          # a pointer bump shows up as that exact path with nothing under it —
+          # that still moves apps/chrome and must run the smoke.
+          if echo "$changed" | grep -E '^(packages/owletto$|packages/owletto/apps/chrome/|\.github/workflows/ci\.yml$)' >/dev/null; then
+            echo "chromeExt=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "chromeExt=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No Chrome extension paths changed - skipping the extension smoke."
           fi
 
   # Fast unit tests — no Postgres, no submodule needed for most.
@@ -628,6 +641,24 @@ jobs:
         # /usr/bin/google-chrome-stable itself and refuses snap Chromium.
         if: steps.submodule.outputs.stubbed != 'true'
         run: cd packages/owletto && bun run smoke:boot
+
+      - name: Install Playwright Chromium (extension smoke)
+        # channel "chromium" needs the Playwright browser build on disk; the
+        # runner's google-chrome-stable cannot host extension service workers in
+        # headless mode. --with-deps pulls the shared libs the Ubuntu image lacks.
+        if: steps.submodule.outputs.stubbed != 'true' && needs.paths.outputs.chromeExt == 'true'
+        run: ../../node_modules/.bin/playwright install --with-deps chromium
+        working-directory: packages/owletto
+
+      - name: Chrome extension smoke (real Chromium, --load-extension)
+        # Loads apps/chrome into headless Chromium against a loopback gateway
+        # fixture: action dispatch, flow isolation, worker eviction/recovery, and
+        # tab-presence reaping. This is the only CI coverage that exercises the
+        # extension in a real browser instead of the hand-written chrome stub, so
+        # it catches behavior the unit suites structurally cannot. One probe
+        # (unfocused-window reaping) self-skips headless -- see the script.
+        if: steps.submodule.outputs.stubbed != 'true' && needs.paths.outputs.chromeExt == 'true'
+        run: cd packages/owletto && bun run smoke:chrome-ext
 
       - name: MCP App failure smoke (built bundle in Chrome)
         if: steps.submodule.outputs.stubbed != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,7 +658,7 @@ jobs:
         # it catches behavior the unit suites structurally cannot. One probe
         # (unfocused-window reaping) self-skips headless -- see the script.
         if: steps.submodule.outputs.stubbed != 'true' && needs.paths.outputs.chromeExt == 'true'
-        run: cd packages/owletto && bun run smoke:chrome-ext
+        run: node packages/owletto/scripts/chrome-reliability-smoke.mjs
 
       - name: MCP App failure smoke (built bundle in Chrome)
         if: steps.submodule.outputs.stubbed != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,8 @@ jobs:
           # gated separately from the rest of the frontend job (which runs for any
           # `packages` change). `packages/owletto` is a submodule POINTER file, so
           # a pointer bump shows up as that exact path with nothing under it —
-          # that still moves apps/chrome and must run the smoke.
-          if echo "$changed" | grep -E '^(packages/owletto$|packages/owletto/apps/chrome/|\.github/workflows/ci\.yml$)' >/dev/null; then
+          # it can move apps/chrome and must run the smoke conservatively.
+          if echo "$changed" | grep -E '^(packages/owletto$|\.github/workflows/ci\.yml$)' >/dev/null; then
             echo "chromeExt=true" >> "$GITHUB_OUTPUT"
           else
             echo "chromeExt=false" >> "$GITHUB_OUTPUT"
@@ -655,7 +655,7 @@ jobs:
         # fixture: action dispatch, flow isolation, worker eviction/recovery, and
         # tab-presence reaping. This is the only CI coverage that exercises the
         # extension in a real browser instead of the hand-written chrome stub, so
-        # it catches behavior the unit suites structurally cannot. One probe
+        # it catches what the unit suites structurally cannot. One probe
         # (unfocused-window reaping) self-skips headless -- see the script.
         if: steps.submodule.outputs.stubbed != 'true' && needs.paths.outputs.chromeExt == 'true'
         run: node packages/owletto/scripts/chrome-reliability-smoke.mjs


### PR DESCRIPTION
## What

Wires `packages/owletto/scripts/chrome-reliability-smoke.mjs` into the `frontend` CI job, gated on a new `chromeExt` paths output. Repins owletto to `59b99284` (#1067 harness fix + presence probes, #1068 script placement).

This is the first CI coverage that runs the extension in a **real browser**. Everything else runs `environment: 'node'` against a hand-written `globalThis.chrome` stub, so a green suite has never been browser evidence.

## The harness already existed and was broken

`chrome-reliability-smoke.mjs` already loaded `apps/chrome` into Chromium via `--load-extension` with a disposable profile and loopback gateway — wired to **no script and no CI job**. Nobody ran it, and it failed on `main`:

```
expected: /No tab|no tab/
actual:   tab 390625389 is not owned by this browser flow
          at enforceTabMutableByFlow (tools.js:3127)
```

Stale assertion, not a regression: `enforceTabMutableByFlow` runs before the existence check, and a closed tab's lease is pruned — so "closed" is indistinguishable from "never ours". Fixed in owletto #1067.

## Why gated separately

The `frontend` job runs on `needs.paths.outputs.frontend == 'true' || needs.paths.outputs.packages == 'true'`, and `packages` fires for `packages/`, `scripts/`, `db/`, `docker/`, `Makefile`, `bun.lock`. Attaching the smoke there would download a Playwright Chromium build on nearly every PR.

`chromeExt` is true only for `apps/chrome/**`, a `packages/owletto` pointer bump, or `ci.yml`. The pointer case matters: a submodule pointer is a single file, so a bump appears as that exact path with nothing under it — yet it can move the whole extension.

Verified against representative change sets:

| change | runs? |
| --- | --- |
| extension source edit | yes |
| submodule pointer bump | yes |
| ci.yml edit | yes |
| owletto SPA only | no |
| server only | no |
| docs only | no |
| multi-file server PR | no |

## Presence probes

The gap these close: unit suites prove the reaper's *logic* but never that Chrome reports `tab.active` / `window.focused` as that logic assumes. The clock is injected (`reapStaleGroups` takes `now`) so a 5-minute TTL costs no wall time, while tab and window state stay real.

| probe | asserts |
| --- | --- |
| A | active tab in a focused window survives past its TTL |
| B | same tab, window unfocused, is reaped (headed only) |
| C | background tab in a focused window is reaped |

**PROBE B self-skips headless** — creating a `focused: true` window leaves *both* windows reporting `focused: true`, so there is no unfocused state to observe. Measured: headed Chromium returns `false`/`true` for identical calls. Asserting headless would test the harness, not the reaper.

**Chrome's listeners demonstrably fire.** My first probe failed because real `onActivated`/`onFocusChanged` re-stamped `userTouchedAt` — 113ms old against a 10-minute aged write. That race is the first direct CI evidence the listener wiring works.

**`channel: "chromium"` is load-bearing.** I tried resolving a system Chrome the way `spa-boot-smoke.mjs` does; branded Chrome's headless mode never registers the extension service worker (30s timeout on the `serviceworker` event). Reverted with a comment.

## Test

Local, both modes green (headed runs all three probes):

```
PASS installed extension: click/type outcomes, navigation refs, flow isolation, titles, worker eviction, close/release guards
SKIP PROBE B (unfocused-window reaping): headless Chromium reports every window focused
PASS tab presence in real Chrome: active+focused survives TTL; unfocused window and background tab are reaped
PASS background worker: poll -> dispatch -> failed action -> 503 -> worker eviction -> recovery -> completion -> cleanup; no duplicate completion
```

This PR edits `ci.yml`, so `chromeExt=true` and **CI runs the new step on this PR** — which is the actual proof that `playwright install --with-deps chromium` works on the runner. That is the one thing local testing cannot establish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated reliability checks for the Chrome extension using a local gateway fixture.
  - Continuous integration now runs these checks when relevant extension changes are detected.

- **Chores**
  - Updated the Chrome extension component to a newer revision.
  - Improved automated validation coverage for Chrome extension updates before release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->