### PR TITLE
fix(cli): use external agent engines without duplicate installs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -141,8 +141,6 @@
         "connector-worker": "./dist/bin.js",
       },
       "dependencies": {
-        "@agentclientprotocol/claude-agent-acp": "0.70.0",
-        "@agentclientprotocol/codex-acp": "1.6.2",
         "@agentclientprotocol/sdk": "1.4.0",
         "@lobu/connector-sdk": "workspace:*",
         "@lobu/core": "workspace:*",
@@ -160,6 +158,8 @@
         "undici": "7.29.0",
       },
       "devDependencies": {
+        "@agentclientprotocol/claude-agent-acp": "0.70.0",
+        "@agentclientprotocol/codex-acp": "1.6.2",
         "@lobu/plugin-api": "workspace:*",
         "@lobu/plugin-conversations": "workspace:*",
         "@lobu/plugin-host": "workspace:*",

--- a/config/knip.ts
+++ b/config/knip.ts
@@ -38,6 +38,9 @@ const config: KnipConfig = {
         // Build step run from the package `build` script after tsc; it writes
         // the prebuilt guest bundle the published package ships.
         "src/agent-turn/build-guest-bundle.ts",
+        // Build step run from the package `build` script after tsc; it bundles
+        // the ACP adapters the published package ships without their engines.
+        "scripts/build-acp-adapters.mjs",
         "src/**/*.test.ts",
       ],
       ignoreDependencies: [

--- a/packages/connector-worker/package.json
+++ b/packages/connector-worker/package.json
@@ -62,7 +62,7 @@
     "!**/*.map"
   ],
   "scripts": {
-    "build": "tsc && node dist/agent-turn/build-guest-bundle.js",
+    "build": "tsc && node dist/agent-turn/build-guest-bundle.js && node scripts/build-acp-adapters.mjs",
     "dev": "tsx watch --tsconfig tsconfig.json src/bin.ts",
     "start": "node dist/bin.js",
     "daemon": "tsx --tsconfig tsconfig.json src/bin.ts daemon",
@@ -72,8 +72,6 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@agentclientprotocol/claude-agent-acp": "0.70.0",
-    "@agentclientprotocol/codex-acp": "1.6.2",
     "@agentclientprotocol/sdk": "1.4.0",
     "@lobu/connector-sdk": "workspace:*",
     "@lobu/core": "workspace:*",
@@ -91,6 +89,8 @@
     "undici": "7.29.0"
   },
   "devDependencies": {
+    "@agentclientprotocol/claude-agent-acp": "0.70.0",
+    "@agentclientprotocol/codex-acp": "1.6.2",
     "@lobu/plugin-api": "workspace:*",
     "@lobu/plugin-conversations": "workspace:*",
     "@lobu/plugin-host": "workspace:*",

--- a/packages/connector-worker/scripts/build-acp-adapters.mjs
+++ b/packages/connector-worker/scripts/build-acp-adapters.mjs
@@ -1,0 +1,57 @@
+// Ship protocol implementations, including the Claude SDK's JavaScript, without
+// exposing their engine-bearing package manifests to the consumer's installer.
+// Keep upstream packages pinned as build inputs; do not replace/stub their SDKs.
+import { build } from 'esbuild';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { isBuiltin } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+// Tests use a private output directory so they cannot overwrite a concurrent build.
+const outputRoot = process.argv[2] ? resolve(process.argv[2]) : join(root, 'dist/daemon/acp-adapters');
+const notices = new Map();
+for (const adapter of ['claude', 'codex']) {
+  const result = await build({
+    absWorkingDir: root,
+    entryPoints: [`src/daemon/acp-adapters/${adapter}.ts`],
+    outfile: join(outputRoot, `${adapter}.js`),
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    target: 'node22',
+    metafile: true,
+    // Upstream prebundled CJS dependencies can require Node builtins from ESM.
+    banner: { js: "import { createRequire as lobuCreateRequire } from 'node:module'; const require = lobuCreateRequire(import.meta.url);" },
+    legalComments: 'inline',
+  });
+  for (const input of Object.keys(result.metafile.inputs)) {
+    if (/@(?:anthropic-ai\/claude-agent-sdk-[^/]+|openai\/codex)(?:\/|$)/.test(input)) {
+      throw new Error(`ACP bundle unexpectedly includes an agent engine: ${input}`);
+    }
+    let directory = dirname(resolve(root, input));
+    while (directory !== dirname(directory) && (!existsSync(join(directory, 'package.json')) ||
+      !JSON.parse(readFileSync(join(directory, 'package.json'), 'utf8')).name)) {
+      directory = dirname(directory);
+    }
+    if (!directory.includes('node_modules')) continue;
+    const manifest = JSON.parse(readFileSync(join(directory, 'package.json'), 'utf8'));
+    const key = `${manifest.name}@${manifest.version}`;
+    if (notices.has(key)) continue;
+    const licenseFiles = ['LICENSE', 'LICENSE.md', 'LICENSE.txt', 'license', 'license.md', 'NOTICE'];
+    const license = licenseFiles.filter((file) => existsSync(join(directory, file)))
+      .map((file) => readFileSync(join(directory, file), 'utf8')).join('\n');
+    if (!license) throw new Error(`Missing license text for bundled dependency ${key}`);
+    notices.set(key, `${key}\nLicense: ${manifest.license}\n${license}`);
+  }
+  for (const output of Object.values(result.metafile.outputs)) {
+    for (const dependency of output.imports) {
+      if (dependency.external && !isBuiltin(dependency.path)) {
+        throw new Error(`ACP bundle has an unresolved runtime dependency: ${dependency.path}`);
+      }
+    }
+  }
+  console.log(`[acp] bundled ${adapter}: ${Object.values(result.metafile.outputs).reduce((sum, output) => sum + output.bytes, 0)} bytes`);
+}
+writeFileSync(join(outputRoot, 'THIRD_PARTY_LICENSES.txt'),
+  [...notices.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([, text]) => text).join('\n\n'));

--- a/packages/connector-worker/src/__tests__/agent-adapter-packaging.test.ts
+++ b/packages/connector-worker/src/__tests__/agent-adapter-packaging.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import packageJson from '../../package.json';
+
+test('published worker does not install agent engines through ACP adapters', () => {
+  for (const name of ['@agentclientprotocol/claude-agent-acp', '@agentclientprotocol/codex-acp']) {
+    expect(Object.keys(packageJson.dependencies)).not.toContain(name);
+  }
+});
+
+// Copy only shipped bundles outside the workspace: package imports accidentally
+// left by esbuild must not be rescued by monorepo node_modules.
+test('standalone adapters use the exact external executable and environment', () => {
+  const root = path.resolve(import.meta.dir, '../..');
+  const directory = mkdtempSync(path.join(tmpdir(), 'lobu-external-acp-'));
+  try {
+    const output = path.join(directory, 'bundles');
+    const build = spawnSync('node', ['scripts/build-acp-adapters.mjs', output], { cwd: root, encoding: 'utf8' });
+    expect(build.status, build.stderr).toBe(0);
+    const home = path.join(directory, 'home');
+    mkdirSync(home);
+    writeFileSync(path.join(directory, 'package.json'), '{"type":"module"}');
+    const executable = path.join(directory, 'external agent');
+    writeFileSync(executable, '#!/bin/sh\nprintf "%s\\n" "$0" "$ACP_TEST_MARKER" "$@"\n', { mode: 0o755 });
+    for (const [adapter, variable, args] of [
+      ['claude', 'CLAUDE_CODE_EXECUTABLE', ['--cli', 'synthetic-argument']],
+      ['codex', 'CODEX_PATH', ['cli', 'synthetic-argument']],
+    ] as const) {
+      const bundle = path.join(directory, `${adapter}.js`);
+      cpSync(path.join(output, `${adapter}.js`), bundle);
+      // PATH is pinned to system directories, so resolve node before narrowing it.
+      const result = spawnSync(Bun.which('node')!, [bundle, ...args], {
+        cwd: directory,
+        env: { PATH: '/usr/bin:/bin', HOME: home, [variable]: executable, ACP_TEST_MARKER: 'synthetic-env' },
+        encoding: 'utf8', timeout: 10_000,
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout.trim().split('\n')).toEqual([executable, 'synthetic-env', 'synthetic-argument']);
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}, 30_000);
+
+test('internal adapter entrypoint refuses a missing external agent', () => {
+  for (const [kind, variable] of [
+    ['codex', 'CODEX_PATH'],
+    ['claude-code', 'CLAUDE_CODE_EXECUTABLE'],
+  ] as const) {
+    const result = spawnSync(process.execPath, [path.resolve(import.meta.dir, '../mac-device-daemon.ts'), '--internal-acp-adapter', kind], {
+      cwd: tmpdir(), env: { PATH: '/usr/bin:/bin', HOME: tmpdir() }, encoding: 'utf8', timeout: 10_000,
+    });
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain(`${variable} must identify an installed`);
+  }
+});

--- a/packages/connector-worker/src/daemon/acp-adapters/claude.ts
+++ b/packages/connector-worker/src/daemon/acp-adapters/claude.ts
@@ -1,0 +1,2 @@
+// Bundled into dist by build-acp-adapters.mjs; source builds also inline it.
+import '@agentclientprotocol/claude-agent-acp/dist/index.js';

--- a/packages/connector-worker/src/daemon/acp-adapters/codex.ts
+++ b/packages/connector-worker/src/daemon/acp-adapters/codex.ts
@@ -1,0 +1,2 @@
+// Bundled into dist by build-acp-adapters.mjs; source builds also inline it.
+import '@agentclientprotocol/codex-acp';

--- a/packages/connector-worker/src/mac-device-daemon.ts
+++ b/packages/connector-worker/src/mac-device-daemon.ts
@@ -160,12 +160,17 @@ async function start(): Promise<void> {
     // exists solely to be that server, may evaluate it.
     const agentKind = process.argv[3];
     if (agentKind === 'codex') {
-      // @ts-expect-error codex-acp is an executable-only package with no declarations.
-      await import('@agentclientprotocol/codex-acp');
+      if (!process.env.CODEX_PATH) {
+        throw new Error('CODEX_PATH must identify an installed Codex executable');
+      }
+      await import('./daemon/acp-adapters/codex.js');
       return;
     }
     if (agentKind === 'claude-code') {
-      await import('@agentclientprotocol/claude-agent-acp/dist/index.js');
+      if (!process.env.CLAUDE_CODE_EXECUTABLE) {
+        throw new Error('CLAUDE_CODE_EXECUTABLE must identify an installed Claude executable');
+      }
+      await import('./daemon/acp-adapters/claude.js');
       return;
     }
     throw new Error(`unknown internal ACP adapter '${agentKind ?? ''}'`);

--- a/scripts/pack-cli-smoke.mjs
+++ b/scripts/pack-cli-smoke.mjs
@@ -59,6 +59,12 @@ const lock = JSON.parse(
   readFileSync(join(destination, "package-lock.json"), "utf8")
 );
 for (const [path, pkg] of Object.entries(lock.packages)) {
+  assert.ok(
+    !/(?:^|\/)node_modules\/(?:@anthropic-ai\/claude-agent-sdk(?:-[^/]+)?|@openai\/codex(?:-[^/]+)?|@agentclientprotocol\/(?:claude-agent-acp|codex-acp))(?:\/|$)/.test(
+      path
+    ),
+    `${path} would install an agent engine; ACP adapters must ship as JavaScript bundles`
+  );
   if (/(?:^|\/)node_modules\/@lobu\/[^/]+$/.test(path)) {
     assert.ok(
       pkg.resolved?.startsWith("file:"),

--- a/scripts/test-mac-device-daemon-package.sh
+++ b/scripts/test-mac-device-daemon-package.sh
@@ -40,6 +40,18 @@ VERSION_JSON="$(run_clean "$ROOT/scripts/verify-mac-device-daemon.sh" ./lobu-dev
 
 run_clean ./lobu-device-daemon --help | grep -q 'Usage:'
 
+# The compiled artifact must contain both adapters even without node_modules,
+# and must never fall back to an installed/bundled engine when no path is given.
+for agent in codex claude-code; do
+  if run_clean ./lobu-device-daemon --internal-acp-adapter "$agent" > /dev/null 2>"$WORK/missing-agent.err"; then
+    echo "error: $agent adapter accepted a missing external executable" >&2
+    exit 1
+  fi
+  grep -q 'must identify an installed' "$WORK/missing-agent.err"
+done
+run_clean env CODEX_PATH=/synthetic/codex ./lobu-device-daemon --internal-acp-adapter codex --version | grep -q '@agentclientprotocol/codex-acp'
+run_clean env CLAUDE_CODE_EXECUTABLE=/synthetic/claude ./lobu-device-daemon --internal-acp-adapter claude-code --version | grep -q '^[0-9]'
+
 if run_clean ./lobu-device-daemon >/dev/null 2>"$WORK/missing-config.err"; then
   echo "error: missing launch configuration unexpectedly succeeded" >&2
   exit 1


### PR DESCRIPTION
## Summary

Installing `@lobu/cli` currently installs Claude and Codex engines through the worker's ACP adapter dependencies, even though the device daemon deliberately discovers and uses existing executables. Bundle the pinned upstream adapters and Claude SDK JavaScript into the existing worker artifact, keep their engine-bearing package manifests as build dependencies, and require the external executable when starting an internal adapter.

The build rejects native engine inputs and unresolved runtime imports and carries dependency license notices. Consumer-install and compiled-Mac checks guard against reintroducing the bundled engines. No public exports, Automation contracts, or agent installation behavior change.

## Test plan

- [x] Intended files staged explicitly; `make pre-pr` passed (build, strict typechecks, knip, naming and platform gates). Pre-commit Biome/typecheck also run before push. GitHub CI remains the canonical full graph.
- [x] `make review-fix` completed; inspected its changes and isolated the packaging test build directory.

- Fresh external npm consumer installs from candidate tarballs, using publication's manifest transforms. On macOS arm64, Node 26.7.0, npm 11.19.0: original dependency graph 1,782,470,937 apparent bytes; candidate 1,183,181,904 bytes (599,289,033 bytes / 33.6% reduction). Candidate lock contains none of the engine-bearing ACP packages, Claude Agent SDK packages, or Codex engine packages. Candidate took 38s; warm-cache baseline took 23.2s, so this is not evidence of faster installs. Both use npm's current lifecycle policy.
- Standalone adapter bundles copied outside the workspace launch the exact synthetic executable path (including spaces) and forward environment and arguments. Missing executable configuration fails before loading an adapter. Regression test: before `0 pass / 1 fail` on production adapter dependencies; after `3 pass / 0 fail`.
- 46 focused ACP, interactive-session, daemon, and packaging tests pass. Full Automation arm suite passes 20/20. An initial combined run missed a fixture's output at its 500ms startup deadline under concurrent build load; the isolated failing test and subsequent full arm suite passed.
- Compiled macOS arm64 package smoke passes, including clean environment, both embedded adapters, missing external executable rejection, and Hardened Runtime/JIT signature checks.
- Real installed Codex 0.154.0 and Claude Code 2.1.260 complete ACP sessions and prompts through the compiled Mac daemon (`ACP_EXTERNAL_OK`). Both installed Node adapter bundles also complete session resume and a second turn (`ACP_RESUMED_OK`). No credentials were copied and no OAuth access was created. An initial Bun harness inherited workspace dotenv and hit a Claude credit error; rerunning under Node with the actual process environment passed.
- Installed CLI connector self-check passes outside the install tree, including real isolated-vm 7.0.1 execution and all 23 connector sources.

## Notes

Fresh-install size measurements above are macOS measurements, separate from the handoff's Linux/Bun baseline. Live-provider checks verify basic session execution; permission, cancellation, timeout, and transcript behavior also have focused synthetic protocol coverage.

- Installed-artifact smoke: 15 passed, 0 failed, 0 skipped; nested daemon MCP lifecycle: 13 passed, 0 failed. Includes embedded Postgres, synthetic-provider agent turn, MCP, command sequencing/concurrency, idempotency, timeout cleanup, credential isolation, and daemon restart.

The Claude SDK JavaScript retains its upstream license notice and terms; it was already linked into the standalone Mac daemon before this change. Native Claude/Codex executables are neither modified nor redistributed by this packaging change.

Default discovery was also verified: Claude resolves to the live-tested installation; Codex resolves to an older 0.144.0 installation. That discovered Codex completes a real turn and resume with the advertised gpt-5.5 model. Its existing default gpt-6-astra configuration is rejected by the provider as requiring a newer Codex; discovery, installations, and user configuration were left unchanged.

The first GitHub run failed one unchanged isolate timer-order assertion (second 2ms interval after the 10ms timer; 1609 other tests passed in that shard). The isolate implementation and fixture have no diff in this PR; the affected shard passed on rerun without weakening its assertions, and the full CI workflow is green for 31deb09dc.
