### PR TITLE
fix(chrome)!: require device-pinned browser execution

### DIFF
--- a/examples/brand-intelligence/capterra.connector.ts
+++ b/examples/brand-intelligence/capterra.connector.ts
@@ -230,7 +230,6 @@ export default class CapterraConnector extends ConnectorRuntime {
       config: REVIEW_SCRAPE_CONFIG,
       parseRows: (raw) => raw as CapterraRow[],
       allowedOrigins: CAPTERRA_ALLOWED_ORIGINS,
-      existingTabMatch: "capterra.com/p/",
     });
 
     const reviews = rows

--- a/examples/brand-intelligence/glassdoor.connector.ts
+++ b/examples/brand-intelligence/glassdoor.connector.ts
@@ -198,7 +198,6 @@ export default class GlassdoorConnector extends ConnectorRuntime {
       allowedOrigins: GLASSDOOR_ALLOWED_ORIGINS,
       // Reviews render for signed-out visitors too, but a signed-in tab sees
       // the full list rather than the teaser, so prefer one the user has open.
-      existingTabMatch: "glassdoor.com/Reviews",
     });
 
     if (!loggedIn) {

--- a/examples/brand-intelligence/trustpilot.connector.ts
+++ b/examples/brand-intelligence/trustpilot.connector.ts
@@ -165,7 +165,6 @@ export default class TrustpilotConnector extends ConnectorRuntime {
       config: REVIEW_SCRAPE_CONFIG,
       parseRows: (raw) => raw as TrustpilotRow[],
       allowedOrigins: TRUSTPILOT_ALLOWED_ORIGINS,
-      existingTabMatch: "trustpilot.com/review/",
     });
 
     // Reviews with meaningful content (more than 10 chars).

--- a/examples/personal-agent/__tests__/connector-sdk.mock.ts
+++ b/examples/personal-agent/__tests__/connector-sdk.mock.ts
@@ -26,7 +26,6 @@ interface DomScrapeOpts {
   allowedOrigins: string[];
   persistent?: boolean;
   focus?: boolean;
-  existingTabMatch?: string;
 }
 
 // Faithful copies of the SDK's pure pagination generators (no browser stack).
@@ -178,9 +177,6 @@ export function connectorSdkMock() {
         url: opts.url,
         scrape_config: opts.config,
         allowed_origins: opts.allowedOrigins,
-        ...(opts.existingTabMatch
-          ? { existing_tab_match: opts.existingTabMatch }
-          : {}),
       });
       const result = observation?.result;
       const items = opts.parseRows(result?.rows ?? []);

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1797,7 +1797,7 @@ describe("LinkedInConnector home_feed", () => {
     expect(calls[0].action).toBe("navigate");
     expect(calls[0].input.cs_scrape).toBe(true);
     expect(calls[0].input.persistent).toBe(true);
-    expect(calls[0].input.existing_tab_match).toBe("linkedin.com/feed/");
+    expect(calls[0].input.existing_tab_match).toBeUndefined();
     expect(calls[0].input.focus).toBe(false);
     expect(calls[0].input.url).toBe("https://www.linkedin.com/feed/");
     expect(

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -3565,7 +3565,6 @@ export default class LinkedInConnector extends ConnectorRuntime<
           post_identity: decodeHomeFeedPostIdentity(row.post_identity),
         })),
       allowedOrigins: LINKEDIN_ALLOWED_ORIGINS,
-      existingTabMatch: "linkedin.com/feed/",
       persistent: true,
     });
 
@@ -3576,7 +3575,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     }
     if (rows.length === 0) {
       throw new Error(
-        "LinkedIn is logged in, but the home feed produced no post rows. Keep a signed-in linkedin.com/feed/ tab open on the paired browser and retry."
+        "LinkedIn is logged in, but the home feed produced no post rows. Confirm that the paired browser is signed into LinkedIn and retry."
       );
     }
 
@@ -3600,7 +3599,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     const events = buildHomeFeedEvents(resolvedRows, new Date());
     if (events.length === 0) {
       throw new Error(
-        "LinkedIn is logged in and returned feed rows, but no row combined usable content with a durable identity. Keep a signed-in linkedin.com/feed/ tab open on the paired browser and retry."
+        "LinkedIn is logged in and returned feed rows, but no row combined usable content with a durable identity. Confirm that the paired browser is signed into LinkedIn and retry."
       );
     }
 

--- a/packages/connector-sdk/src/__tests__/extension-dom-scrape.test.ts
+++ b/packages/connector-sdk/src/__tests__/extension-dom-scrape.test.ts
@@ -156,35 +156,7 @@ describe('extensionDomScrape', () => {
     ).rejects.toThrow(/landedUrl reported evil\.example\.net/);
   });
 
-  test('passes existing_tab_match and reports usedExistingTab when set', async () => {
-    const { dispatcher, log } = makeDispatcher({
-      tab_id: 9,
-      cs_scrape: true,
-      existing_tab: true,
-      result: {
-        loggedIn: true,
-        host: 'www.example.com',
-        rows: [{ id: 'open-tab-row' }],
-      },
-    });
-
-    const res = await extensionDomScrape<{ id?: string }>({
-      dispatcher,
-      url: 'https://www.example.com/feed/',
-      config: {},
-      parseRows: (rows) => rows as { id?: string }[],
-      allowedOrigins: ['example.com'],
-      existingTabMatch: 'example.com/feed',
-    });
-
-    expect(log).toHaveLength(1);
-    expect(log[0].input.existing_tab_match).toBe('example.com/feed');
-    expect(log[0].input.persistent).toBe(false);
-    expect(res.usedExistingTab).toBe(true);
-    expect(res.items).toEqual([{ id: 'open-tab-row' }]);
-  });
-
-  test('omits existing_tab_match and reports usedExistingTab false by default', async () => {
+  test('always dispatches a single owned-tab scrape', async () => {
     const { dispatcher, log } = makeDispatcher({
       tab_id: 10,
       cs_scrape: true,
@@ -201,49 +173,14 @@ describe('extensionDomScrape', () => {
 
     expect(log).toHaveLength(1);
     expect(log[0].input.existing_tab_match).toBeUndefined();
-    expect(res.usedExistingTab).toBe(false);
+    expect(log[0].input.persistent).toBe(false);
+    expect(res.items).toEqual([{ id: 'scratch-row' }]);
   });
 
-  test('falls back to a scratch tab on no_matching_tab when fallbackToScratch is default', async () => {
-    const observations = [
-      {
-        cs_scrape: true,
-        result: { error: 'no_matching_tab', match: 'example.com/feed' },
-      },
-      {
-        tab_id: 11,
-        cs_scrape: true,
-        result: { loggedIn: true, rows: [{ id: 'fallback-row' }] },
-      },
-    ];
-    const log: DispatchLog[] = [];
-    const dispatcher: ChromeActionDispatcher = {
-      dispatch: async (action: string, input: Record<string, unknown>) => {
-        log.push({ action, input });
-        return observations.shift() as never;
-      },
-    };
-
-    const res = await extensionDomScrape<{ id?: string }>({
-      dispatcher,
-      url: 'https://www.example.com/feed/',
-      config: {},
-      parseRows: (rows) => rows as { id?: string }[],
-      allowedOrigins: ['example.com'],
-      existingTabMatch: 'example.com/feed',
-    });
-
-    expect(log).toHaveLength(2);
-    expect(log[0].input.existing_tab_match).toBe('example.com/feed');
-    expect(log[1].input.existing_tab_match).toBeUndefined();
-    expect(res.usedExistingTab).toBe(false);
-    expect(res.items).toEqual([{ id: 'fallback-row' }]);
-  });
-
-  test('fails loudly on no_matching_tab when fallbackToScratch is false', async () => {
+  test('surfaces a scrape error without retrying a second tab source', async () => {
     const { dispatcher, log } = makeDispatcher({
       cs_scrape: true,
-      result: { error: 'no_matching_tab', match: 'example.com/feed' },
+      result: { error: 'injection failed' },
     });
 
     await expect(
@@ -253,10 +190,8 @@ describe('extensionDomScrape', () => {
         config: {},
         parseRows: (rows) => rows,
         allowedOrigins: ['example.com'],
-        existingTabMatch: 'example.com/feed',
-        fallbackToScratch: false,
       })
-    ).rejects.toThrow(/no open tab matches existing_tab_match/);
+    ).rejects.toThrow('injection failed');
     expect(log).toHaveLength(1);
   });
 });

--- a/packages/connector-sdk/src/extension-dom-scrape.ts
+++ b/packages/connector-sdk/src/extension-dom-scrape.ts
@@ -102,9 +102,6 @@ export interface ExtensionDomScrapeResult<TItem> {
   landedUrl?: string;
   /** Tab the content-script scrape ran in. Useful for focusing an auth-wall tab. */
   tabId?: number;
-  /** Whether rows came from a user's already-open tab (true) or a run-scoped
-   * scratch tab the extension opened and closed (false). */
-  usedExistingTab: boolean;
 }
 
 function hostMatchesPattern(host: string, pattern: string): boolean {
@@ -151,11 +148,8 @@ function assertExpectedScrapeSite(
  * Scrapes default to a background, action-scoped tab that the extension closes
  * after harvesting. Set `persistent:true` only for a site with tab-bound state;
  * it selects that site's sticky anchor and serializes work on that anchor.
- *
- * Set `existingTabMatch` to prefer the user's ALREADY-OPEN tab whose URL
- * contains the substring. That tab is read in place — never created, navigated,
- * or closed. When no tab matches, the scrape falls back to a fresh scratch tab
- * unless `fallbackToScratch:false` makes it fail loudly instead.
+ * There is no way to target a user's own tab: the extension refuses any scrape
+ * against a tab it does not lease or hold as that site's anchor.
  */
 export async function extensionDomScrape<TItem>(opts: {
   dispatcher: ChromeActionDispatcher;
@@ -165,45 +159,16 @@ export async function extensionDomScrape<TItem>(opts: {
   allowedOrigins: string[];
   persistent?: boolean;
   focus?: boolean;
-  /** Prefer a user's already-open tab whose URL includes this substring. */
-  existingTabMatch?: string;
-  /** When existingTabMatch finds no open tab, fall back to the default scratch
-   * tab instead of failing (default true). */
-  fallbackToScratch?: boolean;
 }): Promise<ExtensionDomScrapeResult<TItem>> {
-  const wantsExistingTab =
-    typeof opts.existingTabMatch === 'string' && opts.existingTabMatch.length > 0;
-  const fallbackToScratch = opts.fallbackToScratch ?? true;
-  const dispatchScrape = (existing: boolean) =>
-    opts.dispatcher.dispatch<ExtensionScrapeObservation>('navigate', {
-      cs_scrape: true,
-      persistent: opts.persistent ?? false,
-      focus: opts.focus ?? false,
-      url: opts.url,
-      scrape_config: opts.config,
-      allowed_origins: opts.allowedOrigins,
-      ...(existing && wantsExistingTab
-        ? { existing_tab_match: opts.existingTabMatch }
-        : {}),
-    });
-
-  let usedExistingTab = false;
-  let observation = await dispatchScrape(wantsExistingTab);
-  let result = observation?.result;
-  // The extension reports a missing user tab via the error field — it is not a
-  // scrape failure. With a fallback, retry against a fresh scratch tab; without
-  // one, surface a distinct error instead of the generic "failed in the page".
-  if (wantsExistingTab && result?.error === 'no_matching_tab') {
-    if (!fallbackToScratch) {
-      throw new Error(
-        `cs_scrape: no open tab matches existing_tab_match "${opts.existingTabMatch}".`
-      );
-    }
-    observation = await dispatchScrape(false);
-    result = observation?.result;
-  } else if (wantsExistingTab) {
-    usedExistingTab = true;
-  }
+  const observation = await opts.dispatcher.dispatch<ExtensionScrapeObservation>('navigate', {
+    cs_scrape: true,
+    persistent: opts.persistent ?? false,
+    focus: opts.focus ?? false,
+    url: opts.url,
+    scrape_config: opts.config,
+    allowed_origins: opts.allowedOrigins,
+  });
+  const result = observation?.result;
 
   // Fail loudly on a broken scrape. A missing result (dispatch never produced
   // one) or an `error` field (the in-page script threw — e.g. CSP blocked
@@ -229,6 +194,5 @@ export async function extensionDomScrape<TItem>(opts: {
     host: result.host,
     landedUrl: result.landedUrl,
     tabId: observation.tab_id,
-    usedExistingTab,
   };
 }

--- a/packages/connectors/src/__tests__/connector-sdk.mock.ts
+++ b/packages/connectors/src/__tests__/connector-sdk.mock.ts
@@ -27,8 +27,6 @@ interface DomScrapeOpts {
   allowedOrigins: string[];
   persistent?: boolean;
   focus?: boolean;
-  existingTabMatch?: string;
-  fallbackToScratch?: boolean;
 }
 
 // Faithful copies of the SDK's pure pagination generators (no browser stack).
@@ -261,35 +259,15 @@ export function connectorSdkMock() {
       properties: {},
     },
     extensionDomScrape: async (opts: DomScrapeOpts) => {
-      const wantsExistingTab =
-        typeof opts.existingTabMatch === 'string' && opts.existingTabMatch.length > 0;
-      const fallbackToScratch = opts.fallbackToScratch ?? true;
-      const dispatchScrape = (existing: boolean) =>
-        opts.dispatcher.dispatch('navigate', {
-          cs_scrape: true,
-          persistent: opts.persistent ?? false,
-          focus: opts.focus ?? false,
-          url: opts.url,
-          scrape_config: opts.config,
-          allowed_origins: opts.allowedOrigins,
-          ...(existing && wantsExistingTab
-            ? { existing_tab_match: opts.existingTabMatch }
-            : {}),
-        });
-      let usedExistingTab = false;
-      let observation = await dispatchScrape(wantsExistingTab);
-      let result = observation?.result;
-      if (wantsExistingTab && result?.error === 'no_matching_tab') {
-        if (!fallbackToScratch) {
-          throw new Error(
-            `cs_scrape: no open tab matches existing_tab_match "${opts.existingTabMatch}".`
-          );
-        }
-        observation = await dispatchScrape(false);
-        result = observation?.result;
-      } else if (wantsExistingTab) {
-        usedExistingTab = true;
-      }
+      const observation = await opts.dispatcher.dispatch('navigate', {
+        cs_scrape: true,
+        persistent: opts.persistent ?? false,
+        focus: opts.focus ?? false,
+        url: opts.url,
+        scrape_config: opts.config,
+        allowed_origins: opts.allowedOrigins,
+      });
+      const result = observation?.result;
       const items = opts.parseRows(result?.rows ?? []);
       return {
         items,
@@ -297,7 +275,6 @@ export function connectorSdkMock() {
         count: result?.count ?? items.length,
         host: result?.host,
         landedUrl: result?.landedUrl,
-        usedExistingTab,
       };
     },
   };

--- a/packages/connectors/src/__tests__/x.test.ts
+++ b/packages/connectors/src/__tests__/x.test.ts
@@ -1766,13 +1766,13 @@ describe("XConnector home_feed", () => {
 		expect(props.min_scrolls?.type).toBe("integer");
 	});
 
-	test("home_feed configSchema accepts use_existing_tab", () => {
+	test("home_feed no longer offers unattended user-tab mutation", () => {
 		const props = new XConnector().definition.feeds.home_feed.configSchema
 			.properties as Record<string, { type?: string }>;
-		expect(props.use_existing_tab?.type).toBe("boolean");
+		expect(props.use_existing_tab).toBeUndefined();
 	});
 
-	test("use_existing_tab passes existing_tab_match and reports the existing-tab backend", async () => {
+	test("old feed config cannot re-enable unattended user-tab mutation", async () => {
 		const calls: Array<{ action: string; input: Record<string, unknown> }> = [];
 		const dispatcher = {
 			dispatch: async (action: string, input: Record<string, unknown>) => {
@@ -1780,7 +1780,6 @@ describe("XConnector home_feed", () => {
 				return {
 					tab_id: 1,
 					cs_scrape: true,
-					existing_tab: true,
 					result: {
 						loggedIn: true,
 						rows: [
@@ -1805,9 +1804,9 @@ describe("XConnector home_feed", () => {
 		});
 
 		expect(calls).toHaveLength(1);
-		expect(calls[0].input.existing_tab_match).toBe("x.com/home");
+		expect(calls[0].input.existing_tab_match).toBeUndefined();
 		expect(res.events).toHaveLength(1);
-		expect(res.metadata.backend).toBe("extension-cs-scrape-existing-tab");
+		expect(res.metadata.backend).toBe("extension-cs-scrape");
 	});
 
 	test("without use_existing_tab no existing_tab_match is sent and backend stays extension-cs-scrape", async () => {

--- a/packages/connectors/src/x.ts
+++ b/packages/connectors/src/x.ts
@@ -2380,7 +2380,7 @@ async function syncHomeFeedViaDomScrape(
 	checkpoint: XCheckpoint,
 ): Promise<SyncResult> {
 	const maxScrolls = readScrollBudget(config, { defaultMax: 10, cap: 30 });
-	const { items: rows, loggedIn, usedExistingTab } = await extensionDomScrape<HomeFeedRow>({
+	const { items: rows, loggedIn } = await extensionDomScrape<HomeFeedRow>({
 		dispatcher: requireExtensionDispatcher(ctx),
 		url: "https://x.com/home",
 		config: {
@@ -2389,7 +2389,6 @@ async function syncHomeFeedViaDomScrape(
 		},
 		parseRows: (raw) => raw as HomeFeedRow[],
 		allowedOrigins: X_ALLOWED_ORIGINS,
-		existingTabMatch: config.use_existing_tab === true ? "x.com/home" : undefined,
 	});
 
 	if (!loggedIn) {
@@ -2400,7 +2399,7 @@ async function syncHomeFeedViaDomScrape(
 
 	const tweets = buildHomeFeedTweets(rows);
 	return finalizeSyncResult(tweets, checkpoint, {
-		backend: usedExistingTab ? "extension-cs-scrape-existing-tab" : "extension-cs-scrape",
+		backend: "extension-cs-scrape",
 		items_scraped: rows.length,
 		scrolls_this_run: maxScrolls,
 		timeline: "home",
@@ -2487,12 +2486,6 @@ const homeFeedConfigSchema = {
 			maximum: 30,
 			description:
 				"Optional lower bound. When set below max_scrolls, each sync picks a uniform random scroll count in [min_scrolls, max_scrolls].",
-		},
-		use_existing_tab: {
-			type: "boolean",
-			default: false,
-			description:
-				"Scrape your already-open x.com tab instead of opening a throwaway window. The tab is read in place (never navigated or closed); when no matching tab is open, falls back to a throwaway tab. Note: this scrolls your real timeline.",
 		},
 	},
 };

--- a/packages/server/src/__tests__/integration/browser-affinity-poll-claim.test.ts
+++ b/packages/server/src/__tests__/integration/browser-affinity-poll-claim.test.ts
@@ -548,8 +548,8 @@ describe('browser-affinity poll claim', () => {
       browser_context_id: 'conversation:abc123def456',
       browser_context_title: 'Owletto · Conversation abc123def456',
       browser_flow_id: 'conversation:abc123def456',
-      holder_run_id: 'conversation:abc123def456',
     });
+    expect(body.action_input).not.toHaveProperty('holder_run_id');
     expect(body).not.toHaveProperty('run_metadata');
   });
 
@@ -752,6 +752,8 @@ describe('browser-affinity poll claim', () => {
     expect(first.input.browser_flow_id).toBe(String(first.runId));
     expect(second.input.browser_flow_id).toBe(String(second.runId));
     expect(first.input.browser_flow_id).not.toBe(second.input.browser_flow_id);
-    expect(first.input.holder_run_id).toBe(String(first.runId));
+    // Authorization is the flow lease alone. The gateway sends no holder
+    // mirror, so nothing but browser_flow_id can vouch for a tab.
+    expect(first.input).not.toHaveProperty('holder_run_id');
   });
 });

--- a/packages/server/src/__tests__/integration/device-action-wait.test.ts
+++ b/packages/server/src/__tests__/integration/device-action-wait.test.ts
@@ -534,9 +534,19 @@ describe('createConnectorOperationRun — ephemeral expires_at semantics', () =>
   }
 
   it('device-mode (ephemeral browser/device) runs get a bounded expires_at', async () => {
-    const org = await createTestOrganization();
+    const { org, user } = await seedOwnerContext({ orgName: 'Pinned Expiry Fixture' });
+    const sql = getTestDb();
     await insertChromeConnector(org.id);
-    const connId = await insertChromeConnection(org.id);
+    const [device] = (await sql`
+      INSERT INTO device_workers (
+        user_id, worker_id, platform, capabilities, label, organization_id, last_seen_at
+      ) VALUES (
+        ${user.id}, 'synthetic-expiry-browser', 'chrome-extension',
+        ${sql.json(['browser.debugger'])}, 'Synthetic expiry browser', ${org.id}, NOW()
+      )
+      RETURNING id
+    `) as Array<{ id: string }>;
+    const connId = await insertChromeConnection(org.id, device.id);
 
     const createdBefore = Date.now();
     const claim = await createConnectorOperationRun({

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -1853,7 +1853,7 @@ describe('device connector manifests', () => {
     expect((await readDefinition(orgId, CHROME_MANIFEST_KEY))?.version).toBe('2.0.0');
   });
 
-  it('uses only identical winning advertisers for multi-device pinning and unpinned claims', async () => {
+  it('preserves explicit winning-advertiser pins and refuses ambiguous unpinned claims', async () => {
     const { userId, orgId, workerId: workerA } = await seedDeviceOwner('chrome-extension');
     const sql = getTestDb();
     const chromeManifest = chromeConnectorManifest();
@@ -1942,8 +1942,14 @@ describe('device connector manifests', () => {
       [CHROME_MANIFEST_CAPABILITY]: true,
     });
     expect(advertiserPoll.status).toBe(200);
-    expect((await advertiserPoll.json()).run_id).toBe(Number(run.id));
+    expect((await advertiserPoll.json()).run_id).toBeUndefined();
     expect((await readChromeConnectorRows(orgId)).connections[0].device_worker_id).toBeNull();
+    await sql`UPDATE connections SET device_worker_id = ${deviceA.id}::uuid WHERE id = ${connectionId}`;
+    const pinnedPoll = await poll(workerA, [chromeManifest], 'chrome-extension', {
+      [CHROME_MANIFEST_CAPABILITY]: true,
+    });
+    expect(pinnedPoll.status).toBe(200);
+    expect((await pinnedPoll.json()).run_id).toBe(Number(run.id));
   });
 
   it('authorizes a retained v1 manifest only from its advertiser after v2 wins, including hashless attestation', async () => {
@@ -2008,13 +2014,17 @@ describe('device connector manifests', () => {
         AND connector_key = ${CHROME_MANIFEST_KEY}
         AND version = '1.0.0'
     `;
+    const [v1Device] = (await sql`
+      SELECT id FROM device_workers WHERE user_id = ${userId} AND worker_id = ${v1WorkerId}
+    `) as Array<{ id: string }>;
+    // A retained run keeps its exact device target even after a newer manifest wins.
     const [run] = (await sql`
       INSERT INTO runs (
         organization_id, run_type, feed_id, connection_id, connector_key,
-        connector_version, approval_status, status, created_at
+        connector_version, approval_status, status, created_at, target_device_worker_id
       ) VALUES (
         ${orgId}, 'sync', ${messagesFeed!.id}, ${connectionId}, ${CHROME_MANIFEST_KEY},
-        '1.0.0', 'auto', 'pending', NOW()
+        '1.0.0', 'auto', 'pending', NOW(), ${v1Device.id}::uuid
       )
       RETURNING id
     `) as unknown as Array<{ id: number }>;

--- a/packages/server/src/__tests__/integration/device-pin-admission.test.ts
+++ b/packages/server/src/__tests__/integration/device-pin-admission.test.ts
@@ -166,6 +166,35 @@ describe('manifest-backed device pin admission', () => {
     await cleanupTestDatabase();
   });
 
+  it('rejects unpinned browser operations despite two eligible browsers', async () => {
+    const fixture = await seedFixture();
+    await seedDevice(fixture.user.id, fixture.org.id, fixture.advertised);
+    const sql = getTestDb();
+    await sql`UPDATE connections SET device_worker_id = NULL WHERE id = ${fixture.connection.id}`;
+    const available = await readiness(fixture.connection.id, fixture.ctx);
+    expect(available.executable).toBe(false);
+    expect(available.execution_targets[0].reason).toMatch(/paired.*device/i);
+    const result = await queueOperation(fixture);
+    expect(result.status).toBe('failed');
+    expect(result.errorMessage).toMatch(/paired.*device/i);
+    const [feed] = await sql`SELECT id FROM feeds WHERE connection_id = ${fixture.connection.id}`;
+    await expect(createSyncRun(Number(feed.id), {} as Env)).rejects.toThrow(/paired.*device/i);
+  });
+
+  it('neither browser claims an unpinned run queued before the upgrade', async () => {
+    const fixture = await seedFixture();
+    const secondDevice = await seedDevice(fixture.user.id, fixture.org.id, fixture.advertised);
+    const queued = await queueOperation(fixture);
+    expect(queued.status).toBe('pending');
+    const sql = getTestDb();
+    await sql`UPDATE connections SET device_worker_id = NULL WHERE id = ${fixture.connection.id}`;
+    await sql`UPDATE runs SET target_device_worker_id = NULL WHERE id = ${queued.runId}`;
+    expect((await pollDevice(fixture.device, fixture.advertised)).run_id).not.toBe(queued.runId);
+    expect((await pollDevice(secondDevice, fixture.advertised)).run_id).not.toBe(queued.runId);
+    const [run] = await sql`SELECT status, claimed_by FROM runs WHERE id = ${queued.runId}`;
+    expect(run).toEqual({ status: 'pending', claimed_by: null });
+  });
+
   it.each([
     ['different version', manifest('0.9.0')],
     ['different hash at the same version', manifest('1.0.0', 'Other implementation')],
@@ -211,7 +240,9 @@ describe('manifest-backed device pin admission', () => {
     expect((await queueOperation(fixture)).status).toBe('failed');
     expect((await readiness(fixture.connection.id, fixture.ctx)).executable).toBe(false);
     const [feed] = await sql`SELECT id FROM feeds WHERE connection_id = ${fixture.connection.id}`;
-    await expect(createSyncRun(Number(feed.id), {} as Env)).rejects.toThrow(/manifest/i);
+    await expect(createSyncRun(Number(feed.id), {} as Env)).rejects.toThrow(
+      pinned ? /manifest/i : /paired.*device/i
+    );
   });
 
   it('returns the admission failure through operations.execute without waiting for a worker', async () => {

--- a/packages/server/src/__tests__/unit/browser-action-context.test.ts
+++ b/packages/server/src/__tests__/unit/browser-action-context.test.ts
@@ -188,7 +188,6 @@ describe('SDK browser invocation', () => {
       browser_context_id: browser.id,
       browser_context_title: browser.title,
       browser_flow_id: browser.flow_id,
-      holder_run_id: browser.flow_id,
     });
   });
 
@@ -243,15 +242,14 @@ describe('page-activation trust stamp', () => {
   });
 });
 
-// The extension normalizes titles outside this shape. Keep every fixed server
-// fallback within its pass-through contract; user-supplied subjects are
-// bounded by the extension.
+// The gateway is the only party that formats a context title; the extension
+// passes a supplied title through untouched and only bounds its length. So
+// every fixed server fallback must already carry the visible namespace and fit
+// inside the extension's code-point bound.
 //
-// Pinned as a LITERAL on purpose. This is the cross-side contract with
-// GROUP_TITLE_PREFIX in apps/chrome/tab-groups.js, so deriving it from the
-// server's own constant would make the assertion tautological and let a
-// one-sided rename pass. Changing the prefix must fail here until the
-// extension is changed to match.
+// Pinned as a LITERAL on purpose: deriving it from the server's own constant
+// would make the assertion tautological, and this prefix is what users see on
+// every Lobu group. Changing it must fail here rather than silently rebrand.
 const EXTENSION_TITLE_PREFIX = 'Lobu · ';
 const EXTENSION_MAX_TITLE_POINTS = 64;
 

--- a/packages/server/src/lib/device-feed-read.ts
+++ b/packages/server/src/lib/device-feed-read.ts
@@ -40,7 +40,7 @@ import { getDb, pgTextArray } from '../db/client';
 import { createConnectorOperationRun } from '../runs/queue-service';
 import { classifyRunOutcome } from '../runs/run-outcome';
 import { waitForDeviceActionRun } from '../tools/admin/device-action-wait';
-import { hashlessManifestArtifactMayBeClaimed } from '../utils/connector-execution-placement';
+import { describeMissingBrowserExecutionPin, hashlessManifestArtifactMayBeClaimed } from '../utils/connector-execution-placement';
 import { DEVICE_ONLINE_WINDOW_SECONDS, describeDeviceLastSeen } from '../utils/device-liveness';
 import logger from '../utils/logger';
 import {
@@ -241,6 +241,8 @@ export function normalizeDeviceFeedReadOutput(output: unknown): DeviceFeedReadRe
 async function describeUnservableDevice(
   p: DeviceFeedReadParams
 ): Promise<string | null> {
+  const pinError = describeMissingBrowserExecutionPin(p.connectorKey, p.deviceWorkerId);
+  if (pinError) return pinError;
   const sql = getDb();
   const readinessIndex = await loadDeviceConnectorReadiness({
     sql,

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -33,6 +33,7 @@ import { DEVICE_ACTION_QUEUE_BUDGET_MS } from '../config/intervals';
 import type { Env } from '../index';
 import { findBundledConnectorFile } from '../utils/connector-catalog';
 import {
+  describeMissingBrowserExecutionPin,
   hashlessManifestArtifactMayBeClaimed,
   selectedConnectorVersionArtifactSql,
 } from '../utils/connector-execution-placement';
@@ -316,6 +317,8 @@ async function deviceManifestAdmissionError(
   connectorVersion: string,
   deviceWorkerId: string | null
 ): Promise<string | null> {
+  const pinError = describeMissingBrowserExecutionPin(connectorKey, deviceWorkerId);
+  if (pinError) return pinError;
   const [row] = await sql<{
     owner_user_id: string | null;
     manifest_hash: string | null;

--- a/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/list-available.ts
@@ -22,6 +22,7 @@ import { listOperations } from "../../../../operations/connector-operations";
 import { getMissingKnownOAuthScopes } from "../../../../operations/oauth-scope-readiness";
 import type { AvailableOperation, OperationDescriptor } from "../../../../operations/types";
 import {
+	describeMissingBrowserExecutionPin,
 	hashlessManifestArtifactMayBeClaimed,
 	isChromeNamespaceConnectorKey,
 } from "../../../../utils/connector-execution-placement";
@@ -106,6 +107,10 @@ function executionTargetFromRow(
 			executable: false,
 			reason: `Connection status is ${row.status}.`,
 		};
+	}
+	const pinError = describeMissingBrowserExecutionPin(row.connector_key, row.device_worker_id);
+	if (pinError) {
+		return { ...base, status: "setup_required", executable: false, reason: pinError };
 	}
 	if (row.device_worker_id && !row.device_online) {
 		// Fleet readiness cannot override an execution pin: dispatch remains

--- a/packages/server/src/utils/connector-execution-placement.ts
+++ b/packages/server/src/utils/connector-execution-placement.ts
@@ -24,6 +24,16 @@ export function isChromeNamespaceConnectorKey(connectorKey: string): boolean {
   return connectorKey === 'chrome' || connectorKey.startsWith('chrome.');
 }
 
+/** Browser tab ids and profile state belong to one paired device. */
+export function describeMissingBrowserExecutionPin(
+  connectorKey: string,
+  deviceWorkerId: string | null | undefined
+): string | null {
+  return isChromeNamespaceConnectorKey(connectorKey) && !deviceWorkerId
+    ? 'This browser connection is not paired to a specific device. Select a paired browser connection before running browser operations.'
+    : null;
+}
+
 /**
  * A Chrome pin on any other connector delegates browser access to the
  * extension; it does not host the parent run.

--- a/packages/server/src/worker-api/browser-action-context.ts
+++ b/packages/server/src/worker-api/browser-action-context.ts
@@ -2,14 +2,7 @@ import { createHash } from 'node:crypto';
 import { currentMcpActivityAttribution, normalizeMcpConversationTitle } from '../lobu/stores/mcp-client-conversations';
 import type { ToolContext } from '../tools/registry';
 
-/**
- * The one place the server spells the group-title namespace. The extension
- * enforces the identical prefix in titleFor (apps/chrome/tab-groups.js) before
- * storing any title, and there is deliberately no migration on either side: a
- * change here without the matching change there would re-prefix every
- * server-sent title. The contract test pins the separator form as a LITERAL so
- * a one-sided rename fails loudly instead of silently stacking prefixes.
- */
+/** The gateway formats context titles. The extension preserves supplied labels. */
 export const BROWSER_GROUP_TITLE_PREFIX = 'Lobu';
 const TITLE_HEAD = `${BROWSER_GROUP_TITLE_PREFIX} · `;
 
@@ -200,7 +193,6 @@ export function trustedChromeActionInput(
     browser_context_id: context.id,
     browser_context_title: context.title,
     browser_flow_id: context.flow_id,
-    holder_run_id: context.flow_id,
     ...(Number.isInteger(activationTabId) && (activationTabId as number) > 0
       ? { activation_tab_id: activationTabId as number, activation_target_urls: activationTargetUrls }
       : {}),

--- a/packages/server/src/worker-api/connector-claim-lanes.ts
+++ b/packages/server/src/worker-api/connector-claim-lanes.ts
@@ -196,6 +196,9 @@ export function connectorClaimLaneSql(
         -- base org scope. Page-activated work is handled by the fleet parent.
         OR (
           ${context.isUserScopedWorker}
+          -- Browser-local ids cannot move between eligible profiles. Existing
+          -- unpinned rows also stay unclaimable during the gateway upgrade.
+          AND NOT (${chromeNamespaceExecution})
           AND ${refs.connectionDeviceWorkerId} IS NULL
           AND (${refs.runTargetDeviceWorkerId ?? sql`NULL`}::uuid IS NULL)
           AND (


### PR DESCRIPTION
## Summary
Unpinned browser connections could dispatch consecutive actions to different machines, producing an ownership error for a tab created on another device. Require an existing paired-device pin at admission, readiness, and live-feed dispatch; exclude browser actions from unpinned worker claim lanes, including already queued rows.

Consolidate scraping onto extension-owned tabs, remove the existing-tab fallback and legacy holder metadata, and update Owletto for canonical flow ownership and safe historical-store import. Update all four example connector callers (LinkedIn, Capterra, Glassdoor, Trustpilot) to the same scrape path.

## Test plan
- [x] Intended files staged explicitly; full `make pre-pr` and the exact `.husky/pre-commit` checks passed in Daytona before committing.
- [x] 121 server integration tests across nine routing, dispatch, activation, and feed suites passed.
- [x] 122 SDK/X/context/input tests and 32 device-feed unit tests passed in separate package processes.
- [x] 532 Chrome extension tests and real headed Chromium reliability smoke passed in Daytona.
- [x] Red→green: two eligible browser workers previously claimed successive unpinned runs (`firstBrowserClaimed: true`, `secondBrowserClaimed: true`). New integration coverage verifies admission/readiness rejection and that neither worker claims a pre-upgrade unpinned browser row.
- [ ] Canonical GitHub CI and exact-head semantic/UI review complete.

## Notes
Breaking cutover authorized: browser connections require pairing; unattended scraping uses extension-owned tabs, while user-owned interaction requires page activation. No DB migration or new public API. All runtime tests used Daytona, synthetic data, and disposable Chromium profiles. No production deployment or installed-user-extension upgrade is claimed yet.

Additional validation after broad CI exposed stale expectations: all 81 tests in device-connector-manifests, device-action-wait, and device-pin-admission pass in Daytona with explicit pins and retained run targets. LinkedIn passes 150 tests. Both the full pre-PR gate and exact pre-commit hook were rerun successfully after these changes. Child PR: https://github.com/lobu-ai/owletto/pull/1077.
