### PR TITLE
ci(slack): probe QA credential liveness on a schedule

### DIFF
--- a/.github/workflows/slack-qa-token-liveness.yml
+++ b/.github/workflows/slack-qa-token-liveness.yml
@@ -1,0 +1,76 @@
+name: Slack QA token liveness
+
+# Answers one question: do the stored Slack QA credentials still authenticate?
+#
+# The QA_SLACK_* secrets were added in April 2026 and no workflow consumed
+# them, so nothing noticed when they expired — the failure only surfaced when
+# somebody tried to run the smoke by hand and got invalid_auth /
+# account_inactive back. A credential nobody exercises is a credential nobody
+# can trust.
+#
+# Deliberately NOT the smoke itself. scripts/test-bot.sh posts a real message
+# and waits for the agent's reply; it exits 1 the same way whether the bot
+# regressed or the sender token died, and it cannot run on a schedule without
+# writing into a Slack channel every day. This calls auth.test only: no
+# message, no thread, no write anywhere. That is what makes it cron-safe.
+#
+# Not a required check and not a release gate — a dead QA token says nothing
+# about whether the code under review is correct. It is an alarm, so keep it
+# off the branch-protection list.
+
+on:
+  # Daily canary. A Slack token is revoked, an app is uninstalled, a workspace
+  # member is deactivated — none of which involve us pushing anything, and all
+  # of which silently disarm the smoke until someone needs it in a hurry.
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+  # No pull_request trigger on purpose. This repo is public, and GitHub does
+  # not expose secrets to a workflow run from a fork — every fork PR would get
+  # an empty environment, report every credential missing, and fail. Dispatch
+  # covers the "I just changed the smoke, does it still work" case.
+
+permissions:
+  contents: read
+
+jobs:
+  liveness:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      # Shallow checkout, no submodule, no bun, no install: the script is bash
+      # plus curl and jq, both present on the runner image.
+      - uses: actions/checkout@v7
+
+      - name: Probe Slack QA credentials
+        env:
+          QA_SLACK_USER_TOKEN: ${{ secrets.QA_SLACK_USER_TOKEN }}
+          QA_SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          QA_SLACK_TARGET_USER_ID: ${{ secrets.QA_SLACK_TARGET_USER_ID }}
+          QA_SLACK_CHANNEL: ${{ secrets.QA_SLACK_CHANNEL }}
+        run: scripts/slack-qa-token-liveness.sh
+
+      # Same devops channel build-images' notify-failure and the Flux
+      # notification-controller post to, so credential rot lands where the
+      # rest of the operational noise already goes. Skipped when the webhook
+      # is unset, and it runs only after the probe already failed, so it
+      # cannot change the job's verdict either way.
+      #
+      # Scheduled runs only: a manual dispatch already has someone watching it,
+      # and they do not need to be paged about the run they just started.
+      - name: Post failure to Slack devops
+        if: failure() && github.event_name == 'schedule'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEPLOY_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_DEPLOY_WEBHOOK_URL not set; skipping notification."
+            exit 0
+          fi
+          payload=$(jq -nc --arg text \
+            ":key: Slack QA credential check failed — the exact-response smoke cannot run. The run names which credential is dead, or reports Slack unreachable. <${RUN_URL}|run>" \
+            '{text: $text}')
+          curl -sS -X POST -H 'Content-type: application/json' \
+            --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/scripts/__tests__/slack-qa-token-liveness.test.ts
+++ b/scripts/__tests__/slack-qa-token-liveness.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const script = resolve(import.meta.dir, "../slack-qa-token-liveness.sh");
+
+// Real token shapes, so an assertion that the script never echoes a value is
+// checking against something that looks like the thing we are protecting.
+const USER_TOKEN = "xoxp-qa-user-secret-value";
+const BOT_TOKEN = "xoxb-qa-bot-secret-value";
+const TARGET_TOKEN = "xoxb-target-bot-secret-value";
+
+describe("Slack QA credential liveness", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "slack-liveness-"));
+    mkdirSync(join(dir, "bin"));
+    // Fake curl: logs the Slack method it was asked for and answers from
+    // AUTH_RESPONSES, keyed by the bearer token it was handed. A fixture is
+    // either a JSON body, the string "__transport_error__" (curl itself
+    // fails, so the unreachable branch is reachable without a network), a raw
+    // non-JSON string, or { __status, body } to pin an HTTP status. It honours
+    // -w the way curl does, since the script reads the status from there.
+    writeFileSync(
+      join(dir, "bin/curl"),
+      `#!${process.execPath}
+import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+const url = args.find(a => a.startsWith("http")) || "";
+appendFileSync(process.env.CALL_LOG, (url.split("/").pop() || "?") + "\\n");
+if (!url.startsWith("https://slack.com/api/")) process.exit(22);
+const auth = args[args.indexOf("-H") + 1] || "";
+const token = auth.replace("Authorization: Bearer ", "");
+const responses = JSON.parse(process.env.AUTH_RESPONSES);
+let body = responses[token] ?? { ok: false, error: "invalid_auth" };
+if (body === "__transport_error__") process.exit(7);
+let status = 200;
+if (body && body.__status !== undefined) { status = body.__status; body = body.body ?? ""; }
+process.stdout.write(typeof body === "string" ? body : JSON.stringify(body));
+const w = args.indexOf("-w");
+if (w !== -1) {
+  process.stdout.write(args[w + 1].replace(/\\\\n/g, "\\n").replace("%{http_code}", String(status)));
+}
+`,
+      { mode: 0o755 }
+    );
+  });
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const alive = (userId: string) => ({
+    ok: true,
+    team: "lobu-qa",
+    user_id: userId,
+  });
+
+  function run(
+    env: Record<string, string>,
+    responses: Record<string, unknown> = {
+      [USER_TOKEN]: alive("U_QA"),
+      [BOT_TOKEN]: alive("U_QA_BOT"),
+      [TARGET_TOKEN]: alive("U_TARGET"),
+    }
+  ) {
+    const result = Bun.spawnSync(["bash", script], {
+      cwd: dir,
+      env: {
+        PATH: `${join(dir, "bin")}:${process.env.PATH}`,
+        HOME: process.env.HOME,
+        CALL_LOG: join(dir, "calls"),
+        AUTH_RESPONSES: JSON.stringify(responses),
+        ...env,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return {
+      code: result.exitCode,
+      output: result.stdout.toString() + result.stderr.toString(),
+      calls: existsSync(join(dir, "calls"))
+        ? readFileSync(join(dir, "calls"), "utf8").trim().split("\n")
+        : [],
+    };
+  }
+
+  const fullyConfigured = {
+    QA_SLACK_USER_TOKEN: USER_TOKEN,
+    QA_SLACK_BOT_TOKEN: BOT_TOKEN,
+    SLACK_BOT_TOKEN: TARGET_TOKEN,
+    QA_SLACK_CHANNEL: "C_QA",
+  };
+
+  it("passes when every credential authenticates and the smoke has its inputs", () => {
+    const result = run(fullyConfigured);
+    expect(result.code).toBe(0);
+    expect(result.output).toContain("QA_SLACK_USER_TOKEN");
+    expect(result.output).toContain("alive");
+    expect(result.output).toContain("team=lobu-qa");
+    expect(result.output).toContain("✓ target bot: U_TARGET");
+    expect(result.output).toContain("✓ channel: C_QA");
+  });
+
+  // Every branch that prints a credential line has to be covered here, not
+  // just the happy one: the rejected and unreachable paths are where an
+  // implementation is most tempted to dump the response (or the token) to
+  // explain itself, and a leak there lands in a public Actions log.
+  it.each([
+    [
+      "alive",
+      {
+        [USER_TOKEN]: alive("U_QA"),
+        [BOT_TOKEN]: alive("U_QA_BOT"),
+        [TARGET_TOKEN]: alive("U_TARGET"),
+      },
+    ],
+    [
+      "rejected",
+      {
+        [USER_TOKEN]: { ok: false, error: "invalid_auth" },
+        [BOT_TOKEN]: { ok: false, error: "token_revoked" },
+        [TARGET_TOKEN]: { ok: false, error: "account_inactive" },
+      },
+    ],
+    [
+      "unreachable",
+      {
+        [USER_TOKEN]: "__transport_error__",
+        [BOT_TOKEN]: "__transport_error__",
+        [TARGET_TOKEN]: "__transport_error__",
+      },
+    ],
+    [
+      "unparseable",
+      { [USER_TOKEN]: "not json at all", [BOT_TOKEN]: 42, [TARGET_TOKEN]: [] },
+    ],
+    // A non-200 is its own print branch, separate from a curl failure. It is
+    // the branch most likely to want to quote the response, and the body it
+    // gets handed is attacker-adjacent (an edge error page, not Slack JSON).
+    [
+      "http-error",
+      {
+        [USER_TOKEN]: {
+          __status: 503,
+          body: "<html>upstream unavailable</html>",
+        },
+        [BOT_TOKEN]: { __status: 429, body: "rate limited" },
+        [TARGET_TOKEN]: { __status: 500, body: "" },
+      },
+    ],
+  ])("never prints a token value (%s credentials)", (_label, responses) => {
+    const result = run(fullyConfigured, responses as Record<string, unknown>);
+    expect(result.output).not.toContain(USER_TOKEN);
+    expect(result.output).not.toContain(BOT_TOKEN);
+    expect(result.output).not.toContain(TARGET_TOKEN);
+    // The name and length are the whole permitted description of a credential.
+    expect(result.output).toContain(`len=${USER_TOKEN.length}`);
+  });
+
+  it("posts nothing to Slack — auth.test only", () => {
+    const result = run(fullyConfigured);
+    expect(result.calls).toEqual(["auth.test", "auth.test", "auth.test"]);
+    expect(result.calls).not.toContain("chat.postMessage");
+    expect(result.calls).not.toContain("conversations.replies");
+  });
+
+  it("fails on a stored-but-dead credential even though a fallback sender works", () => {
+    const result = run(fullyConfigured, {
+      [USER_TOKEN]: { ok: false, error: "account_inactive" },
+      [BOT_TOKEN]: alive("U_QA_BOT"),
+      [TARGET_TOKEN]: alive("U_TARGET"),
+    });
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("DEAD (account_inactive)");
+    // The working fallback is still reported, so the run says what to keep.
+    expect(result.output).toContain("sender: QA_SLACK_BOT_TOKEN");
+  });
+
+  it("prefers the user token as sender when both authenticate", () => {
+    const result = run(fullyConfigured);
+    expect(result.output).toContain("✓ sender: QA_SLACK_USER_TOKEN (U_QA)");
+  });
+
+  it("reports an unset credential without counting it as rot", () => {
+    const result = run({
+      QA_SLACK_BOT_TOKEN: BOT_TOKEN,
+      SLACK_BOT_TOKEN: TARGET_TOKEN,
+      QA_SLACK_CHANNEL: "C_QA",
+    });
+    expect(result.code).toBe(0);
+    expect(result.output).toContain("QA_SLACK_USER_TOKEN      not set");
+  });
+
+  it("fails when no sender token authenticates", () => {
+    const result = run({
+      SLACK_BOT_TOKEN: TARGET_TOKEN,
+      QA_SLACK_CHANNEL: "C_QA",
+    });
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("no QA sender token authenticates");
+  });
+
+  it("fails when the target bot cannot be resolved", () => {
+    const result = run({
+      QA_SLACK_USER_TOKEN: USER_TOKEN,
+      QA_SLACK_CHANNEL: "C_QA",
+    });
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("target bot unresolved");
+  });
+
+  it("fails when the sender is also the target", () => {
+    const result = run(
+      {
+        QA_SLACK_USER_TOKEN: USER_TOKEN,
+        SLACK_BOT_TOKEN: TARGET_TOKEN,
+        QA_SLACK_CHANNEL: "C_QA",
+      },
+      {
+        [USER_TOKEN]: alive("U_SAME"),
+        [TARGET_TOKEN]: alive("U_SAME"),
+      }
+    );
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("same Slack user (U_SAME)");
+  });
+
+  it("fails when no channel is configured", () => {
+    const result = run({
+      QA_SLACK_USER_TOKEN: USER_TOKEN,
+      SLACK_BOT_TOKEN: TARGET_TOKEN,
+    });
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("QA_SLACK_CHANNEL is not set");
+  });
+
+  it("distinguishes an unreachable Slack from a rejected credential", () => {
+    const result = run(fullyConfigured, {
+      [USER_TOKEN]: "__transport_error__",
+      [BOT_TOKEN]: alive("U_QA_BOT"),
+      [TARGET_TOKEN]: alive("U_TARGET"),
+    });
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("UNREACHABLE");
+    expect(result.output).not.toContain("DEAD");
+  });
+
+  // A Slack outage must not read as credential rot: the scheduled job pages
+  // the devops channel on failure, and a verdict that blamed the token would
+  // send someone rotating a credential that is fine.
+  it("blames Slack, not the credential, for a non-200 response", () => {
+    const result = run(fullyConfigured, {
+      [USER_TOKEN]: {
+        __status: 503,
+        body: "<html>upstream unavailable</html>",
+      },
+      [BOT_TOKEN]: alive("U_QA_BOT"),
+      [TARGET_TOKEN]: alive("U_TARGET"),
+    });
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("UNREACHABLE (HTTP 503)");
+    expect(result.output).not.toContain("DEAD");
+  });
+
+  // jq's `//` fallback only fires on a body that parses, so the two verdicts
+  // are easy to print backwards: an empty parenthetical for a body that is
+  // genuinely not JSON, and "unparseable" for one that parsed fine.
+  it("labels a body that is not JSON, and only that body, unparseable", () => {
+    const garbage = run(fullyConfigured, {
+      [USER_TOKEN]: "<html>captive portal</html>",
+      [BOT_TOKEN]: alive("U_QA_BOT"),
+      [TARGET_TOKEN]: alive("U_TARGET"),
+    });
+    expect(garbage.code).toBe(1);
+    expect(garbage.output).toContain("DEAD (unparseable response)");
+
+    const enumerated = run(fullyConfigured, {
+      [USER_TOKEN]: { ok: false, error: "token_revoked" },
+      [BOT_TOKEN]: alive("U_QA_BOT"),
+      [TARGET_TOKEN]: alive("U_TARGET"),
+    });
+    expect(enumerated.output).toContain("DEAD (token_revoked)");
+    expect(enumerated.output).not.toContain("unparseable");
+  });
+
+  it("honours an explicit target id without needing SLACK_BOT_TOKEN", () => {
+    const result = run({
+      QA_SLACK_USER_TOKEN: USER_TOKEN,
+      QA_SLACK_TARGET_USER_ID: "U_EXPLICIT",
+      QA_SLACK_CHANNEL: "C_QA",
+    });
+    expect(result.code).toBe(0);
+    expect(result.output).toContain("✓ target bot: U_EXPLICIT");
+    expect(result.calls).toEqual(["auth.test"]);
+  });
+});

--- a/scripts/slack-qa-token-liveness.sh
+++ b/scripts/slack-qa-token-liveness.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# slack-qa-token-liveness.sh — report whether the stored Slack QA credentials
+# can still authenticate, without posting anything to Slack.
+#
+# Why this is separate from scripts/test-bot.sh: the QA_SLACK_* secrets were
+# added to this repo in April 2026 and no workflow ever consumed them, so
+# nothing noticed when they stopped working. The exact-response smoke in
+# test-bot.sh cannot distinguish "the bot regressed" from "the sender token
+# died" — it exits 1 either way. This answers only the credential question. It
+# posts no message and writes nothing, which is what makes it safe to schedule.
+#
+# Exit 0 means every credential that IS set authenticates AND the smoke has
+# every input it needs. Exit 1 names what is wrong.
+#
+# A stored-but-dead credential fails the run even when a fallback sender still
+# works: on a schedule, "a secret you are keeping has rotted" is the whole
+# signal. Fix it or unset it — do not let it sit there looking configured.
+#
+# DEAD means Slack rejected the credential — rotate or unset it. UNREACHABLE
+# means Slack never answered a verdict (curl failed, or a non-200: auth.test
+# answers 200 even for a token it rejects), which is Slack's problem, not the
+# secret's. Both fail the run, so an outage is visible rather than silent.
+#
+# Output discipline: token VALUES are never printed. Each credential is
+# reported by env-var name and byte length only, alongside whatever identity
+# Slack itself returns. Slack's auth.test error is a fixed enum
+# (invalid_auth, account_inactive, token_revoked, ...) and carries no secret.
+#
+# Env (all optional here; the smoke's own requirements are what is checked):
+#   QA_SLACK_USER_TOKEN     xoxp- QA sender, posts as a real user (preferred)
+#   QA_SLACK_BOT_TOKEN      xoxb- QA sender, from a *separate* Slack app
+#   SLACK_BOT_TOKEN         the target Lobu bot; also the reply-poll token
+#   QA_SLACK_TARGET_USER_ID target bot's user id, if not resolved via the above
+#   QA_SLACK_CHANNEL        channel the smoke posts into
+set -uo pipefail
+
+failures=0
+sender_name=""
+sender_user_id=""
+target_user_id="${QA_SLACK_TARGET_USER_ID:-}"
+
+fail() {
+  printf '  ✗ %s\n' "$1"
+  failures=$((failures + 1))
+}
+
+# Sets PROBE_USER_ID on success. Returns 0 = alive, 1 = set but broken,
+# 2 = not set (not a failure on its own; the caller decides whether the
+# smoke actually needs this one).
+PROBE_USER_ID=""
+probe() {
+  local name="$1" token="$2" resp status body detail
+  PROBE_USER_ID=""
+  if [ -z "$token" ]; then
+    printf '  %-24s not set\n' "$name"
+    return 2
+  fi
+  if ! resp=$(curl -sS --max-time 30 -w '\n%{http_code}' https://slack.com/api/auth.test \
+    -H "Authorization: Bearer $token" 2>/dev/null); then
+    printf '  %-24s len=%s  UNREACHABLE (curl failed)\n' "$name" "${#token}"
+    return 1
+  fi
+  status="${resp##*$'\n'}"
+  body="${resp%$'\n'*}"
+  # auth.test answers 200 with ok:false for every credential verdict, so a
+  # non-200 is Slack's problem (edge 5xx, rate limit), not a dead token.
+  # Calling that DEAD would page the devops channel during a Slack outage.
+  if [ "$status" != "200" ]; then
+    printf '  %-24s len=%s  UNREACHABLE (HTTP %s)\n' "$name" "${#token}" "$status"
+    return 1
+  fi
+  if ! printf '%s' "$body" | jq -e '.ok == true' >/dev/null 2>&1; then
+    # jq's `//` fallback only fires on a body that PARSES, so it cannot
+    # describe a non-JSON body — an empty extraction is what identifies one.
+    detail=$(printf '%s' "$body" | jq -r '.error // empty' 2>/dev/null) || detail=""
+    [ -n "$detail" ] || detail="unparseable response"
+    printf '  %-24s len=%s  DEAD (%s)\n' "$name" "${#token}" "$detail"
+    return 1
+  fi
+  PROBE_USER_ID=$(printf '%s' "$body" | jq -r '.user_id // empty')
+  printf '  %-24s len=%s  alive  team=%s user_id=%s\n' "$name" "${#token}" \
+    "$(printf '%s' "$body" | jq -r '.team // "?"')" "${PROBE_USER_ID:-?}"
+  return 0
+}
+
+echo "Slack QA credential liveness — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo
+echo "credentials:"
+
+probe QA_SLACK_USER_TOKEN "${QA_SLACK_USER_TOKEN:-}"
+case $? in
+0)
+  sender_name=QA_SLACK_USER_TOKEN
+  sender_user_id="$PROBE_USER_ID"
+  ;;
+1) failures=$((failures + 1)) ;;
+esac
+
+probe QA_SLACK_BOT_TOKEN "${QA_SLACK_BOT_TOKEN:-}"
+case $? in
+0)
+  # A user token is the better sender (a real Slack user, not a second app),
+  # so it wins when both authenticate.
+  if [ -z "$sender_name" ]; then
+    sender_name=QA_SLACK_BOT_TOKEN
+    sender_user_id="$PROBE_USER_ID"
+  fi
+  ;;
+1) failures=$((failures + 1)) ;;
+esac
+
+probe SLACK_BOT_TOKEN "${SLACK_BOT_TOKEN:-}"
+case $? in
+0) [ -n "$target_user_id" ] || target_user_id="$PROBE_USER_ID" ;;
+1) failures=$((failures + 1)) ;;
+esac
+
+echo
+echo "smoke prerequisites:"
+
+if [ -n "$sender_name" ]; then
+  printf '  ✓ sender: %s (%s)\n' "$sender_name" "$sender_user_id"
+else
+  fail "no QA sender token authenticates; set QA_SLACK_USER_TOKEN (xoxp-) or QA_SLACK_BOT_TOKEN (xoxb-)"
+fi
+
+if [ -n "$target_user_id" ]; then
+  printf '  ✓ target bot: %s\n' "$target_user_id"
+else
+  fail "target bot unresolved; set QA_SLACK_TARGET_USER_ID or a working SLACK_BOT_TOKEN"
+fi
+
+# The smoke rejects this before posting, because a sender that is also the
+# target reads its own message back as the bot's reply and passes for free.
+if [ -n "$sender_user_id" ] && [ "$sender_user_id" = "$target_user_id" ]; then
+  fail "sender and target are the same Slack user ($sender_user_id); the smoke needs a separate sender"
+fi
+
+if [ -n "${QA_SLACK_CHANNEL:-}" ]; then
+  printf '  ✓ channel: %s\n' "$QA_SLACK_CHANNEL"
+else
+  fail "QA_SLACK_CHANNEL is not set; the scheduled smoke has nowhere to post (test-bot.sh also takes TEST_CHANNEL, but only a hand-run has it)"
+fi
+
+echo
+if [ "$failures" -gt 0 ]; then
+  echo "❌ $failures problem(s); the exact-response Slack smoke cannot run."
+  exit 1
+fi
+echo "✅ Slack QA credentials are usable; scripts/test-bot.sh can run the exact-response smoke."


### PR DESCRIPTION
## Summary

- The `QA_SLACK_*` secrets were added to this repo in April 2026 and **no workflow ever consumed them** — `git grep 'QA_SLACK\|SLACK_BOT_TOKEN' origin/main -- .github/workflows/` returns nothing. Nothing noticed when they stopped authenticating; the failure only surfaced when someone ran the smoke by hand and got `invalid_auth` / `account_inactive` back.
- #3421 made `scripts/test-bot.sh` trustworthy, but it still exits 1 identically whether the agent regressed or the sender token died, and it posts a real message, so it cannot run on a schedule.
- So: a credential probe that calls `auth.test` only. No message, no thread, no write anywhere — which is what makes it cron-safe. Daily schedule plus `workflow_dispatch`.

Exit 0 means every credential that *is* set authenticates **and** the exact-response smoke has every input it needs. A stored-but-dead credential fails the run even when a fallback sender still works: on a schedule, "a secret you are keeping has rotted" is the whole signal.

`DEAD` (Slack rejected the credential — rotate or unset it) is kept distinct from `UNREACHABLE` (curl failed, or a non-200 — `auth.test` answers 200 even for a token it rejects). Collapsing them would page the devops channel with "rotate your secret" during a Slack outage.

Not a required check and not a release gate — a dead QA token says nothing about whether the code under review is correct. Keep it off the branch-protection list.

Deliberately no `pull_request` trigger: this repo is public and GitHub withholds secrets from a run on a fork, so every fork PR would get an empty environment, report every credential missing, and fail.

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` clean on all 5 gates (full graph runs on CI for this PR)
- [x] The exact CI step — `bun test scripts` → **419 pass, 0 fail** (28 files, 1509 expect() calls); new suite alone **18 pass, 0 fail**
- [x] `shellcheck -S warning`, `bash -n`, `actionlint`, and biome (`--config-path config/biome.config.json`) all clean
- [x] Mutation-proved all 14 guards (below)
- [x] `make review-fix` (Claude reviewer) — it found two real bugs; see Notes
- [ ] Live `workflow_dispatch` against the real secrets — that run *is* the answer we're after, and `workflow_dispatch` only becomes available once this is on `main`

The suite is hermetic: a fake `curl` on `PATH` answers `auth.test` per bearer token (and honours `-w %{http_code}`), so no network and no real credential is involved. Same pattern as the `test-bot.sh` suite from #3421.

### Mutation proof

Each guard reverted independently on a scratch copy; every one turns the suite red.

| mutation | result |
|---|---|
| dead credential no longer counts as a failure | 13 pass **4 fail** |
| drop the sender-is-also-the-target guard | 16 pass **1 fail** |
| bot token wins over user token as sender | 16 pass **1 fail** |
| channel no longer required | 16 pass **1 fail** |
| target bot no longer required | 16 pass **1 fail** |
| "no sender authenticates" no longer required | 16 pass **1 fail** |
| curl failure reported as `DEAD` | 16 pass **1 fail** |
| drop the HTTP-status guard | 16 pass **1 fail** |
| restore the old `jq //` fallback | 17 pass **1 fail** |
| leak the token on the `alive` path | 16 pass **1 fail** |
| leak the token on the `DEAD` path | 15 pass **2 fail** |
| leak the token on the `UNREACHABLE (HTTP)` path | 17 pass **1 fail** |
| leak the token on the curl-failure path | 16 pass **1 fail** |
| dump the raw response body | 15 pass **2 fail** |

Two of those rows exist because the battery caught blind spots in this PR's own tests, not in the script:

1. The first draft of the redaction test only exercised the all-alive branch, so a leak on `DEAD` passed. Fixed by making it table-driven over alive / rejected / unreachable / unparseable credentials.
2. After `review-fix` added the `UNREACHABLE (HTTP …)` branch, a leak there **still** passed — no redaction row produced a non-200. Fixed by adding an `http-error` row (503/429/500). That branch is handed an edge error page rather than Slack JSON, so it is the one most likely to want to quote the response.

A leak on any of those paths lands in a public Actions log, which is why each branch is covered separately rather than once on the happy path.

## Notes

`make review-fix` found two genuine bugs, both mine:

- **`curl -sS` exits 0 on a 502/429 with a body**, so a Slack outage was being reported as a dead credential — and this job pages devops on failure, so it would have sent someone rotating a credential that was fine. Now the status comes from `-w '\n%{http_code}'` and a non-200 is `UNREACHABLE (HTTP nnn)`.
- **`jq -r '.error // "unparseable response"'` was inverted.** `//` only fires its fallback on a body that *parses*, so a genuinely non-JSON body (a Slack edge HTML page) printed `DEAD ()` with no diagnosis, while a parseable `{"ok":false}` printed `DEAD (unparseable response)`.

Output discipline: token **values** are never printed. A credential is described by env-var name and byte length only, plus whatever identity Slack itself returns. Slack's `auth.test` error is a fixed enum (`invalid_auth`, `account_inactive`, `token_revoked`, …) and carries no secret.

Two secrets this reads do not exist yet; the script reports them as `not set` rather than failing on their absence alone:

- `QA_SLACK_USER_TOKEN` — the preferred sender (`xoxp-`, posts as a real user). #3421 added `channels:history` / `groups:history` / `im:history` / `mpim:history` to `config/slack-app-manifest.qa-user.json` specifically so this token can read the target bot's reply, so obtaining it needs the QA user app reauthorized to pick up those scopes.
- `QA_SLACK_TARGET_USER_ID` — optional; a working `SLACK_BOT_TOKEN` resolves the target via `auth.test` instead.

**Open question for the reviewer:** whether an unreachable Slack should fail the job at all. It currently exits 1 with an honest label, so a permanent egress break cannot hide; the trade is a rare false page during a Slack outage. Say the word and it becomes a warning that exits 0.

**Residual risk:** the happy path is proven only against the fake curl — there are no live QA tokens on this machine, so no real `ok:true` has been observed (a real `auth.test` call with a bogus token did return `DEAD (invalid_auth)`, `len=13`, no value echoed). The webhook POST is unexercised, though it is step-for-step the same shape as three shipping workflows. The `429` half of the status guard is reasoned, not observed — three calls a day will not produce one.

Follow-up, once a dispatch confirms which credentials are alive: wire `scripts/test-bot.sh` itself into a workflow with a generated marker and `TEST_EXPECT_RESPONSE`, on its own daily cron. That one does post to Slack, so it should not land until the credential picture is known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2NpHdkUCP9o3tYmmU8tdZ
