### PR TITLE
fix(smoke): decide the guest-bundle expectation from the artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1261,6 +1261,14 @@ jobs:
           bash scripts/lib/__tests__/review-cache.test.sh
           bash scripts/lib/__tests__/process-cleanup.test.sh
 
+      - name: Published-artifact smoke helper tests
+        # The smoke installs whatever is on npm right now, so its guest-bundle
+        # assertion has to decide from the artifact whether that version even
+        # owes us the file. Getting that wrong is silent in both directions:
+        # too strict reds main for every pre-feature release, too loose lets a
+        # broken publish through.
+        run: bash scripts/lib/__tests__/guest-bundle-expectation.test.sh
+
       - name: Preview and staging workflow guards
         # The preview deploy's mid-flight teardown decides whether to delete a
         # namespace out from under a running PR. It only ever executes on a

--- a/scripts/lib/__tests__/guest-bundle-expectation.test.sh
+++ b/scripts/lib/__tests__/guest-bundle-expectation.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+# shellcheck source=scripts/lib/guest-bundle-expectation.sh
+. "$ROOT/scripts/lib/guest-bundle-expectation.sh"
+
+work=""
+cleanup() { [[ -n "$work" ]] && rm -rf "$work"; }
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+work="$(mktemp -d)"
+
+# Builds dist/agent-turn holding exactly the named files, and returns the DIST
+# dir — the verdict function takes dist so it can tell a moved layout from a
+# version that predates the feature.
+fixture() {
+  local name="$1"
+  shift
+  local dist="$work/$name/dist"
+  # ${work:?} so a cleared $work can never make this rm -rf a path under /.
+  rm -rf "${work:?}/$name"
+  mkdir -p "$dist/agent-turn"
+  local f
+  for f in "$@"; do : >"$dist/agent-turn/$f"; done
+  printf '%s' "$dist"
+}
+
+# A dist that exists but has no agent-turn under it at all.
+fixture_no_agent_turn() {
+  local dist="$work/layout_moved/dist"
+  rm -rf "${work:?}/layout_moved"
+  mkdir -p "$dist/executor"
+  printf '%s' "$dist"
+}
+
+expect() {
+  local dir="$1" want="$2" got
+  got="$(lobu_guest_bundle_verdict "$dir")"
+  [ "$got" = "$want" ] || fail "expected '$want', got '$got' for $dir"
+}
+
+# The exact file list the published 19.2.0 tarball ships, read off the registry
+# on 2026-09-09. This is the case that reddened main: neither builder nor
+# bundle, because the version predates both.
+expect "$(fixture published_19_2_0 \
+  bundle.js guest-entry.js index.js types.js workspace.js \
+  bundle.d.ts guest-entry.d.ts index.d.ts types.d.ts workspace.d.ts)" \
+  not-shipped
+
+# A publish that ran `tsc` (so the builder compiled into dist) but never ran
+# the bundle step. THIS is the packaging bug the assertion exists to catch, and
+# it must stay a hard failure — the isolate lane cannot load a turn without it.
+expect "$(fixture builder_without_output \
+  build-guest-bundle.js guest-entry.js index.js)" \
+  missing
+
+# A correctly published post-#3402 artifact.
+expect "$(fixture healthy \
+  build-guest-bundle.js guest.bundle.js guest-entry.js index.js)" \
+  present
+
+# The bundle alone is enough. Nothing requires the builder to be present for
+# the artifact to work at runtime — only for the expectation to be inferable —
+# so a payload trimmed to just the output must not read as broken.
+expect "$(fixture bundle_only guest.bundle.js index.js)" present
+
+# An empty agent-turn is a pre-feature artifact: the directory is there, it
+# just carries neither builder nor bundle.
+expect "$(fixture empty)" not-shipped
+
+# dist present, agent-turn gone. Without this branch both probes come up empty
+# and a real packaging regression would read as `not-shipped` and be SKIPPED —
+# quieter than the bug it is hiding. 19.2.0 does ship dist/agent-turn
+# (verified from the tarball), so this cannot fire on pre-feature versions.
+expect "$(fixture_no_agent_turn)" layout-moved
+
+# Nothing installed at all. The install assertions own that failure, but the
+# verdict must still be a distinct value rather than crashing under `set -e`.
+expect "$work/absent/dist" no-dist
+
+# `guest-entry.js` is a decoy: it ships in 19.2.0 and sits one character from
+# `guest.bundle.js` (`guest-` vs `guest.`). A `guest*.js` glob would read it as
+# `present`; treating it as the builder would read it as `missing`. Either way
+# 19.2.0 stops reading `not-shipped` and main stays red.
+expect "$(fixture decoy_entry_only guest-entry.js)" not-shipped
+
+echo "PASS: guest-bundle expectation verdicts"

--- a/scripts/lib/gate-runner.sh
+++ b/scripts/lib/gate-runner.sh
@@ -177,6 +177,7 @@ gate_format_lint() {
   bash scripts/lib/__tests__/review-skip.test.sh || return 1
   bash scripts/lib/__tests__/review-cache.test.sh || return 1
   bash scripts/lib/__tests__/process-cleanup.test.sh || return 1
+  bash scripts/lib/__tests__/guest-bundle-expectation.test.sh || return 1
   sh scripts/lib/__tests__/kubeconfig-preflight.test.sh || return 1
   cmp -s .github/actions/setup-submodule/action.yml .depot/actions/setup-submodule/action.yml || return 1
   bash scripts/lib/__tests__/remote-ci.test.sh || return 1

--- a/scripts/lib/guest-bundle-expectation.sh
+++ b/scripts/lib/guest-bundle-expectation.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Decide whether a PUBLISHED @lobu/connector-worker is required to carry the
+# isolate agent-turn guest bundle.
+#
+# Why this is not just `[ -f guest.bundle.js ]`: the published-artifact smoke
+# installs the artifact users actually get — the newest version on npm — while
+# the assertion lives on `main`. #3402 added both the bundle builder and a bare
+# file check in one commit, so from the moment it merged the smoke demanded a
+# file that no published version contains. `19.2.0` (2026-09-07) predates the
+# builder by two days, and as of 2026-09-09 release `20.0.0` was still an open
+# PR, so every run on main failed 14/1 for a version that was never supposed to
+# have the file.
+#
+# An artifact from before the feature is not broken. Its agent turn runs the
+# spawned-subprocess lane, which the smoke's own real-turn assertion exercises
+# either way (section 4, "lobu chat returned the model's reply") — so a missing
+# bundle there proves nothing, while a hard failure hides every genuine
+# regression behind noise.
+#
+# The expectation is therefore DERIVED from the artifact rather than pinned to
+# a version number that would rot at the next major:
+#
+#   build script:  `tsc && node dist/agent-turn/build-guest-bundle.js`
+#   files:         ["dist", ...]
+#
+# so the compiled BUILDER ships in the same payload as what it builds. An
+# artifact carrying the builder but not the bundle is the real packaging bug —
+# a publish that ran `tsc` and skipped the bundle step — and that is what this
+# must catch. An artifact carrying neither simply predates the feature, and
+# starts being held to the assertion automatically once the next release
+# publishes. No version table to maintain.
+#
+# One case the builder/bundle pair cannot settle on its own: if
+# `dist/agent-turn` disappears wholesale, both probes come up empty and the
+# artifact reads as "predates the feature" when it is actually a packaging
+# regression. So the caller passes `dist` and an existing `dist` with no
+# `agent-turn` under it is called out separately. 19.2.0 does ship that
+# directory (verified from the published tarball), so pre-feature versions
+# stay unaffected.
+#
+# Usage:
+#   verdict="$(lobu_guest_bundle_verdict "<connector-worker-dist>")"
+#     present      -> the bundle is there; assert on it
+#     missing      -> builder shipped without its output; FAIL, this is the bug
+#     layout-moved -> dist exists but dist/agent-turn does not; FAIL
+#     not-shipped  -> artifact predates the builder; skip, not a failure
+#     no-dist      -> nothing installed; the install assertions own that
+
+lobu_guest_bundle_verdict() {
+  local dist="$1" dir="$1/agent-turn"
+  if [ -f "$dir/guest.bundle.js" ]; then
+    printf 'present'
+  elif [ -f "$dir/build-guest-bundle.js" ]; then
+    printf 'missing'
+  elif [ -d "$dir" ]; then
+    printf 'not-shipped'
+  elif [ -d "$dist" ]; then
+    printf 'layout-moved'
+  else
+    printf 'no-dist'
+  fi
+}

--- a/scripts/published-artifact-smoke.sh
+++ b/scripts/published-artifact-smoke.sh
@@ -54,6 +54,8 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HARNESS="$REPO_ROOT/scripts/sdk-e2e"
 # shellcheck source=scripts/lib/process-cleanup.sh
 . "$REPO_ROOT/scripts/lib/process-cleanup.sh"
+# shellcheck source=scripts/lib/guest-bundle-expectation.sh
+. "$REPO_ROOT/scripts/lib/guest-bundle-expectation.sh"
 LOBU_VERSION="${1:-${LOBU_VERSION:-latest}}"
 GW_PORT="${GW_PORT:-8799}"
 MOCK_PORT="${MOCK_PORT:-11439}"
@@ -74,9 +76,12 @@ WORK="${SMOKE_WORK:-/tmp/lobu-artifact-smoke}"
 rm -rf "$WORK"; mkdir -p "$WORK"
 export HOME="$WORK/home"; mkdir -p "$HOME"
 
-PASSES=0; FAILS=0
+PASSES=0; FAILS=0; SKIPS=0
 pass() { echo "  [OK]   $*"; PASSES=$((PASSES + 1)); }
 fail() { echo "  [FAIL] $*" >&2; FAILS=$((FAILS + 1)); }
+# A guarantee this published version was never supposed to offer. Reported so
+# it cannot hide, counted separately so it cannot red main.
+skip() { echo "  [SKIP] $*"; SKIPS=$((SKIPS + 1)); }
 note() { echo ""; echo "== $* =="; }
 
 MOCK_PID=""
@@ -168,12 +173,27 @@ fi
 # isolate. `@lobu/worker` used to ship the equivalent for the managed
 # subprocess; that package is no longer published, and a turn now evaluates
 # this bundle in-isolate.
-GUEST_BUNDLE="$INSTALL_DIR/node_modules/@lobu/connector-worker/dist/agent-turn/guest.bundle.js"
-if [ -f "$GUEST_BUNDLE" ]; then
-  pass "isolate guest bundle present ($(wc -c < "$GUEST_BUNDLE" | tr -d ' ') bytes)"
-else
-  fail "no guest bundle at $GUEST_BUNDLE — the agent turn cannot work"
-fi
+# Whether this artifact OWES us the bundle is derived from the artifact, not
+# pinned to a version — see scripts/lib/guest-bundle-expectation.sh.
+GUEST_DIST_DIR="$INSTALL_DIR/node_modules/@lobu/connector-worker/dist"
+GUEST_BUNDLE="$GUEST_DIST_DIR/agent-turn/guest.bundle.js"
+case "$(lobu_guest_bundle_verdict "$GUEST_DIST_DIR")" in
+  present)
+    pass "isolate guest bundle present ($(wc -c < "$GUEST_BUNDLE" | tr -d ' ') bytes)"
+    ;;
+  missing)
+    fail "guest bundle builder shipped without its output at $GUEST_BUNDLE — the publish ran tsc but not the bundle step, so the agent turn cannot work"
+    ;;
+  layout-moved)
+    fail "@lobu/connector-worker ships dist but no dist/agent-turn — the packaged layout moved, so no version of this check can hold"
+    ;;
+  no-dist)
+    fail "@lobu/connector-worker has no dist at all in $GUEST_DIST_DIR"
+    ;;
+  not-shipped)
+    skip "isolate guest bundle: published $RESOLVED predates the isolate agent-turn bundle (no builder in dist); its turn runs the subprocess lane, which the real-turn assertion in section 4 covers"
+    ;;
+esac
 
 # ---------------------------------------------------------------------------
 # 2. Deterministic provider, so a real turn needs no key.
@@ -270,7 +290,7 @@ else
   fi
   tail -40 "$RUN_LOG" >&2
   echo ""
-  echo "  smoke summary: $PASSES passed, $FAILS failed"
+  echo "  smoke summary: $PASSES passed, $FAILS failed, $SKIPS skipped"
   echo "RESULT: published-artifact smoke FAILED (boot)"
   exit 1
 fi
@@ -360,7 +380,7 @@ fi
 
 echo ""
 echo "================================================================"
-echo "  smoke summary: $PASSES passed, $FAILS failed"
+echo "  smoke summary: $PASSES passed, $FAILS failed, $SKIPS skipped"
 echo "================================================================"
 if [ "$FAILS" -gt 0 ]; then
   echo "RESULT: published-artifact smoke FAILED"; exit 1


### PR DESCRIPTION
## Summary

The published-artifact smoke has failed on **every push to main** since 19:23 UTC today — 9 consecutive runs, all four OS variants, `14 passed, 1 failed`:

```
[FAIL] no guest bundle at .../@lobu/connector-worker/dist/agent-turn/guest.bundle.js
       — the agent turn cannot work
```

#3402 added the isolate agent-turn bundle builder **and** a bare `[ -f guest.bundle.js ]` assertion in the same commit, merged at 19:23:01 UTC — the exact minute of the first failure. But this smoke installs what users actually get, the newest published version, and that is `19.2.0` (cut 2026-09-07, two days before the builder existed). Release `20.0.0` is still an open PR (#3413, open since 2026-09-07). So the assertion demanded a file no published version can contain.

I confirmed this against the registry rather than inferring it — the published `19.2.0` tarball's `dist/agent-turn/` holds `bundle.js`, `guest-entry.js`, `index.js`, `types.js`, `workspace.js` and their `.d.ts`, and **neither** `guest.bundle.js` nor `build-guest-bundle.js`.

An artifact from before the feature is not broken. Its agent turn runs the subprocess lane, which this same smoke already exercises in section 4 (`[OK] lobu chat returned the model's reply (ARTIFACT_SMOKE_OK)`, `[OK] no worker crash in the run log`) — both of which **pass** on 19.2.0. A hard failure on the file proves nothing while hiding every genuine regression behind noise.

## The fix

The expectation is derived from the artifact rather than pinned to a version number that would rot at the next major. The build script is `tsc && node dist/agent-turn/build-guest-bundle.js` and `files` is `["dist"]`, so the compiled **builder** ships in the same payload as what it builds:

| verdict | condition | outcome |
|---|---|---|
| `present` | `guest.bundle.js` there | assert on it |
| `missing` | builder shipped, output absent | **FAIL** — the real packaging bug |
| `layout-moved` | `dist` there, `dist/agent-turn` gone | **FAIL** — packaged layout changed |
| `not-shipped` | `agent-turn` there, neither file | skip, not a failure |
| `no-dist` | nothing installed | **FAIL** |

`missing` is precisely the failure the assertion exists to catch — a publish that ran `tsc` and skipped the bundle step — and it stays a hard fail. `not-shipped` re-arms itself automatically at the next release, with no version table to maintain.

`skip()` matches `scripts/cli-smoke.sh:101`'s helper byte for byte, and both summary lines now report skips so a skip can never hide. Nothing parses that summary line (checked across the repo).

## Test plan

- [x] **Red reproduced** against a fixture built from the real published 19.2.0 file list
- [x] **Green proved** on all three states
- [x] New helper test: `bash scripts/lib/__tests__/guest-bundle-expectation.test.sh` → `PASS`
- [x] 8 mutations, all caught (below)
- [x] The real smoke block run against all five states end to end
- [x] `shellcheck -S warning` clean on all four shell files; `bash -n` clean; `actionlint` clean (the one SC2129 at `ci.yml:110` is byte-identical on `origin/main` — pre-existing)
- [x] Sibling `process-cleanup.test.sh` still passes; `make pre-pr` clean
- [ ] The first push to main after merge is the real proof — I cannot run the container smoke locally (needs Docker + a registry install)

Red, against the real 19.2.0 layout:
```
  [FAIL] no guest bundle at .../guest.bundle.js — the agent turn cannot work
  -> summary: 0 passed, 1 failed        (this is main's CI today)
```

Green, same fixture:
```
  [SKIP] published 19.2.0 predates the isolate agent-turn bundle
  -> 19.2.0: 0 passed, 0 failed, 1 skipped
  [FAIL] builder shipped without its output
  -> broken publish: 0 passed, 1 failed, 0 skipped
  [OK]   isolate guest bundle present
  -> post-release: 1 passed, 0 failed, 0 skipped
```

### Mutation proof

| mutation | result |
|---|---|
| builder-missing reads as ok | caught |
| no-builder reads as missing | caught |
| builder probe → `guest-entry.js` | caught |
| builder probe → `index.js` | caught |
| bundle probe → `bundle.js` | caught |
| always `present` | caught |
| always `not-shipped` | caught |
| drop the `layout-moved` branch | caught |
| `layout-moved` reads as `not-shipped` | caught |
| `agent-turn` probe always true | caught |
| `no-dist` reads as `not-shipped` | caught |

The `guest-entry.js` row matters: that file *does* exist in 19.2.0 and its name is one character from `guest.bundle.js` (`guest-` vs `guest.`), so a probe matching it would have made the 19.2.0 case read as `missing` and kept main red.

## Notes

`make review-fix` found one real gap: `scripts/lib/gate-runner.sh:180` enumerates the same shell-lib test list as `ci.yml`, so the new test would have run in CI but **not** in the local gate. Both are now registered. It also moved the CI line out of the "Review tooling shell tests" step (a smoke helper is not review tooling) and corrected my skip message, which claimed the real-turn assertion was "above" when it is at line 303, below.

`make review` then flagged the one gap I had written down as a follow-up, and it was right that it should not wait: a vanished `dist/agent-turn/` would have SKIPped where the old check FAILed — a coverage downgrade introduced by this very change. Rather than ship that, the verdict now takes `dist` and separates a moved layout (`layout-moved`) and a missing install (`no-dist`) from a genuine pre-feature artifact. 19.2.0 does ship `dist/agent-turn/` (verified from the tarball), so pre-feature versions are unaffected. Mutations went 7 → 8, all caught.

Also worth noting: the two enumerated lists above are themselves the "name the instance" pattern — a glob over `scripts/lib/__tests__/*.test.sh` in both places would stop new lib tests from being silently unregistered. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2NpHdkUCP9o3tYmmU8tdZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved published-artifact validation to distinguish available, missing, not-shipped, and invalid guest-bundle layouts.
  * Older published versions without the guest bundle are now reported as skipped instead of failing validation.
  * Required or malformed guest bundles continue to produce validation failures.
  * Validation summaries now clearly report passed, failed, and skipped checks.

* **Tests**
  * Added coverage for guest-bundle detection across published, missing, empty, absent, moved, and decoy artifact layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->