### PR TITLE
fix(browser): enforce exact page activation targets

### DIFF
--- a/db/migrations/20260910020000_retire_lossy_page_activations.sql
+++ b/db/migrations/20260910020000_retire_lossy_page_activations.sql
@@ -1,0 +1,16 @@
+-- The previous normalizer discarded resource-identifying query data. There is
+-- no generic way to reconstruct it from connector input. Retire these runs;
+-- recreation must require a fresh full target rather than copying the old one.
+-- The marker is stamped by the new writer in existing run_metadata. New readers
+-- also reject unmarked rows written by old replicas during a rolling deployment.
+-- migrate:up
+UPDATE runs
+SET status = 'failed', completed_at = current_timestamp,
+    expires_at = LEAST(expires_at, current_timestamp),
+    error_message = 'The original page target was lost. Create a new draft with its full URL.'
+WHERE activation_kind = 'page_visit'
+  AND status IN ('pending', 'running')
+  AND run_metadata->>'page_activation_identity' IS DISTINCT FROM 'exact';
+
+-- migrate:down
+-- Irreversible: discarded URL identity cannot be restored safely.

--- a/packages/server/src/__tests__/integration/browser-affinity-poll-claim.test.ts
+++ b/packages/server/src/__tests__/integration/browser-affinity-poll-claim.test.ts
@@ -135,12 +135,12 @@ async function seedPendingAction(opts: {
   return Number(row.id);
 }
 
-async function pollExtension(workerId: string) {
+async function pollExtension(workerId: string, version = '0.6.1') {
   return post('/api/workers/poll', {
     body: {
       worker_id: workerId,
       platform: 'chrome-extension',
-      app_version: '0.1.0',
+      app_version: version,
       label: 'Test Ext',
       capabilities: {
         'browser.tabs': true,
@@ -589,13 +589,13 @@ describe('browser-affinity poll claim', () => {
         organization_id, run_type, connection_id, connector_key, action_key,
         action_input, approval_status, status, created_at, expires_at,
         activation_kind, activation_target_urls, activated_at,
-        activated_by_device_worker_id, activation_tab_id, created_by_user_id
+        activated_by_device_worker_id, activation_tab_id, created_by_user_id, run_metadata
       ) VALUES (
         ${orgId}, 'action', ${connId}, 'chrome', 'prepare_reply',
         ${sql.json({ body: 'draft' })}, 'auto', 'running',
         current_timestamp, current_timestamp + interval '1 day',
-        'page_visit', ARRAY['https://x.example/status/1']::text[],
-        current_timestamp, ${deviceWorkerId}::uuid, 23, ${userId}
+        'page_visit', ARRAY['https://x.example/status/1', 'https://x.example/status/2']::text[],
+        current_timestamp, ${deviceWorkerId}::uuid, 23, ${userId}, ${sql.json({ page_activation_identity: 'exact', page_activation_url: 'https://x.example/status/1' })}
       )
       RETURNING id
     `) as unknown as Array<{ id: number }>;
@@ -612,11 +612,14 @@ describe('browser-affinity poll claim', () => {
         tab_id: 23,
         expression: '1',
         activation_tab_id: 9999,
+        activation_target_urls: ['https://forged.example/'],
         browser_flow_id: 'forged-flow',
       },
       expiresAtAgoSeconds: -60,
     });
 
+    const oldClient = await pollExtension(workerId, '0.6.0');
+    expect((await oldClient.json()).run_id).toBeUndefined();
     const res = await pollExtension(workerId);
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -627,6 +630,7 @@ describe('browser-affinity poll claim', () => {
     // The server's resolution reached the worker, so the guard can authorize
     // the one tab the human opened...
     expect(body.action_input?.activation_tab_id).toBe(23);
+    expect(body.action_input?.activation_target_urls).toEqual(['https://x.example/status/1']);
     // ...and neither forged field survived.
     expect(body.action_input?.browser_flow_id).not.toBe('forged-flow');
   });

--- a/packages/server/src/__tests__/integration/page-activation.test.ts
+++ b/packages/server/src/__tests__/integration/page-activation.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { activateMatchingPage, replacePageActivations } from "../../../../owletto/apps/chrome/page-activation.js";
 import { Hono } from "hono";
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import type { Env } from "../../index";
@@ -46,10 +48,10 @@ async function seed() {
 	`;
 	const workers = await sql<{ id: string; worker_id: string }>`
 		INSERT INTO device_workers (
-			user_id, worker_id, platform, capabilities, organization_id, last_seen_at
+			user_id, worker_id, platform, capabilities, organization_id, last_seen_at, app_version
 		) VALUES
-			(${user.id}, 'chrome-mini', 'chrome-extension', ${sql.json(["browser.debugger"])}, ${org.id}, NOW()),
-			(${user.id}, 'chrome-book', 'chrome-extension', ${sql.json(["browser.debugger"])}, ${org.id}, NOW())
+			(${user.id}, 'chrome-mini', 'chrome-extension', ${sql.json(["browser.debugger"])}, ${org.id}, NOW(), '0.6.1'),
+			(${user.id}, 'chrome-book', 'chrome-extension', ${sql.json(["browser.debugger"])}, ${org.id}, NOW(), '0.6.1')
 		RETURNING id, worker_id
 	`;
 	const [connection] = await sql<{ id: number }>`
@@ -66,21 +68,22 @@ async function seed() {
 		INSERT INTO runs (
 			organization_id, run_type, connection_id, connector_key, action_key,
 			action_input, approval_status, status, created_at, expires_at,
-			activation_kind, activation_target_urls, created_by_user_id
+			activation_kind, activation_target_urls, created_by_user_id, run_metadata
 		) VALUES (
 			${org.id}, 'action', ${connection.id}, 'x', 'prepare_reply',
 			${sql.json({ body: "draft" })}, 'auto', 'pending', NOW(), NOW() + interval '1 day',
-			'page_visit', ARRAY['https://x.com/ada/status/123']::text[], ${user.id}
+			'page_visit', ARRAY['https://x.com/ada/status/123']::text[], ${user.id}, ${sql.json({ page_activation_identity: 'exact' })}
 		)
 		RETURNING id
 	`;
 	return { user, org, workers, connection, run };
 }
 
-function appFor(userId: string, orgId: string) {
+function appFor(userId: string, orgId: string, boundWorkerId?: string) {
 	const app = new Hono<{ Bindings: Env }>();
 	app.use("*", async (c, next) => {
 		c.set("workerAuthMode", "user");
+		if (boundWorkerId) c.set("mcpAuthInfo", { workerId: boundWorkerId } as never);
 		c.set("workerUserId", userId);
 		c.set("workerOrgIds", [orgId]);
 		c.set("organizationId", orgId);
@@ -117,6 +120,78 @@ describe("page-activated operation runs", () => {
 	beforeEach(cleanupTestDatabase);
 	afterAll(cleanupTestDatabase);
 
+	it("runs the real Chrome activation entry through the server handler with exact query identity", async () => {
+		const seeded = await seed();
+		await sql`UPDATE runs SET activation_target_urls = ARRAY['https://example.test/item?id=111']::text[] WHERE id = ${seeded.run.id}`;
+		const app = appFor(seeded.user.id, seeded.org.id);
+		const local: Record<string, unknown> = {
+			"owletto.gatewayUrl": "https://gateway.example.test",
+			"owletto.workerId": "chrome-mini",
+			"owletto.accessToken": "synthetic-token",
+		};
+		const area = (store: Record<string, unknown>) => ({
+			get: async (keys: string | string[]) => Object.fromEntries((Array.isArray(keys) ? keys : [keys]).map(key => [key, store[key]])),
+			set: async (values: Record<string, unknown>) => { Object.assign(store, values); },
+		});
+		const chrome = {
+			storage: { local: area(local), session: area({}) },
+			action: { setBadgeText: async () => {}, setBadgeBackgroundColor: async () => {}, setTitle: async () => {} },
+			tabs: { query: async () => [], get: async (id: number) => ({ id, groupId: -1, windowId: 1 }) },
+			tabGroups: { query: async () => [] },
+		};
+		(globalThis as any).chrome = chrome;
+		let calls = 0;
+		try {
+			await replacePageActivations(chrome, [{ run_id: seeded.run.id, urls: ["https://example.test/item?id=111"] }]);
+			const fetchServer = async (_url: string, init: RequestInit) => { calls++; return app.request("/activate", init); };
+			expect(await activateMatchingPage(chrome, { id: 17, active: true, url: "https://example.test/item?id=222" }, fetchServer)).toBe(false);
+			expect(calls).toBe(0);
+			// Even an old client that mistakenly matches locally cannot unlock it.
+			expect(await (await request(app, "chrome-mini", seeded.run.id, "https://example.test/item?id=222")).json()).toEqual({ status: "unavailable" });
+			expect(await activateMatchingPage(chrome, { id: 17, active: true, url: "https://EXAMPLE.TEST:443/item?id=111" }, fetchServer)).toBe(true);
+			expect(calls).toBe(1);
+			const [activated] = await sql`SELECT run_metadata FROM runs WHERE id = ${seeded.run.id}`;
+			expect(activated.run_metadata.page_activation_url).toBe("https://example.test/item?id=111");
+		} finally { delete (globalThis as any).chrome; }
+	});
+
+	it.each(["expired", "wrong-org", "wrong-device", "old-extension", "unmarked", "invalid-url"])("keeps the %s activation guard closed", async (scenario) => {
+		const seeded = await seed();
+		if (scenario === "expired") await sql`UPDATE runs SET expires_at = NOW() - interval '1 second' WHERE id = ${seeded.run.id}`;
+		if (scenario === "unmarked") await sql`UPDATE runs SET run_metadata = NULL WHERE id = ${seeded.run.id}`;
+		if (scenario === "old-extension") await sql`UPDATE device_workers SET app_version = '0.6.0' WHERE id = ${seeded.workers[0].id}`;
+		const response = await request(appFor(seeded.user.id, scenario === "wrong-org" ? "synthetic-other-org" : seeded.org.id, scenario === "wrong-device" ? "synthetic-other-device" : undefined), "chrome-mini", seeded.run.id, scenario === "invalid-url" ? "file:///tmp/example" : "https://x.com/ada/status/123");
+		expect(await response.json()).not.toEqual({ status: "activated" });
+		const [row] = await sql`SELECT activated_at FROM runs WHERE id = ${seeded.run.id}`;
+		expect(row.activated_at).toBeNull();
+	});
+
+	it("retires lossy pending state repeat-safely and refuses recreation from its stripped target", async () => {
+		const seeded = await seed();
+		const created = await createNotificationForUsers([seeded.user.id], {
+			organizationId: seeded.org.id, type: "agent_message", title: "Synthetic draft", body: "Draft",
+			browserUrl: "https://x.com/ada/status/123", browserRunId: seeded.run.id,
+		});
+		await sql`UPDATE runs SET run_metadata = NULL WHERE id = ${seeded.run.id}`;
+		// Still pending, as an old replica would have written it mid-rollout: the
+		// card must already refuse to promise a page visit that cannot activate.
+		const beforeRetirement = await listNotifications({ organizationId: seeded.org.id, userId: seeded.user.id });
+		expect(beforeRetirement.notifications[0]?.browser_handoff).toMatchObject({
+			run_id: seeded.run.id, state: "expired",
+			error_message: "The original page target was lost. Create a new draft with its full URL.",
+		});
+		const migration = readFileSync(new URL("../../../../../db/migrations/20260910020000_retire_lossy_page_activations.sql", import.meta.url), "utf8").split("-- migrate:down")[0];
+		await sql.unsafe(migration);
+		const [first] = await sql`SELECT status, completed_at, expires_at, error_message FROM runs WHERE id = ${seeded.run.id}`;
+		await sql.unsafe(migration);
+		const [second] = await sql`SELECT status, completed_at, expires_at, error_message FROM runs WHERE id = ${seeded.run.id}`;
+		expect(second).toEqual(first);
+		expect(first.status).toBe("failed");
+		const response = await appFor(seeded.user.id, seeded.org.id).request(`/notifications/${created.eventId}/browser-handoff/recreate`, { method: "POST" });
+		expect(response.status).toBe(409);
+		expect(await response.json()).toMatchObject({ error: expect.stringContaining("original page target was lost") });
+	});
+
 	it("atomically lets the first matching browser win across devices", async () => {
 		const seeded = await seed();
 		const app = appFor(seeded.user.id, seeded.org.id);
@@ -125,13 +200,13 @@ describe("page-activated operation runs", () => {
 				app,
 				"chrome-mini",
 				seeded.run.id,
-				"https://x.com/ada/status/123?ref=home",
+				"https://x.com/ada/status/123",
 			),
 			request(
 				app,
 				"chrome-book",
 				seeded.run.id,
-				"https://x.com/ada/status/123#reply",
+				"https://x.com/ada/status/123",
 			),
 		]);
 		const statuses = await Promise.all([a.json(), b.json()]);
@@ -180,17 +255,17 @@ describe("page-activated operation runs", () => {
 		`;
 		await sql`
 			INSERT INTO device_workers (
-				user_id, worker_id, platform, capabilities, organization_id, last_seen_at
+				user_id, worker_id, platform, capabilities, organization_id, last_seen_at, app_version
 			) VALUES (
 				${other.id}, 'chrome-other', 'chrome-extension',
-				${sql.json(["browser.debugger"])}, ${seeded.org.id}, NOW()
+				${sql.json(["browser.debugger"])}, ${seeded.org.id}, NOW(), '0.6.1'
 			)
 		`;
 		const poll = await post("/api/workers/poll", {
 			body: {
 				worker_id: "chrome-other",
 				platform: "chrome-extension",
-				app_version: "0.5.6",
+				app_version: "0.6.1",
 				capabilities: { "browser.debugger": true },
 			},
 		});
@@ -211,7 +286,7 @@ describe("page-activated operation runs", () => {
 			body: {
 				worker_id: "chrome-mini",
 				platform: "chrome-extension",
-				app_version: "0.5.6",
+				app_version: "0.6.1",
 				capabilities: { "browser.debugger": true },
 			},
 		});
@@ -244,7 +319,7 @@ describe("page-activated operation runs", () => {
 			body: {
 				worker_id: "chrome-mini",
 				platform: "chrome-extension",
-				app_version: "0.5.6",
+				app_version: "0.6.1",
 				capabilities: { "browser.debugger": true },
 			},
 		});
@@ -280,7 +355,7 @@ describe("page-activated operation runs", () => {
 		});
 	});
 
-	it("reuses the activated page without navigating the user-owned tab", async () => {
+	it("requires live Chrome verification and refuses navigation to a different target", async () => {
 		const seeded = await seed();
 		const mini = seeded.workers.find(
 			(worker) => worker.worker_id === "chrome-mini",
@@ -297,16 +372,11 @@ describe("page-activated operation runs", () => {
 			organizationId: seeded.org.id,
 			parentRunId: seeded.run.id,
 			actionKey: "navigate",
-			actionInput: { url: "https://x.com/ada/status/123?ref=timeline" },
+			actionInput: { url: "https://x.com/ada/status/123" },
 		});
-		expect(navigation).toEqual({
-			status: "completed",
-			output: {
-				tab_id: 23,
-				current_url: "https://x.com/ada/status/123",
-				user_owned: true,
-			},
-		});
+		// No online Chrome is seeded: the gateway must not manufacture success
+		// from the stored tab id without asking the extension about its live URL.
+		expect(navigation.status).toBe("failed");
 		const wrongPage = await dispatchChromeActionToExtension({
 			organizationId: seeded.org.id,
 			parentRunId: seeded.run.id,

--- a/packages/server/src/__tests__/unit/page-activation-url.test.ts
+++ b/packages/server/src/__tests__/unit/page-activation-url.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { normalizePageActivationUrl, normalizePageActivationUrls, supportsExactPageActivation } from "../../runs/page-activation";
+import { normalizePageUrl } from "../../../../owletto/apps/chrome/page-url.js";
+
+describe("exact page URL identity on server and Chrome", () => {
+  it.each([
+    ["HTTPS://EXAMPLE.TEST:443/item?id=111", "https://example.test/item?id=111"],
+    ["http://EXAMPLE.TEST:80/", "http://example.test/"],
+    ["https://example.test/item?b=2&a=1&a=3", "https://example.test/item?b=2&a=1&a=3"],
+    ["https://example.test/item?id=%2F&value=a+b", "https://example.test/item?id=%2F&value=a+b"],
+    ["https://example.test/item/#resource", "https://example.test/item/#resource"],
+  ])("canonicalizes %s consistently", (input, expected) => {
+    expect(normalizePageActivationUrl(input)).toBe(expected);
+    expect(normalizePageUrl(input)).toBe(expected);
+  });
+  it.each([
+    ["?id=111", "?id=222"], ["?a=1&b=2", "?b=2&a=1"],
+    ["?a=1&a=2", "?a=2&a=1"], ["?id=%2F", "?id=/"],
+    ["#one", "#two"], ["", "/"],
+  ])("does not collapse potentially distinct targets %s and %s", (a, b) => {
+    for (const normalize of [normalizePageActivationUrl, normalizePageUrl]) {
+      expect(normalize(`https://example.test/item${a}`)).not.toBe(normalize(`https://example.test/item${b}`));
+    }
+  });
+  it.each(["invalid", "file:///tmp/item", "javascript:void(0)"])("rejects %s", (input) => {
+    expect(() => normalizePageActivationUrl(input)).toThrow();
+    expect(normalizePageUrl(input)).toBeNull();
+  });
+  it("bounds and deduplicates targets", () => {
+    expect(normalizePageActivationUrls(["https://EXAMPLE.TEST:443/", "https://example.test/"])).toEqual(["https://example.test/"]);
+    expect(() => normalizePageActivationUrls([])).toThrow();
+    expect(() => normalizePageActivationUrls(Array.from({ length: 9 }, (_, i) => `https://example.test/${i}`))).toThrow();
+  });
+  it.each([null, "", "garbage", "0.6.0", "0.5.99"])("rejects an incompatible extension %s", (version) => {
+    expect(supportsExactPageActivation(version)).toBe(false);
+  });
+  it.each(["0.6.1", "0.6.1.1", "0.7.0", "1.0.0"])("accepts a compatible extension %s", (version) => {
+    expect(supportsExactPageActivation(version)).toBe(true);
+  });
+});

--- a/packages/server/src/notifications/browser-handoff.ts
+++ b/packages/server/src/notifications/browser-handoff.ts
@@ -22,6 +22,7 @@ type HandoffSource = {
 	approval_status: string;
 	activation_kind: string | null;
 	activation_target_urls: string | string[] | null;
+	run_metadata: Record<string, unknown> | null;
 	activated_at: Date | string | null;
 	expires_at: Date | string | null;
 };
@@ -51,6 +52,7 @@ async function loadHandoffSource(
 			r.approval_status,
 			r.activation_kind,
 			r.activation_target_urls,
+			r.run_metadata,
 			r.activated_at,
 			r.expires_at
 		FROM notification_targets t
@@ -80,6 +82,7 @@ async function loadHandoffSource(
 
 function isReady(source: HandoffSource): boolean {
 	return (
+		source.run_metadata?.page_activation_identity === "exact" &&
 		source.status === "pending" &&
 		source.approval_status === "auto" &&
 		source.activation_kind === "page_visit" &&
@@ -174,6 +177,9 @@ export async function recreateBrowserHandoff(
 			`This saved draft no longer matches the connector action: ${validationError}`,
 			409,
 		);
+	}
+	if (source.run_metadata?.page_activation_identity !== "exact") {
+		throw new ToolUserError("This draft's original page target was lost. Create a new draft with its full URL.", 409);
 	}
 	const activationUrls = parsePgTextArray(source.activation_target_urls);
 	if (activationUrls.length === 0) {

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -1363,6 +1363,17 @@ export async function listNotifications(opts: {
             'expires_at', browser_run.expires_at,
             'error_message', NULL
           )
+        -- A target stored without exact query/fragment identity can never be
+        -- activated again (worker-api/page-activation.ts rejects it), so the
+        -- card must explain the lost target instead of promising a page visit.
+        WHEN browser_run.activation_kind = 'page_visit'
+          AND browser_run.run_metadata->>'page_activation_identity' IS DISTINCT FROM 'exact' THEN
+          jsonb_build_object(
+            'run_id', browser_run.id,
+            'state', 'expired',
+            'expires_at', browser_run.expires_at,
+            'error_message', 'The original page target was lost. Create a new draft with its full URL.'
+          )
         WHEN browser_run.status = 'pending'
           AND browser_run.approval_status = 'auto'
           AND browser_run.activation_kind = 'page_visit'

--- a/packages/server/src/runs/page-activation.ts
+++ b/packages/server/src/runs/page-activation.ts
@@ -12,11 +12,8 @@ export function normalizePageActivationUrl(value: string): string {
 	if (url.protocol !== "http:" && url.protocol !== "https:") {
 		throw new ToolUserError("Page activation URLs must use HTTP or HTTPS.", 422);
 	}
-	url.hash = "";
-	url.search = "";
-	// Hostname case and default ports are already canonicalized by URL parsing;
-	// only the trailing-slash trim is normalization the parser does not do.
-	if (url.pathname.length > 1) url.pathname = url.pathname.replace(/\/+$/, "");
+	// Preserve query order, repeated values, fragments and trailing slashes: each
+	// can identify a different resource. URL handles host case and default ports.
 	return url.toString();
 }
 
@@ -26,4 +23,12 @@ export function normalizePageActivationUrls(values: string[]): string[] {
 		throw new ToolUserError("Page activation requires between 1 and 8 unique URLs.", 422);
 	}
 	return urls;
+}
+
+// Chrome extension 0.6.1 is the first release that verifies the trusted exact
+// target URL itself before acting on an activated tab.
+export function supportsExactPageActivation(version: string | null | undefined): boolean {
+	if (!version || !/^\d+\.\d+\.\d+(?:\.\d+)?$/.test(version)) return false;
+	const [major, minor, patch] = version.split(".").map(Number);
+	return major > 0 || minor > 6 || (minor === 6 && patch >= 1);
 }

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -48,6 +48,7 @@ import { stableJson } from '../utils/insert-event';
 import logger from '../utils/logger';
 import { isUniqueViolation } from '../utils/pg-errors';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
+import { normalizePageActivationUrls } from './page-activation';
 import { AUTOMATION_RUN_TYPES_PG } from "./run-types.js";
 
 type AutomationDispatchSource = 'scheduled' | 'manual' | 'event';
@@ -1306,13 +1307,17 @@ export async function createConnectorOperationRun(params: {
       )
     : null;
 
+  const activationUrls = params.activation ? normalizePageActivationUrls(params.activation.urls) : [];
+  const runMetadata = params.activation
+    ? { ...params.runMetadata, page_activation_identity: 'exact' }
+    : params.runMetadata;
   const insertMetadata = params.sdkBrowserContext
     ? {
-        ...params.runMetadata,
+        ...runMetadata,
         browser_context:
           params.runMetadata?.browser_context ?? params.sdkBrowserContext,
       }
-    : params.runMetadata;
+    : runMetadata;
   const inserted = await sql<{
     id: number;
     status: string;
@@ -1347,7 +1352,7 @@ export async function createConnectorOperationRun(params: {
       ${inlineOwner === null ? null : sql`current_timestamp`},
       ${inlineOwner},
       ${params.activation?.kind ?? null},
-      ${params.activation ? pgTextArray(params.activation.urls) : null}::text[],
+      ${params.activation ? pgTextArray(activationUrls) : null}::text[],
       ${insertMetadata == null ? null : sql.json(insertMetadata)},
       ${targetDeviceWorkerId == null ? null : sql`${targetDeviceWorkerId}::uuid`},
       ${admissionError}, ${admissionError ? sql`current_timestamp` : null},
@@ -1409,7 +1414,7 @@ export async function createConnectorOperationRun(params: {
     const sameActivation =
       prior.activation_kind === (params.activation?.kind ?? null) &&
       stableJson(parsePgTextArray(prior.activation_target_urls)) ===
-        stableJson(params.activation?.urls ?? []);
+        stableJson(activationUrls);
     const priorAutomationId = prior.automation_id == null ? null : Number(prior.automation_id);
     const priorParentRunId =
       prior.parent_run_id == null ? null : Number(prior.parent_run_id);

--- a/packages/server/src/worker-api/browser-action-context.ts
+++ b/packages/server/src/worker-api/browser-action-context.ts
@@ -179,7 +179,8 @@ export function deriveBrowserActionContext(ctx: ToolContext): BrowserActionConte
 export function trustedChromeActionInput(
   input: Record<string, unknown>,
   context: BrowserActionContext,
-  activationTabId?: number | null
+  activationTabId?: number | null,
+  activationTargetUrls: string[] = []
 ): Record<string, unknown> {
   const trusted = { ...input };
   delete trusted.browser_context_id;
@@ -188,11 +189,12 @@ export function trustedChromeActionInput(
   delete trusted.holder_run_id;
   delete trusted.parent_run_id;
   // Always deleted, then re-added only from the server's own resolution below.
-  // A connector that names an activated tab itself must never be believed: this
-  // field is what lets the extension mutate a tab the USER owns, so a
-  // caller-supplied copy would be a way to launder any tab id into that
-  // authority.
+  // A connector that names an activated tab — or the pages that tab is allowed
+  // to be on — must never be believed: together these fields are what let the
+  // extension mutate a tab the USER owns, so a caller-supplied copy would be a
+  // way to launder any tab id, or any target URL, into that authority.
   delete trusted.activation_tab_id;
+  delete trusted.activation_target_urls;
   return {
     ...trusted,
     browser_context_id: context.id,
@@ -200,7 +202,7 @@ export function trustedChromeActionInput(
     browser_flow_id: context.flow_id,
     holder_run_id: context.flow_id,
     ...(Number.isInteger(activationTabId) && (activationTabId as number) > 0
-      ? { activation_tab_id: activationTabId as number }
+      ? { activation_tab_id: activationTabId as number, activation_target_urls: activationTargetUrls }
       : {}),
   };
 }

--- a/packages/server/src/worker-api/dispatch-chrome-action.ts
+++ b/packages/server/src/worker-api/dispatch-chrome-action.ts
@@ -647,7 +647,7 @@ export async function dispatchChromeActionToExtension(params: {
     const parentRows = (await sql`
       SELECT created_by_user_id, automation_id,
              activated_by_device_worker_id, activation_tab_id,
-             activation_target_urls, run_metadata
+             activation_target_urls, run_metadata, activation_kind, status
       FROM runs
       WHERE id = ${parentRunId}
         AND organization_id = ${organizationId}
@@ -659,12 +659,20 @@ export async function dispatchChromeActionToExtension(params: {
       activation_tab_id: number | null;
       activation_target_urls: string | string[] | null;
       run_metadata: Record<string, unknown> | null;
+      activation_kind: string | null;
+      status: string;
     }>;
     if (parentRows.length === 0) {
       return {
         status: 'failed',
         error_message: `Parent run ${parentRunId} was not found in this organization.`,
       };
+    }
+    if (parentRows[0].activation_kind === 'page_visit' && (
+      parentRows[0].run_metadata?.page_activation_identity !== 'exact' ||
+      !['pending', 'running'].includes(parentRows[0].status)
+    )) {
+      return { status: 'failed', error_message: 'This page activation is no longer executable. Create a new draft with its full URL.' };
     }
     createdByUserId = parentRows[0].created_by_user_id;
     automationId =
@@ -716,14 +724,8 @@ export async function dispatchChromeActionToExtension(params: {
           'Activated browser operations may not navigate the user-owned tab away from its matching page.',
       };
     }
-    return {
-      status: 'completed',
-      output: {
-        tab_id: activationTabId,
-        current_url: requestedUrl,
-        user_owned: true,
-      },
-    };
+    // Chrome must verify the live URL before returning the user-owned tab.
+    // A stored activation is not evidence that this tab is still on that page.
   }
   // An interactive action may name the browser it wants to be seen in. That
   // beats the parent connection's scrape pin, which points at whichever machine

--- a/packages/server/src/worker-api/page-activation.ts
+++ b/packages/server/src/worker-api/page-activation.ts
@@ -5,7 +5,7 @@ import type {
 import type { Context } from "hono";
 import { getDb, pgTextArray } from "../db/client";
 import type { Env } from "../index";
-import { normalizePageActivationUrl } from "../runs/page-activation";
+import { normalizePageActivationUrl, supportsExactPageActivation } from "../runs/page-activation";
 
 export async function activatePageRun(
 	c: Context<{ Bindings: Env }>,
@@ -42,8 +42,8 @@ export async function activatePageRun(
 	}
 
 	const sql = getDb();
-	const devices = await sql<{ id: string }>`
-		SELECT id
+	const devices = await sql<{ id: string; app_version: string | null }>`
+		SELECT id, app_version
 		FROM device_workers
 		WHERE user_id = ${c.var.workerUserId}
 		  AND worker_id = ${body.worker_id}
@@ -53,6 +53,10 @@ export async function activatePageRun(
 	const deviceId = devices[0]?.id;
 	if (!deviceId) return c.json({ error: "Chrome worker not registered" }, 403);
 
+	if (!supportsExactPageActivation(devices[0].app_version)) {
+		return c.json({ error: "Update the Chrome extension to activate this draft" }, 409);
+	}
+
 	const orgIds = c.var.workerOrgIds ?? [];
 	if (orgIds.length === 0) {
 		return c.json<ActivatePageResponse>({ status: "unavailable" });
@@ -61,7 +65,8 @@ export async function activatePageRun(
 		UPDATE runs
 		SET activated_at = current_timestamp,
 		    activated_by_device_worker_id = ${deviceId},
-		    activation_tab_id = ${body.tab_id}
+		    activation_tab_id = ${body.tab_id},
+		    run_metadata = jsonb_set(run_metadata, '{page_activation_url}', to_jsonb(${normalizedUrl}::text))
 		WHERE id = ${body.run_id}
 		  AND organization_id = ANY(${pgTextArray(orgIds)}::text[])
 		  AND created_by_user_id = ${c.var.workerUserId}
@@ -69,6 +74,7 @@ export async function activatePageRun(
 		  AND status = 'pending'
 		  AND approval_status = 'auto'
 		  AND activation_kind = 'page_visit'
+		  AND run_metadata->>'page_activation_identity' = 'exact'
 		  AND activated_at IS NULL
 		  AND expires_at > current_timestamp
 		  AND ${normalizedUrl} = ANY(activation_target_urls)

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -46,6 +46,7 @@ import {
   notifyThreadResponse,
 } from '../gateway/orchestration/turn-liveness';
 import type { Env } from '../index';
+import { supportsExactPageActivation } from '../runs/page-activation';
 import { claimPendingAutomationRun } from '../runs/queue-service';
 import { parseAutomationSkillSnapshots } from '../automations/skill-snapshots';
 import {
@@ -700,7 +701,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   }
 
   const pageActivations =
-    isUserScopedWorker && effectivePlatform === 'chrome-extension'
+    isUserScopedWorker && effectivePlatform === 'chrome-extension' && supportsExactPageActivation(app_version)
       ? (
           await sql<{ run_id: number; urls: string | string[] }>`
           SELECT id AS run_id, activation_target_urls AS urls
@@ -711,6 +712,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
             AND status = 'pending'
             AND approval_status = 'auto'
             AND activation_kind = 'page_visit'
+            AND run_metadata->>'page_activation_identity' = 'exact'
             AND activated_at IS NULL
             AND expires_at > current_timestamp
           ORDER BY expires_at, id
@@ -720,7 +722,12 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           run_id: Number(row.run_id),
           urls: parsePgTextArray(row.urls),
         }))
-      : undefined;
+      : // An extension that cannot verify the exact target itself gets an
+        // empty list rather than no field: that is what makes it drop the
+        // hints it already cached from a lossily-normalized target.
+        effectivePlatform === 'chrome-extension'
+        ? []
+        : undefined;
   const pollMetadata =
     pageActivations === undefined ? {} : { page_activations: pageActivations };
 
@@ -765,7 +772,23 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           })}
         ) run_cv ON true
         WHERE r.status = 'pending'
-          AND (r.activation_kind IS NULL OR r.activated_at IS NOT NULL)
+          AND (r.activation_kind IS NULL OR (
+            r.activated_at IS NOT NULL AND r.run_metadata->>'page_activation_identity' = 'exact'
+          ))
+          -- A child of a page-activated parent runs on the tab the human opened,
+          -- so it is claimable only while that exact-identity parent is running,
+          -- and never by an extension too old to verify the target URL itself.
+          AND NOT EXISTS (
+            SELECT 1 FROM runs activation_parent
+            WHERE activation_parent.id = r.parent_run_id
+              AND activation_parent.organization_id = r.organization_id
+              AND activation_parent.activation_kind = 'page_visit'
+              AND (
+                activation_parent.run_metadata->>'page_activation_identity' IS DISTINCT FROM 'exact'
+                OR activation_parent.status <> 'running'
+                OR ${effectivePlatform === 'chrome-extension' && !supportsExactPageActivation(app_version)}
+              )
+          )
           AND (
             r.run_type <> 'action'
             OR r.expires_at IS NULL
@@ -1031,7 +1054,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         chat_agent.identity_md AS chat_agent_identity_md,
         chat_agent.soul_md AS chat_agent_soul_md,
         chat_agent.user_md AS chat_agent_user_md,
-        parent.activation_tab_id AS parent_activation_tab_id
+        parent.activation_tab_id AS parent_activation_tab_id,
+        parent.run_metadata->>'page_activation_url' AS parent_activation_url
       FROM runs r
       LEFT JOIN organization org ON org.id = r.organization_id
       LEFT JOIN feeds f ON f.id = r.feed_id
@@ -1206,6 +1230,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     connection_config: Record<string, unknown> | null;
     connection_device_worker_id: string | null;
     parent_activation_tab_id: number | string | null;
+    parent_activation_url: string | null;
     connector_version_row_id: number | null;
     artifact_organization_id: string | null;
     artifact_row_count: number;
@@ -1853,11 +1878,15 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
                 row.run_id
               ) ?? runScopedBrowserActionContext(row.run_id))),
         // The extension's ownership guard has no way to know the human opened
-        // this exact tab, so the server hands down the tab it already resolved
-        // for the page-activated parent. Set here, never from action_input.
+        // this exact tab, nor which pages it was opened for, so the server
+        // hands down the tab and the exact URL that won activation. The
+        // original list can allow several pages; that is not permission to
+        // follow a later navigation to another one. The extension re-checks the
+        // live URL against them. Set here, never from action_input.
         row.parent_activation_tab_id == null
           ? null
-          : Number(row.parent_activation_tab_id)
+          : Number(row.parent_activation_tab_id),
+        row.parent_activation_url ? [row.parent_activation_url] : []
       )
     : selectedActionInput;
 


### PR DESCRIPTION
## Summary
- A draft for `item?id=111` could be unlocked by visiting `item?id=222` because both sides discarded the query string. Preserve full URL identity and bind browser execution to the specific URL that won activation.
- Pass the trusted URL through the existing Chrome execution guard and require Chrome 0.6.1+. Retire incompatible pending/running activations without changing events, and refuse recreation from targets whose identity was discarded.
- Paired Chrome change: https://github.com/lobu-ai/owletto/pull/1071.

## Test plan
- [x] Explicit staging and `make pre-pr` (workspace build, per-package typechecks, knip, naming, runtime write-funnel gates).
- [x] 515 Chrome tests, 35 focused server integration tests, and 43 focused unit tests.
- [x] Red: real Chrome activation-entry regression returned `true` for item222 against item111 (`1 failed | 5 passed`). Green: `515 passed` across the Chrome suite.
- [x] Combined local smoke: real extension activation entry → HTTP → server handler → ephemeral Postgres, plus the actual Hacker News draft helper in isolated Chrome on intercepted synthetic HTML. Only the intended item activated and filled; wrong item and navigation-race textareas remained empty; `submitted=false`.
- [x] Exact-head GitHub CI and independent semantic review; `make land` verified all 10 required checks and merged as `22cff6ff53ab74f7ad020d59b9b716275dd71e18`.

## Notes
Chrome PR #1071 merged as `892ef2d31e6a1cabebc091a2541ccf76487965ad`; this PR pins that exact squash commit. Updated Chrome refuses activated writes from an old gateway that cannot stamp trusted target URLs; the new gateway rejects activation and browser-action claims from extensions older than 0.6.1. The fresh Chrome cache key ignores lossy cached hints.

The migration retires unmarked active activations. New readers also reject unmarked rows written by an older replica during rollout; existing expiry processing handles those rows. Old completed history remains intact, but discarded target identity cannot be reused through the recreate endpoint: request a fresh draft with its full URL.

URL-parser equivalents (host case, default ports) match. Query ordering, repeated parameters, encoded values, fragments, and trailing slashes remain distinct conservatively. No connector-specific runtime branch, new table, automatic tab opening, or draft submission was added.

Live deployed-SHA smoke will be recorded after landing. Synthetic local proof does not establish that an installed personal Chrome extension has updated.
