### PR TITLE
feat(release): publish verified npm canaries from main

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,0 +1,191 @@
+name: Publish Canary
+
+on:
+  workflow_run:
+    workflows: ["Build and Push Images"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: read
+
+# Keep publish, smoke and promotion serialized. Superseded pending runs can be
+# coalesced by GitHub; a running candidate always finishes without cancellation.
+concurrency:
+  group: ${{ github.event.workflow_run.event == 'push' && 'npm-canary' || format('npm-canary-ignored-{0}', github.run_id) }}
+  cancel-in-progress: false
+
+env:
+  REQUIRED_IMAGE_JOBS: generate-tag connector-parity-smoke build-worker build-embeddings-service build-app app-image-smoke promote-images
+
+jobs:
+  attest:
+    name: Attest main image and CI runs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    # `types: [completed]` also fires for failure and cancellation, and
+    # `branches: [main]` admits a manual Build Images dispatch as readily as a
+    # push. Both would start this job and then hard-fail the API checks below,
+    # so screen them out here. The producer's conclusion and event are re-read
+    # from the API regardless: this is noise control, not the gate.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+    outputs:
+      sha: ${{ steps.producer.outputs.sha }}
+    steps:
+      # Deliberately before any checkout: no repository code runs until the
+      # producing run is known to be a completed-success push to a commit
+      # that is still reachable from main.
+      - name: Attest the producing Build Images run
+        id: producer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_IMAGE_RUN_ID: ${{ github.event.workflow_run.id }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          image_run_id="$EVENT_IMAGE_RUN_ID"
+          [ -n "$image_run_id" ] || { echo "::error::image_run_id is required"; exit 1; }
+
+          build_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/build-images.yml" --jq '.id')
+          build_run=$(gh api "repos/${REPOSITORY}/actions/runs/${image_run_id}")
+          workflow_id=$(jq -r '.workflow_id' <<<"$build_run")
+          sha=$(jq -r '.head_sha' <<<"$build_run")
+          head_repo=$(jq -r '.head_repository.full_name // empty' <<<"$build_run")
+          event=$(jq -r '.event' <<<"$build_run")
+          branch=$(jq -r '.head_branch // empty' <<<"$build_run")
+          status=$(jq -r '.status' <<<"$build_run")
+          conclusion=$(jq -r '.conclusion // empty' <<<"$build_run")
+          [ "$workflow_id" = "$build_workflow_id" ] || { echo "::error::wrong Build Images workflow"; exit 1; }
+          [ "$head_repo" = "$REPOSITORY" ] || { echo "::error::Build Images run repository mismatch"; exit 1; }
+          [ "$event" = push ] && [ "$branch" = main ] || { echo "::error::Build Images run must be a main push"; exit 1; }
+          [ "$status" = completed ] && [ "$conclusion" = success ] || { echo "::error::Build Images run is not completed-success"; exit 1; }
+
+          # Reachability, not tip-ness. A release commit's own image build
+          # routinely finishes after later commits have landed; demanding the
+          # tip threw that run away and left the version unreleased with every
+          # run green. A commit still reachable from main got there through
+          # branch protection, which is the property the checkout below needs.
+          current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
+          compare_status=$(gh api "repos/${REPOSITORY}/compare/${sha}...${current_sha}" --jq '.status')
+          [ "$compare_status" = ahead ] || [ "$compare_status" = identical ] || { echo "::error::attested SHA ${sha} is not reachable from main (${compare_status})"; exit 1; }
+
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "image_run_id=$image_run_id" >> "$GITHUB_OUTPUT"
+
+      # Pinned to the SHA the step above proved is reachable from main, so the
+      # policy helper cannot come from a ref that never merged.
+      - name: Check out the attested commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.producer.outputs.sha }}
+          fetch-depth: 2
+
+      - name: Attest required image jobs and the exact CI run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          ATTESTED_SHA: ${{ steps.producer.outputs.sha }}
+          IMAGE_RUN_ID: ${{ steps.producer.outputs.image_run_id }}
+        run: |
+          set -euo pipefail
+          # Piped, never --argjson: a paginated API payload passed as a command
+          # argument dies with "jq: Argument list too long" once it outgrows
+          # ARG_MAX on the runner, and macOS tolerates a payload Linux rejects,
+          # so it cannot be caught locally.
+          gh api --paginate --slurp "repos/${REPOSITORY}/actions/runs/${IMAGE_RUN_ID}/jobs?filter=all&per_page=100" \
+            | jq --arg required "$REQUIRED_IMAGE_JOBS" \
+              '{pages: ., required: ($required | split(" "))}' \
+            | node scripts/release-provenance.mjs attest-jobs >/dev/null
+
+          ci_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml" --jq '.id' | tr -d '\n')
+          ci_run_id=""
+          for _ in $(seq 1 20); do
+            # Re-checked every iteration so the bounded wait still bails out
+            # early: a commit force-pushed off main stops being reachable.
+            current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
+            compare_status=$(gh api "repos/${REPOSITORY}/compare/${ATTESTED_SHA}...${current_sha}" --jq '.status')
+            [ "$compare_status" = ahead ] || [ "$compare_status" = identical ] || { echo "::error::attested SHA left main while waiting for exact CI (${compare_status})"; exit 1; }
+            # Piped, never --argjson, for the same reason as the jobs read
+            # above: a run list is one argv entry, and Linux caps that at
+            # 128KB. Folding it into the existing `|| selection=""` also means
+            # a transient API blip now costs one more turn of this bounded
+            # wait instead of killing the release outright.
+            selection=$(gh api "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${ATTESTED_SHA}&event=push&branch=main&status=completed&per_page=100" \
+              | jq --argjson workflow_id "$ci_workflow_id" --arg repo "$REPOSITORY" --arg sha "$ATTESTED_SHA" \
+                '{runs: [.workflow_runs[] | . + {repo: .repository.full_name}],
+                  expected: {workflow_id: $workflow_id, repo: $repo, event: "push", head_branch: "main", head_sha: $sha, status: "completed", conclusion: "success"}}' \
+              | node scripts/release-provenance.mjs select-run) || selection=""
+            if [ -n "$selection" ]; then
+              ci_run_id=$(jq -r '.id' <<<"$selection")
+              break
+            fi
+            sleep 20
+          done
+          [ -n "$ci_run_id" ] || { echo "::error::exact successful CI push/main run was not observed within the bounded wait"; exit 1; }
+          echo "attested CI run for ${ATTESTED_SHA}: ${ci_run_id}"
+
+  publish:
+    needs: attest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: production
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.attest.outputs.sha }}
+      - uses: ./.github/actions/setup-submodule
+        with:
+          deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+      - run: bun install --frozen-lockfile
+      - name: Prepare exact commit versions
+        id: version
+        run: |
+          version=$(node scripts/canary-publish.mjs prepare)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Build packages
+        run: |
+          bun run build:packages
+          bun run build:lobu
+      - name: Publish candidate without moving stable or canary
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: node scripts/publish-packages.mjs --skip-bump --skip-build --tag=canary-candidate
+
+  smoke:
+    needs: publish
+    uses: ./.github/workflows/published-artifact-smoke.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.publish.outputs.version }}
+
+  promote:
+    needs: [attest, publish, smoke]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: production
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.attest.outputs.sha }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+      - name: Advance canary after the exact artifact passes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          CANARY_VERSION: ${{ needs.publish.outputs.version }}
+        run: node scripts/canary-publish.mjs promote "$CANARY_VERSION"

--- a/.github/workflows/published-artifact-smoke.yml
+++ b/.github/workflows/published-artifact-smoke.yml
@@ -121,7 +121,7 @@ jobs:
           for file in /tmp/lobu-artifact-smoke*/version.txt; do
             [ -f "$file" ] || continue
             version=$(cat "$file")
-            if echo "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            if echo "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-canary\.[0-9]+\.g[0-9a-f]{40})?$'; then
               echo "version=$version" >> "$GITHUB_OUTPUT"
               break
             fi

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ The same MCP endpoint works with **Claude Code, Codex, OpenCode, Antigravity, Ch
 
 Setup guides: [Claude](https://lobu.ai/connect-from/claude/) · [ChatGPT](https://lobu.ai/connect-from/chatgpt/) · [Codex](https://lobu.ai/connect-from/codex/) · [Grok](https://lobu.ai/connect-from/grok/)
 
+To test changes merged to `main`, run `bunx @lobu/cli@canary --help`. The
+`canary` tag advances after CI, image checks, and installation smoke tests in
+four Linux environments pass. Use `@latest` for stable releases. Canary versions
+include the full commit SHA so you can pin a preview when reproducing a bug.
+
 ### Recall what the company knows
 
 Ask from Claude Code, Codex, or ChatGPT:

--- a/scripts/__tests__/canary-publish.test.ts
+++ b/scripts/__tests__/canary-publish.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  canaryVersion,
+  prepareManifests,
+  promotionAllowed,
+} from "../canary-publish.mjs";
+import { __testing } from "../publish-packages.mjs";
+
+const sha = "a".repeat(40);
+const version = `19.2.0-canary.123.g${sha}`;
+
+describe("npm canary publication", () => {
+  it("binds a deterministic prerelease to the full commit", () => {
+    expect(canaryVersion("19.2.0", "123", sha)).toBe(version);
+    for (const args of [
+      ["bad", "123", sha],
+      ["19.2.0", "no", sha],
+      ["19.2.0", "123", "main"],
+    ]) {
+      expect(() => canaryVersion(...args)).toThrow();
+    }
+  });
+
+  it("versions every published package and pins internal dependencies", () => {
+    const manifests = [
+      { name: "@lobu/core", version: "1.0.0" },
+      {
+        name: "@lobu/cli",
+        version: "2.0.0",
+        dependencies: { "@lobu/core": "^1.0.0", external: "^2.0.0" },
+      },
+    ];
+    const prepared = prepareManifests(manifests, version);
+    expect(prepared.map((pkg) => pkg.version)).toEqual([version, version]);
+    expect(prepared[1].dependencies).toEqual({
+      "@lobu/core": version,
+      external: "^2.0.0",
+    });
+    expect(manifests[0].version).toBe("1.0.0");
+  });
+
+  it("keeps prereleases away from latest even on a mistyped invocation", () => {
+    expect(
+      __testing.publishArgs(undefined, "canary-candidate", version)
+    ).toContain("canary-candidate");
+    expect(() => __testing.publishArgs(undefined, "latest", version)).toThrow();
+    expect(() => __testing.publishArgs(undefined, "canary", version)).toThrow();
+    expect(__testing.publishArgs(undefined, "latest", "19.2.0")).toContain(
+      "latest"
+    );
+  });
+
+  it("only promotes first, same, or descendant commits", () => {
+    expect(
+      promotionAllowed(undefined, version, () => {
+        throw new Error("unexpected");
+      })
+    ).toBe(true);
+    expect(promotionAllowed(version, version, () => false)).toBe(true);
+    const old = `19.2.0-canary.122.g${"b".repeat(40)}`;
+    expect(
+      promotionAllowed(
+        old,
+        version,
+        (from, to) => from === "b".repeat(40) && to === sha
+      )
+    ).toBe(true);
+    expect(promotionAllowed(old, version, () => false)).toBe(false);
+    expect(() => promotionAllowed("19.2.0", version, () => true)).toThrow();
+  });
+
+  it("requires artifact smoke before advancing the opt-in tag", () => {
+    const workflow = Bun.YAML.parse(
+      readFileSync(
+        new URL("../../.github/workflows/publish-canary.yml", import.meta.url),
+        "utf8"
+      )
+    ) as any;
+    expect(workflow.on.workflow_run.workflows).toEqual([
+      "Build and Push Images",
+    ]);
+    expect(workflow.jobs.promote.needs).toContain("smoke");
+    expect(workflow.jobs.smoke.uses).toBe(
+      "./.github/workflows/published-artifact-smoke.yml"
+    );
+    expect(workflow.jobs.smoke.with.version).toBe(
+      "${{ needs.publish.outputs.version }}"
+    );
+    expect(workflow.concurrency["cancel-in-progress"]).toBe(false);
+    // The required image-job list is copied from publish-packages.yml, whose
+    // own test pins it to build-images.yml; keep the copy from drifting.
+    const stable = Bun.YAML.parse(
+      readFileSync(
+        new URL(
+          "../../.github/workflows/publish-packages.yml",
+          import.meta.url
+        ),
+        "utf8"
+      )
+    ) as any;
+    expect(workflow.env.REQUIRED_IMAGE_JOBS).toBe(
+      stable.env.REQUIRED_IMAGE_JOBS
+    );
+  });
+});
+
+// Run the actual command entry points in an isolated filesystem with a fake
+// registry. No network or publication credentials are used by these probes.
+describe("canary commands", () => {
+  it("prepares the full fleet, retries promotion and preserves latest", () => {
+    withFixture((root, run, registry) => {
+      const prepared = run("prepare");
+      expect(prepared.status).toBe(0);
+      expect(prepared.stdout.trim()).toBe(version);
+      for (const { dir } of __testing.PACKAGES) {
+        expect(
+          JSON.parse(readFileSync(`${root}/${dir}/package.json`, "utf8"))
+            .version
+        ).toBe(version);
+      }
+      for (let attempt = 0; attempt < 2; attempt++)
+        expect(run("promote", version).status).toBe(0);
+      for (const tags of Object.values(registry()) as any[]) {
+        expect(tags).toEqual({ latest: "19.2.0", canary: version });
+      }
+    });
+  });
+
+  it("fails closed on registry failure or a missing package before moving tags", () => {
+    for (const fault of ["registry", "missing"]) {
+      withFixture((_root, run, registry) => {
+        expect(run("promote", version, fault).status).not.toBe(0);
+        for (const tags of Object.values(registry()) as any[])
+          expect(tags.canary).toBeUndefined();
+      });
+    }
+  });
+});
+
+function withFixture(
+  test: (
+    root: string,
+    run: (
+      op: string,
+      value?: string,
+      fault?: string
+    ) => ReturnType<typeof spawnSync> & { stdout: string },
+    registry: () => Record<string, unknown>
+  ) => void
+) {
+  const root = mkdtempSync(join(tmpdir(), "lobu-canary-test-"));
+  try {
+    mkdirSync(`${root}/scripts`);
+    mkdirSync(`${root}/bin`);
+    for (const file of [
+      "canary-publish.mjs",
+      "publish-packages.mjs",
+      "release-provenance.mjs",
+    ]) {
+      copyFileSync(
+        new URL(`../${file}`, import.meta.url),
+        `${root}/scripts/${file}`
+      );
+    }
+    const tags: Record<string, unknown> = {};
+    for (const { dir } of __testing.PACKAGES) {
+      mkdirSync(`${root}/${dir}`, { recursive: true });
+      const pkg = JSON.parse(
+        readFileSync(
+          new URL(`../../${dir}/package.json`, import.meta.url),
+          "utf8"
+        )
+      );
+      writeFileSync(`${root}/${dir}/package.json`, JSON.stringify(pkg));
+      tags[pkg.name] = { latest: "19.2.0" };
+    }
+    writeFileSync(
+      `${root}/package.json`,
+      JSON.stringify({ version: "19.2.0" })
+    );
+    writeFileSync(`${root}/registry.json`, JSON.stringify(tags));
+    writeFileSync(
+      `${root}/bin/git`,
+      `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === 'rev-parse') console.log('${sha}');
+else if (args[0] === 'show') console.log('123');
+else if (!['fetch', 'merge-base'].includes(args[0])) process.exit(2);
+`
+    );
+    writeFileSync(
+      `${root}/bin/npm`,
+      `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const tags = JSON.parse(fs.readFileSync('registry.json', 'utf8'));
+if (process.env.CANARY_TEST_FAULT === 'registry') process.exit(1);
+if (args[0] === 'view' && args[2] === 'dist-tags') console.log(JSON.stringify(tags[args[1]]));
+else if (args[0] === 'view' && args[2] === 'version') {
+  if (process.env.CANARY_TEST_FAULT === 'missing' && args[1].startsWith('@lobu/core@')) process.exit(1);
+  console.log(args[1].slice(args[1].lastIndexOf('@') + 1));
+} else if (args[0] === 'dist-tag' && args[1] === 'add') {
+  const at = args[2].lastIndexOf('@');
+  tags[args[2].slice(0, at)][args[3]] = args[2].slice(at + 1);
+  fs.writeFileSync('registry.json', JSON.stringify(tags));
+} else process.exit(2);
+`
+    );
+    for (const bin of ["git", "npm"]) chmodSync(`${root}/bin/${bin}`, 0o755);
+    test(
+      root,
+      (op, value, fault) =>
+        spawnSync(
+          "node",
+          ["scripts/canary-publish.mjs", op, ...(value ? [value] : [])],
+          {
+            cwd: root,
+            encoding: "utf8",
+            env: {
+              ...process.env,
+              PATH: `${root}/bin:${process.env.PATH}`,
+              CANARY_TEST_FAULT: fault ?? "",
+            },
+          }
+        ),
+      () => JSON.parse(readFileSync(`${root}/registry.json`, "utf8"))
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}

--- a/scripts/canary-publish.mjs
+++ b/scripts/canary-publish.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { PACKAGES } from "./publish-packages.mjs";
+import { parseStableVersion } from "./release-provenance.mjs";
+
+const CANARY = /^\d+\.\d+\.\d+-canary\.[1-9]\d*\.g([a-f0-9]{40})$/;
+
+export function canaryVersion(base, timestamp, sha) {
+  parseStableVersion(base);
+  if (!/^[1-9]\d*$/.test(timestamp) || !/^[a-f0-9]{40}$/.test(sha)) {
+    throw new Error("Canary requires a commit timestamp and full SHA");
+  }
+  return `${base}-canary.${timestamp}.g${sha}`;
+}
+
+export function prepareManifests(manifests, version) {
+  if (!CANARY.test(version)) throw new Error("Invalid canary version");
+  const names = new Set(manifests.map((pkg) => pkg.name));
+  return manifests.map((manifest) => {
+    const pkg = structuredClone(manifest);
+    pkg.version = version;
+    for (const section of [
+      "dependencies",
+      "optionalDependencies",
+      "peerDependencies",
+      "devDependencies",
+    ]) {
+      for (const name of Object.keys(pkg[section] ?? {})) {
+        if (names.has(name)) pkg[section][name] = version;
+      }
+    }
+    return pkg;
+  });
+}
+
+export function promotionAllowed(current, candidate, isAncestor) {
+  const sha = CANARY.exec(candidate)?.[1];
+  if (!sha) throw new Error("Invalid candidate version");
+  if (current === undefined || current === candidate) return true;
+  const previous = CANARY.exec(current)?.[1];
+  if (!previous) throw new Error(`Unrecognized canary tag: ${current}`);
+  return isAncestor(previous, sha);
+}
+
+function command(bin, args) {
+  return execFileSync(bin, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  }).trim();
+}
+
+function main() {
+  const [operation, version] = process.argv.slice(2);
+  const files = PACKAGES.map(({ dir }) => `${dir}/package.json`);
+  const read = (file) => JSON.parse(readFileSync(file, "utf8"));
+  const manifests = files.map(read);
+  if (operation === "prepare") {
+    const sha = command("git", ["rev-parse", "HEAD"]);
+    const timestamp = command("git", ["show", "-s", "--format=%ct", "HEAD"]);
+    const root = read("package.json");
+    const candidate = canaryVersion(root.version, timestamp, sha);
+    const prepared = prepareManifests(manifests, candidate);
+    for (const [index, file] of files.entries()) {
+      writeFileSync(file, `${JSON.stringify(prepared[index], null, 2)}\n`);
+    }
+    root.version = candidate;
+    writeFileSync("package.json", `${JSON.stringify(root, null, 2)}\n`);
+    console.log(candidate);
+    return;
+  }
+  if (operation !== "promote" || !CANARY.test(version ?? "")) {
+    throw new Error(
+      "Usage: canary-publish.mjs prepare | promote <exact-version>"
+    );
+  }
+  const sha = CANARY.exec(version)[1];
+  if (command("git", ["rev-parse", "HEAD"]) !== sha)
+    throw new Error("Candidate does not match checkout");
+  const isAncestor = (from, to) => {
+    const result = spawnSync("git", ["merge-base", "--is-ancestor", from, to]);
+    if (result.status !== 0 && result.status !== 1)
+      throw new Error("Cannot establish canary ancestry");
+    return result.status === 0;
+  };
+  command("git", ["fetch", "origin", "main"]);
+  if (!isAncestor(sha, "origin/main")) throw new Error("Candidate left main");
+  // Validate the entire fleet before changing any tag. npm has no atomic
+  // multi-package tag update; exact internal versions keep installs coherent.
+  // CLI is last so its opt-in entry point advances only after its dependencies.
+  const names = manifests
+    .map((pkg) => pkg.name)
+    .sort((a, b) =>
+      a === "@lobu/cli" ? 1 : b === "@lobu/cli" ? -1 : a.localeCompare(b)
+    );
+  for (const name of names) {
+    const tags = JSON.parse(
+      command("npm", ["view", name, "dist-tags", "--json"])
+    );
+    if (!tags || typeof tags !== "object" || Array.isArray(tags))
+      throw new Error("Invalid registry tags");
+    if (!promotionAllowed(tags.canary, version, isAncestor)) {
+      console.log(
+        `Skipping older candidate ${version}; ${name} already has ${tags.canary}`
+      );
+      return;
+    }
+    const published = command("npm", ["view", `${name}@${version}`, "version"]);
+    if (published !== version)
+      throw new Error(`Missing candidate ${name}@${version}`);
+  }
+  for (const name of names) {
+    command("npm", ["dist-tag", "add", `${name}@${version}`, "canary"]);
+  }
+  console.log(`Promoted ${version}: bunx @lobu/cli@canary --help`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -377,18 +377,30 @@ function isVersionPublished(name, version) {
   return result.status === 0 && result.stdout.trim() === version;
 }
 
-function publishArgs(otp) {
-  const args = ["publish", "--access", "public"];
+function publishArgs(otp, tag, version) {
+  if (tag !== "latest" && tag !== "canary-candidate") {
+    throw new Error(
+      "Publish only to latest or canary-candidate; promotion owns canary"
+    );
+  }
+  if (
+    (tag === "latest" && version.includes("-")) ||
+    (tag === "canary-candidate" && !version.includes("-canary."))
+  ) {
+    throw new Error(`Version ${version} cannot publish under ${tag}`);
+  }
+  const args = ["publish", "--access", "public", "--tag", tag];
   if (otp) args.push(`--otp=${otp}`);
   return args;
 }
 
-async function publishPackage({ dir, transform }, otp) {
+async function publishPackage({ dir, transform }, otp, tag) {
   const absDir = path.join(REPO_ROOT, dir);
   const pkgPath = path.join(absDir, "package.json");
   const originalText = await readFile(pkgPath, "utf8");
   const pkg = JSON.parse(originalText);
 
+  const args = publishArgs(otp, tag, pkg.version);
   if (isVersionPublished(pkg.name, pkg.version)) {
     console.log(`  → ${pkg.name}@${pkg.version} already on npm, skipping`);
     return;
@@ -407,7 +419,7 @@ async function publishPackage({ dir, transform }, otp) {
     }
 
     console.log(`  → publishing ${pkg.name}@${pkg.version}`);
-    runPublish(pkg.name, dir, publishArgs(otp), { cwd: absDir });
+    runPublish(pkg.name, dir, args, { cwd: absDir });
   } finally {
     if (mutated) {
       await writeFile(pkgPath, originalText, "utf8");
@@ -419,10 +431,17 @@ function parseArgs(argv) {
   // Positional bump: patch | minor | major | <explicit-version> | skip
   // Flags: --otp=<code>, --skip-build, --skip-bump
   const positional = [];
-  const flags = { otp: process.env.NPM_OTP, skipBuild: false, skipBump: false };
+  const flags = {
+    otp: process.env.NPM_OTP,
+    skipBuild: false,
+    skipBump: false,
+    tag: "latest",
+  };
   for (const arg of argv) {
     if (arg.startsWith("--otp=")) {
       flags.otp = arg.slice("--otp=".length);
+    } else if (arg.startsWith("--tag=")) {
+      flags.tag = arg.slice("--tag=".length);
     } else if (arg === "--skip-build") {
       flags.skipBuild = true;
     } else if (arg === "--skip-bump") {
@@ -435,7 +454,9 @@ function parseArgs(argv) {
 }
 
 async function main() {
-  const { bump, otp, skipBuild, skipBump } = parseArgs(process.argv.slice(2));
+  const { bump, otp, skipBuild, skipBump, tag } = parseArgs(
+    process.argv.slice(2)
+  );
 
   if (skipBump) {
     console.log("\n[1/4] Skipping version bump (--skip-bump)");
@@ -480,7 +501,7 @@ async function main() {
       continue;
     }
     try {
-      await publishPackage(pkg, otp);
+      await publishPackage(pkg, otp, tag);
     } catch (error) {
       if (error instanceof FirstPublishBlockedError) {
         blocked.push(error);
@@ -562,11 +583,12 @@ if (
   });
 }
 
-export { rewriteWorkspaceRefs };
+export { PACKAGES, rewriteWorkspaceRefs };
 
 /** Internals exposed for the guard tests; not part of any published surface. */
 export const __testing = {
   PACKAGES,
+  publishArgs,
   lobuRuntimeDeps,
   markUnavailablePackage,
   packageNameFor,


### PR DESCRIPTION
## Summary
Main merges currently cannot be installed from npm until the next stable release. Publish commit-specific prereleases after the exact main CI and image build pass, then advance `@lobu/cli@canary` only after the existing four-environment published-artifact smoke succeeds.

All seven published packages receive the same preview version and exact internal dependency pins. Publication uses `canary-candidate`; promotion preserves `latest`, checks every candidate exists, refuses backward ancestry, and advances the CLI last. The workflow serializes running candidates; GitHub may coalesce pending runs during busy merge periods.

## Test plan
- [x] Six intended paths staged explicitly; `make pre-pr` passed (build, per-package typechecks, knip, naming and runtime boundary gates).
- [x] 128 tests passed across canary-publish, publish-packages-guard and release-publish-order.
- [x] Command fixtures exercised version preparation, promotion retries, registry errors and missing candidates without live publication.
- [x] `actionlint` passed on both workflows; repository Biome checks and `git diff --check` passed.
- [x] Independent `make review-fix` completed; fixes inspected.
- [x] Production environment verified to have no required-reviewer or branch restriction rules.

Feature red → green:
```
Before: Cannot find module '../canary-publish.mjs'; 0 pass, 1 fail, 1 error.
After: 128 pass, 0 fail, 967 expect() calls across 3 files.
```

## Notes
First real npm publication and four-environment artifact proof must run after merge because the workflow only accepts attested main builds. Stable npm release behavior remains on `latest`. Test a promoted preview with `bunx @lobu/cli@canary --help`, or pin its exact SHA-bearing version.

Post-merge verification: main image run https://github.com/lobu-ai/lobu/actions/runs/34422084264 passed for squash `945959f0ceda6bf8972c889120bb3c6042af0956`. The new workflow triggered automatically: https://github.com/lobu-ai/lobu/actions/runs/34422946396 . Attestation and package builds passed; npm PUTs were rejected with E404/permission errors for existing packages. Artifact smoke and promotion were correctly skipped. All seven packages still have `latest=19.2.0` and no canary/candidate tags. The channel is NOT live yet.

Operational prerequisite: replace the production environment's `NPM_TOKEN` with a valid package-scoped write token for the seven published @lobu packages, usable for CI publishing and dist-tag updates, then rerun the failed workflow. npm trusted publishing alone does not cover post-smoke dist-tag promotion (https://docs.npmjs.com/trusted-publishers/).
