### PR TITLE
fix(cli): correlate chat SSE events with submitted requests

### DIFF
--- a/packages/cli/src/__tests__/chat-correlation.test.ts
+++ b/packages/cli/src/__tests__/chat-correlation.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chatCommand } from "../commands/chat.js";
+
+const stdoutWrite = process.stdout.write;
+const stderrWrite = process.stderr.write;
+const token = process.env.LOBU_API_TOKEN;
+const idle = process.env.LOBU_CHAT_IDLE_TIMEOUT_MS;
+afterEach(() => {
+  process.stdout.write = stdoutWrite;
+  process.stderr.write = stderrWrite;
+  process.exitCode = 0;
+  if (token === undefined) delete process.env.LOBU_API_TOKEN;
+  else process.env.LOBU_API_TOKEN = token;
+  if (idle === undefined) delete process.env.LOBU_CHAT_IDLE_TIMEOUT_MS;
+  else process.env.LOBU_CHAT_IDLE_TIMEOUT_MS = idle;
+});
+
+type Event = { event: string; data: Record<string, unknown> };
+const frame = ({ event, data }: Event) =>
+  `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+
+async function runChat(
+  reply: (id: string) => Event[],
+  options: {
+    json?: boolean;
+    thread?: string;
+    new?: boolean;
+    continue?: boolean;
+    user?: string;
+  } = {},
+  staleTraffic = false
+) {
+  process.env.LOBU_API_TOKEN = "synthetic-token";
+  process.env.LOBU_CHAT_IDLE_TIMEOUT_MS = "150";
+  const output = { stdout: "", stderr: "" };
+  for (const key of ["stdout", "stderr"] as const) {
+    process[key].write = ((chunk: unknown, cb?: unknown) => {
+      output[key] += String(chunk);
+      if (typeof cb === "function") cb();
+      return true;
+    }) as typeof process.stdout.write;
+  }
+  const requests: Record<string, unknown>[] = [];
+  let stream: ReadableStreamDefaultController<Uint8Array>;
+  const encoder = new TextEncoder();
+  let subscribed = false;
+  let cancelled = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let pending: Event[] = [];
+  const send = (event: Event) => stream.enqueue(encoder.encode(frame(event)));
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const path = new URL(request.url).pathname;
+      if (path.endsWith("/events")) {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              stream = controller;
+              subscribed = true;
+              send({
+                event: "output",
+                data: { messageId: "old", content: "OLD ANSWER" },
+              });
+              send({ event: "complete", data: { messageId: "old" } });
+              send({ event: "complete", data: {} });
+              for (const event of pending) send(event);
+              if (staleTraffic)
+                timer = setInterval(() => {
+                  try {
+                    send({
+                      event: "status",
+                      data: { messageId: "old", status: "working" },
+                    });
+                  } catch {
+                    clearInterval(timer);
+                  }
+                }, 10);
+            },
+            cancel() {
+              cancelled = true;
+              clearInterval(timer);
+            },
+          }),
+          { headers: { "Content-Type": "text/event-stream" } }
+        );
+      }
+      const body = (await request.json()) as Record<string, unknown>;
+      requests.push(body);
+      if (path.endsWith("/agents"))
+        return Response.json({
+          agentId: "synthetic-session",
+          token: "synthetic-session-token",
+        });
+      const id = options.user
+        ? "synthetic-platform-message"
+        : String(body.messageId);
+      pending = reply(id);
+      if (subscribed) for (const event of pending) send(event);
+      return Response.json({
+        success: true,
+        messageId: id,
+        ...(options.user
+          ? { eventsUrl: "/api/v1/agents/synthetic-session/events" }
+          : {}),
+      });
+    },
+  });
+  try {
+    await chatCommand("/tmp", "NEW QUESTION", {
+      gateway: `http://127.0.0.1:${server.port}`,
+      agent: "synthetic-agent",
+      org: "synthetic-org",
+      context: "synthetic-context",
+      ...options,
+    });
+    // Let the server observe cancellation of the HTTP response body.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    return {
+      ...output,
+      requests,
+      subscribed,
+      cancelled,
+      exitCode: process.exitCode ?? 0,
+    };
+  } finally {
+    clearInterval(timer);
+    await server.stop(true);
+  }
+}
+
+describe("chat request correlation over HTTP", () => {
+  for (const options of [
+    {},
+    { json: true },
+    { thread: "synthetic-thread" },
+    { new: true },
+    { continue: true },
+  ]) {
+    test(`ignores replay and completes the submitted request ${JSON.stringify(options)}`, async () => {
+      const result = await runChat(
+        (id) => [
+          {
+            event: "output",
+            data: { messageId: id, content: "CURRENT ANSWER" },
+          },
+          {
+            event: "complete",
+            data: { messageId: id, finalText: "CURRENT ANSWER" },
+          },
+        ],
+        options
+      );
+      expect(result.stdout).not.toContain("OLD ANSWER");
+      expect(result.stdout).toContain("CURRENT ANSWER");
+      expect(result.requests[1]?.messageId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(result.exitCode).toBe(0);
+      expect(result.cancelled).toBe(true);
+    });
+  }
+  test("batch membership accepts the terminal answer and rejects unrelated batches", async () => {
+    const result = await runChat((id) => [
+      {
+        event: "complete",
+        data: {
+          messageId: "other",
+          processedMessageIds: ["unrelated"],
+          finalText: "WRONG BATCH",
+        },
+      },
+      {
+        event: "complete",
+        data: {
+          messageId: "batch-owner",
+          processedMessageIds: ["batch-owner", id],
+          finalText: "BATCH ANSWER",
+        },
+      },
+    ]);
+    expect(result.stdout).toBe("BATCH ANSWER\n");
+    expect(result.exitCode).toBe(0);
+  });
+  test("cards match their originating request rather than their delivery ID", async () => {
+    const result = await runChat(
+      (id) => [
+        {
+          event: "tool-approval",
+          data: {
+            messageId: "old-card",
+            turnMessageId: "old",
+            requestId: "old-approval",
+          },
+        },
+        {
+          event: "tool-approval",
+          data: {
+            messageId: "new-card",
+            turnMessageId: id,
+            requestId: "current-approval",
+          },
+        },
+        { event: "complete", data: { messageId: id } },
+      ],
+      { json: true }
+    );
+    expect(result.stdout).toContain("current-approval");
+    expect(result.stdout).not.toContain("old-approval");
+    expect(result.exitCode).toBe(0);
+  });
+  for (const json of [false, true]) {
+    for (const terminal of ["error", "ephemeral"]) {
+      test(`${terminal} terminates in ${json ? "JSON" : "normal"} mode`, async () => {
+        const result = await runChat(
+          (id) => [
+            {
+              event: terminal,
+              data: {
+                messageId: id,
+                error: "synthetic failure",
+                content: "sign in",
+              },
+            },
+          ],
+          { json }
+        );
+        expect(result.exitCode).toBe(terminal === "error" ? 1 : 0);
+        expect(result.stderr).not.toContain("timed out");
+        expect(result.cancelled).toBe(true);
+      });
+    }
+  }
+  test("stale activity cannot renew the idle budget", async () => {
+    const result = await runChat(() => [], {}, true);
+    expect(result.stderr).toContain("timed out");
+    expect(result.exitCode).toBe(1);
+  });
+  test("platform replies use the returned request ID", async () => {
+    const result = await runChat(
+      (id) => [
+        {
+          event: "complete",
+          data: { messageId: id, finalText: "PLATFORM ANSWER" },
+        },
+      ],
+      { user: "slack:synthetic-channel" }
+    );
+    expect(result.stdout).toBe("PLATFORM ANSWER\n");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+test("batched ephemeral terminates only its member request", async () => {
+  const result = await runChat(
+    (id) => [
+      {
+        event: "ephemeral",
+        data: {
+          messageId: "other",
+          processedMessageIds: ["unrelated"],
+          content: "OLD NOTICE",
+        },
+      },
+      {
+        event: "ephemeral",
+        data: {
+          messageId: "batch-owner",
+          processedMessageIds: [id],
+          content: "CURRENT NOTICE",
+        },
+      },
+    ],
+    { json: true }
+  );
+  expect(result.stdout).toContain("CURRENT NOTICE");
+  expect(result.stdout).not.toContain("OLD NOTICE");
+  expect(result.exitCode).toBe(0);
+});

--- a/packages/cli/src/__tests__/chat-org.test.ts
+++ b/packages/cli/src/__tests__/chat-org.test.ts
@@ -38,18 +38,23 @@ function silenceTerminal(): void {
   process.stderr.write = sink;
 }
 
+let sentMessageId = "synthetic-platform-message";
+
 function createSseResponse(
   events: Array<{ event: string; data: Record<string, unknown> }>
 ): Response {
   const encoder = new TextEncoder();
-  const payload = events
-    .map(
-      ({ event, data }) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
-    )
-    .join("");
   return new Response(
     new ReadableStream({
-      start(controller) {
+      async start(controller) {
+        // Subscription starts first; delivery follows the POST in this fixture.
+        await Promise.resolve();
+        const payload = events
+          .map(
+            ({ event, data }) =>
+              `event: ${event}\ndata: ${JSON.stringify({ messageId: sentMessageId, turnMessageId: sentMessageId, ...data })}\n\n`
+          )
+          .join("");
         controller.enqueue(encoder.encode(payload));
         controller.close();
       },
@@ -66,6 +71,8 @@ afterEach(() => {
   else process.env.LOBU_API_TOKEN = originalToken;
   if (originalOrg === undefined) delete process.env.LOBU_ORG;
   else process.env.LOBU_ORG = originalOrg;
+  sentMessageId = "synthetic-platform-message";
+  process.exitCode = 0;
   mock.restore();
 });
 
@@ -143,6 +150,7 @@ describe("chatCommand — x-lobu-org header threading", () => {
           init?.method === "POST"
         ) {
           headerSeen.messages = orgHeader;
+          sentMessageId = JSON.parse(String(init?.body)).messageId;
           return Response.json({ success: true });
         }
         throw new Error(`Unexpected fetch: ${url}`);
@@ -194,6 +202,7 @@ describe("chatCommand — x-lobu-org header threading", () => {
           url === "http://gateway.test/lobu/api/v1/agents/session-1/messages" &&
           init?.method === "POST"
         ) {
+          sentMessageId = JSON.parse(String(init?.body)).messageId;
           return Response.json({ success: true });
         }
         throw new Error(`Unexpected fetch: ${url}`);

--- a/packages/cli/src/__tests__/chat-stream-timeout.test.ts
+++ b/packages/cli/src/__tests__/chat-stream-timeout.test.ts
@@ -68,8 +68,10 @@ function sseResponse(
   );
 }
 
+let sentMessageId: string;
+
 function sse(event: string, data: Record<string, unknown>): string {
-  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  return `event: ${event}\ndata: ${JSON.stringify({ messageId: sentMessageId, ...data })}\n\n`;
 }
 
 function installFetch(sseFor: (signal?: AbortSignal | null) => Response): void {
@@ -80,9 +82,11 @@ function installFetch(sseFor: (signal?: AbortSignal | null) => Response): void {
         return Response.json({ agentId: "session-1", token: "session-token" });
       }
       if (url.endsWith("/session-1/events") && !init?.method) {
+        await Promise.resolve();
         return sseFor(init?.signal);
       }
       if (url.endsWith("/session-1/messages") && init?.method === "POST") {
+        sentMessageId = JSON.parse(String(init.body)).messageId;
         return Response.json({ success: true });
       }
       throw new Error(`Unexpected fetch: ${url}`);

--- a/packages/cli/src/__tests__/chat.integration.test.ts
+++ b/packages/cli/src/__tests__/chat.integration.test.ts
@@ -20,19 +20,23 @@ const originalConsoleError = console.error;
 const originalToken = process.env.LOBU_API_TOKEN;
 const exampleDir = join(import.meta.dir, "../../../../examples/market");
 
+let sentMessageId = "synthetic-platform-message";
+
 function createSseResponse(
   events: Array<{ event: string; data: Record<string, unknown> }>
 ): Response {
   const encoder = new TextEncoder();
-  const payload = events
-    .map(
-      ({ event, data }) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
-    )
-    .join("");
-
   return new Response(
     new ReadableStream({
-      start(controller) {
+      async start(controller) {
+        // Subscription starts first; delivery follows the POST in this fixture.
+        await Promise.resolve();
+        const payload = events
+          .map(
+            ({ event, data }) =>
+              `event: ${event}\ndata: ${JSON.stringify({ messageId: sentMessageId, turnMessageId: sentMessageId, ...data })}\n\n`
+          )
+          .join("");
         controller.enqueue(encoder.encode(payload));
         controller.close();
       },
@@ -80,6 +84,8 @@ afterEach(() => {
   } else {
     process.env.LOBU_API_TOKEN = originalToken;
   }
+  sentMessageId = "synthetic-platform-message";
+  process.exitCode = 0;
   mock.restore();
 });
 
@@ -159,6 +165,7 @@ describe("chatCommand example integration", () => {
           url === "http://gateway.test/lobu/api/v1/agents/session-1/messages" &&
           init?.method === "POST"
         ) {
+          sentMessageId = JSON.parse(String(init?.body)).messageId;
           return Response.json({ success: true });
         }
 
@@ -230,6 +237,7 @@ describe("chatCommand example integration", () => {
         ) {
           return Response.json({
             success: true,
+            messageId: "synthetic-platform-message",
             eventsUrl: "/api/v1/agents/vc-tracking/events?platform=telegram",
           });
         }
@@ -295,6 +303,7 @@ describe("chatCommand example integration", () => {
         ) {
           return Response.json({
             success: true,
+            messageId: "synthetic-platform-message",
             eventsUrl: "/api/v1/agents/vc-tracking/events?platform=telegram",
           });
         }
@@ -348,6 +357,7 @@ describe("chatCommand example integration", () => {
         ) {
           return Response.json({
             success: true,
+            messageId: "synthetic-platform-message",
             eventsUrl: "/api/v1/agents/vc-tracking/events?platform=telegram",
           });
         }
@@ -399,6 +409,7 @@ describe("chatCommand example integration", () => {
           messageBodies.push(body);
           return Response.json({
             success: true,
+            messageId: "synthetic-platform-message",
             eventsUrl: "/api/v1/agents/vc-tracking/events?platform=telegram",
           });
         }

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
@@ -255,12 +256,14 @@ async function sendViaPlatform(
   const result = (await res.json()) as {
     success: boolean;
     agentId?: string;
-    messageId?: string;
+    messageId: string;
     eventsUrl?: string;
     queued?: boolean;
   };
 
   if (result.eventsUrl) {
+    if (!result.messageId)
+      throw new Error("Message response omitted its message ID");
     const sseUrl = result.eventsUrl.startsWith("http")
       ? result.eventsUrl
       : `${gatewayUrl}${result.eventsUrl}`;
@@ -367,31 +370,39 @@ async function sendViaApi(
   const sseUrl = `${base}/events`;
   const messagesUrl = `${base}/messages`;
 
+  const messageId = randomUUID();
   const sseController = new AbortController();
+  // Observe the stream immediately so an SSE failure during POST cannot become
+  // an unhandled rejection. Every send outcome releases the subscription.
   const streaming = streamResponse(sseUrl, session.token, sseController, {
+    expectedMessageId: messageId,
     autoApprove: opts.autoApprove,
     json: opts.json,
     org: opts.org,
-  });
+  }).then(
+    () => ({ error: undefined }),
+    (error: unknown) => ({ error })
+  );
 
-  const msgRes = await fetch(messagesUrl, {
-    method: "POST",
-    headers: agentApiHeaders(session.token, opts.org, {
-      "Content-Type": "application/json",
-    }),
-    body: JSON.stringify({ content: opts.message }),
-  });
+  try {
+    const msgRes = await fetch(messagesUrl, {
+      method: "POST",
+      headers: agentApiHeaders(session.token, opts.org, {
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify({ content: opts.message, messageId }),
+    });
 
-  if (!msgRes.ok) {
+    if (!msgRes.ok) {
+      const body = await msgRes.text().catch(() => "");
+      throw new Error(`Failed to send message (${msgRes.status}): ${body}`);
+    }
+    const result = await streaming;
+    if (result.error) throw result.error;
+  } finally {
     sseController.abort();
-    const body = await msgRes.text().catch(() => "");
-    console.error(
-      chalk.red(`\n  Failed to send message (${msgRes.status}): ${body}\n`)
-    );
-    process.exit(1);
+    await streaming;
   }
-
-  await streaming;
 
   if (opts.contextName && session.threadId) {
     await setLastThread(opts.contextName, session.agentId, session.threadId);
@@ -432,7 +443,7 @@ async function writeStderr(text: string): Promise<void> {
 }
 
 interface StreamOptions {
-  expectedMessageId?: string;
+  expectedMessageId: string;
   autoApprove?: boolean;
   json?: boolean;
   org?: string;
@@ -457,7 +468,7 @@ async function streamResponse(
   sseUrl: string,
   token: string,
   controller: AbortController,
-  options: StreamOptions = {}
+  options: StreamOptions
 ): Promise<void> {
   // How long the AGENT may go quiet, not the socket.
   //
@@ -541,6 +552,7 @@ async function streamResponse(
     let currentEvent = "";
     let sawFileUploadedEvent = false;
     let sawSandboxLink = false;
+    let outputText = "";
 
     while (true) {
       const { done, value } = await waitForStream(reader.read());
@@ -561,26 +573,40 @@ async function streamResponse(
       for (const line of lines) {
         if (line.startsWith("event: ")) {
           currentEvent = line.slice(7).trim();
-          noteAgentActivity(currentEvent);
         } else if (line.startsWith("data: ") && currentEvent) {
           const data = parseJSON(line.slice(6));
           if (!data) continue;
-          if (
-            options.expectedMessageId &&
-            currentEvent !== "connected" &&
-            currentEvent !== "ping" &&
-            typeof data.messageId === "string" &&
-            data.messageId !== options.expectedMessageId
-          ) {
+          const transportEvent =
+            currentEvent === "connected" || currentEvent === "ping";
+          const interactionEvent = [
+            "tool-approval",
+            "question",
+            "link-button",
+            "suggestion",
+          ].includes(currentEvent);
+          const matches = interactionEvent
+            ? data.turnMessageId === options.expectedMessageId
+            : data.messageId === options.expectedMessageId ||
+              ((currentEvent === "complete" ||
+                currentEvent === "error" ||
+                currentEvent === "ephemeral") &&
+                Array.isArray(data.processedMessageIds) &&
+                data.processedMessageIds.includes(options.expectedMessageId));
+          if (!transportEvent && !matches) {
             currentEvent = "";
             continue;
           }
+          if (matches) noteAgentActivity(currentEvent);
 
           if (options.json) {
             await writeStdout(
               `${JSON.stringify({ event: currentEvent, ...data })}\n`
             );
-            if (currentEvent === "complete" || currentEvent === "error") {
+            if (
+              currentEvent === "complete" ||
+              currentEvent === "error" ||
+              currentEvent === "ephemeral"
+            ) {
               if (currentEvent === "error") process.exitCode = 1;
               controller.abort();
               return;
@@ -595,6 +621,7 @@ async function streamResponse(
                 if (data.content.includes("sandbox:/")) {
                   sawSandboxLink = true;
                 }
+                outputText += data.content;
                 await writeStdout(data.content);
               }
               break;
@@ -699,6 +726,14 @@ async function streamResponse(
               );
               break;
             case "complete":
+              // Batch members may have no matching deltas. The terminal reply
+              // is authoritative and also repairs a missed suffix on reconnect.
+              if (
+                typeof data.finalText === "string" &&
+                data.finalText.startsWith(outputText)
+              ) {
+                await writeStdout(data.finalText.slice(outputText.length));
+              }
               await writeStdout("\n");
               if (sawSandboxLink && !sawFileUploadedEvent) {
                 await writeStderr(

--- a/packages/server/src/gateway/__tests__/routes/interactions.test.ts
+++ b/packages/server/src/gateway/__tests__/routes/interactions.test.ts
@@ -24,6 +24,7 @@ describe("interaction routes", () => {
       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     workerToken = generateWorkerToken("user-1", "conv-1", "deploy-1", {
+      messageId: "synthetic-request",
       channelId: "chan-1",
       teamId: "team-1",
     });
@@ -84,6 +85,7 @@ describe("interaction routes", () => {
       expect(body.id).toBe("interaction-123");
       expect(body.status).toBe("posted");
       expect(mockInteractionService.postQuestion).toHaveBeenCalledTimes(1);
+      expect(mockInteractionService.postQuestion.mock.calls[0].at(-1)).toBe("synthetic-request");
     });
 
     test("posts link button and returns id", async () => {
@@ -105,6 +107,7 @@ describe("interaction routes", () => {
       expect(body.id).toBe("link-123");
       expect(body.status).toBe("posted");
       expect(mockInteractionService.postLinkButton).toHaveBeenCalledTimes(1);
+      expect(mockInteractionService.postLinkButton.mock.calls[0].at(-1)).toBe("synthetic-request");
     });
 
     test("returns 500 on service error", async () => {

--- a/packages/server/src/gateway/__tests__/unified-thread-consumer.test.ts
+++ b/packages/server/src/gateway/__tests__/unified-thread-consumer.test.ts
@@ -264,6 +264,7 @@ describe("UnifiedThreadResponseConsumer interaction card owner-routing", () => {
     );
     expect(suggestionBroadcast?.[2]).toMatchObject({
       prompts: [{ title: "New", message: "Use the newer turn" }],
+      turnMessageId: "m-new",
     });
     // The card carries prompts only, exactly like the terminal `complete`
     // embed and history replay. A stale enqueued id must not ride along.

--- a/packages/server/src/gateway/api/__tests__/platform-card-source.test.ts
+++ b/packages/server/src/gateway/api/__tests__/platform-card-source.test.ts
@@ -175,3 +175,21 @@ describe("ApiPlatform durable approval card (builder gate)", () => {
     expect(ctx.sends).toHaveLength(0);
   });
 });
+
+test("interaction cards retain request correlation independently of their queue and card IDs", async () => {
+  const ctx = makePlatform();
+  await new ApiPlatform().initialize(ctx.services as never);
+  const svc = ctx.interactionService;
+  const route = ["synthetic-user", "synthetic-conversation", "synthetic-channel", undefined, undefined, "api"] as const;
+  await svc.postQuestion(...route, "Continue?", ["yes"], undefined, "synthetic-request");
+  await svc.postLinkButton(...route, "https://example.test", "Sign in", "oauth", undefined, undefined, "synthetic-request");
+  await svc.postSuggestion("synthetic-org", ...route, [{ title: "Next", message: "Continue" }], undefined, "synthetic-request");
+  await svc.postDurableApprovalCard(...route, 123, "create", {}, null, undefined, null, null, "agent", "synthetic-request");
+  await svc.postToolApproval("synthetic-approval", "synthetic-agent", ...route, "synthetic-mcp", "write", {}, "write", undefined, "synthetic-request");
+  expect(ctx.sends).toHaveLength(5);
+  for (const { payload } of ctx.sends) {
+    expect(payload.messageId).not.toBe("synthetic-request");
+    expect(payload.customEvent.data.turnMessageId).toBe("synthetic-request");
+  }
+  expect(ctx.sends[4]!.payload.customEvent.data.requestId).toBe("synthetic-approval");
+});

--- a/packages/server/src/gateway/api/__tests__/response-renderer-finaltext.test.ts
+++ b/packages/server/src/gateway/api/__tests__/response-renderer-finaltext.test.ts
@@ -200,3 +200,15 @@ describe("ApiResponseRenderer.handleError targeting context", () => {
     expect(broadcasts).toEqual([]);
   });
 });
+
+test("errors preserve every processed request ID for batched CLI requests", async () => {
+  const { renderer, broadcasts } = makeRenderer();
+  await renderer.handleError(basePayload({ error: "synthetic failure", processedMessageIds: ["m1", "m2"] }), "session-key");
+  expect(broadcasts.find(b => b.event === "error")?.data.processedMessageIds).toEqual(["m1", "m2"]);
+});
+
+test("ephemeral terminal forwards available batch membership", async () => {
+  const { renderer, broadcasts } = makeRenderer();
+  await renderer.handleEphemeral(basePayload({ content: "synthetic notice", processedMessageIds: ["m1", "m2"] }));
+  expect(broadcasts.find(b => b.event === "ephemeral")?.data.processedMessageIds).toEqual(["m1", "m2"]);
+});

--- a/packages/server/src/gateway/api/platform.ts
+++ b/packages/server/src/gateway/api/platform.ts
@@ -157,6 +157,7 @@ export class ApiPlatform implements PlatformAdapter {
       organizationId?: string;
       userId?: string;
       source?: string;
+      turnMessageId?: string;
     },
     name: string,
     data: Record<string, unknown>
@@ -178,7 +179,7 @@ export class ApiPlatform implements PlatformAdapter {
       ...(event.source
         ? { platformMetadata: { source: event.source } }
         : {}),
-      customEvent: { name, data, requireSseOwner: true },
+      customEvent: { name, data: { ...data, turnMessageId: event.turnMessageId }, requireSseOwner: true },
     };
     void queue
       .send("thread_response", payload, TERMINAL_DELIVERY_SEND_OPTS)

--- a/packages/server/src/gateway/api/response-renderer.ts
+++ b/packages/server/src/gateway/api/response-renderer.ts
@@ -210,6 +210,7 @@ export class ApiResponseRenderer implements ResponseRenderer {
       error: errorText,
       errorCode: code,
       errorContext: payload.errorContext,
+      processedMessageIds: payload.processedMessageIds,
       messageId: payload.messageId,
       timestamp: payload.timestamp || Date.now(),
     };
@@ -289,6 +290,7 @@ export class ApiResponseRenderer implements ResponseRenderer {
       type: "ephemeral",
       content: payload.content,
       messageId: payload.messageId,
+      processedMessageIds: payload.processedMessageIds,
       timestamp: payload.timestamp || Date.now(),
     });
   }

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -100,6 +100,7 @@ export class McpProxy {
 		connectionId: string | undefined,
 		platform: string | undefined,
 		source: string | undefined,
+		turnMessageId: string | undefined,
 	) => Promise<void>;
 
 	constructor(
@@ -680,6 +681,7 @@ export class McpProxy {
 			tokenData.connectionId,
 			tokenData.platform,
 			tokenData.source,
+			tokenData.messageId,
 		).catch((err) =>
 			logger.error(
 				{ requestId, error: String(err) },

--- a/packages/server/src/gateway/interactions.ts
+++ b/packages/server/src/gateway/interactions.ts
@@ -62,10 +62,15 @@ export function assertRoutableInteraction(
   }
 }
 
+interface PostedInteraction extends BaseMessage {
+  /** Request that produced this card; distinct from the interaction's own id. */
+  turnMessageId?: string;
+}
+
 /**
  * Payload emitted on "question:created" — platform renderers listen for this.
  */
-export interface PostedQuestion extends BaseMessage {
+export interface PostedQuestion extends PostedInteraction {
   userId: string;
   platform: string;
   question: string;
@@ -82,7 +87,7 @@ export interface PostedQuestion extends BaseMessage {
  * and a full `message` (what actually gets sent) rather than a single string —
  * the label is a summary, not the payload.
  */
-export interface PostedSuggestion extends BaseMessage {
+export interface PostedSuggestion extends PostedInteraction {
   organizationId: string;
   userId: string;
   platform: string;
@@ -97,7 +102,7 @@ export interface PostedSuggestion extends BaseMessage {
  * renderer will skip the card-body text entirely rather than duplicate the
  * button's own label.
  */
-export interface PostedLinkButton extends BaseMessage {
+export interface PostedLinkButton extends PostedInteraction {
   userId: string;
   platform: string;
   url: string;
@@ -109,7 +114,7 @@ export interface PostedLinkButton extends BaseMessage {
 /**
  * Payload emitted on "tool:approval-needed" — platform renderers listen for this.
  */
-export interface PostedToolApproval extends BaseMessage {
+export interface PostedToolApproval extends PostedInteraction {
   agentId: string;
   userId: string;
   platform: string;
@@ -129,7 +134,7 @@ export interface PostedToolApproval extends BaseMessage {
  * approve/reject). Only the API platform renders it — the chat-platform bridge
  * intentionally does not subscribe (it would mis-handle this as an MCP grant).
  */
-export interface PostedDurableApproval extends BaseMessage {
+export interface PostedDurableApproval extends PostedInteraction {
   userId: string;
   platform: string;
   /** Pending run id; the SPA card's Approve/Reject target. */
@@ -185,7 +190,8 @@ export class InteractionService extends EventEmitter {
     platform: string,
     question: string,
     options: string[],
-    source?: string
+    source?: string,
+    turnMessageId?: string
   ): Promise<PostedQuestion> {
     assertRoutableInteraction(connectionId, platform, "question");
     if (this.beforeCreateHook) {
@@ -203,6 +209,7 @@ export class InteractionService extends EventEmitter {
       question,
       options,
       source,
+      turnMessageId,
     };
 
     logger.info(
@@ -231,7 +238,8 @@ export class InteractionService extends EventEmitter {
     connectionId: string | undefined,
     platform: string,
     prompts: Array<{ title: string; message: string }>,
-    source?: string
+    source?: string,
+    turnMessageId?: string
   ): Promise<PostedSuggestion> {
     assertRoutableInteraction(connectionId, platform, "suggestion");
     if (this.beforeCreateHook) {
@@ -254,6 +262,7 @@ export class InteractionService extends EventEmitter {
       platform,
       prompts,
       source,
+      turnMessageId,
     };
 
     logger.info(
@@ -285,7 +294,8 @@ export class InteractionService extends EventEmitter {
     toolName: string,
     args: Record<string, unknown>,
     grantPattern: string,
-    source?: string
+    source?: string,
+    turnMessageId?: string
   ): Promise<PostedToolApproval> {
     assertRoutableInteraction(connectionId, platform, "tool approval");
     if (this.beforeCreateHook) {
@@ -306,6 +316,7 @@ export class InteractionService extends EventEmitter {
       args,
       grantPattern,
       source,
+      turnMessageId,
     };
 
     logger.info(
@@ -337,7 +348,8 @@ export class InteractionService extends EventEmitter {
     source?: string,
     fields: Record<string, unknown> | null = null,
     attribution: ApprovalAttribution | null = null,
-    resourceKind: InteractionResourceKind | null = null
+    resourceKind: InteractionResourceKind | null = null,
+    turnMessageId?: string
   ): Promise<PostedDurableApproval> {
     assertRoutableInteraction(connectionId, platform, "approval card");
     if (this.beforeCreateHook) {
@@ -360,6 +372,7 @@ export class InteractionService extends EventEmitter {
       attribution,
       resourceKind,
       source,
+      turnMessageId,
     };
 
     logger.info(
@@ -385,7 +398,8 @@ export class InteractionService extends EventEmitter {
     label: string,
     linkType: "settings" | "install" | "oauth",
     body?: string,
-    source?: string
+    source?: string,
+    turnMessageId?: string
   ): Promise<PostedLinkButton> {
     assertRoutableInteraction(connectionId, platform, "link button");
     assertSafeLinkButtonUrl(url);
@@ -406,6 +420,7 @@ export class InteractionService extends EventEmitter {
       body,
       linkType,
       source,
+      turnMessageId,
     };
 
     logger.info(

--- a/packages/server/src/gateway/platform/unified-thread-consumer.ts
+++ b/packages/server/src/gateway/platform/unified-thread-consumer.ts
@@ -636,6 +636,7 @@ export class UnifiedThreadResponseConsumer {
           customEventData = {
             type: "suggestion",
             prompts: current?.prompts ?? [],
+            turnMessageId: current?.turnMessageId ?? undefined,
           };
         } catch (err) {
           // The terminal completion remains the authoritative delivery path.

--- a/packages/server/src/gateway/routes/internal/interactions.ts
+++ b/packages/server/src/gateway/routes/internal/interactions.ts
@@ -50,6 +50,7 @@ export function createInteractionRoutes(
           // it from the SSE-owner gate — a headless turn has no browser SSE on
           // any pod, so an owner-gated card would dead-letter.
           source,
+          messageId,
         } = worker;
         const body = await c.req.json();
         const interactionType =
@@ -80,7 +81,8 @@ export function createInteractionRoutes(
             body.label,
             body.linkType || "oauth",
             typeof body.body === "string" ? body.body : undefined,
-            source
+            source,
+            messageId
           );
           return c.json({ id: posted.id, status: "posted" });
         }
@@ -110,7 +112,8 @@ export function createInteractionRoutes(
             isApprovalAttribution(body.attribution) ? body.attribution : null,
             isInteractionResourceKind(body.resourceKind)
               ? body.resourceKind
-              : null
+              : null,
+            messageId
           );
           // The live approval card is a one-shot SSE push, and the transcript
           // doesn't carry interaction parts — so on reload the card is lost.
@@ -139,7 +142,8 @@ export function createInteractionRoutes(
           platform || "unknown",
           body.question,
           body.options || [],
-          source
+          source,
+          messageId
         );
 
         return c.json({ id: posted.id, status: "posted" });
@@ -241,7 +245,8 @@ export function createInteractionRoutes(
         connectionId,
         platform || "unknown",
         prompts,
-        source
+        source,
+        messageId
       );
 
       return c.json({ success: true, prompts: prompts.length, id: posted.id });

--- a/packages/server/src/gateway/services/core-services.ts
+++ b/packages/server/src/gateway/services/core-services.ts
@@ -843,6 +843,7 @@ export class CoreServices {
 			connectionId,
 			platform,
 			source,
+			turnMessageId,
 		) => {
 			await this.interactionService?.postToolApproval(
 				requestId,
@@ -858,6 +859,7 @@ export class CoreServices {
 				args,
 				grantPattern,
 				source,
+				turnMessageId,
 			);
 		};
 		logger.debug("MCP proxy initialized");


### PR DESCRIPTION
## Summary

Correlate `lobu chat` with the submitted request before subscribing to SSE. Retained output and terminal events from earlier requests no longer print or end the new invocation. Only matching activity renews the idle budget.

Use existing message IDs and processed batch membership, and carry the originating `turnMessageId` on interaction cards independently of their card/delivery IDs. Preserve gateway replay. Matching batched completions can render authoritative final text; JSON ephemeral terminals now finish consistently with normal output. Failed sends release the stream.

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` passed (GitHub CI remains the full-graph gate).
- [x] Focused CLI suite: 31 passed. Gateway correlation/delivery suite: 60 passed. Broader MCP/queue tests: 74 passed.
- [x] `make review-fix` completed; edits inspected. Server and CLI typechecks passed.
- [x] Red reproduction through actual `chatCommand` and `SseManager`: `NEW QUESTION` printed `OLD ANSWER`, accepted `complete(old)`, exit 0.
- [x] Built CLI / real gateway routes / isolated Postgres red reproduction: two repeated chats both printed `OLD ANSWER`, exit 0; synthetic queue received both new messages.

- [x] Green with rebuilt CLI / same real gateway setup: request 1 prints `CURRENT ANSWER 1`, request 2 prints `CURRENT ANSWER 2`; both exit 0, both omit retained old output. The synthetic queue received both distinct request IDs.

- [x] GitHub CI passed on `e5c1be7ba0c04a6f7d15bb123372b9ecb219051d`. CLI smoke: 100 passed, 0 failed, 4 explicit skips; real worker turns against the synthetic provider passed `chat --json`, `--new`, `--dry-run`, and `--continue`. Platform-provider smoke remains skipped because no live chat connection was configured.

- [x] Merged as `d3d66ec99f112b0c062a7a8b8b06bf9f1da5676f`; `EXPECT_SHA=d3d66ec99f112b0c062a7a8b8b06bf9f1da5676f ROLLOUT_WAIT=1800 scripts/prod-smoke.sh` passed **9/9**, verifying that exact revision deployed.

## Notes

Deploy the server before distributing the new CLI: unstamped interaction cards are deliberately rejected. Synthetic response evidence does not exercise live model providers or grant live tenant approvals. No database schema changes.
