### PR TITLE
fix(test): retry live provider turns and report capacity gaps

### DIFF
--- a/.github/workflows/providers-live.yml
+++ b/.github/workflows/providers-live.yml
@@ -11,7 +11,10 @@ name: Live Providers
 #     with NO secrets, every time.
 #   - keyed:   production-adapter streaming + tool-call round-trip. The required
 #     readiness tier fails closed when a credential is missing; extra provider
-#     secrets remain optional coverage.
+#     secrets remain optional coverage. Each turn is retried, and a failure the
+#     retries cannot clear that classifies as provider quota is logged as a
+#     CAPACITY-SKIP rather than asserted — so a green keyed tier can mean one
+#     required provider was quota-blocked. It stays red when quota hid them all.
 
 on:
   schedule:
@@ -31,7 +34,10 @@ permissions:
 jobs:
   live-providers:
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    # Every keyed turn now retries up to 3 times behind a 60s per-attempt
+    # timeout, so one hung provider can burn ~3min per turn instead of ~1min.
+    # A job-timeout kill reports nothing at all, which is worse than a red turn.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
         with:
@@ -56,9 +62,12 @@ jobs:
         run: make test-providers-live
         env:
           REQUIRED_LIVE_PROVIDERS: claude,openai,gemini,openrouter
+          # Anthropic deliberately gets no OAuth passthrough: `resolveCredential`
+          # prefers an OAuth token over ANTHROPIC_API_KEY, and subscription OAuth
+          # is refused for API inference with a 403
+          # `oauth_not_allowed_for_organization`, which would fail the required
+          # claude tier on auth instead of exercising the contract.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}

--- a/.github/workflows/providers-live.yml
+++ b/.github/workflows/providers-live.yml
@@ -35,9 +35,12 @@ jobs:
   live-providers:
     runs-on: ubuntu-24.04
     # Every keyed turn now retries up to 3 times behind a 60s per-attempt
-    # timeout, so one hung provider can burn ~3min per turn instead of ~1min.
-    # A job-timeout kill reports nothing at all, which is worse than a red turn.
-    timeout-minutes: 30
+    # timeout, so its own test ceiling is ~3.6min instead of ~1min. The suite
+    # is serial, so the pathological run is (keyed providers x 2 turns x
+    # 3.6min) plus the keyless tier — already past 25min at the handful of
+    # provider credentials configured here. A job-timeout kill reports nothing
+    # at all, which is worse than a red turn, so keep headroom above that.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
         with:

--- a/packages/server/src/__tests__/live-providers/live-failure.ts
+++ b/packages/server/src/__tests__/live-providers/live-failure.ts
@@ -1,5 +1,9 @@
 /**
  * Semantic capacity markers independent of HTTP status.
+ *
+ * Deliberately stricter than core's remediation classifier: a rate-limit docs
+ * URL or invalid parameter name must not suppress an integration assertion.
+ * Core selects advice for an already-failed turn; this predicate skips checks.
  */
 const QUOTA_SIGNALS: readonly RegExp[] = [
 	/\bRESOURCE_EXHAUSTED\b/,
@@ -42,7 +46,6 @@ export function isCapacityFailure(message: string | undefined | null): boolean {
 
 interface LiveOutcome {
 	stopReason?: string;
-	errorMessage?: string;
 }
 
 /**

--- a/packages/server/src/__tests__/live-providers/live-failure.ts
+++ b/packages/server/src/__tests__/live-providers/live-failure.ts
@@ -16,7 +16,7 @@ const QUOTA_SIGNALS: readonly RegExp[] = [
 	/\bthis request requires more credits\b/i,
 	/["']type["']\s*:\s*["']rate_limit_error["']/i,
 	/\brate[ -]limit(?:ed| (?:exceeded|reached))\b/i,
-	/\btoo many requests\b/i,
+	/^\s*too many requests\b/i,
 ];
 
 /**

--- a/packages/server/src/__tests__/live-providers/live-failure.ts
+++ b/packages/server/src/__tests__/live-providers/live-failure.ts
@@ -1,0 +1,89 @@
+/**
+ * Semantic capacity markers independent of HTTP status.
+ */
+const QUOTA_SIGNALS: readonly RegExp[] = [
+	/\bRESOURCE_EXHAUSTED\b/,
+	/\blimit exhausted\b/i,
+	/\bquota exceeded\b/i,
+	/\bexceeded your current quota\b/i,
+	/\binsufficient[_ ]quota\b/i,
+	/\byour credit balance is too low\b/i,
+	/\byou have no credits remaining\b/i,
+	/["']type["']\s*:\s*["']rate_limit_error["']/i,
+	/\brate[ -]limit(?:ed| (?:exceeded|reached))\b/i,
+	/\btoo many requests\b/i,
+];
+
+/**
+ * A 429 counts only in HTTP-status position. `completeSimple` hands back the
+ * provider SDK's own `Error.message`, which leads with the status (`429 <body>`,
+ * `401 <body>`), so that position is the head of the string; the remaining
+ * alternatives catch a status quoted inside a log line. A bare `429` also turns
+ * up inside token counts (`"total_tokens":429`) and vendor error codes, so
+ * matching it anywhere would classify a genuine break as mere throttling — the
+ * one direction of error this module must never make.
+ */
+const HTTP_429 =
+	/^\s*429\b|(?:returned|failed:|status(?:\s+code)?:?)\s*429\b|\bHTTP\s*429\b/i;
+
+/**
+ * True when a failed live turn is a quota/rate-limit condition rather than a
+ * broken integration.
+ *
+ * Undefined or empty input is NOT quota: an error we cannot read is a break we
+ * have not diagnosed, and defaulting to "quota" there would silently disarm
+ * the whole tier.
+ */
+export function isCapacityFailure(message: string | undefined | null): boolean {
+	if (!message) return false;
+	if (HTTP_429.test(message)) return true;
+	return QUOTA_SIGNALS.some((signal) => signal.test(message));
+}
+
+interface LiveOutcome {
+	stopReason?: string;
+	errorMessage?: string;
+}
+
+/**
+ * Run a live turn repeatedly so a transient provider failure can clear.
+ *
+ * Capacity classification belongs to the caller after the final attempt: a
+ * generic 429 can be a short, windowed limit that succeeds on retry.
+ */
+export async function completeWithLiveRetry<T extends LiveOutcome>(
+	attempt: () => Promise<T>,
+	opts: {
+		attempts: number;
+		backoffMs: number;
+		sleep?: (ms: number) => Promise<void>;
+	},
+): Promise<T> {
+	const sleep =
+		opts.sleep ??
+		((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+	let outcome = await attempt();
+	for (let n = 2; n <= opts.attempts; n++) {
+		if (outcome.stopReason !== "error") return outcome;
+		await sleep(opts.backoffMs * (n - 1));
+		outcome = await attempt();
+	}
+	return outcome;
+}
+
+/**
+ * True when quota alone decided the keyed tier: at least one required provider
+ * was capacity-skipped and no required provider ever got past that gate, so no
+ * contract assertion ran and a green result would prove nothing.
+ *
+ * An empty `capacitySkipped` is never a quota verdict — the turns either ran
+ * and their own assertions decided, or none produced an outcome at all and is
+ * already red on its own test. Reporting that as a quota problem would only
+ * misattribute it.
+ */
+export function quotaHidKeyedTier(
+	capacitySkipped: ReadonlySet<string>,
+	reachedContract: ReadonlySet<string>,
+): boolean {
+	return capacitySkipped.size > 0 && reachedContract.size === 0;
+}

--- a/packages/server/src/__tests__/live-providers/live-failure.ts
+++ b/packages/server/src/__tests__/live-providers/live-failure.ts
@@ -13,6 +13,7 @@ const QUOTA_SIGNALS: readonly RegExp[] = [
 	/\binsufficient[_ ]quota\b/i,
 	/\byour credit balance is too low\b/i,
 	/\byou have no credits remaining\b/i,
+	/\bthis request requires more credits\b/i,
 	/["']type["']\s*:\s*["']rate_limit_error["']/i,
 	/\brate[ -]limit(?:ed| (?:exceeded|reached))\b/i,
 	/\btoo many requests\b/i,

--- a/packages/server/src/__tests__/live-providers/provider-smoke.test.ts
+++ b/packages/server/src/__tests__/live-providers/provider-smoke.test.ts
@@ -9,9 +9,10 @@
  * worker turns are.
  *
  * REQUIRED_LIVE_PROVIDERS is a comma-separated readiness tier. Every listed
- * provider must have a dedicated credential, answer a text turn, and return a
- * forced tool call. Other configured credentials receive text coverage and a
- * best-effort tool probe without becoming release blockers.
+ * provider must have a dedicated credential and is asked for a text turn and
+ * forced tool call. Contract failures fail the tier; persistent capacity
+ * failures are reported separately. Other configured credentials receive text
+ * coverage and a best-effort tool probe without becoming release blockers.
  */
 
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
@@ -24,6 +25,11 @@ import {
 	type Context,
 	type Model,
 } from "@mariozechner/pi-ai";
+import {
+	completeWithLiveRetry,
+	isCapacityFailure,
+	quotaHidKeyedTier,
+} from "./live-failure.js";
 import {
 	type ProviderApi,
 	resolveProviderApi,
@@ -66,7 +72,14 @@ const FALLBACK_MODELS: Record<string, string> = {
 };
 
 const TIMEOUT_MS = 60_000;
-setDefaultTimeout(120_000);
+const LIVE_ATTEMPTS = 3;
+const RETRY_BACKOFF_MS = 1_500;
+
+/** Cover every per-attempt timeout and the complete linear backoff schedule. */
+const RETRY_SCHEDULE_MS =
+	LIVE_ATTEMPTS * TIMEOUT_MS +
+	RETRY_BACKOFF_MS * (((LIVE_ATTEMPTS - 1) * LIVE_ATTEMPTS) / 2);
+setDefaultTimeout(RETRY_SCHEDULE_MS + 30_000);
 
 function firstEnv(names: string[]): string | undefined {
 	for (const name of names) {
@@ -202,8 +215,11 @@ function buildLiveModel(
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 128_000,
 		maxTokens: 16_384,
-		// Match the worker's production payload guard. Gemini's OpenAI-compatible
-		// endpoint returns 400 for OpenAI's `store` field.
+		// Gemini's OpenAI-compatible endpoint returns 400 for OpenAI's `store`
+		// field. No completions entry in the catalog is api.openai.com either —
+		// official OpenAI is promoted to Responses above — so every provider
+		// this smoke reaches over completions is one production also withholds
+		// `store` from; see `resolveTurnCompat` in `agent-turn-producer.ts`.
 		...(api === "openai-completions"
 			? { compat: { supportsStore: false } }
 			: {}),
@@ -262,6 +278,30 @@ function forceWeatherTool(api: ProviderApi, payload: unknown): unknown {
 		};
 	}
 	return { ...body, tool_choice: { type: "function", name: "get_weather" } };
+}
+
+const capacitySkippedRequired = new Set<string>();
+const nonCapacityRequired = new Set<string>();
+
+async function completeWithRetry(
+	args: Parameters<typeof completeWithProductionAdapter>[0],
+) {
+	return completeWithLiveRetry(() => completeWithProductionAdapter(args), {
+		attempts: LIVE_ATTEMPTS,
+		backoffMs: RETRY_BACKOFF_MS,
+	});
+}
+
+function skipIfAtCapacity(id: string, errorMessage?: string): boolean {
+	if (!isCapacityFailure(errorMessage)) {
+		if (requiredIds.has(id)) nonCapacityRequired.add(id);
+		return false;
+	}
+	if (requiredIds.has(id)) capacitySkippedRequired.add(id);
+	console.warn(
+		`[live-providers] ${id} CAPACITY-SKIP — provider quota/rate limit, contract not exercised: ${errorMessage}`,
+	);
+	return true;
 }
 
 async function completeWithProductionAdapter(args: {
@@ -333,13 +373,14 @@ for (const { id, provider } of flattened) {
 
 		test("answers a streamed production-adapter turn", async () => {
 			expect(modelId, `${id} has no configured live model`).toBeDefined();
-			const response = await completeWithProductionAdapter({
+			const response = await completeWithRetry({
 				id,
 				provider,
 				credential: credential!,
 				modelId: modelId!,
 				context: textContext(),
 			});
+			if (skipIfAtCapacity(id, response.errorMessage)) return;
 			expect(
 				response.stopReason,
 				`${id} turn failed: ${response.errorMessage ?? "unknown provider error"}`,
@@ -354,7 +395,7 @@ for (const { id, provider } of flattened) {
 
 		test("returns a parsed streamed tool call", async () => {
 			expect(modelId, `${id} has no configured live model`).toBeDefined();
-			const response = await completeWithProductionAdapter({
+			const response = await completeWithRetry({
 				id,
 				provider,
 				credential: credential!,
@@ -362,6 +403,7 @@ for (const { id, provider } of flattened) {
 				context: toolContext(),
 				forceTool: required,
 			});
+			if (skipIfAtCapacity(id, response.errorMessage)) return;
 			const toolCall = response.content.find(
 				(block) => block.type === "toolCall",
 			);
@@ -382,3 +424,23 @@ for (const { id, provider } of flattened) {
 		});
 	});
 }
+
+/** Fail if quota prevented every required provider from completing any turn. */
+describe("keyed tier coverage", () => {
+	const anyRequiredExercisable = [...requiredIds].some((id) =>
+		flattened.some(
+			(entry) =>
+				entry.id === id && !!resolveCredential(id, entry.provider.envVarName),
+		),
+	);
+
+	test.skipIf(!anyRequiredExercisable)(
+		"at least one required provider reached its contract assertions",
+		() => {
+			expect(
+				quotaHidKeyedTier(capacitySkippedRequired, nonCapacityRequired),
+				`every required provider was capacity-skipped (${[...capacitySkippedRequired].join(", ")}) — the keyed tier proved nothing this run`,
+			).toBe(false);
+		},
+	);
+});

--- a/packages/server/src/__tests__/live-providers/provider-smoke.test.ts
+++ b/packages/server/src/__tests__/live-providers/provider-smoke.test.ts
@@ -10,8 +10,10 @@
  *
  * REQUIRED_LIVE_PROVIDERS is a comma-separated readiness tier. Every listed
  * provider must have a dedicated credential and is asked for a text turn and
- * forced tool call. Contract failures fail the tier; persistent capacity
- * failures are reported separately. Other configured credentials receive text
+ * forced tool call. A contract failure fails the tier. A failure the retries
+ * could not clear and `isCapacityFailure` reads as quota logs a CAPACITY-SKIP
+ * warning and leaves that turn unasserted; it fails the tier only when quota
+ * hid EVERY required provider. Other configured credentials receive text
  * coverage and a best-effort tool probe without becoming release blockers.
  */
 
@@ -75,7 +77,12 @@ const TIMEOUT_MS = 60_000;
 const LIVE_ATTEMPTS = 3;
 const RETRY_BACKOFF_MS = 1_500;
 
-/** Cover every per-attempt timeout and the complete linear backoff schedule. */
+/**
+ * Cover every per-attempt timeout plus the complete linear backoff schedule
+ * (`backoffMs * 1 … backoffMs * (attempts - 1)`), then leave headroom for the
+ * SDK's own request setup. A file-level `setDefaultTimeout` overrides the CLI
+ * `--timeout` the Makefile target passes, so this is the timeout that applies.
+ */
 const RETRY_SCHEDULE_MS =
 	LIVE_ATTEMPTS * TIMEOUT_MS +
 	RETRY_BACKOFF_MS * (((LIVE_ATTEMPTS - 1) * LIVE_ATTEMPTS) / 2);
@@ -281,7 +288,7 @@ function forceWeatherTool(api: ProviderApi, payload: unknown): unknown {
 }
 
 const capacitySkippedRequired = new Set<string>();
-const nonCapacityRequired = new Set<string>();
+const contractReachedRequired = new Set<string>();
 
 async function completeWithRetry(
 	args: Parameters<typeof completeWithProductionAdapter>[0],
@@ -294,7 +301,7 @@ async function completeWithRetry(
 
 function skipIfAtCapacity(id: string, errorMessage?: string): boolean {
 	if (!isCapacityFailure(errorMessage)) {
-		if (requiredIds.has(id)) nonCapacityRequired.add(id);
+		if (requiredIds.has(id)) contractReachedRequired.add(id);
 		return false;
 	}
 	if (requiredIds.has(id)) capacitySkippedRequired.add(id);
@@ -427,18 +434,13 @@ for (const { id, provider } of flattened) {
 
 /** Fail if quota prevented every required provider from completing any turn. */
 describe("keyed tier coverage", () => {
-	const anyRequiredExercisable = [...requiredIds].some((id) =>
-		flattened.some(
-			(entry) =>
-				entry.id === id && !!resolveCredential(id, entry.provider.envVarName),
-		),
-	);
+	const anyRequiredExercisable = activeIds.some((id) => requiredIds.has(id));
 
 	test.skipIf(!anyRequiredExercisable)(
 		"at least one required provider reached its contract assertions",
 		() => {
 			expect(
-				quotaHidKeyedTier(capacitySkippedRequired, nonCapacityRequired),
+				quotaHidKeyedTier(capacitySkippedRequired, contractReachedRequired),
 				`every required provider was capacity-skipped (${[...capacitySkippedRequired].join(", ")}) — the keyed tier proved nothing this run`,
 			).toBe(false);
 		},

--- a/packages/server/src/__tests__/unit/live-failure.test.ts
+++ b/packages/server/src/__tests__/unit/live-failure.test.ts
@@ -34,11 +34,17 @@ describe("isCapacityFailure", () => {
 				"429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47",
 			],
 			["429 quoted inside a log line", "x chat returned 429: slow down"],
-			["SDK 429 without quota prose", '429 {"error":{"message":"Too many concurrent requests"}}'],
+			[
+				"SDK 429 without quota prose",
+				'429 {"error":{"message":"Too many concurrent requests"}}',
+			],
 			// The rest carry no 429 in HTTP-status position, keeping each semantic
 			// signal independently covered.
 			["bare RESOURCE_EXHAUSTED status", '{"status":"RESOURCE_EXHAUSTED"}'],
-			["weekly limit prose with no status", '{"message":"Weekly/Monthly Limit Exhausted"}'],
+			[
+				"weekly limit prose with no status",
+				'{"message":"Weekly/Monthly Limit Exhausted"}',
+			],
 			[
 				"Google metric exhaustion without a status line",
 				"Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 0",
@@ -55,9 +61,11 @@ describe("isCapacityFailure", () => {
 				"OpenAI exhausted credits",
 				"You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/.",
 			],
+			// The two underscored codes `classifyErrorMessage` does not reach, so
+			// `UNDERSCORED_QUOTA_CODES` cannot be dropped without a red test.
 			["OpenAI insufficient_quota", '{"code":"insufficient_quota"}'],
-			["plain rate limit prose", "rate limited, retry later"],
 			["rate_limit_error token", '{"type":"rate_limit_error"}'],
+			["plain rate limit prose", "rate limited, retry later"],
 			["too many requests prose", "Too Many Requests"],
 		];
 		for (const [label, message] of quota) {
@@ -92,6 +100,10 @@ describe("isCapacityFailure", () => {
 			["429 as a vendor error code", '400 {"vendor_code":1429}'],
 			["429 in a structured provider code", '400 {"error":{"code":429}}'],
 			["rate_limit in an invalid parameter name", "400 invalid rate_limit option"],
+			["camel-case rateLimit parameter", "400 invalid rateLimit option"],
+			["hyphenated rate-limit parameter", "400 invalid rate-limit option"],
+			["rate-limit documentation URL", "404 model not found; see https://example.test/docs/rate-limits"],
+			["error type used as an invalid parameter", "400 invalid rate_limit_error option"],
 		];
 		for (const [label, message] of notQuota) {
 			test(label, () => {
@@ -114,7 +126,9 @@ describe("completeWithLiveRetry", () => {
 		errorMessage,
 	});
 	/** Records the backoffs so the schedule itself is asserted, not just the count. */
-	function harness(outcomes: Array<{ stopReason: string; errorMessage?: string }>) {
+	function harness(
+		outcomes: Array<{ stopReason: string; errorMessage?: string }>,
+	) {
 		const slept: number[] = [];
 		let calls = 0;
 		const attempt = async () => {

--- a/packages/server/src/__tests__/unit/live-failure.test.ts
+++ b/packages/server/src/__tests__/unit/live-failure.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "bun:test";
+import {
+	completeWithLiveRetry,
+	isCapacityFailure,
+	quotaHidKeyedTier,
+} from "../live-providers/live-failure";
+
+/**
+ * `completeSimple` reports the provider SDK's own `Error.message`, which leads
+ * with the HTTP status (`429 <body>`, `401 <body>`) and carries no test-side
+ * prefix. Fixtures use that shape, since it is the only input the live smoke
+ * ever passes to `isCapacityFailure`.
+ */
+const GEMINI_FREE_TIER_429 =
+	'429 [{"error":{"code":429,"message":"You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits.\\n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_input_token_count, limit: 0, model: gemini-2.5-pro","status":"RESOURCE_EXHAUSTED"}}]';
+
+const ZAI_WEEKLY_429 =
+	'429 {"error":{"code":"1310","message":"Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47"}}';
+
+const CLAUDE_OAUTH_403 =
+	'403 {"type":"error","error":{"type":"permission_error","message":"OAuth authentication is currently not allowed for this organization.","details":{"error_code":"oauth_not_allowed_for_organization"}}}';
+
+const GEMINI_BODILESS_404 = "404 status code (no body)";
+
+describe("isCapacityFailure", () => {
+	describe("classifies a real operating condition as quota", () => {
+		const quota: ReadonlyArray<[string, string]> = [
+			["gemini free-tier exhaustion", GEMINI_FREE_TIER_429],
+			["z.ai weekly limit", ZAI_WEEKLY_429],
+			[
+				// Byte-identical to `QUOTA_BODY` in scripts/sdk-e2e/mock-openai.mjs,
+				// which pins z.ai's real production body.
+				"z.ai body as the repo already pins it",
+				"429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47",
+			],
+			["429 quoted inside a log line", "x chat returned 429: slow down"],
+			["SDK 429 without quota prose", '429 {"error":{"message":"Too many concurrent requests"}}'],
+			// The rest carry no 429 in HTTP-status position, keeping each semantic
+			// signal independently covered.
+			["bare RESOURCE_EXHAUSTED status", '{"status":"RESOURCE_EXHAUSTED"}'],
+			["weekly limit prose with no status", '{"message":"Weekly/Monthly Limit Exhausted"}'],
+			[
+				"Google metric exhaustion without a status line",
+				"Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 0",
+			],
+			[
+				"OpenAI billing prose without a status line",
+				"You exceeded your current quota, please check your plan and billing details.",
+			],
+			[
+				"Anthropic exhausted credit balance",
+				'400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."}}',
+			],
+			[
+				"OpenAI exhausted credits",
+				"You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/.",
+			],
+			["OpenAI insufficient_quota", '{"code":"insufficient_quota"}'],
+			["plain rate limit prose", "rate limited, retry later"],
+			["rate_limit_error token", '{"type":"rate_limit_error"}'],
+			["too many requests prose", "Too Many Requests"],
+		];
+		for (const [label, message] of quota) {
+			test(label, () => {
+				expect(isCapacityFailure(message)).toBe(true);
+			});
+		}
+	});
+
+	describe("classifies a real break as NOT quota", () => {
+		const breaks: ReadonlyArray<[string, string]> = [
+			["claude OAuth 403", CLAUDE_OAUTH_403],
+			["bodiless 404", GEMINI_BODILESS_404],
+			["400 invalid request", '400 {"error":{"code":"invalid_request_error"}}'],
+			["401 bad credential", "401 Incorrect API key provided: sk-not-a***robe"],
+			["500 upstream error", "500 internal server error"],
+			["unparseable provider error", "unknown provider error"],
+		];
+		for (const [label, message] of breaks) {
+			test(label, () => {
+				expect(isCapacityFailure(message)).toBe(false);
+			});
+		}
+	});
+
+	describe("never mistakes an incidental number for throttling", () => {
+		// The one direction this must never get wrong: reading a genuine break
+		// as mere quota silently disarms the tier for that provider.
+		const notQuota: ReadonlyArray<[string, string]> = [
+			["429 inside a token count", '400 {"usage":{"total_tokens":429}}'],
+			["429 inside a request id", "400 req_0429ab"],
+			["429 as a vendor error code", '400 {"vendor_code":1429}'],
+			["429 in a structured provider code", '400 {"error":{"code":429}}'],
+			["rate_limit in an invalid parameter name", "400 invalid rate_limit option"],
+		];
+		for (const [label, message] of notQuota) {
+			test(label, () => {
+				expect(isCapacityFailure(message)).toBe(false);
+			});
+		}
+	});
+
+	test("an unreadable failure is a break, not quota", () => {
+		expect(isCapacityFailure(undefined)).toBe(false);
+		expect(isCapacityFailure(null)).toBe(false);
+		expect(isCapacityFailure("")).toBe(false);
+	});
+});
+
+describe("completeWithLiveRetry", () => {
+	const ok = { stopReason: "stop" as const };
+	const err = (errorMessage: string) => ({
+		stopReason: "error" as const,
+		errorMessage,
+	});
+	/** Records the backoffs so the schedule itself is asserted, not just the count. */
+	function harness(outcomes: Array<{ stopReason: string; errorMessage?: string }>) {
+		const slept: number[] = [];
+		let calls = 0;
+		const attempt = async () => {
+			calls++;
+			return outcomes[Math.min(calls - 1, outcomes.length - 1)];
+		};
+		return {
+			slept,
+			run: () =>
+				completeWithLiveRetry(attempt, {
+					attempts: 3,
+					backoffMs: 10,
+					sleep: async (ms) => {
+						slept.push(ms);
+					},
+				}),
+			calls: () => calls,
+		};
+	}
+
+	test("a success is returned without retrying", async () => {
+		const h = harness([ok]);
+		expect((await h.run()).stopReason).toBe("stop");
+		expect(h.calls()).toBe(1);
+		expect(h.slept).toEqual([]);
+	});
+
+	test("a transient failure clears on retry", async () => {
+		const h = harness([err(GEMINI_BODILESS_404), ok]);
+		const outcome = await h.run();
+		expect(outcome.stopReason).toBe("stop");
+		expect(h.calls()).toBe(2);
+	});
+
+	test("a transient rate limit can clear on retry", async () => {
+		const h = harness([err("429 Too Many Requests"), ok]);
+		expect((await h.run()).stopReason).toBe("stop");
+		expect(h.calls()).toBe(2);
+	});
+
+	test("a persistent break exhausts every attempt and still fails", async () => {
+		const h = harness([err("401 invalid x-api-key")]);
+		const outcome = await h.run();
+		expect(outcome.stopReason).toBe("error");
+		expect(h.calls()).toBe(3);
+		// Backoff grows, so a flapping upstream is not hammered.
+		expect(h.slept).toEqual([10, 20]);
+	});
+
+	test("persistent quota is returned after the retry budget", async () => {
+		const h = harness([err("429 Weekly/Monthly Limit Exhausted")]);
+		const outcome = await h.run();
+		expect(outcome.stopReason).toBe("error");
+		expect(h.calls()).toBe(3);
+		expect(h.slept).toEqual([10, 20]);
+	});
+
+	test("a failure that only clears on the last attempt still passes", async () => {
+		const h = harness([err("boom"), err("boom"), ok]);
+		expect((await h.run()).stopReason).toBe("stop");
+		expect(h.calls()).toBe(3);
+	});
+});
+
+describe("quotaHidKeyedTier", () => {
+	const set = (...ids: string[]) => new Set(ids);
+
+	test("quota alone decided the tier when every required provider was skipped", () => {
+		expect(quotaHidKeyedTier(set("gemini"), set())).toBe(true);
+		expect(quotaHidKeyedTier(set("gemini", "claude"), set())).toBe(true);
+	});
+
+	test("one required provider reaching its contract clears the tier", () => {
+		expect(quotaHidKeyedTier(set("gemini"), set("claude"))).toBe(false);
+	});
+
+	test("a provider skipped on one turn and exercised on another clears it", () => {
+		expect(quotaHidKeyedTier(set("gemini"), set("gemini"))).toBe(false);
+	});
+
+	// A run with nothing capacity-skipped is never a quota verdict: the turns
+	// either ran and their own assertions decided, or they are already red.
+	test("no capacity skip is never reported as a quota problem", () => {
+		expect(quotaHidKeyedTier(set(), set())).toBe(false);
+		expect(quotaHidKeyedTier(set(), set("gemini"))).toBe(false);
+	});
+});

--- a/packages/server/src/__tests__/unit/live-failure.test.ts
+++ b/packages/server/src/__tests__/unit/live-failure.test.ts
@@ -63,6 +63,10 @@ describe("isCapacityFailure", () => {
 			],
 			// The two underscored codes `classifyErrorMessage` does not reach, so
 			// `UNDERSCORED_QUOTA_CODES` cannot be dropped without a red test.
+			[
+				"OpenRouter insufficient reservation budget",
+				"402 This request requires more credits, or fewer max_tokens. You requested up to 1024 tokens, but can only afford 824.",
+			],
 			["OpenAI insufficient_quota", '{"code":"insufficient_quota"}'],
 			["rate_limit_error token", '{"type":"rate_limit_error"}'],
 			["plain rate limit prose", "rate limited, retry later"],

--- a/packages/server/src/__tests__/unit/live-failure.test.ts
+++ b/packages/server/src/__tests__/unit/live-failure.test.ts
@@ -34,6 +34,9 @@ describe("isCapacityFailure", () => {
 				"429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47",
 			],
 			["429 quoted inside a log line", "x chat returned 429: slow down"],
+			["429 after a failure prefix", "openrouter request failed: 429"],
+			["429 in a status-code line", "provider error, status code: 429"],
+			["429 named as an HTTP status", "upstream responded HTTP 429"],
 			[
 				"SDK 429 without quota prose",
 				'429 {"error":{"message":"Too many concurrent requests"}}',
@@ -61,8 +64,11 @@ describe("isCapacityFailure", () => {
 				"OpenAI exhausted credits",
 				"You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/.",
 			],
-			// The two underscored codes `classifyErrorMessage` does not reach, so
-			// `UNDERSCORED_QUOTA_CODES` cannot be dropped without a red test.
+			// The three shapes `classifyErrorMessage` (packages/core) leaves
+			// UNCLASSIFIED: its balance alternatives want "insufficient quota" with
+			// a space rather than the underscored code and cover no "requires more
+			// credits" wording, and `rate[-\s]?limit` never spans `rate_limit_error`.
+			// So `QUOTA_SIGNALS` cannot be dropped without a red test.
 			[
 				"OpenRouter insufficient reservation budget",
 				"402 This request requires more credits, or fewer max_tokens. You requested up to 1024 tokens, but can only afford 824.",
@@ -86,6 +92,7 @@ describe("isCapacityFailure", () => {
 			["400 invalid request", '400 {"error":{"code":"invalid_request_error"}}'],
 			["401 bad credential", "401 Incorrect API key provided: sk-not-a***robe"],
 			["500 upstream error", "500 internal server error"],
+			["invalid batch size", "400 unsupported parameter: too many requests in batch"],
 			["unparseable provider error", "unknown provider error"],
 		];
 		for (const [label, message] of breaks) {


### PR DESCRIPTION
## Summary
Provider smoke turns currently fail on a single transient upstream error. Retry bounded production-adapter turns, distinguish persistent provider capacity failures from contract failures, and fail the coverage guard when capacity prevents every required provider from reaching its assertions. Missing credentials and persistent auth/protocol failures remain failures.

Use dedicated API credentials in the scheduled workflow. Its OAuth inputs previously took precedence over the Anthropic API key, so an API-ineligible subscription token prevented the suite from reaching that key.

## Test plan
- [x] Red: origin/main against a local upstream returning one 404 then healthy SSE: `3 pass, 1 fail`.
- [x] Green: updated full suite against the same upstream: `5 pass, 0 fail`.
- [x] Forced persistent 500: both turn assertions fail. Forced persistent quota: coverage guard fails. Missing required credential: credential assertion fails.
- [x] Live keyless routes/catalogs: `31 pass, 3 skip, 0 fail`.
- [x] Real Gemini production-adapter suite: `5 pass, 0 fail`.
- [x] Billing classifier red/green: `31 pass, 2 fail` -> `33 pass, 0 fail`; final focused suite including coverage, reservation-budget, and false-skip tests: `46 pass, 0 fail`.
- [x] Conservative classification red/green: broader remediation reuse falsely skipped four invalid-parameter/docs-URL cases (`37 pass, 4 fail`); strict matching keeps them failures (`41 pass, 0 fail`).
- [x] Wider unit job: `1564 pass, 2 skip, 0 fail` across 149 files.
- [x] `make pre-pr`: all gates clean.
- [x] Eight local-upstream scenarios: success, quota, bare 429, both billing errors, persistent 500, transient 404, transient 429; expected exit codes and coverage diagnostics verified.
- [x] Live combined run: Gemini exercises its contract; Anthropic/OpenAI explicitly report exhausted-credit capacity skips. The runner reports `13 pass, 0 fail`; four of those turn tests return early with CAPACITY-SKIP, so this is not successful inference coverage for those two providers.
- [x] Exact-head Live Providers Actions run: https://github.com/lobu-ai/lobu/actions/runs/34429176329 — green on 53cd853e916282d754d5bf48b371c7e1af38ccb8. Gemini model listing, streamed text, and tool call all pass. Anthropic, OpenAI, and OpenRouter emit six explicit CAPACITY-SKIP warnings for unfunded/insufficient budgets; their inference is not proven. Runner totals are `48 pass, 42 skip, 0 fail`, with the six early-return turn tests included in the pass count.
- [x] UI review: not applicable (test/workflow-only diff).
- [x] Previous revision CI: https://github.com/lobu-ai/lobu/actions/runs/34429168080 — passed for 53cd853e916282d754d5bf48b371c7e1af38ccb8.
- [x] Final revision CI: https://github.com/lobu-ai/lobu/actions/runs/34430923779 — passed for 6078d1a31d0cb865f2fcdc827b1016c5449b5b3a, including frontend, Mac, and integration jobs.
- [x] Exact-head Opus review: passed on 6078d1a31, zero bugs and zero blockers.

## Notes
This is test-only. It does not establish funded live coverage for OpenAI or Anthropic: the available Anthropic/OpenAI credentials can list models but their turns are rejected for exhausted credits, and OpenRouter cannot reserve the requested token budget. The Actions secrets now use validated API credentials, including the locally proven Gemini key. The required provider declaration remains intact.

Post-merge verification: https://github.com/lobu-ai/lobu/actions/runs/34435709956 passed on the exact squash commit 2bddbfa7eddbf52631abbfecd48ba34b0e9015b2. All four merged files match the reviewed branch byte-for-byte.
