### PR TITLE
fix(proxy): strip ingress routing headers from provider requests

### DIFF
--- a/packages/server/src/gateway/__tests__/secret-proxy-harden.test.ts
+++ b/packages/server/src/gateway/__tests__/secret-proxy-harden.test.ts
@@ -12,6 +12,7 @@
  *  - ResolutionFailureLimiter throttles after repeated failures.
  *  - storeSecretMapping + PlaceholderCache TTL interaction.
  *  - Placeholder NOT swapped on ingress (real secret never reaches worker).
+ *  - Ingress routing headers (cf-*, x-forwarded-*, via, …) never reach the upstream.
  */
 
 import { beforeEach, describe, expect, test } from "bun:test";
@@ -779,5 +780,64 @@ describe("secret-proxy forward — header stripping (#1176)", () => {
     // Kept: regular request headers still reach the upstream.
     expect(forwarded?.["content-type"]).toBe("application/json");
     expect(forwarded?.["x-custom-header"]).toBe("kept");
+  });
+
+  // Ingress routing metadata describes the hop into Lobu. Relaying it upstream
+  // makes ChatGPT answer with an HTML 403 before the request reaches the Codex
+  // API, so every `cf-*` / `x-forwarded-*` / forwarding header is dropped while
+  // provider protocol headers survive untouched.
+  test("ingress routing headers are stripped; provider protocol headers survive", async () => {
+    const proxy = buildProxy(makeSecretStore({}));
+    const ingressHeaders = {
+      "CF-Connecting-IP": "192.0.2.10",
+      "cf-visitor": '{"scheme":"https"}',
+      "cf-ray": "synthetic-ray",
+      "cf-ipcountry": "XX",
+      "cf-worker": "edge.example.com",
+      "cdn-loop": "cloudflare; loops=1",
+      forwarded: "for=192.0.2.10;proto=https",
+      "x-forwarded-for": "192.0.2.10",
+      "x-forwarded-host": "gateway.example.com",
+      "x-forwarded-proto": "https",
+      "x-forwarded-port": "443",
+      "x-forwarded-server": "gateway-test",
+      "x-real-ip": "192.0.2.10",
+      "true-client-ip": "192.0.2.10",
+      via: "1.1 gateway.example.com",
+    };
+    const providerHeaders = {
+      "content-type": "application/json",
+      accept: "text/event-stream",
+      "openai-beta": "responses=experimental",
+      "anthropic-version": "2023-06-01",
+      "chatgpt-account-id": "synthetic-account",
+      "x-client-request-id": "synthetic-request",
+      session_id: "synthetic-session",
+    };
+
+    let forwarded: Record<string, string> | null = null;
+    await withFetch(async (_input, init) => {
+      forwarded = (init?.headers as Record<string, string>) ?? null;
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }, async () => {
+      const res = await proxy.getApp().request("/v1/chat/completions", {
+        method: "POST",
+        headers: { ...ingressHeaders, ...providerHeaders },
+        body: "{}",
+      });
+      expect(res.status).toBe(200);
+    });
+
+    expect(forwarded).not.toBeNull();
+    const keys = Object.keys(forwarded ?? {}).map((k) => k.toLowerCase());
+    for (const name of Object.keys(ingressHeaders)) {
+      expect(keys).not.toContain(name.toLowerCase());
+    }
+    for (const [name, value] of Object.entries(providerHeaders)) {
+      expect(forwarded?.[name]).toBe(value);
+    }
   });
 });

--- a/packages/server/src/gateway/proxy/secret-proxy.ts
+++ b/packages/server/src/gateway/proxy/secret-proxy.ts
@@ -899,7 +899,7 @@ export class SecretProxy {
     // Build headers, swapping placeholder secrets in auth headers
     const headers: Record<string, string> = {};
 
-    // Forward all original headers (except host/connection and inbound auth).
+    // Forward provider headers, excluding ingress routing and inbound auth.
     // We always set our own Authorization below, so the caller's Authorization
     // (which carries an opaque placeholder) must never reach the upstream.
     const skip = new Set([
@@ -920,9 +920,21 @@ export class SecretProxy {
       "authorization",
       "x-api-key",
       "x-lobu-worker-token",
+      // Ingress routing metadata (these, plus the `cf-*` / `x-forwarded-*`
+      // prefixes matched in `shouldSkipHeader`). They describe the hop INTO
+      // Lobu, not our request to the provider: ChatGPT answers an egress
+      // request that relays Cloudflare ingress metadata with an HTML 403,
+      // before it ever reaches the Codex API.
+      "forwarded",
+      "x-real-ip",
+      "true-client-ip",
+      "via",
+      "cdn-loop",
     ]);
+    const shouldSkipHeader = (name: string): boolean =>
+      skip.has(name) || name.startsWith("cf-") || name.startsWith("x-forwarded-");
     for (const [key, val] of Object.entries(c.req.header())) {
-      if (val && !skip.has(key.toLowerCase())) {
+      if (val && !shouldSkipHeader(key.toLowerCase())) {
         headers[key] = val;
       }
     }


### PR DESCRIPTION
## Summary
Production Codex requests reached the restored isolate adapter but failed with an upstream HTML 403 because the secret proxy relayed Cloudflare ingress headers to ChatGPT. Strip ingress routing metadata at the shared proxy boundary while preserving provider protocol headers and credential injection.

## Test plan
- [x] Regression test: old proxy 17 pass / 1 fail; fixed focused suites 42 pass / 0 fail.
- [x] Provider health integration suite: 7 pass / 0 fail (30-second hook timeout for embedded Postgres startup).
- [x] Booted proxy on localhost with Cloudflare ingress headers, forwarded to the real Codex endpoint without credentials: JSON 401 Unauthorized, proving it reaches API authentication instead of the edge HTML 403.
- [x] Production-pod diagnosis without credentials: baseline JSON 401; adding either `cf-connecting-ip` or `cf-visitor` causes HTML 403; provider protocol headers alone retain JSON 401.
- [x] Intended files staged explicitly; `make pre-pr` passed.
- [x] GitHub CI and exact-head semantic review passed; all 10 required checks passed before merge.
- [x] Deployed squash `8f72dfdc597e2fd38fa806ecad64aa34e70ef0d1`; production smoke 9 passed / 0 failed.
- [x] Live signed-in web chat returned `LOBU_LUNA_PROD_8F72DFDC_OK`. Durable run completed with `gpt-5.6-luna` through `openai-codex-responses`.
- [x] Live read-only tool round trip: transcript records successful `read` and `ls` results, then `LOBU_LUNA_TOOL_8F72DFDC_OK`; durable run completed.

The first local Chromium smoke hung and was stopped; the bounded retry completed all four rendered MCP scenarios and the full 9/9 production smoke. A new Slack DM smoke was not completed: desktop automation timed out and the browser lacks the target workspace session.

Red → green:
```text
Before:
17 pass
1 fail
Expected: false
Received: true

After:
42 pass
0 fail
104 expect() calls

Provider health:
7 pass
0 fail
17 expect() calls
```

Follow-up to #3473. No auth configuration or database changes.
