### PR TITLE
fix(device-daemon): self-exec the compiled CLI supervisor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1705,7 +1705,7 @@ jobs:
             exit 0
           fi
           changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if echo "$changed" | grep -E '^(packages/owletto($|/)|packages/cli/|packages/connector-worker/|packages/core/|packages/device-connectors/|config/macos/lobu-auth\.entitlements$|scripts/(build-mac-auth-cli|build-mac-device-daemon|test-mac-device-daemon-package|check-mac-device-daemon-graph|verify-mac-device-daemon|with-owletto-mac-daemon)\.|package\.json$|bun\.lock$|\.github/workflows/mac-release\.yml$|\.github/workflows/ci\.yml$|\.github/actions/setup-submodule(/|$)|\.gitmodules$)' >/dev/null; then
+          if echo "$changed" | grep -E '^(packages/owletto($|/)|packages/cli/|packages/connector-worker/|packages/core/|packages/device-connectors/|config/macos/lobu-auth\.entitlements$|scripts/(build-mac-auth-cli|build-mac-device-daemon|test-mac-device-daemon-package|test-mac-device-daemon-chat|check-mac-device-daemon-graph|verify-mac-device-daemon|with-owletto-mac-daemon)\.|package\.json$|bun\.lock$|\.github/workflows/mac-release\.yml$|\.github/workflows/ci\.yml$|\.github/actions/setup-submodule(/|$)|\.gitmodules$)' >/dev/null; then
             echo "mac=true" >> "$GITHUB_OUTPUT"
           else
             echo "mac=false" >> "$GITHUB_OUTPUT"

--- a/packages/connector-worker/src/daemon/automation-process.ts
+++ b/packages/connector-worker/src/daemon/automation-process.ts
@@ -19,13 +19,14 @@ const PROCESS_REAP_GRACE_MS = 5000;
  * descendants still receive the group signal, while the supervisor remains the
  * ownership anchor until the daemon releases or SIGKILLs it.
  *
- * POSIX caller contract: serialize and spawn this closure-free function with
- * `detached: true`, making the supervisor the session/process-group leader
- * whose pgid equals its pid. Its parent-loss path uses that invariant for safe
- * negative-pid group signals.
+ * POSIX caller contract: run this in a process of its own, spawned with
+ * `detached: true`, so the supervisor is the session/process-group leader whose
+ * pgid equals its pid. Its parent-loss path uses that invariant for safe
+ * negative-pid group signals. Keep the body closure-free: one launch mechanism
+ * serializes it through `toString()`.
  */
-function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): void {
-  const [binary, ...args] = process.argv.slice(1);
+function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number, argv: string[]): void {
+  const [binary, ...args] = argv;
   let targetFinished = false;
   let parentLost = false;
   let target: ChildProcess | undefined;
@@ -145,7 +146,24 @@ function runCliSupervisor(spawnChild: typeof spawn, treeTermGraceMs: number): vo
   });
 }
 
-export const CLI_SUPERVISOR_SOURCE = `(${runCliSupervisor.toString()})(require('node:child_process').spawn, ${TREE_TERM_GRACE_MS});`;
+export const CLI_SUPERVISOR_SOURCE = `(${runCliSupervisor.toString()})(require('node:child_process').spawn, ${TREE_TERM_GRACE_MS}, process.argv.slice(1));`;
+
+// `-e CLI_SUPERVISOR_SOURCE` needs a runtime that evaluates source from the
+// command line, which every host running this package from source or a Node
+// bundle has. A `bun build --compile` artifact cannot re-enter itself that way,
+// so its entrypoint registers a self-exec command instead: the same supervisor,
+// reached through the executable's own internal argument. Set once at startup,
+// before any job is admitted, and process-local by construction.
+let supervisorCommand: { command: string; prefix: readonly string[] } | undefined;
+
+export function configureCliSupervisorCommand(command: string, prefix: readonly string[]): void {
+  supervisorCommand = { command, prefix: [...prefix] };
+}
+
+/** Entrypoint-side landing for the self-exec command above. */
+export function runPackagedCliSupervisor(argv: string[]): void {
+  runCliSupervisor(spawn, TREE_TERM_GRACE_MS, argv);
+}
 
 export type TargetExitStage =
   | 'target_exit'
@@ -367,8 +385,8 @@ export function spawnSupervisedCli(
   options: { stdin?: 'ignore' | 'pipe'; cwd?: string } = {}
 ): SupervisedCli {
   const supervisor = spawn(
-    process.execPath,
-    ['-e', CLI_SUPERVISOR_SOURCE, '--', binary, ...args],
+    supervisorCommand?.command ?? process.execPath,
+    [...(supervisorCommand?.prefix ?? ['-e', CLI_SUPERVISOR_SOURCE, '--']), binary, ...args],
     {
       detached: SUPPORTS_PROCESS_GROUPS,
       env,

--- a/packages/connector-worker/src/daemon/mac-device-daemon.ts
+++ b/packages/connector-worker/src/daemon/mac-device-daemon.ts
@@ -72,8 +72,12 @@ function defaultWorkerId(): string {
   return `${MAC_DEVICE_PLATFORM}:${shortHostname}`;
 }
 
-function packagedAcpAdapterArgs(agentKind: 'claude-code' | 'codex'): string[] {
-  const args = [INTERNAL_ACP_ADAPTER_ARG, agentKind];
+/**
+ * Argv for re-entering this daemon's own entrypoint. A compiled artifact is its
+ * own interpreter, so the internal argument stands alone; running from source
+ * needs the script path back in front of it.
+ */
+export function packagedDaemonArgs(...args: string[]): string[] {
   return process.argv[1] && /\.[cm]?[jt]s$/.test(process.argv[1])
     ? [process.argv[1], ...args]
     : args;
@@ -309,7 +313,7 @@ export function createMacDeviceDaemon(
   if (codexPath) {
     acpAdapters.codex = {
       command: process.execPath,
-      args: packagedAcpAdapterArgs('codex'),
+      args: packagedDaemonArgs(INTERNAL_ACP_ADAPTER_ARG, 'codex'),
       env: { CODEX_PATH: codexPath },
       defaultMode: 'agent',
       effortConfigId: 'reasoning_effort',
@@ -318,7 +322,7 @@ export function createMacDeviceDaemon(
   if (claudePath) {
     acpAdapters['claude-code'] = {
       command: process.execPath,
-      args: packagedAcpAdapterArgs('claude-code'),
+      args: packagedDaemonArgs(INTERNAL_ACP_ADAPTER_ARG, 'claude-code'),
       env: {
         CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
         CLAUDE_CODE_EXECUTABLE: claudePath,

--- a/packages/connector-worker/src/mac-device-daemon.ts
+++ b/packages/connector-worker/src/mac-device-daemon.ts
@@ -3,14 +3,20 @@
 import packageJson from '../package.json' with { type: 'json' };
 import type { AgentKind } from '@lobu/core/contracts/worker/device-automation';
 import {
+  configureCliSupervisorCommand,
+  runPackagedCliSupervisor,
+} from './daemon/automation-process.js';
+import {
   INTERNAL_ACP_ADAPTER_ARG,
   macDeviceDaemonMetadata,
+  packagedDaemonArgs,
   runMacDeviceDaemon,
   validateMacDeviceDaemonOptions,
 } from './daemon/mac-device-daemon.js';
 import { NATIVE_BRIDGE_PROTOCOL } from './daemon/native-bridge/protocol.js';
 
 const VERSION = packageJson.version;
+const INTERNAL_CLI_SUPERVISOR_ARG = '--internal-cli-supervisor';
 
 function printHelp(): void {
   process.stdout.write(`lobu-device-daemon ${VERSION}
@@ -151,6 +157,10 @@ async function main(): Promise<void> {
 }
 
 async function start(): Promise<void> {
+  if (process.argv[2] === INTERNAL_CLI_SUPERVISOR_ARG) {
+    runPackagedCliSupervisor(process.argv.slice(3));
+    return;
+  }
   if (process.argv[2] === INTERNAL_ACP_ADAPTER_ARG) {
     // Dynamic on purpose, and not for bundle size — `bun build --compile` links
     // this module into the artifact either way. The adapter is a side-effectful
@@ -175,6 +185,7 @@ async function start(): Promise<void> {
     }
     throw new Error(`unknown internal ACP adapter '${agentKind ?? ''}'`);
   }
+  configureCliSupervisorCommand(process.execPath, packagedDaemonArgs(INTERNAL_CLI_SUPERVISOR_ARG));
   await main();
 }
 

--- a/scripts/test-mac-device-daemon-chat.mjs
+++ b/scripts/test-mac-device-daemon-chat.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Drive one device chat turn through the shipped executable rather than
+// importing runCli into Node/Bun: a compiled Bun artifact cannot re-enter its
+// runtime with `process.execPath -e`, and only the real binary proves which
+// supervisor launch it actually uses.
+//
+// Usage: node scripts/test-mac-device-daemon-chat.mjs <path-to-lobu-device-daemon>
+if (!process.argv[2]) {
+  console.error(
+    "usage: node scripts/test-mac-device-daemon-chat.mjs <path-to-lobu-device-daemon>"
+  );
+  process.exit(2);
+}
+const artifact = resolve(process.argv[2]);
+const work = await mkdtemp(join(tmpdir(), "lobu-packaged-chat-"));
+const bin = join(work, "bin");
+await mkdir(bin);
+await writeFile(
+  join(bin, "codex"),
+  "#!/bin/sh\n" +
+    'if [ -n "$WORKER_API_TOKEN" ]; then echo "WORKER_API_TOKEN reached the CLI" >&2; exit 42; fi\n' +
+    'printf "%s\\n" "$@" > "$ARG_LOG"\n' +
+    'printf "COMPILED_DEVICE_CHAT_OK\\n"\n',
+  { mode: 0o755 }
+);
+let claimed = false;
+let complete;
+const completed = new Promise((settle) => {
+  complete = settle;
+});
+const server = createServer(async (req, res) => {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const body = JSON.parse(Buffer.concat(chunks).toString() || "{}");
+  res.setHeader("content-type", "application/json");
+  if (req.url === "/api/workers/poll" && !claimed) {
+    claimed = true;
+    res.end(
+      JSON.stringify({
+        run_id: 91,
+        run_type: "chat_message",
+        organization_id: "org-synthetic",
+        payload: {
+          chat: {
+            agent_kind: "codex",
+            execution_config: { model: "synthetic-model", effort: "xhigh" },
+            message: "Return the synthetic test reply.",
+            history: [],
+            agent: { id: "synthetic-agent" },
+          },
+          context: {
+            device: { worker_id: "synthetic-device" },
+            user: { user_id: "synthetic-user" },
+            agent_session: {
+              conversation_id: "synthetic-conversation",
+              mcp_url: "https://example.test/mcp",
+              token: "synthetic-run-token",
+              expires_at: Date.now() + 60_000,
+            },
+          },
+        },
+      })
+    );
+  } else if (req.url === "/api/workers/me/runs/91/complete-chat") {
+    res.end(
+      JSON.stringify({ ok: true, status: body.error ? "failed" : "completed" })
+    );
+    complete(body);
+  } else {
+    res.end(JSON.stringify({ next_poll_seconds: 1 }));
+  }
+});
+let child;
+let timeout;
+let stderr = "";
+try {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const port = server.address().port;
+  child = spawn(
+    artifact,
+    [
+      "--api-url",
+      `http://127.0.0.1:${port}`,
+      "--worker-id",
+      "synthetic-device",
+      "--default-agent-kind",
+      "codex",
+      "--poll-interval-ms",
+      "50",
+    ],
+    {
+      env: {
+        PATH: `${bin}:/usr/bin:/bin`,
+        HOME: work,
+        TMPDIR: work,
+        WORKER_API_TOKEN: `owl_pat_${"x".repeat(32)}`,
+        ARG_LOG: join(work, "args"),
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    }
+  );
+  const exited = once(child, "exit");
+  child.stderr.on("data", (chunk) => {
+    stderr = (stderr + chunk).slice(-4000);
+  });
+  const report = await Promise.race([
+    completed,
+    exited.then(([code]) => {
+      throw new Error(`Daemon exited ${code}: ${stderr}`);
+    }),
+    new Promise((_, reject) => {
+      timeout = setTimeout(
+        () => reject(new Error(`Timed out: ${stderr}`)),
+        20_000
+      );
+    }),
+  ]);
+  assert.equal(report.error, null, JSON.stringify(report));
+  assert.equal(report.exit_code, 0);
+  assert.equal(report.output, "COMPILED_DEVICE_CHAT_OK");
+  const args = await readFile(join(work, "args"), "utf8");
+  assert.match(args, /model_reasoning_effort="xhigh"/);
+  assert.match(args, /synthetic-model/);
+  console.log(
+    "Compiled device chat: poll → supervised CLI → completion passed"
+  );
+} finally {
+  clearTimeout(timeout);
+  if (child && child.exitCode === null && child.signalCode === null) {
+    const exited = once(child, "exit");
+    child.kill("SIGTERM");
+    const kill = setTimeout(() => child.kill("SIGKILL"), 8000);
+    await exited;
+    clearTimeout(kill);
+  }
+  server.closeAllConnections();
+  await new Promise((closed) => server.close(closed));
+  await rm(work, { recursive: true, force: true });
+}

--- a/scripts/test-mac-device-daemon-package.sh
+++ b/scripts/test-mac-device-daemon-package.sh
@@ -75,6 +75,10 @@ codesign --force --options runtime --sign - \
 HARDENED_JSON="$(run_clean "$ROOT/scripts/verify-mac-device-daemon.sh" ./lobu-device-daemon)"
 [[ "$HARDENED_JSON" == "$VERSION_JSON" ]]
 
+# Run a real poll/CLI/completion cycle through the copied, hardened artifact.
+# Metadata-only checks cannot detect an invalid self-exec supervisor command.
+node "$ROOT/scripts/test-mac-device-daemon-chat.mjs" "$CLEAN/lobu-device-daemon"
+
 echo "Mac device-daemon package smoke passed"
 echo "$VERSION_JSON"
 stat -f 'artifact_bytes=%z' "$CLEAN/lobu-device-daemon"


### PR DESCRIPTION
## Summary
Compiled Mac daemons failed before starting a local agent because the supervisor invoked the compiled executable with `-e`, which its argument parser rejects. Re-enter the daemon through an internal supervisor command while retaining the existing process-group ownership and cancellation logic.

Add a compiled-artifact chat smoke to the hardened Mac packaging gate, including argument forwarding and worker-token isolation. Include the harness in CI path selection.

## Test plan
- [x] Six intended files staged explicitly; `make pre-pr` and pre-commit checks clean.
- [x] Full hardened Mac packaging smoke passed after review fixes.
- [x] Focused runner, device chat, daemon, and signing tests: 69 passed, 0 failed.
- [x] Regression reproduced against the original compiled executable and mutation-proved by removing supervisor setup.
- [x] Worker-token isolation mutation fails with exit 42; restored implementation passes.
- [x] Real Slack reply through the installed signed Mac app using Codex Astra with medium effort.
- [x] Real device shell operation returned `LOBU_COMPILED_SHELL_OK`, exit 0.

Red:
```text
codex exited with status 1: error: unexpected argument '-e'
```
Green:
```text
Compiled device chat: poll → supervised CLI → completion passed
Mac device-daemon package smoke passed
```

## Notes
This repairs CLI startup. The separate end-to-end poll test reached the agent but stopped because its poll skill was unavailable; poll creation, voting, and deadline handling are not claimed as verified by this PR.

## Completion
Merged as `0b45a63d5c2eeb0cbb4c1859c2a78580e34560ba`; ancestry verified on `origin/main`. All ten required checks passed. Final semantic review: confidence 90, zero bugs/blockers.

Installed signed Mac app was rebuilt from the reviewed commit; its daemon matches the build byte for byte, and runtime source is identical to the squash commit. A fresh real Slack request returned `LOBU_SLACK_FINAL_ASTRA_MEDIUM_OK` using Astra medium. Existing device registration and credentials were preserved. No GitHub release was created for proof.
