### PR TITLE
fix(runtime): restore Codex subscription inference in isolates

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -50,8 +50,9 @@
           "iconUrl": "https://www.google.com/s2/favicons?domain=chatgpt.com&sz=128",
           "envVarName": "OPENAI_API_KEY",
           "upstreamBaseUrl": "https://chatgpt.com/backend-api",
-          "apiKeyInstructions": "Sign in with ChatGPT Plus/Pro, or paste an OpenAI API key",
-          "apiKeyPlaceholder": "sk-...",
+          "sdkCompat": "openai-codex",
+          "apiKeyInstructions": "Sign in with ChatGPT Plus/Pro.",
+          "apiKeyPlaceholder": "",
           "modalities": ["text"],
           "oauth": {
             "clientId": "app_EMoamEEZ73f0CkXaXp7hrann",

--- a/config/providers.json
+++ b/config/providers.json
@@ -52,7 +52,7 @@
           "upstreamBaseUrl": "https://chatgpt.com/backend-api",
           "sdkCompat": "openai-codex",
           "apiKeyInstructions": "Sign in with ChatGPT Plus/Pro.",
-          "apiKeyPlaceholder": "",
+          "apiKeyPlaceholder": "Sign in with ChatGPT",
           "modalities": ["text"],
           "oauth": {
             "clientId": "app_EMoamEEZ73f0CkXaXp7hrann",

--- a/packages/connector-worker/src/agent-turn/native-session.ts
+++ b/packages/connector-worker/src/agent-turn/native-session.ts
@@ -2,6 +2,7 @@ import { Agent, type AgentTool } from '@mariozechner/pi-agent-core';
 import { registerApiProvider, streamSimple, type Api, type Model } from '@mariozechner/pi-ai';
 import { streamAnthropic } from '@mariozechner/pi-ai/anthropic';
 import { streamOpenAICompletions } from '@mariozechner/pi-ai/openai-completions';
+import { streamOpenAICodexResponses } from '@mariozechner/pi-ai/openai-codex-responses';
 import { streamOpenAIResponses } from '@mariozechner/pi-ai/openai-responses';
 import { AgentSession, SessionManager, SettingsManager, convertToLlm, CURRENT_SESSION_VERSION, type ModelRegistry } from '@mariozechner/pi-coding-agent';
 import { createLobuResourceLoader, type TransientTurnContextLookup } from '@lobu/plugin-toolkit/pi-resources';
@@ -58,6 +59,18 @@ export function createNativeSession(
   // models can use tools, and the two speak different request shapes.
   if (input.provider.api === 'anthropic-messages') {
     registerApiProvider({ api: 'anthropic-messages', stream: streamAnthropic, streamSimple: streamAnthropic });
+  } else if (input.provider.api === 'openai-codex-responses') {
+    // pi-ai extracts an account id before invoking fetch. This inert JWT is
+    // only adapter input: the isolate host replaces Authorization with the
+    // signed turn token, and the gateway derives the real account from OAuth.
+    // `transport` is pinned, not preferred: the adapter's default ("auto")
+    // dials the upstream over a WebSocket, which the guest has no constructor
+    // for, and each failed dial appends a `provider_transport_failure`
+    // diagnostic to the assistant message before it falls back to SSE.
+    const placeholder = `e30.${btoa(JSON.stringify({ 'https://api.openai.com/auth': { chatgpt_account_id: 'lobu-proxy' } }))}.placeholder`;
+    const stream: typeof streamOpenAICodexResponses = (model, context, options) =>
+      streamOpenAICodexResponses(model, context, { ...options, apiKey: placeholder, transport: 'sse' });
+    registerApiProvider({ api: 'openai-codex-responses', stream, streamSimple: stream });
   } else if (input.provider.api === 'openai-responses') {
     registerApiProvider({ api: 'openai-responses', stream: streamOpenAIResponses, streamSimple: streamOpenAIResponses });
   } else {

--- a/packages/connector-worker/src/agent-turn/types.ts
+++ b/packages/connector-worker/src/agent-turn/types.ts
@@ -7,7 +7,7 @@
 /** Which provider the turn talks to, and how it authenticates. */
 export interface AgentTurnProvider {
   /** pi-ai's api id. Only the two fetch-native families run on this lane. */
-  api: 'anthropic-messages' | 'openai-completions' | 'openai-responses';
+  api: 'anthropic-messages' | 'openai-completions' | 'openai-responses' | 'openai-codex-responses';
   /** Provider slug pi-ai reports on the model (`anthropic`, `openai`, ...). */
   provider: string;
   modelId: string;

--- a/packages/connector-worker/src/executor/isolate.ts
+++ b/packages/connector-worker/src/executor/isolate.ts
@@ -417,6 +417,8 @@ function agentInferencePath(api: AgentTurnInput['provider']['api']): string {
       return '/chat/completions';
     case 'openai-responses':
       return '/responses';
+    case 'openai-codex-responses':
+      return '/codex/responses';
   }
 }
 

--- a/packages/core/src/__tests__/sdk-compat.test.ts
+++ b/packages/core/src/__tests__/sdk-compat.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { Value } from "@sinclair/typebox/value";
+import { AgentTurnPollPayloadSchema } from "../contracts/worker/protocol";
 import {
   isSdkCompat,
   resolveSdkCompat,
@@ -50,16 +52,11 @@ describe("sdk-compat registry", () => {
   });
 
   test("every routable protocol is one a turn envelope can carry", () => {
-    // The isolate lane admits exactly these three adapters (`LANE_APIS` in the
-    // agent-turn producer). A row whose `api` is not among them cannot run, so
-    // this is the invariant that keeps the table honest as it grows.
-    const laneAdapters = new Set([
-      "openai-completions",
-      "openai-responses",
-      "anthropic-messages",
-    ]);
+    const apiSchema =
+      AgentTurnPollPayloadSchema.properties.turn.properties.provider.properties
+        .api;
     for (const [key, p] of Object.entries(SDK_COMPAT_PROTOCOLS)) {
-      expect(laneAdapters.has(p.api), `${key} -> ${p.api}`).toBe(true);
+      expect(Value.Check(apiSchema, p.api), `${key} -> ${p.api}`).toBe(true);
     }
   });
 

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -432,6 +432,7 @@ export const AgentTurnPollPayloadSchema = Type.Object({
         // `provider-catalog.ts`. pi-ai implements it on the same `openai` SDK
         // as completions, so it is isolate-compatible for the same reason.
         Type.Literal("openai-responses"),
+        Type.Literal("openai-codex-responses"),
       ]),
       provider: Type.String({ minLength: 1 }),
       model_id: Type.String({ minLength: 1 }),

--- a/packages/core/src/sdk-compat.ts
+++ b/packages/core/src/sdk-compat.ts
@@ -28,12 +28,17 @@
  * OpenAI-compatible entries in `config/providers.json` work. Add a vendor
  * there, not here.
  */
-export type SdkCompat = "openai" | "openai-responses" | "anthropic";
+export type SdkCompat =
+  | "openai"
+  | "openai-responses"
+  | "openai-codex"
+  | "anthropic";
 
 /** pi-ai API adapter names, narrowed to the ones a turn can speak. */
 export type PiAiApi =
   | "openai-completions"
   | "openai-responses"
+  | "openai-codex-responses"
   | "anthropic-messages";
 
 export interface SdkCompatProtocol {
@@ -72,6 +77,11 @@ export const SDK_COMPAT_PROTOCOLS: Record<SdkCompat, SdkCompatProtocol> = {
     api: "openai-responses",
     registryAlias: "openai",
     label: "OpenAI Responses",
+  },
+  "openai-codex": {
+    api: "openai-codex-responses",
+    registryAlias: "openai-codex",
+    label: "OpenAI Codex Responses",
   },
   anthropic: {
     api: "anthropic-messages",

--- a/packages/server/src/__tests__/integration/agent-turn-capture.test.ts
+++ b/packages/server/src/__tests__/integration/agent-turn-capture.test.ts
@@ -100,6 +100,7 @@ describe('native capture over HTTP and Postgres', () => {
     app.route('/lobu', provider.getApp());
     app.post('/upstream/v1/messages', (c) => { upstream(c.req.path); return c.json({ content: [] }); });
     app.post('/upstream/responses', (c) => { upstream(c.req.path); return c.json({ output: [] }); });
+    app.post('/upstream/codex/responses', (c) => { upstream(c.req.path); return c.json({ output: [] }); });
     server = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' });
     if (!server.listening) await new Promise<void>((resolve) => server.once('listening', resolve));
     origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
@@ -299,22 +300,22 @@ describe('native capture over HTTP and Postgres', () => {
     expect(upstream).toHaveBeenCalledTimes(1);
   });
 
-  it('admits the OpenAI Responses path during capture', async () => {
+  it.each([['openai-responses', '/responses'], ['openai-codex-responses', '/codex/responses']])('admits the %s path during capture', async (api, suffix) => {
     const sql = getTestDb();
     const [row] = await sql`SELECT action_input->'turn'->'provider' AS provider FROM runs WHERE id = ${runId}`;
     const path = new URL(row.provider.base_url).pathname;
     await sql`
       UPDATE runs
-      SET action_input = jsonb_set(action_input, '{turn,provider,api}', '"openai-responses"')
+      SET action_input = jsonb_set(action_input, '{turn,provider,api}', to_jsonb(${api}::text))
       WHERE id = ${runId}
     `;
     upstream.mockClear();
     try {
       const denied = await request(path + '/v1/messages', {}, '', { authorization: `Bearer ${token}` });
       expect(denied.status).toBe(403);
-      const response = await request(path + '/responses', {}, '', { authorization: `Bearer ${token}` });
+      const response = await request(path + suffix, {}, '', { authorization: `Bearer ${token}` });
       expect(response.status, await response.clone().text()).toBe(200);
-      expect(upstream).toHaveBeenCalledWith('/upstream/responses');
+      expect(upstream).toHaveBeenCalledWith('/upstream' + suffix);
     } finally {
       await sql`
         UPDATE runs

--- a/packages/server/src/__tests__/integration/agent-turn-producer.test.ts
+++ b/packages/server/src/__tests__/integration/agent-turn-producer.test.ts
@@ -20,6 +20,7 @@ import { AGENT_ERRORS, AgentErrorCode, parseSessionEntries, type MessagePayload,
 import { Value } from '@sinclair/typebox/value';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as db from '../../db/client';
+import { ChatGPTOAuthModule } from '../../gateway/auth/chatgpt/chatgpt-oauth-module';
 import { createInteractionRoutes } from '../../gateway/routes/internal/interactions';
 import { enqueueAgentTurn,
   cancelAgentTurn,
@@ -335,7 +336,7 @@ describe('agent turn producer', () => {
     }
   });
 
-  it('executes a compatible-provider tool round trip through worker HTTP and an isolate', async () => {
+  it.each(['compatible', 'codex'])('executes a %s tool round trip through worker HTTP and an isolate', async (protocol) => {
     const requests: Array<Record<string, any>> = [];
     const serverErrors: string[] = [];
     const server = createServer(async (req, res) => {
@@ -344,8 +345,32 @@ describe('agent turn producer', () => {
         for await (const chunk of req) chunks.push(Buffer.from(chunk));
         const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
         const path = new URL(req.url!, 'http://localhost').pathname;
-        if (path.startsWith('/lobu/api/proxy/compatible/')) {
+        if (path.startsWith('/lobu/api/proxy/compatible/') || path.startsWith('/lobu/api/proxy/openai-codex/')) {
           requests.push(body);
+          if (protocol === 'codex') {
+            expect(path.endsWith('/codex/responses')).toBe(true);
+            expect(verifyWorkerToken(req.headers.authorization!.slice(7)).agentId).toBe(AGENT_ID);
+            expect(req.headers['chatgpt-account-id']).toBe('lobu-proxy');
+            expect(body.store).toBe(false);
+            expect(body.model).toBe('gpt-5.6-luna');
+            const tool = requests.length === 1;
+            const item = tool
+              ? { type: 'function_call', id: 'fc_probe', call_id: 'call_probe', name: 'write', arguments: JSON.stringify({ file_path: 'probe.txt', content: 'codex verified' }), status: 'completed' }
+              : { type: 'message', id: 'msg_probe', role: 'assistant', content: [{ type: 'output_text', text: 'Codex verified.', annotations: [] }], status: 'completed' };
+            res.writeHead(200, { 'content-type': 'text/event-stream' });
+            const send = (event: Record<string, unknown>) => res.write(`data: ${JSON.stringify(event)}\n\n`);
+            send({ type: 'response.created', response: { id: 'resp_probe', status: 'in_progress' } });
+            send({ type: 'response.output_item.added', item: { ...item, arguments: '', content: [], status: 'in_progress' } });
+            if (tool) send({ type: 'response.function_call_arguments.delta', delta: item.arguments });
+            else {
+              send({ type: 'response.content_part.added', part: { type: 'output_text', text: '', annotations: [] } });
+              send({ type: 'response.output_text.delta', delta: 'Codex verified.' });
+            }
+            send({ type: 'response.output_item.done', item });
+            send({ type: 'response.completed', response: { id: 'resp_probe', status: 'completed', output: [item], usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } } });
+            res.end();
+            return;
+          }
           // Gemini rejects even store:false. This stub enforces that wire
           // contract while the real producer, daemon and Pi guest execute.
           if (Object.hasOwn(body, 'store')) {
@@ -378,10 +403,10 @@ describe('agent turn producer', () => {
       const origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
       const org = await createTestOrganization();
       const message = messageFor(org.id);
-      message.agentOptions!.model = 'compatible/compatible-model';
+      message.agentOptions!.model = protocol === 'codex' ? 'chatgpt/gpt-5.6-luna' : 'compatible/compatible-model';
       await enqueueMessage(message, {
         agentSettings: settingsStore, gatewayUrl: `${origin}/lobu`,
-        catalog: catalogFor(claudeModule({ providerId: 'compatible', sdkCompat: 'openai',
+        catalog: catalogFor(protocol === 'codex' ? new ChatGPTOAuthModule({} as never) : claudeModule({ providerId: 'compatible', sdkCompat: 'openai',
           getUpstreamConfig: () => ({ slug: 'compatible', upstreamBaseUrl: 'https://compatible.example.test/v1' }),
           getProxyBaseUrlMappings: () => ({ OPENAI_BASE_URL: `${origin}/lobu/api/proxy/compatible/a/turn-agent` }),
         })),
@@ -397,8 +422,12 @@ describe('agent turn producer', () => {
       expect(serverErrors).toEqual([]);
       expect(result.error).toBeUndefined();
       expect(requests).toHaveLength(2);
-      expect(requests.every((request) => !Object.hasOwn(request, 'store'))).toBe(true);
-      expect(requests[1].messages.some((message: { role: string }) => message.role === 'tool')).toBe(true);
+      if (protocol === 'codex') {
+        expect(requests[1].input.some((item: { type: string }) => item.type === 'function_call_output')).toBe(true);
+      } else {
+        expect(requests.every((request) => !Object.hasOwn(request, 'store'))).toBe(true);
+        expect(requests[1].messages.some((message: { role: string }) => message.role === 'tool')).toBe(true);
+      }
       expect((await runRow(Number(run.id))).status).toBe('completed');
     } finally {
       server.closeAllConnections();
@@ -2596,7 +2625,7 @@ describe('agent turn producer', () => {
     // package as completions, so it is isolate-compatible for the same
     // reason; the omission was the bug, not the promotion.
     const org = await createTestOrganization();
-    for (const sdkCompat of ['anthropic', 'openai', 'openai-responses'] as const) {
+    for (const sdkCompat of ['anthropic', 'openai', 'openai-responses', 'openai-codex'] as const) {
       expect(
         await enqueueMessage(messageFor(org.id), {
           agentSettings: settingsStore,
@@ -2606,7 +2635,7 @@ describe('agent turn producer', () => {
       ).toBeUndefined();
     }
     // One admitted run per protocol — none silently dropped.
-    expect(await agentTurnRuns()).toHaveLength(3);
+    expect(await agentTurnRuns()).toHaveLength(4);
   });
 
   it("delivers the named misconfiguration to the client, not a deadline timeout", async () => {

--- a/packages/server/src/__tests__/integration/gateway-completion-resolve.test.ts
+++ b/packages/server/src/__tests__/integration/gateway-completion-resolve.test.ts
@@ -20,6 +20,7 @@ import {
 } from '@lobu/core';
 import { createInferenceProvider } from '../../lobu/stores/provider-secrets';
 import { resolveCompletionTarget } from '../../gateway/inference/gateway-completion';
+import { ChatGPTOAuthModule } from '../../gateway/auth/chatgpt/chatgpt-oauth-module';
 import { getDb } from '../../db/client';
 import { cleanupTestDatabase } from '../setup/test-db';
 import { createTestOrganization } from '../setup/test-fixtures';
@@ -97,107 +98,38 @@ function registerOpenAiCompatible(providerId: string, upstreamBaseUrl: string) {
 }
 
 describe('resolveCompletionTarget protocol gating', () => {
-  /**
-   * The ChatGPT subscription provider resolves to null, and that is CORRECT.
-   *
-   * Its upstream is `chatgpt.com/backend-api` — Codex's subscription backend,
-   * not an OpenAI-compatible `/chat/completions` API. Its models endpoint
-   * returns `{models:[{slug,title}]}` rather than OpenAI's `{data:[{id}]}`
-   * (chatgpt-oauth-module.ts:94), and that module's comment records the
-   * incident where an `openai/<model>` request leaking to this host returned
-   * `403` without a ChatGPT session. Treating "undefined sdkCompat" as
-   * "probably OpenAI" would re-create exactly that misroute.
-   *
-   * providers.json used to declare `sdkCompat: "openai"` for this id. It was
-   * inert — the specialized module claims the id first and the config loop
-   * skips it — but it was still a false claim about the wire protocol, so it
-   * has been removed. `sdkCompatIsNotDeclaredForChatgpt` below pins that.
-   *
-   * If ChatGPT should ever back these features, the fix is to give it a real
-   * OpenAI-compatible upstream — not to loosen this check.
-   */
-  it('does NOT resolve a provider whose module leaves sdkCompat undefined', async () => {
-    const orgId = await newOrgWithProvider('chatgpt', 'gpt-5');
-    register({
-      name: 'chatgpt-oauth',
-      providerId: 'chatgpt',
-      providerDisplayName: 'ChatGPT (subscription login)',
-      // Deliberately absent — mirrors ChatGPTOAuthModule.
-      getUpstreamConfig: () => ({
-        slug: 'openai-codex',
-        upstreamBaseUrl: 'https://chatgpt.com/backend-api',
-      }),
-    });
+  // Seed a real credential so these refusals reach the protocol check instead
+  // of passing accidentally at the earlier missing-credential guard.
+  it.each([undefined, 'openai-codex'])(
+    'does not resolve the unsupported gateway protocol %s',
+    async (sdkCompat) => {
+      const orgId = await newOrgWithProvider('test-provider', 'test-model');
+      register({
+        name: 'test-provider',
+        providerId: 'test-provider',
+        providerDisplayName: 'Test provider',
+        sdkCompat,
+        getUpstreamConfig: () => ({
+          slug: 'test-provider',
+          upstreamBaseUrl: 'https://provider.example.invalid',
+        }),
+      });
+      expect(await resolveCompletionTarget(orgId)).toBeNull();
+    },
+  );
 
-    expect(await resolveCompletionTarget(orgId)).toBeNull();
-  });
-
-  /**
-   * The ordering is what makes the case above real, so assert it directly.
-   *
-   * providers.json DOES declare `sdkCompat: "openai"` for id `chatgpt`. It
-   * never takes effect because core-services registers the specialized module
-   * FIRST and the config loop then skips ids already claimed
-   * (`registeredIds.has(id)`). `getModelProviderModules().find()` returns the
-   * first match by providerId, so the OAuth module — sdkCompat undefined —
-   * wins.
-   *
-   * Registering config-first inverts the outcome and the provider resolves.
-   * A live e2e that got this order wrong reported a false failure, which is
-   * what prompted pinning it.
-   *
-   * SCOPE: this simulates the two registry states directly; it does not import
-   * core-services, so reordering the real registrations there would NOT fail
-   * here. What it pins is the consequence — that whichever module wins the
-   * providerId lookup decides the protocol — so the resolver's semantics under
-   * each state is locked even though the wiring that produces them is not.
-   */
-  it('the specialized module wins over the config entry, and only because it registers first', async () => {
-    const orgId = await newOrgWithProvider('chatgpt', 'gpt-5');
-
-    // Config-first: providers.json's sdkCompat "openai" wins and it resolves.
-    register({
-      name: 'chatgpt-config-driven',
-      providerId: 'chatgpt',
-      providerDisplayName: 'ChatGPT',
-      sdkCompat: 'openai',
-      getUpstreamConfig: () => ({
-        slug: 'chatgpt',
-        upstreamBaseUrl: 'https://chatgpt.com/backend-api',
-      }),
-    });
-    expect(await resolveCompletionTarget(orgId)).not.toBeNull();
-
-    // Production order: specialized first, config skipped. Now it does not.
-    registry.modules = new Map(savedModules);
-    register({
-      name: 'chatgpt-oauth',
-      providerId: 'chatgpt',
-      providerDisplayName: 'ChatGPT (subscription login)',
-      getUpstreamConfig: () => ({
-        slug: 'openai-codex',
-        upstreamBaseUrl: 'https://chatgpt.com/backend-api',
-      }),
-    });
-    expect(await resolveCompletionTarget(orgId)).toBeNull();
-  });
-
-  /**
-   * The config must not claim a protocol the upstream does not speak.
-   *
-   * This was inert (the specialized module wins the id), but a false entry is
-   * a trap: `buildProviderCatalog` resolves `config?.sdkCompat ?? module…`, so
-   * config wins wherever it IS consulted. With it removed, the catalog, the
-   * API-key creation gate in agent-routes.ts, and this resolver all agree that
-   * chatgpt is not routable as OpenAI.
-   */
-  it('providers.json does not declare an OpenAI protocol for chatgpt', async () => {
+  it('declares the real ChatGPT Codex protocol without enabling Chat Completions', async () => {
     const cfg = JSON.parse(
       readFileSync(resolve(import.meta.dirname, '../../../../../config/providers.json'), 'utf8'),
     ) as { providers: Array<{ id: string; providers: Array<{ sdkCompat?: string }> }> };
     const chatgpt = cfg.providers.find((g) => g.id === 'chatgpt');
-    expect(chatgpt).toBeDefined();
-    expect(chatgpt?.providers[0]?.sdkCompat).toBeUndefined();
+    expect(chatgpt?.providers[0]?.sdkCompat).toBe('openai-codex');
+
+    const module = new ChatGPTOAuthModule({} as never);
+    expect(module.sdkCompat).toBe(chatgpt?.providers[0]?.sdkCompat);
+    moduleRegistry.register(module as unknown as ModuleInterface);
+    const orgId = await newOrgWithProvider('chatgpt', 'gpt-5.6-luna');
+    expect(await resolveCompletionTarget(orgId)).toBeNull();
   });
 
   /**

--- a/packages/server/src/__tests__/live-providers/provider-protocol.ts
+++ b/packages/server/src/__tests__/live-providers/provider-protocol.ts
@@ -4,8 +4,6 @@ import {
 	resolveSdkCompat,
 } from "@lobu/core";
 
-export type ProviderApi = PiAiApi | "openai-codex-responses";
-
 export interface ProtocolProviderEntry {
 	upstreamBaseUrl: string;
 	sdkCompat?: SdkCompat;
@@ -15,13 +13,12 @@ export interface ProtocolProviderEntry {
 export function resolveProviderApi(
 	id: string,
 	provider: ProtocolProviderEntry,
-): ProviderApi | null {
-	if (id === "chatgpt") return "openai-codex-responses";
+): PiAiApi | null {
 	if (id === "openai") return "openai-responses";
 	return resolveSdkCompat(provider.sdkCompat)?.api ?? null;
 }
 
-export function providerCompletionPath(api: ProviderApi): string {
+export function providerCompletionPath(api: PiAiApi): string {
 	switch (api) {
 		case "anthropic-messages":
 			return "/v1/messages";

--- a/packages/server/src/__tests__/live-providers/provider-smoke.test.ts
+++ b/packages/server/src/__tests__/live-providers/provider-smoke.test.ts
@@ -18,16 +18,13 @@ import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { SdkCompat } from "@lobu/core";
+import type { PiAiApi, SdkCompat } from "@lobu/core";
 import {
 	completeSimple,
 	type Context,
 	type Model,
 } from "@mariozechner/pi-ai";
-import {
-	type ProviderApi,
-	resolveProviderApi,
-} from "./provider-protocol.js";
+import { resolveProviderApi } from "./provider-protocol.js";
 
 const thisDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(thisDir, "../../../../..");
@@ -249,7 +246,7 @@ function toolContext(): Context {
 	};
 }
 
-function forceWeatherTool(api: ProviderApi, payload: unknown): unknown {
+function forceWeatherTool(api: PiAiApi, payload: unknown): unknown {
 	if (typeof payload !== "object" || payload === null) return payload;
 	const body = payload as Record<string, unknown>;
 	if (api === "anthropic-messages") {

--- a/packages/server/src/gateway/__tests__/chatgpt-session-credentials.test.ts
+++ b/packages/server/src/gateway/__tests__/chatgpt-session-credentials.test.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { generateWorkerToken } from "@lobu/core";
 import { ApiKeyProviderModule } from "../auth/api-key-provider-module.js";
 import { ChatGPTOAuthModule } from "../auth/chatgpt/chatgpt-oauth-module.js";
-import type { BaseProviderModule } from "../auth/base-provider-module.js";
 import { AuthProfilesManager } from "../auth/settings/auth-profiles-manager.js";
 import { WorkerGateway } from "../worker-dispatch/worker-gateway.js";
 
@@ -42,23 +41,12 @@ afterEach(() => {
 });
 
 describe("ChatGPT subscription credentials", () => {
-  test("org-bucket account reaches the placeholder without exposing its credential", async () => {
-    const module: BaseProviderModule = new ChatGPTOAuthModule(makeManager());
-    const placeholder = await module.buildCredentialPlaceholder(AGENT, {
-      organizationId: ORG, userId: USER,
-    });
-    expect(placeholder).not.toBe(STORED_CREDENTIAL);
-    expect(placeholder.split(".")).toHaveLength(3);
-    expect(JSON.parse(Buffer.from(placeholder.split(".")[1]!, "base64url").toString()))
-      .toEqual({ "https://api.openai.com/auth": { chatgpt_account_id: ACCOUNT } });
-  });
-
-  test("another user cannot borrow the agent owner's subscription", async () => {
-    const module: BaseProviderModule = new ChatGPTOAuthModule(makeManager());
+  test("admits the Codex protocol with the signed turn credential", async () => {
+    const module = new ChatGPTOAuthModule(makeManager());
+    expect(module.sdkCompat).toBe("openai-codex");
     expect(await module.buildCredentialPlaceholder(AGENT, {
-      organizationId: ORG, userId: "unlinked-user",
-    })).toBe("lobu-proxy");
-    expect(await module.buildCredentialPlaceholder(AGENT)).toBe("lobu-proxy");
+      organizationId: ORG, userId: USER, workerToken: "synthetic-signed-turn",
+    })).toBe("synthetic-signed-turn");
   });
 
   test("model listing retains the requesting user", async () => {
@@ -165,11 +153,11 @@ describe("ChatGPT subscription credentials", () => {
           | Record<string, string>
           | undefined;
         expect(placeholders).toBeDefined();
-        // Proxied providers receive the worker token; ChatGPT does not, so its
-        // subscription cannot be spent by anything holding that token.
+        // All proxied providers receive only the signed token. The gateway
+        // resolves the subscription under its verified org/agent/user scope.
         expect(placeholders?.openai).toBe(workerToken);
         expect(placeholders?.deepseek).toBe(workerToken);
-        expect(placeholders?.chatgpt).not.toBe(workerToken);
+        expect(placeholders?.chatgpt).toBe(workerToken);
       } finally {
         gateway.shutdown();
       }

--- a/packages/server/src/gateway/__tests__/secret-proxy-org-upstream.test.ts
+++ b/packages/server/src/gateway/__tests__/secret-proxy-org-upstream.test.ts
@@ -43,6 +43,43 @@ describe("SecretProxy — org custom-upstream slug routing (URL invariant)", () 
     };
   });
 
+  test.each([true, false])("Codex account header comes only from the stored credential (identity=%s)", async (hasIdentity) => {
+    inferenceConfig = { custom: false };
+    const credential = `e30.${Buffer.from(JSON.stringify(hasIdentity
+      ? { "https://api.openai.com/auth": { chatgpt_account_id: "synthetic-account" } }
+      : {})).toString("base64url")}.synthetic`;
+    const proxy = new SecretProxy({ defaultUpstreamUrl: "https://default.example.com" }, { get: async () => null });
+    proxy.registerUpstream({ slug: "openai-codex", upstreamBaseUrl: "https://chatgpt.com/backend-api" }, "chatgpt");
+    proxy.setAuthProfilesManager({
+      getBestProfile: async () => ({ credential, authType: "oauth" }),
+      ensureFreshCredential: async () => credential,
+    } as never);
+    proxy.setAgentOrgResolver(async () => "org-1");
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; headers: Headers }> = [];
+    globalThis.fetch = (async (url, init) => {
+      requests.push({ url: String(url), headers: new Headers(init?.headers) });
+      return new Response("data: [DONE]\n\n", { headers: { "content-type": "text/event-stream" } });
+    }) as typeof fetch;
+    try {
+      const res = await proxy.getApp().request("/api/proxy/openai-codex/a/agent-1/codex/responses", {
+        method: "POST", headers: { authorization: "Bearer worker-token-test", "content-type": "application/json",
+          "ChatGPT-Account-Id": "attacker-account" }, body: JSON.stringify({ model: "gpt-5.6-luna", stream: true }),
+      });
+      expect(res.status).toBe(hasIdentity ? 200 : 401);
+      expect(requests).toHaveLength(hasIdentity ? 1 : 0);
+      if (!hasIdentity) {
+        // pi-ai reads `error.message`; a bare string reaches the user as JSON.
+        expect((await res.json()).error.message).toContain("account identity");
+      }
+      if (hasIdentity) {
+        expect(requests[0]!.url).toBe("https://chatgpt.com/backend-api/codex/responses");
+        expect(requests[0]!.headers.get("authorization")).toBe(`Bearer ${credential}`);
+        expect(requests[0]!.headers.get("chatgpt-account-id")).toBe("synthetic-account");
+      }
+    } finally { globalThis.fetch = originalFetch; }
+  });
+
   test("registered org slug routes to the row base_url with the org key", async () => {
     const proxy = new SecretProxy(
       { defaultUpstreamUrl: "https://default.example.com" },

--- a/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
@@ -281,7 +281,7 @@ describe("ProviderCatalogService.getInstalledModules — org inference providers
     // — there is nothing for an API key to reach. Routing must refuse such a
     // row, because the create route already does ("it signs in instead"), and
     // the two disagreeing is what promotes an unroutable row to org default.
-    registerFakeModule("chatgpt", "device-code");
+    registerFakeModule("chatgpt", "openai-codex");
     const catalog = makeCatalog({
       models: ["my-chatgpt/gpt-5"],
       orgRows: [

--- a/packages/server/src/gateway/auth/chatgpt/chatgpt-oauth-module.ts
+++ b/packages/server/src/gateway/auth/chatgpt/chatgpt-oauth-module.ts
@@ -1,22 +1,20 @@
 import type { ModelOption } from "@lobu/core";
-import type { ProviderCredentialContext } from "../../embedded.js";
 import { BaseProviderModule } from "../base-provider-module.js";
-import { extractJwtAccountId } from "../oauth/client.js";
-import { getOAuthProviderConfig } from "../oauth/providers.js";
 import type { AuthProfilesManager } from "../settings/auth-profiles-manager.js";
 import { fetchModelOptions } from "../utils/fetch-model-options.js";
 
 /**
  * ChatGPT provider module — runtime credential surface for the ChatGPT
  * (subscription login) provider. The OAuth device-code FLOW lives in the
- * generic org routes; this module keeps codex-backend credential placeholders
- * and model listing. Does not require the oauth registry at construction time.
+ * generic org routes; this module declares the Codex wire protocol and keeps
+ * model listing. Does not require the oauth registry at construction time.
  */
 export class ChatGPTOAuthModule extends BaseProviderModule {
   constructor(authProfilesManager: AuthProfilesManager) {
     super(
       {
         providerId: "chatgpt",
+        sdkCompat: "openai-codex",
         providerDisplayName: "ChatGPT (subscription login)",
         providerIconUrl:
           "https://www.google.com/s2/favicons?domain=chatgpt.com&sz=128",
@@ -32,10 +30,7 @@ export class ChatGPTOAuthModule extends BaseProviderModule {
         // own key so the two never collide.
         baseUrlEnvVarName: "OPENAI_CODEX_BASE_URL",
         authType: "device-code",
-        supportedAuthTypes: ["device-code", "api-key"],
-        apiKeyInstructions:
-          'Enter your <a href="https://platform.openai.com/api-keys" target="_blank" class="text-blue-600 underline">OpenAI API key</a>:',
-        apiKeyPlaceholder: "sk-...",
+        supportedAuthTypes: ["device-code"],
         catalogDescription:
           "Sign in with your ChatGPT Plus/Pro subscription (device code). No API key; uses your subscription, not metered API billing.",
       },
@@ -43,39 +38,6 @@ export class ChatGPTOAuthModule extends BaseProviderModule {
     );
     // Preserve existing module name
     this.name = "chatgpt-oauth";
-  }
-
-  async buildCredentialPlaceholder(
-    agentId: string,
-    context?: ProviderCredentialContext,
-  ): Promise<string> {
-    const profile = await this.authProfilesManager.getBestProfile(
-      agentId,
-      this.providerId,
-      undefined,
-      context,
-    );
-    // Try metadata first, then extract from the stored credential JWT
-    let accountId = profile?.metadata?.accountId as string | undefined;
-    if (!accountId && profile?.credential) {
-      const claimPath =
-        getOAuthProviderConfig("chatgpt")?.accountIdClaimPath ??
-        "https://api.openai.com/auth";
-      accountId = extractJwtAccountId(profile.credential, claimPath);
-    }
-    if (!accountId) return "lobu-proxy";
-
-    // Minimal JWT with the chatgpt_account_id claim.
-    // Not a valid credential — only used by the codex backend to extract accountId.
-    const header = Buffer.from(
-      JSON.stringify({ alg: "none", typ: "JWT" }),
-    ).toString("base64url");
-    const payload = Buffer.from(
-      JSON.stringify({
-        "https://api.openai.com/auth": { chatgpt_account_id: accountId },
-      }),
-    ).toString("base64url");
-    return `${header}.${payload}.placeholder`;
   }
 
   async getModelOptions(

--- a/packages/server/src/gateway/auth/provider-catalog.ts
+++ b/packages/server/src/gateway/auth/provider-catalog.ts
@@ -69,8 +69,10 @@ export interface ProviderCatalogEntry {
   supportedAuthTypes: ProviderAuthType[];
   /**
    * Wire protocol the provider speaks. "openai" for the config-driven OpenAI-
-   * compatible providers; null when unknown/not-yet-routable (the OAuth
-   * providers — their real protocol is wired in a later phase).
+   * compatible providers; the subscription providers declare their own
+   * ("anthropic" for Claude, "openai-codex" for ChatGPT). null when the
+   * protocol is unknown. Speaking a routable protocol says nothing about how
+   * the provider authenticates — `supportedAuthTypes` is that answer.
    */
   sdkCompat: string | null;
   /** Upstream base URL pre-fill ("" when the module doesn't expose one). */
@@ -426,8 +428,8 @@ export class ProviderCatalogService {
       catalogByKind = new Map();
       for (const entry of buildProviderCatalog()) {
         // Only offer a fallback upstream for a kind an API key can actually
-        // reach. A kind with no usable `sdkCompat` (chatgpt) has a real
-        // `baseUrl` that answers to a signed-in session, not a Bearer key.
+        // reach. A subscription-only kind may speak a supported protocol but
+        // its upstream still requires a signed-in session, not an API key.
         // Carry the protocol either way — the synthesizer needs it — but never
         // the URL.
         const sdkCompat = isSdkCompat(entry.sdkCompat)
@@ -435,7 +437,7 @@ export class ProviderCatalogService {
           : undefined;
         catalogByKind.set(entry.slug, {
           sdkCompat,
-          baseUrl: sdkCompat ? entry.baseUrl || undefined : undefined,
+          baseUrl: sdkCompat && entry.supportedAuthTypes.includes("api-key") ? entry.baseUrl || undefined : undefined,
         });
       }
     }

--- a/packages/server/src/gateway/orchestration/agent-turn-producer.ts
+++ b/packages/server/src/gateway/orchestration/agent-turn-producer.ts
@@ -82,6 +82,10 @@ const logger = createLogger("agent-turn-producer");
  * use tools, so omitting it here left every official-OpenAI agent unable to
  * run at all.
  *
+ * `openai-codex-responses` (the ChatGPT subscription protocol) is fetch-native
+ * too, but only over SSE — the worker pins that transport because the guest
+ * has no WebSocket (`native-session.ts`).
+ *
  * Typed as the envelope's own `api` union so the set and the wire contract
  * cannot drift: adding an adapter here without widening the schema is a
  * compile error, not a run that fails validation on the worker.
@@ -91,6 +95,7 @@ const LANE_APIS = new Set<string>([
   "anthropic-messages",
   "openai-completions",
   "openai-responses",
+  "openai-codex-responses",
 ] satisfies LaneApi[]);
 
 const TURN_MESSAGE_CHARS = 32_000;

--- a/packages/server/src/gateway/proxy/secret-proxy.ts
+++ b/packages/server/src/gateway/proxy/secret-proxy.ts
@@ -6,6 +6,7 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { getDb } from "../../db/client.js";
 import { resolveUrlInvariant } from "../auth/inference-invariant.js";
+import { extractJwtAccountId } from "../auth/oauth/client.js";
 import type { AuthProfilesManager } from "../auth/settings/auth-profiles-manager.js";
 import type { ProviderCredentialContext } from "../embedded.js";
 import type { ProviderUpstreamConfig } from "../modules/module-system.js";
@@ -44,6 +45,8 @@ function captureInferencePath(api: AgentTurnInput["provider"]["api"]): string {
       return "/chat/completions";
     case "openai-responses":
       return "/responses";
+    case "openai-codex-responses":
+      return "/codex/responses";
   }
 }
 
@@ -721,6 +724,7 @@ export class SecretProxy {
       const suffix = provider?.api === "anthropic-messages"
         || provider?.api === "openai-completions"
         || provider?.api === "openai-responses"
+        || provider?.api === "openai-codex-responses"
         ? captureInferencePath(provider.api)
         : null;
       const expected = suffix && typeof provider?.base_url === "string"
@@ -998,6 +1002,31 @@ export class SecretProxy {
             resolvedCredential.value,
             resolvedCredential.kind
           );
+          if (providerId === "chatgpt") {
+            // Codex binds requests to the stored OAuth account, never a guest
+            // header or the adapter's non-secret account placeholder.
+            const accountId = extractJwtAccountId(
+              resolvedCredential.value,
+              "https://api.openai.com/auth"
+            );
+            // Same envelope as the no-credentials refusal below: pi-ai reads
+            // `error.message` off the body, so a bare string would surface to
+            // the user as raw JSON.
+            if (!accountId) {
+              return c.json(
+                {
+                  error: {
+                    message:
+                      "The stored ChatGPT credential carries no account identity. Sign in again to reconnect the subscription.",
+                    type: "authentication_error",
+                    code: "no_account_identity",
+                  },
+                },
+                401
+              );
+            }
+            headers["chatgpt-account-id"] = accountId;
+          }
         } else {
           logger.warn(
             `No auth profile, org-shared key, or system key for agent ${urlAgentId}, provider ${providerId}`

--- a/packages/server/src/gateway/services/core-services.ts
+++ b/packages/server/src/gateway/services/core-services.ts
@@ -621,9 +621,10 @@ export class CoreServices {
 		);
 		logger.debug("Token refresh job constructed");
 
-		// Runtime modules with provider-specific credential injection (Anthropic
-		// headers, Codex account placeholders). OAuth *endpoints* still come from
-		// providers.json via the registry above.
+		// Runtime modules with provider-specific credential surfaces (Anthropic
+		// headers; the Codex wire protocol and model listing — ChatGPT's account
+		// binding is applied at egress by the secret proxy). OAuth *endpoints*
+		// still come from providers.json via the registry above.
 		this.oauthStateStore = createOAuthStateStore("claude");
 		const claudeOAuthModule = new ClaudeOAuthModule(
 			this.authProfilesManager,

--- a/packages/server/src/lobu/__tests__/inference-provider-create-seeds-model.test.ts
+++ b/packages/server/src/lobu/__tests__/inference-provider-create-seeds-model.test.ts
@@ -15,6 +15,7 @@ import {
 	moduleRegistry,
 } from "@lobu/core";
 import { ApiKeyProviderModule } from "../../gateway/auth/api-key-provider-module.js";
+import { ChatGPTOAuthModule } from "../../gateway/auth/chatgpt/chatgpt-oauth-module.js";
 import {
 	ensureDbForGatewayTests,
 	resetTestDatabase,
@@ -118,6 +119,7 @@ function registerCatalogModules(): void {
 			authProfilesManager: { getBestProfile: async () => null } as never,
 		}) as unknown as ModuleInterface,
 	);
+	moduleRegistry.register(new ChatGPTOAuthModule({} as never) as unknown as ModuleInterface);
 	moduleRegistry.register({
 		name: "claude-provider",
 		isEnabled: () => true,
@@ -125,6 +127,7 @@ function registerCatalogModules(): void {
 		providerDisplayName: "Claude",
 		providerIconUrl: "",
 		authType: "oauth",
+		supportedAuthTypes: ["oauth", "api-key"],
 		sdkCompat: "anthropic",
 		hasSystemKey: () => false,
 		getSecretEnvVarNames: () => [],
@@ -168,6 +171,13 @@ describe("POST /inference-providers seeds a routable text model", () => {
 	});
 
 	afterEach(() => restoreModules());
+
+	test("Codex runtime support does not allow subscription credentials through API-key creation", async () => {
+		const res = await createProvider({ slug: "chatgpt", kind: "chatgpt", apiKey: "synthetic-not-a-subscription" });
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "Provider 'chatgpt' can't be added with an API key — it signs in instead." });
+		expect(await readCapabilities("chatgpt")).toBeUndefined();
+	});
 
 	test("a catalog provider created with NO capabilities gets the catalog default model", async () => {
 		const res = await createProvider({

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -953,10 +953,11 @@ routes.post("/inference-providers", async (c) => {
 	const capErr = validateCapabilitiesMap(body.capabilities);
 	if (capErr) return c.json({ error: capErr }, 400);
 
-	// Known catalog kinds must use a routable wire protocol. Unknown kinds pass
-	// because custom endpoints are synthesized as OpenAI-compatible providers.
-	// Read the default from configs because the catalog contains only provider
-	// modules registered in this process.
+	// Known catalog kinds must accept API keys AND speak a routable wire
+	// protocol — a subscription kind can speak one and still have nothing an API
+	// key may reach. Unknown kinds pass because custom endpoints are synthesized
+	// as OpenAI-compatible providers. Read the default from configs because the
+	// catalog contains only provider modules registered in this process.
 	let catalogDefaultModel: string | undefined;
 	// The upstream this `kind` already resolves to. An alias row (slug !== kind)
 	// with no base_url of its own is synthesized against it, so its presence is
@@ -967,7 +968,11 @@ routes.post("/inference-providers", async (c) => {
 		const configs = await registry.getProviderConfigs();
 		const catalog = buildProviderCatalog(configs);
 		const entry = catalog.find((e) => e.slug === kind);
-		if (entry && !isSdkCompat(entry.sdkCompat)) {
+		if (
+			entry &&
+			(!entry.supportedAuthTypes.includes("api-key") ||
+				!isSdkCompat(entry.sdkCompat))
+		) {
 			return c.json(
 				{
 					error: `Provider '${kind}' can't be added with an API key — it signs in instead.`,
@@ -977,19 +982,22 @@ routes.post("/inference-providers", async (c) => {
 		}
 		catalogDefaultModel = configs[kind]?.defaultModel ?? undefined;
 		// The EXACT expression `getModelPolicy` evaluates — argless
-		// `buildProviderCatalog()`, then the same `sdkCompat` gate. These two must
-		// agree: a text model is what `promoteOldestRunnableProvider` keys on, so
-		// a row seeded as routable and then dropped at routing becomes the org
-		// DEFAULT and breaks every allow-all agent in the org.
+		// `buildProviderCatalog()`, then the same auth-method and `sdkCompat`
+		// gates. These two must agree: a text model is what
+		// `promoteOldestRunnableProvider` keys on, so a row seeded as routable and
+		// then dropped at routing becomes the org DEFAULT and breaks every
+		// allow-all agent in the org.
 		//
 		// `configs[kind].upstreamBaseUrl` looks equivalent and is not. It gives
 		// `claude` a URL, but claude registers as an OAuth module rather than an
 		// ApiKeyProviderModule, so the catalog reports "" and synthesis refuses
 		// it — trusting providers.json would seed exactly that unroutable row.
 		const catalogEntry = buildProviderCatalog().find((e) => e.slug === kind);
-		catalogBaseUrl = isSdkCompat(catalogEntry?.sdkCompat ?? null)
-			? catalogEntry?.baseUrl || undefined
-			: undefined;
+		catalogBaseUrl =
+			catalogEntry?.supportedAuthTypes.includes("api-key") &&
+			isSdkCompat(catalogEntry.sdkCompat)
+				? catalogEntry.baseUrl || undefined
+				: undefined;
 	} catch (err) {
 		// Fail open on catalog-load errors: don't block creation on a metadata
 		// read. The synthesize path still gates routing downstream.


### PR DESCRIPTION
## Summary
Restores ChatGPT subscription inference lost during the native isolate cutover (#3402). Agents configured with `chatgpt/gpt-5.6-luna` now reach the Codex Responses adapter through the real queued worker path instead of being rejected as having no configured model.

The worker receives only its signed turn token and an inert adapter placeholder; the gateway supplies the stored OAuth credential and account identity. ChatGPT remains device-sign-in only: API-key creation and the frontend setup controls consult supported authentication methods separately from runtime protocol support.

## Test plan
- [x] Explicit-path staging and `make pre-pr` passed (build, typecheck, knip, lint/naming and platform gates).
- [x] Real worker HTTP + V8 isolate test performs a Codex tool call, returns its result to the model, and completes the durable run. Compatible-provider sibling also passes.
- [x] Producer + isolate suites: 226 passed. Capture suite: 14 passed, including Codex endpoint restrictions.
- [x] Gateway compatibility boundary + native tool round trips: 11 passed. Registry/authentication suites after metadata correction: 169 passed.
- [x] Core tests: 486 passed. Auth/catalog/create regression suites: 44 passed. Proxy/provider boundary suites: 74 passed.
- [x] Owletto provider setup/detail tests: 7 passed; actual form rendered in Chrome with synthetic catalog data.
- [x] Pre-review fixer completed; removed the superseded gateway JWT-placeholder branch and expanded protocol/capture coverage.

Red → green:
```text
Before runtime fix: ChatGPT module sdkCompat expected "openai-codex", received undefined (1 failed).
After: actual Codex tool round trip through worker HTTP and an isolate passed.

API-key creation regression before auth fix: expected 400, received 201 (1 failed, 8 passed).
After: 44 passed, 0 failed across auth/catalog/create suites.

UI regression before auth fix: expected API-key button to be null (1 failed, 2 passed).
After: 7 passed across provider setup/detail suites; browser confirms device sign-in only.
```

## Notes
Includes the exact squash commit of owletto#1073 (Opus review approved; reported CodeRabbit check green).

[Before/after browser proof](https://htmlpreview.github.io/?https://gist.githubusercontent.com/buremba/82d7741077fc8b4b8d9af4f1c72d8dc2/raw/0d67a63868b5f9f220c78095c0da158a3f3eb769/comparison.html).

Live subscription and Slack verification will follow rollout of the squash commit. No live credentials or tenant identifiers are included in this change.
