### PR TITLE
fix(agent-turn): preserve provider storage compatibility

### DIFF
--- a/packages/connector-worker/src/__tests__/agent-turn-arm.test.ts
+++ b/packages/connector-worker/src/__tests__/agent-turn-arm.test.ts
@@ -213,6 +213,30 @@ describe("executeAgentTurnRun", () => {
     expect(seen.credentials?.accessToken).toBe("lobu_secret_placeholder");
   });
 
+  // The guest cannot re-derive this: pi-ai infers upstream capabilities from
+  // `baseUrl`, which on this lane is the proxy. The gateway resolved them, so
+  // the arm has to carry them across unchanged.
+  test("carries the gateway's provider compat through to the guest", async () => {
+    const job = turnJob();
+    const turn = (job.payload as { turn: { provider: Record<string, unknown> } }).turn;
+    turn.provider.compat = { supportsStore: false };
+    let seen: ExecutorJob | undefined;
+    const executor: SyncExecutor = {
+      execute: async (_code, input) => {
+        seen = input;
+        return {
+          mode: "agent_turn",
+          turn: { text: "", stopReason: "stop", usage: null, consumedInputs: [], sessionJsonl: SESSION_JSONL },
+        };
+      },
+    };
+
+    await executeAgentTurnRun(fakeClient({ calls: [] }) as never, job, {}, cfgWith(executor));
+
+    if (seen?.mode !== "agent_turn") throw new Error("expected an agent_turn job");
+    expect(seen.turn.provider.compat).toEqual({ supportsStore: false });
+  });
+
   test("hands the guest the tool manifest in the guest's own shape", async () => {
     const reported: Reported = { calls: [] };
     let seen: ExecutorJob | undefined;

--- a/packages/connector-worker/src/__tests__/native-session-compat.test.ts
+++ b/packages/connector-worker/src/__tests__/native-session-compat.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { createNativeSession, promptNativeSession } from '../agent-turn/native-session.js';
+import type { AgentTurnInput } from '../agent-turn/types.js';
+
+const originalFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = originalFetch; });
+
+describe('native session provider compatibility', () => {
+  test.each([false, true])('uses supportsStore=%s for prompts and compaction', async (supportsStore) => {
+    const requests: Record<string, unknown>[] = [];
+    globalThis.fetch = (async (_url, init) => {
+      requests.push(JSON.parse(String(init?.body)));
+      const chunk = { id: 'synthetic-completion', object: 'chat.completion.chunk', created: 1,
+        model: 'compatible-model', choices: [{ index: 0, delta: { role: 'assistant', content: 'A concise answer and summary.' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 100, completion_tokens: 10, total_tokens: 110 } };
+      return new Response(`data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`, { headers: { 'content-type': 'text/event-stream' } });
+    }) as typeof fetch;
+    const input = {
+      provider: { api: 'openai-completions', provider: 'openai', modelId: 'compatible-model',
+        baseUrl: 'https://gateway.example.test/proxy/compatible', apiKey: 'synthetic-credential',
+        compat: { supportsStore } },
+      systemPrompt: 'Be brief.', sessionJsonl: '', userMessage: 'Summarize this text.',
+      compaction: { enabled: false, contextWindow: 128000, reserveTokens: 100, keepRecentTokens: 1 },
+    } as AgentTurnInput;
+    const session = createNativeSession(input, [], () => undefined);
+    try {
+      await promptNativeSession(session, 'Summarize this text. '.repeat(30));
+      await session.compact();
+      expect(requests.length).toBeGreaterThanOrEqual(2);
+      for (const request of requests) {
+        expect(Object.hasOwn(request, 'store')).toBe(supportsStore);
+        if (supportsStore) expect(request.store).toBe(false);
+      }
+    } finally { session.dispose(); }
+  });
+});

--- a/packages/connector-worker/src/agent-turn/native-session.ts
+++ b/packages/connector-worker/src/agent-turn/native-session.ts
@@ -32,6 +32,11 @@ export function createNativeSession(
     api: input.provider.api,
     provider: input.provider.provider,
     baseUrl: input.provider.baseUrl,
+    // Upstream capabilities the gateway resolved for us. pi-ai would otherwise
+    // auto-detect them from `baseUrl`, which on this lane is always the secret
+    // proxy, so it can never see which provider it is really talking to. Set
+    // on the one model object both `Agent` and `AgentSession.compact` use.
+    ...(input.provider.compat ? { compat: input.provider.compat } : {}),
     // Registry facts, carried on the envelope because the guest has no
     // registry to ask. Hardcoding them here made the model lie about itself:
     // `claude-sonnet-4` reports `reasoning:true, maxTokens:64000` upstream and

--- a/packages/connector-worker/src/agent-turn/types.ts
+++ b/packages/connector-worker/src/agent-turn/types.ts
@@ -11,6 +11,8 @@ export interface AgentTurnProvider {
   /** Provider slug pi-ai reports on the model (`anthropic`, `openai`, ...). */
   provider: string;
   modelId: string;
+  /** Resolved upstream capabilities; the proxy URL cannot identify the provider. */
+  compat?: { supportsStore?: boolean };
   /**
    * The gateway's agent-scoped secret-proxy URL. The guest never learns a real
    * provider key: the proxy swaps the credential it sends for the real key.

--- a/packages/connector-worker/src/daemon/agent-turn.ts
+++ b/packages/connector-worker/src/daemon/agent-turn.ts
@@ -297,6 +297,7 @@ export async function executeAgentTurnRun(
             api: turn.provider.api,
             provider: turn.provider.provider,
             modelId: turn.provider.model_id,
+            ...(turn.provider.compat ? { compat: turn.provider.compat } : {}),
             baseUrl: turn.provider.base_url,
             ...(turn.provider.max_tokens !== undefined ? { maxTokens: turn.provider.max_tokens } : {}),
             ...(turn.provider.reasoning !== undefined ? { reasoning: turn.provider.reasoning } : {}),

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -435,6 +435,17 @@ export const AgentTurnPollPayloadSchema = Type.Object({
       ]),
       provider: Type.String({ minLength: 1 }),
       model_id: Type.String({ minLength: 1 }),
+      /**
+       * Upstream capabilities pi-ai would otherwise auto-detect from a model's
+       * base URL. It cannot here: `base_url` below is the secret proxy, so
+       * every provider wears the same hostname. The gateway resolves them
+       * while it still holds the real upstream; absent leaves pi-ai to guess.
+       */
+      compat: Type.Optional(
+        Type.Object({
+          supportsStore: Type.Optional(Type.Boolean()),
+        })
+      ),
       /** The gateway's agent-scoped secret-proxy base URL. */
       base_url: Type.String({ minLength: 1 }),
       /**

--- a/packages/server/src/__tests__/integration/agent-turn-producer.test.ts
+++ b/packages/server/src/__tests__/integration/agent-turn-producer.test.ts
@@ -335,6 +335,77 @@ describe('agent turn producer', () => {
     }
   });
 
+  it('executes a compatible-provider tool round trip through worker HTTP and an isolate', async () => {
+    const requests: Array<Record<string, any>> = [];
+    const serverErrors: string[] = [];
+    const server = createServer(async (req, res) => {
+      try {
+        const chunks = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+        const path = new URL(req.url!, 'http://localhost').pathname;
+        if (path.startsWith('/lobu/api/proxy/compatible/')) {
+          requests.push(body);
+          // Gemini rejects even store:false. This stub enforces that wire
+          // contract while the real producer, daemon and Pi guest execute.
+          if (Object.hasOwn(body, 'store')) {
+            res.writeHead(400, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ error: { message: "Unknown name 'store'" } }));
+            return;
+          }
+          const toolCall = requests.length === 1;
+          const delta = toolCall
+            ? { role: 'assistant', tool_calls: [{ index: 0, id: 'synthetic-write', type: 'function',
+                function: { name: 'write', arguments: JSON.stringify({ file_path: 'probe.txt', content: 'compatibility verified' }) } }] }
+            : { role: 'assistant', content: 'Compatibility verified.' };
+          res.writeHead(200, { 'content-type': 'text/event-stream' });
+          res.end(`data: ${JSON.stringify({ id: 'synthetic-completion', object: 'chat.completion.chunk', created: 1,
+            model: 'compatible-model', choices: [{ index: 0, delta, finish_reason: toolCall ? 'tool_calls' : 'stop' }],
+            usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } })}\n\ndata: [DONE]\n\n`);
+          return;
+        }
+        const response = await post(path, { body, headers: { authorization: req.headers.authorization ?? '' },
+          env: { WORKER_API_TOKEN: 'synthetic-compat-fleet' } });
+        res.writeHead(response.status, { 'content-type': 'application/json' });
+        res.end(await response.text());
+      } catch (error) {
+        serverErrors.push(String(error));
+        res.writeHead(500).end();
+      }
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    try {
+      const origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+      const org = await createTestOrganization();
+      const message = messageFor(org.id);
+      message.agentOptions!.model = 'compatible/compatible-model';
+      await enqueueMessage(message, {
+        agentSettings: settingsStore, gatewayUrl: `${origin}/lobu`,
+        catalog: catalogFor(claudeModule({ providerId: 'compatible', sdkCompat: 'openai',
+          getUpstreamConfig: () => ({ slug: 'compatible', upstreamBaseUrl: 'https://compatible.example.test/v1' }),
+          getProxyBaseUrlMappings: () => ({ OPENAI_BASE_URL: `${origin}/lobu/api/proxy/compatible/a/turn-agent` }),
+        })),
+      });
+      const [run] = await agentTurnRuns();
+      const client = new WorkerClient({ apiUrl: origin, workerId: 'synthetic-compat-worker',
+        authToken: 'synthetic-compat-fleet', capabilities: { agent_turn: true } });
+      const job = await client.poll();
+      expect(job.run_id).toBe(Number(run.id));
+      const result = await executeRun(client, job, {}, {
+        executor: new IsolateExecutor({ allowedDomains: ['127.0.0.1'], timeoutMs: 20_000 }), timeoutMs: 20_000,
+      });
+      expect(serverErrors).toEqual([]);
+      expect(result.error).toBeUndefined();
+      expect(requests).toHaveLength(2);
+      expect(requests.every((request) => !Object.hasOwn(request, 'store'))).toBe(true);
+      expect(requests[1].messages.some((message: { role: string }) => message.role === 'tool')).toBe(true);
+      expect((await runRow(Number(run.id))).status).toBe('completed');
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  }, 30_000);
+
   it('executes write/edit over worker HTTP with admitted history', async () => {
     const calls = [
       { name: 'write', input: { file_path: 'a.txt', content: '\ufeffbefore\r\n' } },
@@ -2490,6 +2561,29 @@ describe('agent turn producer', () => {
     // an empty message with a lone CTA button. Assert the text, not just the
     // code, because the code alone looks right while showing the user nothing.
     expect(AGENT_ERRORS[AgentErrorCode.NO_MODEL_CONFIGURED].message).toBeTruthy();
+  });
+
+  it.each([
+    ['https://generativelanguage.googleapis.com/v1beta/openai', false],
+    ['https://compatible.example.test/v1', false],
+    ['https://api.openai.com.evil.example/v1', false],
+    ['http://api.openai.com/v1', false],
+    ['https://api.openai.com/v1', true],
+  ])('carries storage capability from upstream %s through the proxy', async (upstreamBaseUrl, supportsStore) => {
+    const org = await createTestOrganization();
+    await enqueueMessage(messageFor(org.id), {
+      agentSettings: settingsStore,
+      catalog: catalogFor(claudeModule({
+        sdkCompat: 'openai',
+        getUpstreamConfig: () => ({ slug: 'compatible', upstreamBaseUrl }),
+      })),
+      gatewayUrl: GATEWAY_URL,
+    });
+    const [run] = await agentTurnRuns();
+    expect(run.action_input.turn.provider).toMatchObject({
+      api: 'openai-completions', compat: { supportsStore },
+    });
+    expect(run.action_input.turn.provider.base_url).toContain('gateway.test.invalid');
   });
 
   it('routes every fetch-native protocol, including OpenAI Responses', async () => {

--- a/packages/server/src/__tests__/live-providers/provider-smoke.test.ts
+++ b/packages/server/src/__tests__/live-providers/provider-smoke.test.ts
@@ -202,8 +202,11 @@ function buildLiveModel(
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 128_000,
 		maxTokens: 16_384,
-		// Match the worker's production payload guard. Gemini's OpenAI-compatible
-		// endpoint returns 400 for OpenAI's `store` field.
+		// Gemini's OpenAI-compatible endpoint returns 400 for OpenAI's `store`
+		// field. No completions entry in the catalog is api.openai.com either —
+		// official OpenAI is promoted to Responses above — so every provider
+		// this smoke reaches over completions is one production also withholds
+		// `store` from; see `resolveTurnCompat` in `agent-turn-producer.ts`.
 		...(api === "openai-completions"
 			? { compat: { supportsStore: false } }
 			: {}),

--- a/packages/server/src/gateway/orchestration/agent-turn-producer.ts
+++ b/packages/server/src/gateway/orchestration/agent-turn-producer.ts
@@ -420,6 +420,7 @@ interface TurnProvider {
   api: LaneApi;
   provider: string;
   providerSlug: string;
+  compat?: { supportsStore?: boolean };
   modelId: string;
   baseUrl: string;
   credential: string;
@@ -439,6 +440,36 @@ interface TurnProvider {
  * finite context window.
  */
 const DEFAULT_CONTEXT_WINDOW = 128_000;
+
+/**
+ * The OpenAI-completions capabilities pi-ai cannot work out for itself.
+ *
+ * pi-ai auto-detects them from the model's `baseUrl`, and on this lane that
+ * URL is always Lobu's secret proxy — every upstream wears the same hostname,
+ * so detection sees nothing. The gateway resolves them here instead, while the
+ * real upstream is still in hand, and carries the answer on the envelope.
+ *
+ * Only `store` so far, because "OpenAI-compatible" names a wire format and not
+ * OpenAI's optional storage flag: Gemini's OpenAI endpoint 400s the whole
+ * request on the unknown field. Anything but api.openai.com fails closed, and
+ * pi-ai sends `store: false` when support is declared, so preserve the
+ * explicit opt-out for OpenAI rather than disabling the field universally.
+ */
+function resolveTurnCompat(
+  api: LaneApi,
+  upstreamBaseUrl: string | undefined
+): Pick<TurnProvider, "compat"> {
+  if (api !== "openai-completions") return {};
+  let supportsStore = false;
+  try {
+    const upstream = new URL(upstreamBaseUrl ?? "");
+    supportsStore =
+      upstream.protocol === "https:" && upstream.hostname === "api.openai.com";
+  } catch {
+    // A provider with no parseable upstream declares no capability.
+  }
+  return { compat: { supportsStore } };
+}
 
 /**
  * What pi-ai's own model registry says about this model: modalities, context
@@ -625,6 +656,10 @@ async function resolveTurnProvider(
     credential,
     host,
     ...resolveModelMetadata(protocol.registryAlias, modelId),
+    ...resolveTurnCompat(
+      protocol.api,
+      module.getUpstreamConfig?.()?.upstreamBaseUrl
+    ),
   };
 }
 
@@ -1075,6 +1110,7 @@ export async function enqueueAgentTurn(
         // adapter's own ceiling instead of a number invented on either side.
         ...(provider.maxTokens !== null ? { max_tokens: provider.maxTokens } : {}),
         reasoning: provider.reasoning,
+        ...(provider.compat ? { compat: provider.compat } : {}),
       },
       ...(tools ? { tools } : {}),
       // The memory hooks, when the agent has the server they call. They are


### PR DESCRIPTION
## Summary
Gemini Automations stopped after the native Pi runtime migration because the runtime sent OpenAI's optional `store: false` field to Gemini's compatible endpoint. Google rejects the field with HTTP 400 before executing the model request.

Resolve storage support from the upstream before its URL is replaced by the gateway proxy, carry the capability through the typed turn and daemon, and reuse it for normal Pi requests and compaction. No provider-slug special case or proxy body rewriting is needed.

## Test plan
- [x] Regression reproduced before the fix: daemon dropped `compat`; native prompt/compaction serialized `store` despite `supportsStore: false`.
- [x] Focused worker suites: 33 passed, 0 failed.
- [x] Producer integration suite: 162 passed, 0 failed.
- [x] Additional real worker HTTP/V8-isolate tool round trip: 1 passed; endpoint rejects any `store` field, tool executes, run completes.
- [x] Local `make pre-pr` gates passed; GitHub CI is the canonical full-graph gate.
- [x] Exact-head semantic review and all 10 required checks passed; merged as `ef9269d91cc0967d29304fc359239fdd8f0357ca`.

### Red → green evidence
Before:
```
preserves provider compatibility through the daemon boundary: FAIL (compat missing)
native session supportsStore=false: Expected false; Received true
1 pass, 1 fail
```
Live Gemini differential (same production system credential, no credentials printed):
```
stream + stream_options.include_usage: HTTP 200
stream + stream_options.include_usage + store:false + max_completion_tokens:256: HTTP 400
store:false alone: HTTP 400 — Invalid JSON payload received. Unknown name "store": Cannot find field.
max_completion_tokens:256 without store: HTTP 200
```

After:
```
33 pass, 0 fail (worker/native session suites)
162 passed (producer integration suite)
1 passed (additional real HTTP/isolate tool round trip)
pre-pr gates clean
```

## Notes
Live diagnosis confirmed the same Gemini request returns HTTP 400 with `store: false` and HTTP 200 when the field is omitted. Post-deployment verification will check the merged revision and the affected Automation. Error-message normalization is outside this change.

Deployment verification: squash `ef9269d91cc0967d29304fc359239fdd8f0357ca` is deployed; production smoke passed 9/9. A real Gemini tool call through the deployed native session completed successfully (synthetic addition tool, result 7). Retrying the affected Automation was rejected before execution because the connected authorization no longer has access to its owning workspace; Automation recovery remains unverified.
