### PR TITLE
fix(release): publish canaries manually with npm OIDC

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,19 +1,15 @@
 name: Publish Canary
 
 on:
-  workflow_run:
-    workflows: ["Build and Push Images"]
-    types: [completed]
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
   actions: read
 
-# Keep publish, smoke and promotion serialized. Superseded pending runs can be
-# coalesced by GitHub; a running candidate always finishes without cancellation.
+# Serialize manual publications so an older run cannot move canary backwards.
 concurrency:
-  group: ${{ github.event.workflow_run.event == 'push' && 'npm-canary' || format('npm-canary-ignored-{0}', github.run_id) }}
+  group: npm-canary
   cancel-in-progress: false
 
 env:
@@ -24,35 +20,34 @@ jobs:
     name: Attest main image and CI runs
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    # `types: [completed]` also fires for failure and cancellation, and
-    # `branches: [main]` admits a manual Build Images dispatch as readily as a
-    # push. Both would start this job and then hard-fail the API checks below,
-    # so screen them out here. The producer's conclusion and event are re-read
-    # from the API regardless: this is noise control, not the gate.
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push'
     outputs:
       sha: ${{ steps.producer.outputs.sha }}
     steps:
+      # Require main's workflow policy before checking out repository code.
+      - name: Require manual dispatch from main
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          [ "$WORKFLOW_REF" = refs/heads/main ] || { echo "::error::Run Publish Canary from main"; exit 1; }
+
       # Deliberately before any checkout: no repository code runs until the
-      # producing run is known to be a completed-success push to a commit
-      # that is still reachable from main.
+      # dispatched commit is known to have a completed-success push build and
+      # to still be reachable from main.
       - name: Attest the producing Build Images run
         id: producer
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EVENT_IMAGE_RUN_ID: ${{ github.event.workflow_run.id }}
+          DISPATCH_SHA: ${{ github.sha }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          image_run_id="$EVENT_IMAGE_RUN_ID"
-          [ -n "$image_run_id" ] || { echo "::error::image_run_id is required"; exit 1; }
-
           build_workflow_id=$(gh api "repos/${REPOSITORY}/actions/workflows/build-images.yml" --jq '.id')
+          image_run_id=$(gh api "repos/${REPOSITORY}/actions/workflows/build-images.yml/runs?head_sha=${DISPATCH_SHA}&event=push&branch=main&status=success&per_page=100" --jq '.workflow_runs[0].id // empty')
+          [ -n "$image_run_id" ] || { echo "::error::No successful main image build for this dispatch commit; retry after it passes"; exit 1; }
           build_run=$(gh api "repos/${REPOSITORY}/actions/runs/${image_run_id}")
           workflow_id=$(jq -r '.workflow_id' <<<"$build_run")
           sha=$(jq -r '.head_sha' <<<"$build_run")
+          [ "$sha" = "$DISPATCH_SHA" ] || { echo "::error::Image run does not match dispatch commit"; exit 1; }
           head_repo=$(jq -r '.head_repository.full_name // empty' <<<"$build_run")
           event=$(jq -r '.event' <<<"$build_run")
           branch=$(jq -r '.head_branch // empty' <<<"$build_run")
@@ -63,11 +58,11 @@ jobs:
           [ "$event" = push ] && [ "$branch" = main ] || { echo "::error::Build Images run must be a main push"; exit 1; }
           [ "$status" = completed ] && [ "$conclusion" = success ] || { echo "::error::Build Images run is not completed-success"; exit 1; }
 
-          # Reachability, not tip-ness. A release commit's own image build
-          # routinely finishes after later commits have landed; demanding the
-          # tip threw that run away and left the version unreleased with every
-          # run green. A commit still reachable from main got there through
-          # branch protection, which is the property the checkout below needs.
+          # Reachability, not tip-ness: main can move between this dispatch
+          # and the checkout below, and demanding the tip would throw away a
+          # run that is still perfectly good. A commit reachable from main got
+          # there through branch protection, which is the property the
+          # checkout below needs.
           current_sha=$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
           compare_status=$(gh api "repos/${REPOSITORY}/compare/${sha}...${current_sha}" --jq '.status')
           [ "$compare_status" = ahead ] || [ "$compare_status" = identical ] || { echo "::error::attested SHA ${sha} is not reachable from main (${compare_status})"; exit 1; }
@@ -130,14 +125,18 @@ jobs:
   publish:
     needs: attest
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     environment: production
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.attest.outputs.sha }}
+          fetch-depth: 0
       - uses: ./.github/actions/setup-submodule
         with:
           deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
@@ -158,10 +157,22 @@ jobs:
         run: |
           bun run build:packages
           bun run build:lobu
-      - name: Publish candidate without moving stable or canary
+      - name: Smoke the packed CLI before publication
+        run: |
+          node scripts/pack-cli-smoke.mjs "$RUNNER_TEMP/canary-smoke"
+          cd "$RUNNER_TEMP/canary-smoke"
+          node node_modules/@lobu/cli/bin/lobu.js --version
+          node node_modules/@lobu/cli/bin/lobu.js connector runtime-self-check --json
+      - name: Require forward-only canary publication
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: node scripts/publish-packages.mjs --skip-bump --skip-build --tag=canary-candidate
+          CANARY_VERSION: ${{ steps.version.outputs.version }}
+        run: node scripts/canary-publish.mjs check "$CANARY_VERSION"
+      # npm trusted publishing authenticates npm publish through OIDC.
+      # Separate dist-tag mutations do not support this authentication.
+      - name: Publish canary with npm trusted publishing
+        env:
+          NPM_CONFIG_PROVENANCE: "true"
+        run: node scripts/publish-packages.mjs --skip-bump --skip-build --tag=canary
 
   smoke:
     needs: publish
@@ -169,23 +180,3 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.publish.outputs.version }}
-
-  promote:
-    needs: [attest, publish, smoke]
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    environment: production
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.attest.outputs.sha }}
-          fetch-depth: 0
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-      - name: Advance canary after the exact artifact passes
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          CANARY_VERSION: ${{ needs.publish.outputs.version }}
-        run: node scripts/canary-publish.mjs promote "$CANARY_VERSION"

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,16 +1,11 @@
 name: Publish Canary
 
 on:
-  workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read
   actions: read
-
-# Serialize manual publications so an older run cannot move canary backwards.
-concurrency:
-  group: npm-canary
-  cancel-in-progress: false
 
 env:
   REQUIRED_IMAGE_JOBS: generate-tag connector-parity-smoke build-worker build-embeddings-service build-app app-image-smoke promote-images
@@ -23,12 +18,14 @@ jobs:
     outputs:
       sha: ${{ steps.producer.outputs.sha }}
     steps:
-      # Require main's workflow policy before checking out repository code.
-      - name: Require manual dispatch from main
+      # github.ref and github.sha are the CALLER's, so this pins the policy to
+      # the ref publish-packages.yml was dispatched from, before any repository
+      # code is checked out.
+      - name: Require a caller dispatched from main
         env:
           WORKFLOW_REF: ${{ github.ref }}
         run: |
-          [ "$WORKFLOW_REF" = refs/heads/main ] || { echo "::error::Run Publish Canary from main"; exit 1; }
+          [ "$WORKFLOW_REF" = refs/heads/main ] || { echo "::error::Run Publish Packages with channel=canary from main"; exit 1; }
 
       # Deliberately before any checkout: no repository code runs until the
       # dispatched commit is known to have a completed-success push build and

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -3,13 +3,23 @@ name: Publish Packages
 on:
   workflow_dispatch:
     inputs:
+      # Not `required: true`: build-images.yml's trigger-package-publish
+      # dispatches this workflow with only the two stable inputs, and a
+      # required input the dispatcher never sends is a 422 that strands the
+      # release off npm. The default carries the stable path instead.
+      channel:
+        description: "Publication channel (canary needs no release inputs)"
+        type: choice
+        options: [stable, canary]
+        default: stable
+        required: false
       release_tag:
-        description: "Exact published lobu-vSemVer release tag"
-        required: true
+        description: "Stable only: exact published lobu-vSemVer release tag"
+        required: false
         type: string
       image_run_id:
-        description: "Exact Build and Push Images release run"
-        required: true
+        description: "Stable only: exact Build and Push Images release run"
+        required: false
         type: string
       provenance:
         description: "Attach npm provenance"
@@ -25,7 +35,23 @@ env:
   REQUIRED_IMAGE_JOBS: generate-tag connector-parity-smoke build-worker build-embeddings-service build-app app-image-smoke promote-images
 
 jobs:
+  # npm validates the caller identity for reusable workflows. Keep canaries
+  # behind the existing publish-packages.yml trusted publisher.
+  canary:
+    if: inputs.channel == 'canary'
+    # Hold the lock across attestation, publication and the registry smoke.
+    concurrency:
+      group: npm-canary
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+    uses: ./.github/workflows/publish-canary.yml
+    secrets: inherit
+
   attest-publish:
+    if: inputs.channel == 'stable'
     name: Attest release, image, and CI provenance
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -49,9 +75,12 @@ jobs:
       - name: Verify current-main workflow policy
         env:
           WORKFLOW_REF: ${{ github.ref }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          IMAGE_RUN_ID: ${{ inputs.image_run_id }}
         run: |
           set -euo pipefail
           [ "$WORKFLOW_REF" = refs/heads/main ] || { echo "::error::publish policy must run from current main"; exit 1; }
+          [ -n "$RELEASE_TAG" ] && [ -n "$IMAGE_RUN_ID" ] || { echo "::error::Stable publication requires release_tag and image_run_id"; exit 1; }
 
       - name: Check out current main
         uses: actions/checkout@v7

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -22,7 +22,7 @@ on:
         required: false
         type: string
       provenance:
-        description: "Attach npm provenance"
+        description: "Stable only: attach npm provenance"
         required: false
         default: false
         type: boolean

--- a/.github/workflows/published-artifact-smoke.yml
+++ b/.github/workflows/published-artifact-smoke.yml
@@ -15,9 +15,12 @@ name: Published-artifact smoke
 # scripts/sdk-e2e/, so no secret is required and the run is reproducible.
 
 on:
-  # Called by publish-packages.yml after npm accepts the new version. Keeping
-  # this in the same workflow makes the four-environment artifact matrix a
-  # required part of the publication run instead of a best-effort follow-up.
+  # Called by publish-packages.yml and publish-canary.yml after npm accepts the
+  # new version. Keeping this in the same workflow makes the four-environment
+  # artifact matrix a required part of the publication run instead of a
+  # best-effort follow-up. It does not gate the canary dist-tag: `npm publish
+  # --tag canary` moves that tag at publication because a separate
+  # `npm dist-tag add` cannot authenticate through OIDC.
   workflow_call:
     inputs:
       version:

--- a/README.md
+++ b/README.md
@@ -63,9 +63,12 @@ The same MCP endpoint works with **Claude Code, Codex, OpenCode, Antigravity, Ch
 Setup guides: [Claude](https://lobu.ai/connect-from/claude/) · [ChatGPT](https://lobu.ai/connect-from/chatgpt/) · [Codex](https://lobu.ai/connect-from/codex/) · [Grok](https://lobu.ai/connect-from/grok/)
 
 To test changes merged to `main`, run `bunx @lobu/cli@canary --help`. The
-`canary` tag advances after CI, image checks, and installation smoke tests in
-four Linux environments pass. Use `@latest` for stable releases. Canary versions
-include the full commit SHA so you can pin a preview when reproducing a bug.
+`canary` tag moves only when a maintainer runs **Publish Canary** from `main`
+in GitHub Actions; that run requires the commit's CI and image checks and
+smokes the packed CLI before publishing. The published version is then
+exercised in four Linux environments, so check the run's result before
+depending on it. Use `@latest` for stable releases. Canary versions include the
+full commit SHA so you can pin a preview when reproducing a bug.
 
 ### Recall what the company knows
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ The same MCP endpoint works with **Claude Code, Codex, OpenCode, Antigravity, Ch
 Setup guides: [Claude](https://lobu.ai/connect-from/claude/) · [ChatGPT](https://lobu.ai/connect-from/chatgpt/) · [Codex](https://lobu.ai/connect-from/codex/) · [Grok](https://lobu.ai/connect-from/grok/)
 
 To test changes merged to `main`, run `bunx @lobu/cli@canary --help`. The
-`canary` tag moves only when a maintainer runs **Publish Canary** from `main`
-in GitHub Actions; that run requires the commit's CI and image checks and
-smokes the packed CLI before publishing. The published version is then
-exercised in four Linux environments, so check the run's result before
+`canary` tag moves only when a maintainer runs **Publish Packages** from `main`
+in GitHub Actions with channel `canary`; that run requires the commit's CI and
+image checks and smokes the packed CLI before publishing. The published version
+is then exercised in four Linux environments, so check the run's result before
 depending on it. Use `@latest` for stable releases. Canary versions include the
 full commit SHA so you can pin a preview when reproducing a bug.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-The published packages ship as a synchronized release: `@lobu/core`, `@lobu/cli`, `@lobu/connector-sdk`, `@lobu/connector-worker`, `@lobu/worker`, `@lobu/embeddings`, `@lobu/client`, and `@lobu/promptfoo-provider`. (The previously published `lobu` unscoped package was retired when its commands moved into `@lobu/cli` as the `lobu memory` namespace.) [release-please](https://github.com/googleapis/release-please) reads conventional commits on `main` and drives versioning. Stable publication (`publish-packages.yml`) supports npm OIDC trusted publishing with `NPM_TOKEN` as a fallback; manual canary publication (`publish-canary.yml`) uses OIDC only. Each has its own trusted-publisher entry — see [Canary publication](#canary-publication).
+The published packages ship as a synchronized release: `@lobu/core`, `@lobu/cli`, `@lobu/connector-sdk`, `@lobu/connector-worker`, `@lobu/embeddings`, `@lobu/client`, and `@lobu/promptfoo-provider`. (The previously published `lobu` unscoped package was retired when its commands moved into `@lobu/cli` as the `lobu memory` namespace.) [release-please](https://github.com/googleapis/release-please) reads conventional commits on `main` and drives versioning. Both channels are dispatched from `publish-packages.yml`. Stable publication supports npm OIDC trusted publishing with `NPM_TOKEN` as a fallback; the canary channel calls the reusable `publish-canary.yml` and uses OIDC only. One trusted-publisher entry per package covers both — see [Canary publication](#canary-publication).
 
 ## Flow
 
@@ -14,21 +14,23 @@ Every provenance decision in that chain is one subcommand of `scripts/release-pr
 
 To force a specific version, land a commit on `main` whose body contains `Release-As: 7.2.0`; release-please then opens or updates the release PR for that version.
 
-Only stable `X.Y.Z` versions can be released. The attestation chain rejects anything else — `parseStableVersion` in `scripts/release-provenance.mjs` throws, so a prerelease `Release-As:` fails the release step with `invalid stable Lobu version` rather than shipping. Release a prerelease by publishing from a branch by hand instead.
+Only stable `X.Y.Z` versions can be released. The attestation chain rejects anything else — `parseStableVersion` in `scripts/release-provenance.mjs` throws, so a prerelease `Release-As:` fails the release step with `invalid stable Lobu version` rather than shipping. Use the manual canary channel below for a prerelease.
 
 ## Canary publication
 
-No canary is published automatically. A maintainer dispatches `publish-canary.yml` from `main`, and the run attests the dispatched commit before any repository code executes — a completed-success `build-images` push run for that exact SHA, every required image job green, an exact successful `ci.yml` run, and the SHA still reachable from `main` — then packs the candidate with `scripts/pack-cli-smoke.mjs` and drives the installed CLI before anything reaches the registry. `node scripts/canary-publish.mjs check <version>` then rejects a candidate that is not a descendant of the commit a package's current `canary` tag names, so a late dispatch cannot move `canary` backwards.
+No canary is published automatically. A maintainer dispatches **Publish Packages** (`publish-packages.yml`) from `main` with channel `canary` and leaves the stable-only inputs empty. That workflow calls `publish-canary.yml`, and the run attests the dispatched commit before any repository code executes — a completed-success `build-images` push run for that exact SHA, every required image job green, an exact successful `ci.yml` run, and the SHA still reachable from `main` — then packs the candidate with `scripts/pack-cli-smoke.mjs` and drives the installed CLI before anything reaches the registry. `node scripts/canary-publish.mjs check <version>` then rejects a candidate that is not a descendant of the commit a package's current `canary` tag names, so a late dispatch cannot move `canary` backwards.
 
 Publication itself is `npm publish --tag canary`: the tag moves as part of the publish because a separate `npm dist-tag add` cannot authenticate through OIDC. The four-environment `published-artifact-smoke` run is therefore a post-publication check, not a gate — a canary that fails it is already on the registry and needs `npm deprecate` plus a newer canary.
 
-Each published package needs a trusted publisher on npmjs.com naming repository `lobu-ai/lobu`, workflow file `publish-canary.yml`, environment `production`, with publishing allowed:
+The entry point stays the already trusted `publish-packages.yml`. npm's [trusted-publisher troubleshooting](https://docs.npmjs.com/trusted-publishers/) notes that with `workflow_call` the check may match the parent workflow rather than the file running `npm publish`, and asks for `id-token: write` at both levels — which the `canary` caller job and the reusable `publish` job both grant. So each package keeps its existing `lobu-ai/lobu` / `publish-packages.yml` / `production` trusted publisher with direct publishing allowed, and no second entry is needed. The canary publish step sets no `NODE_AUTH_TOKEN`, so npm authenticates through OIDC alone. Trusted publishing needs npm ≥ 11.5.1, supplied by `node-version: 24`.
+
+Dispatch a canary from the CLI with:
 
 ```bash
-npm trust github @lobu/<pkg> --repo lobu-ai/lobu --file publish-canary.yml --env production --allow-publish
+gh workflow run publish-packages.yml --repo lobu-ai/lobu --ref main -f channel=canary
 ```
 
-Add this connection alongside the existing stable publisher; do not replace it. [npm supports up to 10 trusted publishers per package](https://docs.npmjs.com/trusted-publishers/#managing-trusted-publisher-configurations), so both workflows can use OIDC. Trusted publishing needs npm ≥ 11.5.1, which the workflow gets from `node-version: 24`.
+Stable release dispatches keep the default `stable` channel and their existing release-tag and image-run attestation, which the canary channel skips.
 
 ## Commit prefixes → version bump
 
@@ -56,7 +58,7 @@ BREAKING CHANGE: RuntimeProviderCredentialResolver now returns
    ```
    (`extra-files[]` is also where the synchronized version is propagated to `charts/lobu/Chart.yaml` — both `$.version` and `$.appVersion` are bumped there on every release.)
 2. `scripts/publish-packages.mjs` — add to the `PACKAGES` array (use `transform: rewriteWorkspaceRefs` if it has `workspace:*` deps), keeping dependencies ahead of their dependents and `@lobu/cli` last.
-3. Bootstrap it on npm and register its canary trusted publisher before the next canary dispatch. Until the package exists, `canary-publish.mjs check` cannot read its dist-tags and the whole canary run fails closed.
+3. Bootstrap it on npm and register the shared `publish-packages.yml` trusted publisher before the next canary dispatch. Until the package exists, `canary-publish.mjs check` cannot read its dist-tags and the whole canary run fails closed.
 
 ## Recovery
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-The published packages ship as a synchronized release: `@lobu/core`, `@lobu/cli`, `@lobu/connector-sdk`, `@lobu/connector-worker`, `@lobu/worker`, `@lobu/embeddings`, `@lobu/client`, and `@lobu/promptfoo-provider`. (The previously published `lobu` unscoped package was retired when its commands moved into `@lobu/cli` as the `lobu memory` namespace.) [release-please](https://github.com/googleapis/release-please) reads conventional commits on `main` and drives versioning. Automated publishing prefers npm OIDC trusted publishing and keeps `NPM_TOKEN` only as a fallback for packages that are not registered as trusted publishers yet.
+The published packages ship as a synchronized release: `@lobu/core`, `@lobu/cli`, `@lobu/connector-sdk`, `@lobu/connector-worker`, `@lobu/worker`, `@lobu/embeddings`, `@lobu/client`, and `@lobu/promptfoo-provider`. (The previously published `lobu` unscoped package was retired when its commands moved into `@lobu/cli` as the `lobu memory` namespace.) [release-please](https://github.com/googleapis/release-please) reads conventional commits on `main` and drives versioning. Stable publication (`publish-packages.yml`) supports npm OIDC trusted publishing with `NPM_TOKEN` as a fallback; manual canary publication (`publish-canary.yml`) uses OIDC only. Each has its own trusted-publisher entry — see [Canary publication](#canary-publication).
 
 ## Flow
 
@@ -15,6 +15,20 @@ Every provenance decision in that chain is one subcommand of `scripts/release-pr
 To force a specific version, land a commit on `main` whose body contains `Release-As: 7.2.0`; release-please then opens or updates the release PR for that version.
 
 Only stable `X.Y.Z` versions can be released. The attestation chain rejects anything else — `parseStableVersion` in `scripts/release-provenance.mjs` throws, so a prerelease `Release-As:` fails the release step with `invalid stable Lobu version` rather than shipping. Release a prerelease by publishing from a branch by hand instead.
+
+## Canary publication
+
+No canary is published automatically. A maintainer dispatches `publish-canary.yml` from `main`, and the run attests the dispatched commit before any repository code executes — a completed-success `build-images` push run for that exact SHA, every required image job green, an exact successful `ci.yml` run, and the SHA still reachable from `main` — then packs the candidate with `scripts/pack-cli-smoke.mjs` and drives the installed CLI before anything reaches the registry. `node scripts/canary-publish.mjs check <version>` then rejects a candidate that is not a descendant of the commit a package's current `canary` tag names, so a late dispatch cannot move `canary` backwards.
+
+Publication itself is `npm publish --tag canary`: the tag moves as part of the publish because a separate `npm dist-tag add` cannot authenticate through OIDC. The four-environment `published-artifact-smoke` run is therefore a post-publication check, not a gate — a canary that fails it is already on the registry and needs `npm deprecate` plus a newer canary.
+
+Each published package needs a trusted publisher on npmjs.com naming repository `lobu-ai/lobu`, workflow file `publish-canary.yml`, environment `production`, with publishing allowed:
+
+```bash
+npm trust github @lobu/<pkg> --repo lobu-ai/lobu --file publish-canary.yml --env production --allow-publish
+```
+
+Add this connection alongside the existing stable publisher; do not replace it. [npm supports up to 10 trusted publishers per package](https://docs.npmjs.com/trusted-publishers/#managing-trusted-publisher-configurations), so both workflows can use OIDC. Trusted publishing needs npm ≥ 11.5.1, which the workflow gets from `node-version: 24`.
 
 ## Commit prefixes → version bump
 
@@ -41,7 +55,8 @@ BREAKING CHANGE: RuntimeProviderCredentialResolver now returns
    { "type": "json", "path": "packages/<new-pkg>/package.json", "jsonpath": "$.version" }
    ```
    (`extra-files[]` is also where the synchronized version is propagated to `charts/lobu/Chart.yaml` — both `$.version` and `$.appVersion` are bumped there on every release.)
-2. `scripts/publish-packages.mjs` — add to the `PACKAGES` array (use `transform: rewriteWorkspaceRefs` if it has `workspace:*` deps).
+2. `scripts/publish-packages.mjs` — add to the `PACKAGES` array (use `transform: rewriteWorkspaceRefs` if it has `workspace:*` deps), keeping dependencies ahead of their dependents and `@lobu/cli` last.
+3. Bootstrap it on npm and register its canary trusted publisher before the next canary dispatch. Until the package exists, `canary-publish.mjs check` cannot read its dist-tags and the whole canary run fails closed.
 
 ## Recovery
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -76,7 +76,7 @@ BREAKING CHANGE: RuntimeProviderCredentialResolver now returns
   The workflow must be dispatched from `main` so it runs main's policy; the release tag is data, not the ref.
 - **`release-please.yml` skipped a push because `main` moved** — the attestation binds to one commit, so a merge landing mid-attestation aborts that run rather than releasing a commit it did not verify. The next push re-attests from scratch; nothing needs unsticking. To release without waiting, dispatch it manually from `main` with the exact producing run: `gh workflow run release-please.yml --ref main -f image_run_id=<build-images run id>`.
 
-`publish-packages.mjs` is idempotent (skips already-published packages), so re-running is safe.
+`publish-packages.mjs` skips already-published packages. A canary retry verifies that each skipped package already has the matching `canary` tag, which was set by its successful publish. If that tag is missing, different, or unreadable, the retry stops; retry after registry propagation, or publish from a newer main commit if the mismatch persists. OIDC cannot repair a tag separately.
 
 **Helm publish says the chart package is private** — GitHub does not expose a package-visibility update API. A package administrator must open the `charts/lobu` package settings once and change its visibility to **Public**. Organization owners have admin permission to organization packages. Re-run the failed Helm workflow afterward. The workflow verifies the live package visibility and fails closed; it never treats a private chart as a successful public release.
 
@@ -102,7 +102,7 @@ After a local publish, land a `chore(main): release lobu <version>` commit on `m
 ## Verify
 
 ```bash
-for pkg in @lobu/core @lobu/cli @lobu/connector-sdk @lobu/connector-worker @lobu/worker @lobu/embeddings @lobu/client @lobu/promptfoo-provider; do
+for pkg in @lobu/core @lobu/cli @lobu/connector-sdk @lobu/connector-worker @lobu/embeddings @lobu/client @lobu/promptfoo-provider; do
   npm view "$pkg" version
 done
 ```

--- a/scripts/__tests__/canary-publish.test.ts
+++ b/scripts/__tests__/canary-publish.test.ts
@@ -83,14 +83,14 @@ describe("npm canary publication", () => {
     expect(() => publicationAllowed("19.2.0", version, () => true)).toThrow();
   });
 
-  it("requires a manual dispatch, OIDC and packed artifact smoke before publishing", () => {
+  it("requires a main-only caller, OIDC and packed artifact smoke before publishing", () => {
     const workflow = Bun.YAML.parse(
       readFileSync(
         new URL("../../.github/workflows/publish-canary.yml", import.meta.url),
         "utf8"
       )
     ) as any;
-    expect(Object.keys(workflow.on)).toEqual(["workflow_dispatch"]);
+    expect(Object.keys(workflow.on)).toEqual(["workflow_call"]);
     expect(workflow.jobs.promote).toBeUndefined();
     expect(workflow.jobs.publish.permissions["id-token"]).toBe("write");
     const steps = workflow.jobs.publish.steps;
@@ -111,7 +111,6 @@ describe("npm canary publication", () => {
     expect(workflow.jobs.smoke.with.version).toBe(
       "${{ needs.publish.outputs.version }}"
     );
-    expect(workflow.concurrency["cancel-in-progress"]).toBe(false);
     // The required image-job list is copied from publish-packages.yml, whose
     // own test pins it to build-images.yml; keep the copy from drifting.
     const stable = Bun.YAML.parse(
@@ -123,6 +122,18 @@ describe("npm canary publication", () => {
         "utf8"
       )
     ) as any;
+    expect(Object.keys(stable.on)).toEqual(["workflow_dispatch"]);
+    expect(stable.on.workflow_dispatch.inputs.channel.default).toBe("stable");
+    expect(stable.jobs.canary.if).toBe("inputs.channel == 'canary'");
+    expect(stable.jobs.canary.uses).toBe(
+      "./.github/workflows/publish-canary.yml"
+    );
+    expect(stable.jobs.canary.permissions["id-token"]).toBe("write");
+    expect(stable.jobs.canary.concurrency).toEqual({
+      group: "npm-canary",
+      "cancel-in-progress": false,
+    });
+    expect(stable.jobs["attest-publish"].if).toBe("inputs.channel == 'stable'");
     expect(workflow.env.REQUIRED_IMAGE_JOBS).toBe(
       stable.env.REQUIRED_IMAGE_JOBS
     );

--- a/scripts/__tests__/canary-publish.test.ts
+++ b/scripts/__tests__/canary-publish.test.ts
@@ -14,7 +14,7 @@ import { join } from "node:path";
 import {
   canaryVersion,
   prepareManifests,
-  promotionAllowed,
+  publicationAllowed,
 } from "../canary-publish.mjs";
 import { __testing } from "../publish-packages.mjs";
 
@@ -52,46 +52,59 @@ describe("npm canary publication", () => {
   });
 
   it("keeps prereleases away from latest even on a mistyped invocation", () => {
-    expect(
-      __testing.publishArgs(undefined, "canary-candidate", version)
-    ).toContain("canary-candidate");
+    expect(__testing.publishArgs(undefined, "canary", version)).toContain(
+      "canary"
+    );
     expect(() => __testing.publishArgs(undefined, "latest", version)).toThrow();
-    expect(() => __testing.publishArgs(undefined, "canary", version)).toThrow();
+    expect(() =>
+      __testing.publishArgs(undefined, "canary-candidate", version)
+    ).toThrow();
     expect(__testing.publishArgs(undefined, "latest", "19.2.0")).toContain(
       "latest"
     );
   });
 
-  it("only promotes first, same, or descendant commits", () => {
+  it("only publishes first, same, or descendant commits", () => {
     expect(
-      promotionAllowed(undefined, version, () => {
+      publicationAllowed(undefined, version, () => {
         throw new Error("unexpected");
       })
     ).toBe(true);
-    expect(promotionAllowed(version, version, () => false)).toBe(true);
+    expect(publicationAllowed(version, version, () => false)).toBe(true);
     const old = `19.2.0-canary.122.g${"b".repeat(40)}`;
     expect(
-      promotionAllowed(
+      publicationAllowed(
         old,
         version,
         (from, to) => from === "b".repeat(40) && to === sha
       )
     ).toBe(true);
-    expect(promotionAllowed(old, version, () => false)).toBe(false);
-    expect(() => promotionAllowed("19.2.0", version, () => true)).toThrow();
+    expect(publicationAllowed(old, version, () => false)).toBe(false);
+    expect(() => publicationAllowed("19.2.0", version, () => true)).toThrow();
   });
 
-  it("requires artifact smoke before advancing the opt-in tag", () => {
+  it("requires a manual dispatch, OIDC and packed artifact smoke before publishing", () => {
     const workflow = Bun.YAML.parse(
       readFileSync(
         new URL("../../.github/workflows/publish-canary.yml", import.meta.url),
         "utf8"
       )
     ) as any;
-    expect(workflow.on.workflow_run.workflows).toEqual([
-      "Build and Push Images",
-    ]);
-    expect(workflow.jobs.promote.needs).toContain("smoke");
+    expect(Object.keys(workflow.on)).toEqual(["workflow_dispatch"]);
+    expect(workflow.jobs.promote).toBeUndefined();
+    expect(workflow.jobs.publish.permissions["id-token"]).toBe("write");
+    const steps = workflow.jobs.publish.steps;
+    const publishIndex = steps.findIndex((step: any) =>
+      step.run?.includes("--tag=canary")
+    );
+    const packIndex = steps.findIndex((step: any) =>
+      step.run?.includes("pack-cli-smoke.mjs")
+    );
+    expect(packIndex).toBeGreaterThan(-1);
+    expect(publishIndex).toBeGreaterThan(packIndex);
+    expect(JSON.stringify(workflow)).not.toContain("NPM_TOKEN");
+    expect(JSON.stringify(workflow)).not.toContain("NODE_AUTH_TOKEN");
+    expect(JSON.stringify(workflow)).not.toContain("canary-candidate");
     expect(workflow.jobs.smoke.uses).toBe(
       "./.github/workflows/published-artifact-smoke.yml"
     );
@@ -119,7 +132,7 @@ describe("npm canary publication", () => {
 // Run the actual command entry points in an isolated filesystem with a fake
 // registry. No network or publication credentials are used by these probes.
 describe("canary commands", () => {
-  it("prepares the full fleet, retries promotion and preserves latest", () => {
+  it("prepares the full fleet and performs read-only publication preflight", () => {
     withFixture((root, run, registry) => {
       const prepared = run("prepare");
       expect(prepared.status).toBe(0);
@@ -131,19 +144,28 @@ describe("canary commands", () => {
         ).toBe(version);
       }
       for (let attempt = 0; attempt < 2; attempt++)
-        expect(run("promote", version).status).toBe(0);
+        expect(run("check", version).status).toBe(0);
       for (const tags of Object.values(registry()) as any[]) {
-        expect(tags).toEqual({ latest: "19.2.0", canary: version });
+        expect(tags).toEqual({ latest: "19.2.0" });
       }
     });
   });
 
-  it("fails closed on registry failure or a missing package before moving tags", () => {
-    for (const fault of ["registry", "missing"]) {
-      withFixture((_root, run, registry) => {
-        expect(run("promote", version, fault).status).not.toBe(0);
-        for (const tags of Object.values(registry()) as any[])
-          expect(tags.canary).toBeUndefined();
+  it("stops canary publication at the first npm failure and keeps CLI last", () => {
+    expect(__testing.PACKAGES.at(-1)?.dir).toBe("packages/cli");
+    withFixture((root, run) => {
+      expect(run("prepare").status).toBe(0);
+      expect(run("publish", undefined, "blocked").status).not.toBe(0);
+      expect(readFileSync(`${root}/publish.log`, "utf8").trim()).toBe(
+        "@lobu/core"
+      );
+    });
+  });
+
+  it("fails closed on registry failure or an older candidate", () => {
+    for (const fault of ["registry", "older"]) {
+      withFixture((_root, run) => {
+        expect(run("check", version, fault).status).not.toBe(0);
       });
     }
   });
@@ -195,7 +217,8 @@ function withFixture(
       `${root}/bin/git`,
       `#!/usr/bin/env node
 const args = process.argv.slice(2);
-if (args[0] === 'rev-parse') console.log('${sha}');
+if (args[0] === 'merge-base' && process.env.CANARY_TEST_FAULT === 'older' && args[2] !== '${sha}') process.exit(1);
+else if (args[0] === 'rev-parse') console.log('${sha}');
 else if (args[0] === 'show') console.log('123');
 else if (!['fetch', 'merge-base'].includes(args[0])) process.exit(2);
 `
@@ -205,16 +228,14 @@ else if (!['fetch', 'merge-base'].includes(args[0])) process.exit(2);
       `#!/usr/bin/env node
 const fs = require('node:fs');
 const args = process.argv.slice(2);
-const tags = JSON.parse(fs.readFileSync('registry.json', 'utf8'));
+const tags = JSON.parse(fs.readFileSync('${root}/registry.json', 'utf8'));
 if (process.env.CANARY_TEST_FAULT === 'registry') process.exit(1);
-if (args[0] === 'view' && args[2] === 'dist-tags') console.log(JSON.stringify(tags[args[1]]));
-else if (args[0] === 'view' && args[2] === 'version') {
-  if (process.env.CANARY_TEST_FAULT === 'missing' && args[1].startsWith('@lobu/core@')) process.exit(1);
-  console.log(args[1].slice(args[1].lastIndexOf('@') + 1));
-} else if (args[0] === 'dist-tag' && args[1] === 'add') {
-  const at = args[2].lastIndexOf('@');
-  tags[args[2].slice(0, at)][args[3]] = args[2].slice(at + 1);
-  fs.writeFileSync('registry.json', JSON.stringify(tags));
+if (args[0] === 'view' && args[2] === 'dist-tags') console.log(JSON.stringify(process.env.CANARY_TEST_FAULT === 'older' ? { canary: '19.2.0-canary.124.g${"b".repeat(40)}' } : tags[args[1]]));
+else if (args[0] === 'view' && args[2] === 'version') process.exit(1);
+else if (args[0] === 'publish') {
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  fs.appendFileSync('${root}/publish.log', pkg.name + '\\n');
+  if (process.env.CANARY_TEST_FAULT === 'blocked') { console.error('E404 Not Found - PUT'); process.exit(1); }
 } else process.exit(2);
 `
     );
@@ -224,7 +245,14 @@ else if (args[0] === 'view' && args[2] === 'version') {
       (op, value, fault) =>
         spawnSync(
           "node",
-          ["scripts/canary-publish.mjs", op, ...(value ? [value] : [])],
+          op === "publish"
+            ? [
+                "scripts/publish-packages.mjs",
+                "--skip-bump",
+                "--skip-build",
+                "--tag=canary",
+              ]
+            : ["scripts/canary-publish.mjs", op, ...(value ? [value] : [])],
           {
             cwd: root,
             encoding: "utf8",

--- a/scripts/__tests__/canary-publish.test.ts
+++ b/scripts/__tests__/canary-publish.test.ts
@@ -173,6 +173,40 @@ describe("canary commands", () => {
     });
   });
 
+  it("retries a partial publish without republishing packages or changing latest", () => {
+    withFixture((root, run, registry) => {
+      expect(run("prepare").status).toBe(0);
+      expect(run("publish", undefined, "partial").status).not.toBe(0);
+      expect(registry()["@lobu/core"]).toEqual({
+        latest: "19.2.0",
+        canary: version,
+      });
+      expect(registry()["@lobu/cli"]).toEqual({ latest: "19.2.0" });
+      const retry = run("publish");
+      expect(retry.status, retry.stderr?.toString()).toBe(0);
+      for (const tags of Object.values(registry()))
+        expect(tags).toEqual({ latest: "19.2.0", canary: version });
+      const calls = readFileSync(`${root}/publish.log`, "utf8")
+        .trim()
+        .split("\n");
+      expect(calls.filter((name) => name === "@lobu/core")).toHaveLength(1);
+      expect(calls.at(-1)).toBe("@lobu/cli");
+    });
+  });
+
+  it("rejects an existing canary version whose tag is missing or unreadable", () => {
+    for (const fault of ["untagged", "tag-read"]) {
+      withFixture((_root, run) => {
+        expect(run("prepare").status).toBe(0);
+        const result = run("publish", undefined, fault);
+        expect(result.status).not.toBe(0);
+        expect(result.stderr?.toString()).toContain(
+          "canary tag does not match"
+        );
+      });
+    }
+  });
+
   it("fails closed on registry failure or an older candidate", () => {
     for (const fault of ["registry", "older"]) {
       withFixture((_root, run) => {
@@ -216,6 +250,11 @@ function withFixture(
           "utf8"
         )
       );
+      // The fixture materializes only the published packages, so a
+      // `workspace:*` devDependency on a private sibling has nothing to
+      // resolve against. Consumers never install devDependencies, so dropping
+      // them keeps the probe on the graph publication actually ships.
+      delete pkg.devDependencies;
       writeFileSync(`${root}/${dir}/package.json`, JSON.stringify(pkg));
       tags[pkg.name] = { latest: "19.2.0" };
     }
@@ -224,6 +263,7 @@ function withFixture(
       JSON.stringify({ version: "19.2.0" })
     );
     writeFileSync(`${root}/registry.json`, JSON.stringify(tags));
+    writeFileSync(`${root}/published.json`, "{}");
     writeFileSync(
       `${root}/bin/git`,
       `#!/usr/bin/env node
@@ -240,13 +280,27 @@ else if (!['fetch', 'merge-base'].includes(args[0])) process.exit(2);
 const fs = require('node:fs');
 const args = process.argv.slice(2);
 const tags = JSON.parse(fs.readFileSync('${root}/registry.json', 'utf8'));
-if (process.env.CANARY_TEST_FAULT === 'registry') process.exit(1);
-if (args[0] === 'view' && args[2] === 'dist-tags') console.log(JSON.stringify(process.env.CANARY_TEST_FAULT === 'older' ? { canary: '19.2.0-canary.124.g${"b".repeat(40)}' } : tags[args[1]]));
-else if (args[0] === 'view' && args[2] === 'version') process.exit(1);
+const published = JSON.parse(fs.readFileSync('${root}/published.json', 'utf8'));
+const fault = process.env.CANARY_TEST_FAULT;
+if (fault === 'registry') process.exit(1);
+if (args[0] === 'view' && args[2] === 'dist-tags') console.log(JSON.stringify(fault === 'older' ? { canary: '19.2.0-canary.124.g${"b".repeat(40)}' } : tags[args[1]]));
+else if (args[0] === 'view' && args[2] === 'version') {
+  const at = args[1].lastIndexOf('@');
+  const name = args[1].slice(0, at), requested = args[1].slice(at + 1);
+  if (published[name] === requested || (['untagged', 'tag-read'].includes(fault) && name === '@lobu/core')) console.log(requested);
+  else process.exit(1);
+} else if (args[0] === 'view' && args[2] === 'dist-tags.canary') {
+  if (fault === 'tag-read') process.exit(1);
+  if (tags[args[1]].canary) console.log(tags[args[1]].canary);
+}
 else if (args[0] === 'publish') {
   const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
   fs.appendFileSync('${root}/publish.log', pkg.name + '\\n');
-  if (process.env.CANARY_TEST_FAULT === 'blocked') { console.error('E404 Not Found - PUT'); process.exit(1); }
+  if (fault === 'blocked' || (fault === 'partial' && pkg.name === '@lobu/client')) { console.error('E404 Not Found - PUT'); process.exit(1); }
+  published[pkg.name] = pkg.version;
+  tags[pkg.name][args[args.indexOf('--tag') + 1]] = pkg.version;
+  fs.writeFileSync('${root}/published.json', JSON.stringify(published));
+  fs.writeFileSync('${root}/registry.json', JSON.stringify(tags));
 } else process.exit(2);
 `
     );

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -565,8 +565,35 @@ describe("publishing requires an attested release", () => {
         inputs: Record<string, { required?: boolean }>;
       }
     ).inputs;
-    expect(inputs.release_tag.required).toBe(true);
-    expect(inputs.image_run_id.required).toBe(true);
+    // Canary dispatches leave these empty; the stable job requires both
+    // before checkout or any release API calls.
+    expect(inputs.release_tag.required).toBe(false);
+    expect(inputs.image_run_id.required).toBe(false);
+    const gate = steps("publish-packages.yml", "attest-publish")[0].run!;
+    for (const [tag, run, status] of [
+      ["", "", 1],
+      ["lobu-v1.2.3", "", 1],
+      ["", "123", 1],
+      ["lobu-v1.2.3", "123", 0],
+    ] as const) {
+      const result = spawnSync("bash", ["-c", gate], {
+        env: {
+          ...process.env,
+          WORKFLOW_REF: "refs/heads/main",
+          RELEASE_TAG: tag,
+          IMAGE_RUN_ID: run,
+        },
+        encoding: "utf8",
+      });
+      expect(result.status, result.stderr).toBe(status);
+    }
+    // build-images.yml dispatches this workflow with only release_tag and
+    // image_run_id, so any input it omits must stay optional or the dispatch
+    // is rejected outright and the release never reaches npm.
+    const dispatched = shell("build-images.yml", "trigger-package-publish");
+    for (const [name, spec] of Object.entries(inputs))
+      if (!dispatched.includes(`-f ${name}=`))
+        expect(spec.required).toBe(false);
     expect(Object.keys(inputs)).not.toContain("bump");
   });
 

--- a/scripts/canary-publish.mjs
+++ b/scripts/canary-publish.mjs
@@ -37,7 +37,7 @@ export function prepareManifests(manifests, version) {
   });
 }
 
-export function promotionAllowed(current, candidate, isAncestor) {
+export function publicationAllowed(current, candidate, isAncestor) {
   const sha = CANARY.exec(candidate)?.[1];
   if (!sha) throw new Error("Invalid candidate version");
   if (current === undefined || current === candidate) return true;
@@ -72,9 +72,9 @@ function main() {
     console.log(candidate);
     return;
   }
-  if (operation !== "promote" || !CANARY.test(version ?? "")) {
+  if (operation !== "check" || !CANARY.test(version ?? "")) {
     throw new Error(
-      "Usage: canary-publish.mjs prepare | promote <exact-version>"
+      "Usage: canary-publish.mjs prepare | check <exact-version>"
     );
   }
   const sha = CANARY.exec(version)[1];
@@ -88,34 +88,22 @@ function main() {
   };
   command("git", ["fetch", "origin", "main"]);
   if (!isAncestor(sha, "origin/main")) throw new Error("Candidate left main");
-  // Validate the entire fleet before changing any tag. npm has no atomic
-  // multi-package tag update; exact internal versions keep installs coherent.
-  // CLI is last so its opt-in entry point advances only after its dependencies.
-  const names = manifests
-    .map((pkg) => pkg.name)
-    .sort((a, b) =>
-      a === "@lobu/cli" ? 1 : b === "@lobu/cli" ? -1 : a.localeCompare(b)
-    );
+  // Validate every current tag before npm publish can advance any of them.
+  // This check is read-only: OIDC supports publication, not dist-tag updates.
+  const names = manifests.map((pkg) => pkg.name);
   for (const name of names) {
     const tags = JSON.parse(
       command("npm", ["view", name, "dist-tags", "--json"])
     );
     if (!tags || typeof tags !== "object" || Array.isArray(tags))
       throw new Error("Invalid registry tags");
-    if (!promotionAllowed(tags.canary, version, isAncestor)) {
-      console.log(
-        `Skipping older candidate ${version}; ${name} already has ${tags.canary}`
+    if (!publicationAllowed(tags.canary, version, isAncestor)) {
+      throw new Error(
+        `${name} canary ${tags.canary} is not an ancestor of ${version}`
       );
-      return;
     }
-    const published = command("npm", ["view", `${name}@${version}`, "version"]);
-    if (published !== version)
-      throw new Error(`Missing candidate ${name}@${version}`);
   }
-  for (const name of names) {
-    command("npm", ["dist-tag", "add", `${name}@${version}`, "canary"]);
-  }
-  console.log(`Promoted ${version}: bunx @lobu/cli@canary --help`);
+  console.log(`Canary publication allowed: ${version}`);
 }
 
 if (

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -50,8 +50,9 @@ const PACKAGES = [
   // blocked-dependency skip below relies on a dependency always being attempted
   // before its dependents. A guard test asserts this ordering holds.
   { dir: "packages/connector-worker", transform: rewriteWorkspaceRefs },
-  { dir: "packages/cli", transform: rewriteWorkspaceRefs },
   { dir: "packages/promptfoo-provider", transform: rewriteWorkspaceRefs },
+  // Advance the CLI entry point only after every sibling package succeeds.
+  { dir: "packages/cli", transform: rewriteWorkspaceRefs },
 ];
 
 // Published package names that don't use the @lobu/ scope. The unscoped
@@ -378,14 +379,12 @@ function isVersionPublished(name, version) {
 }
 
 function publishArgs(otp, tag, version) {
-  if (tag !== "latest" && tag !== "canary-candidate") {
-    throw new Error(
-      "Publish only to latest or canary-candidate; promotion owns canary"
-    );
+  if (tag !== "latest" && tag !== "canary") {
+    throw new Error("Publish only to latest or canary");
   }
   if (
     (tag === "latest" && version.includes("-")) ||
-    (tag === "canary-candidate" && !version.includes("-canary."))
+    (tag === "canary" && !version.includes("-canary."))
   ) {
     throw new Error(`Version ${version} cannot publish under ${tag}`);
   }
@@ -503,6 +502,8 @@ async function main() {
     try {
       await publishPackage(pkg, otp, tag);
     } catch (error) {
+      // Direct canary publication must stop before advancing any later tag.
+      if (tag === "canary") throw error;
       if (error instanceof FirstPublishBlockedError) {
         blocked.push(error);
         unavailableNames.add(error.pkgName);

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -401,6 +401,25 @@ async function publishPackage({ dir, transform }, otp, tag) {
 
   const args = publishArgs(otp, tag, pkg.version);
   if (isVersionPublished(pkg.name, pkg.version)) {
+    if (tag === "canary") {
+      // A prior successful publish moved the tag with the version. Verify that
+      // before skipping: manually published or legacy candidates may exist
+      // under another tag, and OIDC cannot repair that with dist-tag add.
+      const currentTag = spawnSync(
+        "npm",
+        ["view", pkg.name, "dist-tags.canary"],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+          encoding: "utf8",
+        }
+      );
+      if (currentTag.status !== 0 || currentTag.stdout.trim() !== pkg.version) {
+        throw new Error(
+          `${pkg.name}@${pkg.version} exists but its canary tag does not match or could not be read. ` +
+            "Retry after registry propagation; if it persists, publish a newer main commit. OIDC cannot repair tags separately."
+        );
+      }
+    }
     console.log(`  → ${pkg.name}@${pkg.version} already on npm, skipping`);
     return;
   }


### PR DESCRIPTION
## Summary
Canaries currently publish automatically after main image builds and require an npm token for separate dist-tag promotion. The manual Publish Packages workflow now offers a `canary` channel and calls the reusable canary workflow. There is no daily or merge-triggered canary publication.

Both channels reuse the existing `publish-packages.yml` / `production` npm trusted publisher. The canary publish job uses OIDC with no npm token environment variable. Stable remains the default, and its release tag and image-run ID are still required by a pre-checkout gate.

Canary dispatches require successful CI and image jobs for the exact dispatched main commit, smoke the packed CLI before publishing directly to `canary`, and smoke the published version in four Linux environments afterward. Publication is forward-only, stops at the first package failure, and attempts the CLI last. Stable `latest` stays separate.

## Test plan
- [x] Targeted release tests: 131 pass, 0 fail across canary, package guard, and release-order suites.
- [x] Red before fix: direct canary publishing and manual dispatch checks failed; caller-routing check also failed before routing through the shared publisher.
- [x] Stable input gate executed: missing either producer identifier fails before checkout; both present pass.
- [x] actionlint for the changed workflows; git diff --check.
- [x] Executed canary dispatch shell gate: non-main rejected, unfinished image build rejected, exact successful main image run accepted.
- [x] Read-only canary preflight against the live registry.
- [x] Partial fleet retry converges without duplicate publishing; an existing version with a missing or unreadable canary tag fails closed (red before the guard, green after).
- [x] Verified all seven npm packages already trust lobu-ai/lobu / publish-packages.yml / production with direct publishing allowed. No npm settings changed.
- [x] Final local make pre-pr after merging current main.
- [x] Full scripts suite: 430 pass; packed CLI version and connector runtime self-check passed.
- [x] Final GitHub CI: run 34431915168 on 02ee231c08664c0ee1b7c868cbd9064ea7b9e535.
- [x] Exact-head semantic review passed: zero bugs, zero blockers. UI gate passed as not applicable.

## Notes
Manual invocation:
```sh
gh workflow run publish-packages.yml --repo lobu-ai/lobu --ref main -f channel=canary
```
Leave the stable-only inputs empty. npm validates the calling workflow identity for reusable workflows; both caller and child grant id-token: write. See https://docs.npmjs.com/trusted-publishers/ and https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-with-reusable-workflows.

The four-Linux registry smoke detects failures after publication, because OIDC publish and the dist-tag change happen together. Check the complete workflow result before using the preview. The first live manual OIDC run remains pending.
