### PR TITLE
fix(auth): resolve owner subscriptions for cloud Automations

### DIFF
--- a/packages/server/src/gateway/__tests__/oauth-refresh-eligibility.test.ts
+++ b/packages/server/src/gateway/__tests__/oauth-refresh-eligibility.test.ts
@@ -25,9 +25,9 @@ import {
 import {
   isOrgBucketAgentId,
   orgBucketAgentId,
+  REFRESHABLE_AUTH_TYPES,
   UserAuthProfileStore,
 } from "../auth/settings/user-auth-profile-store.js";
-import { REFRESHABLE_AUTH_TYPES } from "../proxy/token-refresh-job.js";
 import {
   ensureDbForGatewayTests,
   ensureEncryptionKey,

--- a/packages/server/src/gateway/__tests__/token-refresh-lock.test.ts
+++ b/packages/server/src/gateway/__tests__/token-refresh-lock.test.ts
@@ -68,10 +68,9 @@ function makeManager(opts: {
   const upserts: unknown[] = [];
   return {
     upserts,
-    getProviderProfilesCount: () => getCount,
     manager: {
       getUserAuthProfileStore: () => ({}),
-      async getProviderProfiles() {
+      async getStoredProviderProfiles() {
         const idx = Math.min(getCount, opts.profileSequence.length - 1);
         getCount += 1;
         return opts.profileSequence[idx];
@@ -118,7 +117,7 @@ describe("TokenRefreshJob advisory lock (F5)", () => {
     const expiring = Date.now() + 60_000; // pre-check (outside lock) sees expiring
     const rotated = Date.now() + 3600_000; // in-lock re-read sees future expiry
     const { manager, upserts } = makeManager({
-      // 1st getProviderProfiles (pre-check) → expiring; 2nd (inside lock) → rotated.
+      // 1st getStoredProviderProfiles (pre-check) → expiring; 2nd (inside lock) → rotated.
       profileSequence: [[makeProfile(expiring)], [makeProfile(rotated)]],
     });
 

--- a/packages/server/src/gateway/auth/oauth/__tests__/oauth-registry.test.ts
+++ b/packages/server/src/gateway/auth/oauth/__tests__/oauth-registry.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import type { ProviderConfigEntry, ProvidersConfigFile } from "@lobu/core";
-import { REFRESHABLE_AUTH_TYPES } from "../../../proxy/token-refresh-job.js";
+import { REFRESHABLE_AUTH_TYPES } from "../../settings/user-auth-profile-store.js";
 import { buildOAuthRefreshers } from "../client.js";
 import { grantStrategyFor } from "../grant-strategy.js";
 import {

--- a/packages/server/src/gateway/auth/settings/__tests__/auth-profiles-manager-org-bucket.test.ts
+++ b/packages/server/src/gateway/auth/settings/__tests__/auth-profiles-manager-org-bucket.test.ts
@@ -74,7 +74,7 @@ function makeManager(opts: {
       }),
     } as never,
     secretStore: secretStore as never,
-    // No owner fallback for OAuth (owner-fallback is api-key-only by design).
+    // This fixture tests requesting-user precedence without an owner fallback.
     agentOwnerResolver: async () => undefined,
     agentOrgResolver: async () => ORG_ID,
   });

--- a/packages/server/src/gateway/auth/settings/__tests__/auth-profiles-manager-owner-refresh.test.ts
+++ b/packages/server/src/gateway/auth/settings/__tests__/auth-profiles-manager-owner-refresh.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { orgContext, tryGetOrgId } from "../../../../lobu/stores/org-context.js";
+import { TokenRefreshJob } from "../../../proxy/token-refresh-job.js";
 import { AuthProfilesManager } from "../auth-profiles-manager.js";
 import { orgBucketAgentId } from "../user-auth-profile-store.js";
 
@@ -8,18 +9,24 @@ import { orgBucketAgentId } from "../user-auth-profile-store.js";
 // A scheduled/chat run executes as a synthetic principal that owns no auth
 // profile, so resolution falls back to the agent owner's rows. For a
 // subscription sign-in that row lives in the org bucket
-// (`orgBucketAgentId(orgId)`), not under the running agentId. Two things have
-// to hold for the fallback to be usable rather than merely visible:
+// (`orgBucketAgentId(orgId)`), not under the running agentId. Three things
+// have to hold for the fallback to be usable rather than merely visible:
 //
 //   * refresh must target the row the credential was READ from — the owner
 //     plus that storage agentId, inside that row's org partition — never the
-//     synthetic requesting principal, and
-//   * an already-expired subscription must be refreshed BEFORE the expiry
-//     filter in `getBestProfile` drops it, or a scheduled run can never
-//     recover once its token lapses.
+//     synthetic requesting principal,
+//   * an already-lapsed subscription must be rotated BEFORE the expiry filter
+//     in `getBestProfile` drops it, or a run can never recover once its token
+//     lapses, and
+//   * the periodic refresher must NOT do the reverse: a merged fallback
+//     credential must never be written into the row it happens to be scanning.
 //
-// The last test pins the tenant boundary: the owner-bucket read follows the
-// AMBIENT org, so a run in another org never touches this org's subscription.
+// The tenant boundary is pinned too: the owner-bucket read follows the AMBIENT
+// org, so a run in another org never touches this org's subscription.
+//
+// Both refreshable literals are exercised: "device-code" is what a ChatGPT
+// subscription persists, "oauth" is Claude's. A guard that named only one
+// would leave the other permanently un-refreshable.
 
 const AGENT_ID = "agent-1";
 const ORG_ID = "org-A";
@@ -32,6 +39,8 @@ const REFRESHED_TOKEN = "refreshed-access-token";
 const HOUR_MS = 60 * 60 * 1000;
 /** Inside `LAZY_REFRESH_BUFFER_MS` (5min): reads take the async-trigger path. */
 const SOON_MS = 60 * 1000;
+/** The exact literals a subscription sign-in persists (ChatGPT, then Claude). */
+const REFRESHABLE_TYPES = ["device-code", "oauth"] as const;
 
 type RefreshTarget = {
   userId: string;
@@ -40,14 +49,18 @@ type RefreshTarget = {
 };
 
 /**
- * Build a manager whose only stored profile is the OWNER's OAuth profile, held
- * under `storageAgentId` — the org bucket by default, or the agent's own id
- * when `bucket: false`. `refreshNow` mutates that row the way TokenRefreshJob
- * does, and both hooks record the (userId, agentId, org) they were asked to
- * refresh so a test can assert the refresh targeted the storage row rather
- * than the principal that requested the credential.
+ * Build a manager whose only stored profile is the OWNER's subscription
+ * profile, held under `storageAgentId` — the org bucket by default, or the
+ * agent's own id when `bucket: false`. `refreshNow` mutates that row the way
+ * TokenRefreshJob does, and both hooks record the (userId, agentId, org) they
+ * were asked to refresh so a test can assert the refresh targeted the storage
+ * row rather than the principal that requested the credential.
  */
-function makeManager(opts: { expiresAt: number; bucket?: boolean }) {
+function makeManager(opts: {
+  expiresAt: number;
+  authType: "oauth" | "device-code";
+  bucket?: boolean;
+}) {
   const storageAgentId =
     opts.bucket === false ? AGENT_ID : orgBucketAgentId(ORG_ID);
   let credential = STORED_TOKEN;
@@ -59,7 +72,7 @@ function makeManager(opts: { expiresAt: number; bucket?: boolean }) {
             id: PROFILE_ID,
             provider: "chatgpt",
             model: "*",
-            authType: "oauth" as const,
+            authType: opts.authType,
             credential,
             createdAt: 0,
             metadata: { expiresAt },
@@ -102,63 +115,82 @@ const ownerStorage = (agentId: string): RefreshTarget[] => [
 
 describe("owner subscription credentials for cloud Automations", () => {
   test("resolves the owner's org subscription for a synthetic run", async () => {
-    const { manager } = makeManager({ expiresAt: Date.now() + HOUR_MS });
-
-    const profile = await manager.getBestProfile(AGENT_ID, "chatgpt", undefined, {
-      userId: RUN_USER_ID,
+    const { manager } = makeManager({
+      expiresAt: Date.now() + HOUR_MS,
+      authType: "device-code",
     });
+
+    const profile = await manager.getBestProfile(
+      AGENT_ID,
+      "chatgpt",
+      undefined,
+      { userId: RUN_USER_ID }
+    );
 
     expect(profile?.credential).toBe(STORED_TOKEN);
   });
 
-  for (const bucket of [true, false]) {
-    test(`refreshes the owner storage row, not the run user (bucket=${bucket})`, async () => {
-      const { manager, refreshTargets, storageAgentId } = makeManager({
-        expiresAt: Date.now() + SOON_MS,
-        bucket,
+  for (const authType of REFRESHABLE_TYPES) {
+    for (const bucket of [true, false]) {
+      test(`refreshes the owner storage row, not the run user (${authType}, bucket=${bucket})`, async () => {
+        const { manager, refreshTargets, storageAgentId } = makeManager({
+          expiresAt: Date.now() + SOON_MS,
+          authType,
+          bucket,
+        });
+
+        const profile = await manager.getBestProfile(
+          AGENT_ID,
+          "chatgpt",
+          undefined,
+          { userId: RUN_USER_ID }
+        );
+        expect(profile).not.toBeNull();
+        // Still valid for the buffer window, so the current token comes back
+        // while the refresh is triggered against the owner's row.
+        const credential = await manager.ensureFreshCredential(profile!, {
+          userId: RUN_USER_ID,
+          agentId: AGENT_ID,
+        });
+
+        expect(credential).toBe(STORED_TOKEN);
+        expect(refreshTargets).toEqual(ownerStorage(storageAgentId));
       });
 
-      const profile = await manager.getBestProfile(
-        AGENT_ID,
-        "chatgpt",
-        undefined,
-        { userId: RUN_USER_ID }
-      );
-      expect(profile).not.toBeNull();
-      // Still valid for the buffer window, so the current token comes back
-      // while the refresh is triggered against the owner's row.
-      const credential = await manager.ensureFreshCredential(profile!, {
-        userId: RUN_USER_ID,
-        agentId: AGENT_ID,
-      });
+      test(`rotates a lapsed owner subscription instead of dropping it (${authType}, bucket=${bucket})`, async () => {
+        const { manager, refreshNow, refreshTargets, storageAgentId } =
+          makeManager({
+            expiresAt: Date.now() - HOUR_MS,
+            authType,
+            bucket,
+          });
 
-      expect(credential).toBe(STORED_TOKEN);
-      expect(refreshTargets).toEqual(ownerStorage(storageAgentId));
-    });
+        const profile = await manager.getBestProfile(
+          AGENT_ID,
+          "chatgpt",
+          undefined,
+          { userId: RUN_USER_ID }
+        );
+
+        expect(profile?.credential).toBe(REFRESHED_TOKEN);
+        expect(refreshNow).toHaveBeenCalledTimes(1);
+        expect(refreshTargets).toEqual(ownerStorage(storageAgentId));
+      });
+    }
   }
-
-  test("refreshes an expired owner subscription instead of dropping it", async () => {
-    const { manager, refreshNow, refreshTargets, storageAgentId } = makeManager({
-      expiresAt: Date.now() - HOUR_MS,
-    });
-
-    const profile = await manager.getBestProfile(AGENT_ID, "chatgpt", undefined, {
-      userId: RUN_USER_ID,
-    });
-
-    expect(profile?.credential).toBe(REFRESHED_TOKEN);
-    expect(refreshNow).toHaveBeenCalledTimes(1);
-    expect(refreshTargets).toEqual(ownerStorage(storageAgentId));
-  });
 
   test("refreshes the org bucket for a direct owner request too", async () => {
     const { manager, refreshTargets, storageAgentId } = makeManager({
       expiresAt: Date.now() + SOON_MS,
+      authType: "device-code",
     });
 
-    const profile = await manager.getBestProfile(AGENT_ID, "chatgpt", undefined, {
-      userId: OWNER_ID,
-    });
+    const profile = await manager.getBestProfile(
+      AGENT_ID,
+      "chatgpt",
+      undefined,
+      { userId: OWNER_ID }
+    );
     await manager.ensureFreshCredential(profile!, {
       userId: OWNER_ID,
       agentId: AGENT_ID,
@@ -170,7 +202,10 @@ describe("owner subscription credentials for cloud Automations", () => {
   });
 
   test("does not read another organization's subscription bucket", async () => {
-    const { manager, list } = makeManager({ expiresAt: Date.now() + HOUR_MS });
+    const { manager, list } = makeManager({
+      expiresAt: Date.now() + HOUR_MS,
+      authType: "device-code",
+    });
 
     await orgContext.run({ organizationId: OTHER_ORG_ID }, async () => {
       const profile = await manager.getBestProfile(
@@ -185,5 +220,165 @@ describe("owner subscription credentials for cloud Automations", () => {
     expect(list.mock.calls.map(([, agentId]) => agentId)).not.toContain(
       orgBucketAgentId(ORG_ID)
     );
+  });
+});
+
+describe("periodic refresh stays inside the row it scanned", () => {
+  const BUCKET_ID = orgBucketAgentId(ORG_ID);
+
+  /**
+   * Drive `TokenRefreshJob.runOnce` over a single scanned row. Only the
+   * owner's bucket row physically holds the subscription, so scanning the run
+   * user's per-agent row must rotate nothing — the merged owner fallback that
+   * inference sees is not a refresh grant this row owns.
+   */
+  function makeJob(scanned: { userId: string; agentId: string }) {
+    const refreshToken = mock(async () => ({
+      accessToken: "rotated-access",
+      refreshToken: "rotated-refresh",
+      expiresAt: Date.now() + HOUR_MS,
+    }));
+    const upsert = mock(
+      async (_userId: string, _agentId: string, profile: unknown) => profile
+    );
+    const manager = new AuthProfilesManager({
+      ephemeralProfiles: { get: () => undefined } as never,
+      declaredAgents: { get: () => undefined } as never,
+      userAuthProfiles: {
+        list: async (userId: string, agentId: string) =>
+          userId === OWNER_ID && agentId === BUCKET_ID
+            ? [
+                {
+                  id: PROFILE_ID,
+                  provider: "chatgpt",
+                  model: "*",
+                  authType: "device-code",
+                  credential: STORED_TOKEN,
+                  createdAt: 0,
+                  metadata: {
+                    expiresAt: 1,
+                    refreshToken: "owner-refresh-token",
+                  },
+                },
+              ]
+            : [],
+        upsert,
+        scanAllOAuth: async function* () {
+          yield { ...scanned, organizationId: ORG_ID };
+        },
+      } as never,
+      secretStore: { get: async () => undefined } as never,
+      agentOwnerResolver: async () => OWNER_ID,
+    });
+    const db = {
+      begin: async (fn: (tx: unknown) => Promise<void>) =>
+        fn({ unsafe: async () => [] }),
+    };
+    const job = new TokenRefreshJob(
+      manager,
+      [{ providerId: "chatgpt", refresher: { refreshToken } }],
+      () => db as never
+    );
+    return { job, refreshToken, upsert };
+  }
+
+  test("rotates the owner bucket row it scanned", async () => {
+    const { job, refreshToken, upsert } = makeJob({
+      userId: OWNER_ID,
+      agentId: BUCKET_ID,
+    });
+
+    await job.runOnce();
+
+    expect(refreshToken).toHaveBeenCalledTimes(1);
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(upsert.mock.calls[0]?.slice(0, 2)).toEqual([OWNER_ID, BUCKET_ID]);
+  });
+
+  test("writes nothing when the scanned row holds no profile of its own", async () => {
+    const { job, refreshToken, upsert } = makeJob({
+      userId: RUN_USER_ID,
+      agentId: AGENT_ID,
+    });
+
+    await job.runOnce();
+
+    expect(refreshToken).not.toHaveBeenCalled();
+    expect(upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("owner lookups are cached per (org, agent)", () => {
+  const OWNER_B = "owner-user-b";
+  const TOKEN_B = "org-b-access-token";
+  const ownerFor = (orgId: string) =>
+    orgId === OTHER_ORG_ID ? OWNER_B : OWNER_ID;
+
+  /**
+   * Two orgs can own an agent with the same id — `agents` is keyed on
+   * `(organization_id, id)` — and the real resolver reads it behind a
+   * cross-tenant guard that yields nothing without org context. So the owner
+   * answer is per (org, agent), and the short-lived owner cache has to be too.
+   */
+  function makeMultiOrgManager() {
+    return new AuthProfilesManager({
+      ephemeralProfiles: { get: () => undefined } as never,
+      declaredAgents: { get: () => undefined } as never,
+      userAuthProfiles: {
+        list: async (userId: string, agentId: string) => {
+          const orgId = tryGetOrgId();
+          if (!orgId || agentId !== orgBucketAgentId(orgId)) return [];
+          if (userId !== ownerFor(orgId)) return [];
+          return [
+            {
+              id: PROFILE_ID,
+              provider: "chatgpt",
+              model: "*",
+              authType: "device-code",
+              credential: userId === OWNER_B ? TOKEN_B : STORED_TOKEN,
+              createdAt: 0,
+              metadata: { expiresAt: Date.now() + HOUR_MS },
+            },
+          ];
+        },
+      } as never,
+      secretStore: { get: async () => undefined } as never,
+      agentOwnerResolver: async () => {
+        const orgId = tryGetOrgId();
+        return orgId ? ownerFor(orgId) : undefined;
+      },
+    });
+  }
+
+  const resolve = (manager: AuthProfilesManager) =>
+    manager.getBestProfile(AGENT_ID, "chatgpt", undefined, {
+      userId: RUN_USER_ID,
+    });
+
+  test("each org resolves its own owner for the same agent id", async () => {
+    const manager = makeMultiOrgManager();
+
+    const inOwnOrg = await orgContext.run({ organizationId: ORG_ID }, () =>
+      resolve(manager)
+    );
+    const inOtherOrg = await orgContext.run(
+      { organizationId: OTHER_ORG_ID },
+      () => resolve(manager)
+    );
+
+    expect(inOwnOrg?.credential).toBe(STORED_TOKEN);
+    expect(inOtherOrg?.credential).toBe(TOKEN_B);
+  });
+
+  test("a miss without org context does not poison the scoped lookup", async () => {
+    const manager = makeMultiOrgManager();
+
+    // No ambient org and no `agentOrgResolver`: the guard yields no owner.
+    expect(await resolve(manager)).toBeNull();
+    const scoped = await orgContext.run({ organizationId: ORG_ID }, () =>
+      resolve(manager)
+    );
+
+    expect(scoped?.credential).toBe(STORED_TOKEN);
   });
 });

--- a/packages/server/src/gateway/auth/settings/__tests__/auth-profiles-manager-owner-refresh.test.ts
+++ b/packages/server/src/gateway/auth/settings/__tests__/auth-profiles-manager-owner-refresh.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, mock, test } from "bun:test";
+import { orgContext, tryGetOrgId } from "../../../../lobu/stores/org-context.js";
+import { AuthProfilesManager } from "../auth-profiles-manager.js";
+import { orgBucketAgentId } from "../user-auth-profile-store.js";
+
+// Owner-fallback coverage for OAUTH SUBSCRIPTIONS on cloud Automation runs.
+//
+// A scheduled/chat run executes as a synthetic principal that owns no auth
+// profile, so resolution falls back to the agent owner's rows. For a
+// subscription sign-in that row lives in the org bucket
+// (`orgBucketAgentId(orgId)`), not under the running agentId. Two things have
+// to hold for the fallback to be usable rather than merely visible:
+//
+//   * refresh must target the row the credential was READ from — the owner
+//     plus that storage agentId, inside that row's org partition — never the
+//     synthetic requesting principal, and
+//   * an already-expired subscription must be refreshed BEFORE the expiry
+//     filter in `getBestProfile` drops it, or a scheduled run can never
+//     recover once its token lapses.
+//
+// The last test pins the tenant boundary: the owner-bucket read follows the
+// AMBIENT org, so a run in another org never touches this org's subscription.
+
+const AGENT_ID = "agent-1";
+const ORG_ID = "org-A";
+const OTHER_ORG_ID = "org-B";
+const OWNER_ID = "owner-user";
+const RUN_USER_ID = "run-user";
+const PROFILE_ID = "owner-chatgpt-1";
+const STORED_TOKEN = "stored-access-token";
+const REFRESHED_TOKEN = "refreshed-access-token";
+const HOUR_MS = 60 * 60 * 1000;
+/** Inside `LAZY_REFRESH_BUFFER_MS` (5min): reads take the async-trigger path. */
+const SOON_MS = 60 * 1000;
+
+type RefreshTarget = {
+  userId: string;
+  agentId: string;
+  organizationId: string | null;
+};
+
+/**
+ * Build a manager whose only stored profile is the OWNER's OAuth profile, held
+ * under `storageAgentId` — the org bucket by default, or the agent's own id
+ * when `bucket: false`. `refreshNow` mutates that row the way TokenRefreshJob
+ * does, and both hooks record the (userId, agentId, org) they were asked to
+ * refresh so a test can assert the refresh targeted the storage row rather
+ * than the principal that requested the credential.
+ */
+function makeManager(opts: { expiresAt: number; bucket?: boolean }) {
+  const storageAgentId =
+    opts.bucket === false ? AGENT_ID : orgBucketAgentId(ORG_ID);
+  let credential = STORED_TOKEN;
+  let expiresAt = opts.expiresAt;
+  const list = mock(async (userId: string, agentId: string) =>
+    userId === OWNER_ID && agentId === storageAgentId
+      ? [
+          {
+            id: PROFILE_ID,
+            provider: "chatgpt",
+            model: "*",
+            authType: "oauth" as const,
+            credential,
+            createdAt: 0,
+            metadata: { expiresAt },
+          },
+        ]
+      : []
+  );
+
+  const manager = new AuthProfilesManager({
+    ephemeralProfiles: { get: () => undefined } as never,
+    declaredAgents: { get: () => undefined } as never,
+    userAuthProfiles: { list } as never,
+    secretStore: { get: async () => undefined } as never,
+    agentOwnerResolver: async () => OWNER_ID,
+    agentOrgResolver: async () => ORG_ID,
+  });
+
+  // Recorded rather than asserted in-place: a hook that is never called would
+  // make in-mock expectations pass vacuously.
+  const refreshTargets: RefreshTarget[] = [];
+  const record = (userId: string, agentId: string) => {
+    refreshTargets.push({ userId, agentId, organizationId: tryGetOrgId() });
+  };
+  const triggerAsync = mock(async (userId: string, agentId: string) => {
+    record(userId, agentId);
+  });
+  const refreshNow = mock(async (userId: string, agentId: string) => {
+    record(userId, agentId);
+    credential = REFRESHED_TOKEN;
+    expiresAt = Date.now() + HOUR_MS;
+  });
+  manager.setLazyRefreshHooks({ triggerAsync, refreshNow });
+
+  return { manager, list, refreshNow, refreshTargets, storageAgentId };
+}
+
+const ownerStorage = (agentId: string): RefreshTarget[] => [
+  { userId: OWNER_ID, agentId, organizationId: ORG_ID },
+];
+
+describe("owner subscription credentials for cloud Automations", () => {
+  test("resolves the owner's org subscription for a synthetic run", async () => {
+    const { manager } = makeManager({ expiresAt: Date.now() + HOUR_MS });
+
+    const profile = await manager.getBestProfile(AGENT_ID, "chatgpt", undefined, {
+      userId: RUN_USER_ID,
+    });
+
+    expect(profile?.credential).toBe(STORED_TOKEN);
+  });
+
+  for (const bucket of [true, false]) {
+    test(`refreshes the owner storage row, not the run user (bucket=${bucket})`, async () => {
+      const { manager, refreshTargets, storageAgentId } = makeManager({
+        expiresAt: Date.now() + SOON_MS,
+        bucket,
+      });
+
+      const profile = await manager.getBestProfile(
+        AGENT_ID,
+        "chatgpt",
+        undefined,
+        { userId: RUN_USER_ID }
+      );
+      expect(profile).not.toBeNull();
+      // Still valid for the buffer window, so the current token comes back
+      // while the refresh is triggered against the owner's row.
+      const credential = await manager.ensureFreshCredential(profile!, {
+        userId: RUN_USER_ID,
+        agentId: AGENT_ID,
+      });
+
+      expect(credential).toBe(STORED_TOKEN);
+      expect(refreshTargets).toEqual(ownerStorage(storageAgentId));
+    });
+  }
+
+  test("refreshes an expired owner subscription instead of dropping it", async () => {
+    const { manager, refreshNow, refreshTargets, storageAgentId } = makeManager({
+      expiresAt: Date.now() - HOUR_MS,
+    });
+
+    const profile = await manager.getBestProfile(AGENT_ID, "chatgpt", undefined, {
+      userId: RUN_USER_ID,
+    });
+
+    expect(profile?.credential).toBe(REFRESHED_TOKEN);
+    expect(refreshNow).toHaveBeenCalledTimes(1);
+    expect(refreshTargets).toEqual(ownerStorage(storageAgentId));
+  });
+
+  test("refreshes the org bucket for a direct owner request too", async () => {
+    const { manager, refreshTargets, storageAgentId } = makeManager({
+      expiresAt: Date.now() + SOON_MS,
+    });
+
+    const profile = await manager.getBestProfile(AGENT_ID, "chatgpt", undefined, {
+      userId: OWNER_ID,
+    });
+    await manager.ensureFreshCredential(profile!, {
+      userId: OWNER_ID,
+      agentId: AGENT_ID,
+    });
+
+    // The credential lives in the bucket, so refreshing `AGENT_ID` — the id the
+    // caller passed — would find no refresh token at all.
+    expect(refreshTargets).toEqual(ownerStorage(storageAgentId));
+  });
+
+  test("does not read another organization's subscription bucket", async () => {
+    const { manager, list } = makeManager({ expiresAt: Date.now() + HOUR_MS });
+
+    await orgContext.run({ organizationId: OTHER_ORG_ID }, async () => {
+      const profile = await manager.getBestProfile(
+        AGENT_ID,
+        "chatgpt",
+        undefined,
+        { userId: RUN_USER_ID }
+      );
+      expect(profile).toBeNull();
+    });
+
+    expect(list.mock.calls.map(([, agentId]) => agentId)).not.toContain(
+      orgBucketAgentId(ORG_ID)
+    );
+  });
+});

--- a/packages/server/src/gateway/auth/settings/auth-profiles-manager.ts
+++ b/packages/server/src/gateway/auth/settings/auth-profiles-manager.ts
@@ -13,6 +13,7 @@ import type { DeclaredAgentRegistry } from "../../services/declared-agent-regist
 import type { EphemeralAuthProfileRegistry } from "./agent-settings-store.js";
 import {
   orgBucketAgentId,
+  REFRESHABLE_AUTH_TYPES,
   type UserAuthProfileStore,
 } from "./user-auth-profile-store.js";
 
@@ -32,6 +33,12 @@ type ProfileSource = {
 type SourcedAuthProfile = AuthProfile & {
   [PROFILE_SOURCE]?: ProfileSource;
 };
+
+/** The storage row a resolved profile was read from, if any. Merged ephemeral
+ *  and declared profiles have no row and so are never refresh targets. */
+function profileSource(profile: AuthProfile): ProfileSource | undefined {
+  return (profile as SourcedAuthProfile)[PROFILE_SOURCE];
+}
 
 /** Refresh tokens that expire within this window from now. */
 const LAZY_REFRESH_BUFFER_MS = 5 * 60 * 1000;
@@ -112,8 +119,8 @@ interface AuthProfilesManagerOptions {
  *
  * Callers pass `ProviderCredentialContext.userId` when they have one
  * (worker proxy, OAuth route, agent-config route). The agent-owner fallback
- * is resolved from the agent's own metadata, independently of the (often
- * synthetic) requesting principal.
+ * comes from `agentOwnerResolver` (the agent's own `agents` row), so it
+ * resolves even when the requesting principal is synthetic or absent.
  */
 export class AuthProfilesManager {
   private readonly ephemeralProfiles: EphemeralAuthProfileRegistry;
@@ -127,8 +134,9 @@ export class AuthProfilesManager {
   private readonly agentOrgResolver?: (
     agentId: string
   ) => Promise<string | undefined>;
-  /** Short-lived `agentId → ownerUserId` cache — owner lookups happen on the
-   *  credential hot path (per proxy request), the owner rarely changes. */
+  /** Short-lived `(orgId, agentId) → ownerUserId` cache — owner lookups happen
+   *  on the credential hot path (per proxy request), the owner rarely changes.
+   *  Keyed by org too because the `agents` PK is `(organization_id, id)`. */
   private readonly agentOwnerCache = new Map<
     string,
     { ownerUserId: string | undefined; expiresAt: number }
@@ -173,8 +181,9 @@ export class AuthProfilesManager {
   /**
    * Returns a credential guaranteed valid right now for the given profile.
    * Three paths:
-   *  - Token has > 5min until expiry, or profile is non-OAuth: returns
-   *    `profile.credential` immediately (fast path).
+   *  - Token has > 5min until expiry, or the profile carries no rotatable
+   *    refresh grant (`REFRESHABLE_AUTH_TYPES`): returns `profile.credential`
+   *    immediately (fast path).
    *  - Token expires within 5min but is still valid: fires a fire-and-forget
    *    refresh task (idempotency-keyed) and returns the current credential
    *    (still valid for the buffer window).
@@ -192,20 +201,9 @@ export class AuthProfilesManager {
     profile: AuthProfile,
     ctx: { userId: string; agentId: string },
   ): Promise<string | undefined> {
-    const source = (profile as SourcedAuthProfile)[PROFILE_SOURCE];
-    // The refresh job rewrites the stored row and the re-read below resolves
-    // secret refs, both through the org-partitioned secret store. Callers hand
-    // us a profile after the org scope that produced it has unwound, so
-    // re-enter that partition instead of the caller's ambient scope.
-    if (source?.organizationId && tryGetOrgId() !== source.organizationId) {
-      return orgContext.run({ organizationId: source.organizationId }, () =>
-        this.ensureFreshCredential(profile, ctx)
-      );
-    }
-    const refreshContext = source ?? ctx;
     const credential = profile.credential;
     if (!credential) return credential;
-    if (profile.authType !== "oauth") return credential;
+    if (!REFRESHABLE_AUTH_TYPES.has(profile.authType)) return credential;
     if (!this.lazyRefreshHooks) return credential;
 
     const expiresAt = profile.metadata?.expiresAt ?? 0;
@@ -213,6 +211,20 @@ export class AuthProfilesManager {
 
     const now = Date.now();
     if (expiresAt > now + LAZY_REFRESH_BUFFER_MS) return credential;
+
+    const source = profileSource(profile);
+    // The refresh job rewrites the stored row and the re-read below resolves
+    // secret refs, both through the org-partitioned secret store. Callers hand
+    // us a profile after the org scope that produced it has unwound, so
+    // re-enter that partition instead of the caller's ambient scope. Placed
+    // after the fast-path returns above so the common per-request read never
+    // pays for an extra AsyncLocalStorage scope.
+    if (source?.organizationId && tryGetOrgId() !== source.organizationId) {
+      return orgContext.run({ organizationId: source.organizationId }, () =>
+        this.ensureFreshCredential(profile, ctx)
+      );
+    }
+    const refreshContext = source ?? ctx;
 
     if (expiresAt > now) {
       // Soon-expiring: fire async, return current credential.
@@ -348,8 +360,11 @@ export class AuthProfilesManager {
     const ownerUserId = await this.resolveAgentOwnerUserId(agentId);
     if (!ownerUserId || ownerUserId === requestingUserId) return [];
     const ownerProfiles = await this.listStoredProfiles(ownerUserId, agentId);
-    // The owner's org-bucket sign-in covers every agent in the org, so a run
-    // executing as a synthetic user reaches it through the owner too.
+    // The owner's org-bucket sign-in covers every agent in the org, so an
+    // Automation running as a synthetic user reaches it through the owner too.
+    // Reach is the same one the API-key fallback already had: ANY non-owner
+    // principal permitted to run this agent — synthetic or human — resolves the
+    // owner's credential, subscription sign-ins now included.
     const organizationId = tryGetOrgId();
     const bucketProfiles = organizationId
       ? await this.listStoredProfiles(
@@ -432,8 +447,38 @@ export class AuthProfilesManager {
       ...declared,
     ]);
 
+    return this.resolveProfiles(agentId, merged);
+  }
+
+  /**
+   * Profiles physically stored under `(userId, agentId)` — no owner-, org-bucket-,
+   * ephemeral-, or declared-source merging. The token-refresh job rotates a
+   * profile and writes it back to the `(userId, agentId)` it was scanning, so it
+   * must read only that row: resolving through `listProfiles` would let a merged
+   * fallback profile be persisted into a row that never owned its refresh grant.
+   *
+   * Unlike `listProfiles`, this does NOT establish org context — the caller must
+   * already be inside the row's org scope so credential refs resolve against the
+   * right secret-store partition (`TokenRefreshJob` wraps both call sites).
+   */
+  async getStoredProviderProfiles(
+    agentId: string,
+    provider: string,
+    userId: string
+  ): Promise<AuthProfile[]> {
+    const stored = await this.listStoredProfiles(userId, agentId);
+    return this.resolveProfiles(
+      agentId,
+      stored.filter((profile) => profile.provider === provider)
+    );
+  }
+
+  private async resolveProfiles(
+    agentId: string,
+    profiles: AuthProfile[]
+  ): Promise<AuthProfile[]> {
     const resolved = await Promise.all(
-      merged.map(async (profile) => {
+      profiles.map(async (profile) => {
         try {
           return await this.resolveProfile(profile);
         } catch (error) {
@@ -502,27 +547,27 @@ export class AuthProfilesManager {
       return null;
     }
 
-    // A persisted OAuth profile that has already expired still has a refresh
-    // path; without this the filter below drops it and a scheduled run can
-    // never recover once its token lapses.
-    const expiredBefore = Date.now();
-    const expiredRefreshable = providerProfiles.filter(
-      (profile) =>
-        profile.authType === "oauth" &&
-        !!(profile as SourcedAuthProfile)[PROFILE_SOURCE] &&
-        !!profile.metadata?.expiresAt &&
-        profile.metadata.expiresAt <= expiredBefore
-    );
-    if (this.lazyRefreshHooks && expiredRefreshable.length > 0) {
-      for (const profile of expiredRefreshable) {
-        const source = (profile as SourcedAuthProfile)[PROFILE_SOURCE]!;
+    // A stored profile whose token has already lapsed still holds a refresh
+    // grant. Rotate it BEFORE the expiry filter below, or that filter drops it
+    // and no run — scheduled or interactive — can ever recover the sign-in.
+    if (this.lazyRefreshHooks) {
+      const lapsedAt = Date.now();
+      let rotated = false;
+      for (const profile of providerProfiles) {
+        const source = profileSource(profile);
+        const expiresAt = profile.metadata?.expiresAt;
+        if (!source || !expiresAt || expiresAt > lapsedAt) continue;
+        if (!REFRESHABLE_AUTH_TYPES.has(profile.authType)) continue;
         await this.ensureFreshCredential(profile, source);
+        rotated = true;
       }
-      providerProfiles = await this.getProviderProfiles(
-        agentId,
-        provider,
-        context?.userId
-      );
+      if (rotated) {
+        providerProfiles = await this.getProviderProfiles(
+          agentId,
+          provider,
+          context?.userId
+        );
+      }
     }
 
     const now = Date.now();

--- a/packages/server/src/gateway/auth/settings/auth-profiles-manager.ts
+++ b/packages/server/src/gateway/auth/settings/auth-profiles-manager.ts
@@ -20,6 +20,19 @@ const logger = createLogger("auth-profiles-manager");
 
 const ANY_MODEL_SCOPE = "*";
 
+// Gateway-local provenance travels with the resolved object, never in JSON or
+// worker credentials. Refresh must target the persisted owner/bucket row, not
+// the synthetic principal that is executing the Automation.
+const PROFILE_SOURCE = Symbol("auth-profile-source");
+type ProfileSource = {
+  userId: string;
+  agentId: string;
+  organizationId?: string;
+};
+type SourcedAuthProfile = AuthProfile & {
+  [PROFILE_SOURCE]?: ProfileSource;
+};
+
 /** Refresh tokens that expire within this window from now. */
 const LAZY_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
@@ -98,8 +111,9 @@ interface AuthProfilesManagerOptions {
  *    surfaced via `DeclaredAgentRegistry`.
  *
  * Callers pass `ProviderCredentialContext.userId` when they have one
- * (worker proxy, OAuth route, agent-config route). When `userId` is
- * absent, only declared + runtime sources are consulted.
+ * (worker proxy, OAuth route, agent-config route). The agent-owner fallback
+ * is resolved from the agent's own metadata, independently of the (often
+ * synthetic) requesting principal.
  */
 export class AuthProfilesManager {
   private readonly ephemeralProfiles: EphemeralAuthProfileRegistry;
@@ -169,11 +183,26 @@ export class AuthProfilesManager {
    *
    * If LazyRefreshHooks aren't wired (boot order, tests), returns
    * `profile.credential` unchanged — periodic safety-net catches it later.
+   *
+   * Refresh targets the row the profile was READ from, not `ctx`. Under the
+   * agent-owner fallback `ctx` is the synthetic run principal, which owns no
+   * stored profile and so has nothing to refresh.
    */
   async ensureFreshCredential(
     profile: AuthProfile,
     ctx: { userId: string; agentId: string },
   ): Promise<string | undefined> {
+    const source = (profile as SourcedAuthProfile)[PROFILE_SOURCE];
+    // The refresh job rewrites the stored row and the re-read below resolves
+    // secret refs, both through the org-partitioned secret store. Callers hand
+    // us a profile after the org scope that produced it has unwound, so
+    // re-enter that partition instead of the caller's ambient scope.
+    if (source?.organizationId && tryGetOrgId() !== source.organizationId) {
+      return orgContext.run({ organizationId: source.organizationId }, () =>
+        this.ensureFreshCredential(profile, ctx)
+      );
+    }
+    const refreshContext = source ?? ctx;
     const credential = profile.credential;
     if (!credential) return credential;
     if (profile.authType !== "oauth") return credential;
@@ -188,10 +217,15 @@ export class AuthProfilesManager {
     if (expiresAt > now) {
       // Soon-expiring: fire async, return current credential.
       this.lazyRefreshHooks
-        .triggerAsync(ctx.userId, ctx.agentId)
+        .triggerAsync(refreshContext.userId, refreshContext.agentId)
         .catch((err) =>
           logger.warn(
-            { err, profileId: profile.id, userId: ctx.userId },
+            {
+              err,
+              profileId: profile.id,
+              userId: refreshContext.userId,
+              agentId: refreshContext.agentId,
+            },
             "[lazy-refresh] async trigger failed; periodic task will retry",
           ),
         );
@@ -200,17 +234,31 @@ export class AuthProfilesManager {
 
     // Already expired: inline refresh + re-read.
     try {
-      await this.lazyRefreshHooks.refreshNow(ctx.userId, ctx.agentId);
-      const refreshed = await this.getProviderProfiles(
-        ctx.agentId,
-        profile.provider,
-        ctx.userId,
+      await this.lazyRefreshHooks.refreshNow(
+        refreshContext.userId,
+        refreshContext.agentId
       );
-      const fresh = refreshed.find((p) => p.id === profile.id);
-      return fresh?.credential ?? credential;
+      const rows = source
+        ? await this.listStoredProfiles(source.userId, source.agentId)
+        : await this.getProviderProfiles(
+            ctx.agentId,
+            profile.provider,
+            ctx.userId
+          );
+      const row = rows.find((p) => p.id === profile.id);
+      if (!row) return credential;
+      // `listStoredProfiles` hands back stored rows; only the
+      // `getProviderProfiles` path has already resolved credential refs.
+      const fresh = source ? await this.resolveProfile(row) : row;
+      return fresh.credential ?? credential;
     } catch (err) {
       logger.error(
-        { err, profileId: profile.id, userId: ctx.userId },
+        {
+          err,
+          profileId: profile.id,
+          userId: refreshContext.userId,
+          agentId: refreshContext.agentId,
+        },
         "[lazy-refresh] inline refresh failed; returning stale credential",
       );
       return credential;
@@ -241,7 +289,11 @@ export class AuthProfilesManager {
     agentId: string
   ): Promise<string | undefined> {
     if (!this.agentOwnerResolver) return undefined;
-    const cached = this.agentOwnerCache.get(agentId);
+    // The resolver reads `agents` behind a cross-tenant guard that returns null
+    // without org context, so the answer is per (org, agent) — an agentId-only
+    // key would let one scope's miss serve another's hit for the TTL.
+    const cacheKey = JSON.stringify([tryGetOrgId(), agentId]);
+    const cached = this.agentOwnerCache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) return cached.ownerUserId;
     let ownerUserId: string | undefined;
     try {
@@ -256,7 +308,7 @@ export class AuthProfilesManager {
       );
       return undefined;
     }
-    this.cacheSet(this.agentOwnerCache, agentId, {
+    this.cacheSet(this.agentOwnerCache, cacheKey, {
       ownerUserId,
       expiresAt: Date.now() + AuthProfilesManager.AGENT_OWNER_CACHE_TTL_MS,
     });
@@ -295,12 +347,34 @@ export class AuthProfilesManager {
   ): Promise<AuthProfile[]> {
     const ownerUserId = await this.resolveAgentOwnerUserId(agentId);
     if (!ownerUserId || ownerUserId === requestingUserId) return [];
-    const ownerProfiles = await this.userAuthProfiles.list(ownerUserId, agentId);
-    // Only API-key profiles fall back to the owner. OAuth/device-code profiles
-    // carry per-user refresh state (`ensureFreshCredential` keys refresh by the
-    // *requesting* userId, which here is the synthetic run user) — surfacing an
-    // owner OAuth token would attribute its refresh to the wrong user row.
-    return ownerProfiles.filter((profile) => profile.authType === "api-key");
+    const ownerProfiles = await this.listStoredProfiles(ownerUserId, agentId);
+    // The owner's org-bucket sign-in covers every agent in the org, so a run
+    // executing as a synthetic user reaches it through the owner too.
+    const organizationId = tryGetOrgId();
+    const bucketProfiles = organizationId
+      ? await this.listStoredProfiles(
+          ownerUserId,
+          orgBucketAgentId(organizationId)
+        )
+      : [];
+    return [...ownerProfiles, ...bucketProfiles];
+  }
+
+  /** Read one `(userId, agentId)` storage row set, stamping each profile with
+   *  the row it came from so a later refresh targets that row rather than the
+   *  principal that happened to request it. */
+  private async listStoredProfiles(
+    userId: string,
+    agentId: string
+  ): Promise<AuthProfile[]> {
+    const profiles = await this.userAuthProfiles.list(userId, agentId);
+    const organizationId = tryGetOrgId() ?? undefined;
+    return this.normalizeProfiles(profiles).map(
+      (profile): SourcedAuthProfile => ({
+        ...profile,
+        [PROFILE_SOURCE]: { userId, agentId, organizationId },
+      })
+    );
   }
 
   async listProfiles(agentId: string, userId?: string): Promise<AuthProfile[]> {
@@ -325,7 +399,7 @@ export class AuthProfilesManager {
     userId?: string
   ): Promise<AuthProfile[]> {
     const userProfiles = userId
-      ? await this.userAuthProfiles.list(userId, agentId)
+      ? await this.listStoredProfiles(userId, agentId)
       : [];
 
     // Org bucket: one subscription sign-in on the org inference-providers page
@@ -337,12 +411,12 @@ export class AuthProfilesManager {
     const orgId = tryGetOrgId();
     const orgBucketProfiles =
       userId && orgId
-        ? await this.userAuthProfiles.list(userId, orgBucketAgentId(orgId))
+        ? await this.listStoredProfiles(userId, orgBucketAgentId(orgId))
         : [];
 
     // Agent runs execute as a synthetic/platform user, not the operator who
     // connected the provider in the agent settings UI. Fall back to the agent
-    // owner's user-scoped profiles so a UI-connected API key actually resolves
+    // owner's user-scoped profiles so a UI-connected provider actually resolves
     // for chat/automation/Telegram runs. (`dedupeByScope` keeps the run user's
     // own profile when both exist.)
     const ownerProfiles = await this.listAgentOwnerProfiles(agentId, userId);
@@ -351,9 +425,9 @@ export class AuthProfilesManager {
     const declared = this.synthesizeDeclaredProfiles(agentId);
 
     const merged = this.dedupeByScope([
-      ...this.normalizeProfiles(userProfiles),
-      ...this.normalizeProfiles(orgBucketProfiles),
-      ...this.normalizeProfiles(ownerProfiles),
+      ...userProfiles,
+      ...orgBucketProfiles,
+      ...ownerProfiles,
       ...this.normalizeProfiles(ephemeral),
       ...declared,
     ]);
@@ -419,13 +493,36 @@ export class AuthProfilesManager {
       return runtimeProfile;
     }
 
-    const providerProfiles = await this.getProviderProfiles(
+    let providerProfiles = await this.getProviderProfiles(
       agentId,
       provider,
       context?.userId
     );
     if (providerProfiles.length === 0) {
       return null;
+    }
+
+    // A persisted OAuth profile that has already expired still has a refresh
+    // path; without this the filter below drops it and a scheduled run can
+    // never recover once its token lapses.
+    const expiredBefore = Date.now();
+    const expiredRefreshable = providerProfiles.filter(
+      (profile) =>
+        profile.authType === "oauth" &&
+        !!(profile as SourcedAuthProfile)[PROFILE_SOURCE] &&
+        !!profile.metadata?.expiresAt &&
+        profile.metadata.expiresAt <= expiredBefore
+    );
+    if (this.lazyRefreshHooks && expiredRefreshable.length > 0) {
+      for (const profile of expiredRefreshable) {
+        const source = (profile as SourcedAuthProfile)[PROFILE_SOURCE]!;
+        await this.ensureFreshCredential(profile, source);
+      }
+      providerProfiles = await this.getProviderProfiles(
+        agentId,
+        provider,
+        context?.userId
+      );
     }
 
     const now = Date.now();

--- a/packages/server/src/gateway/auth/settings/user-auth-profile-store.ts
+++ b/packages/server/src/gateway/auth/settings/user-auth-profile-store.ts
@@ -29,6 +29,20 @@ export function isOrgBucketAgentId(agentId: string): boolean {
   return agentId.startsWith(ORG_BUCKET_AGENT_PREFIX);
 }
 
+/**
+ * Profile auth types that carry a refresh token we can rotate. "oauth" =
+ * Claude (authorization-code), "device-code" = ChatGPT/Codex; "api-key" is the
+ * only non-member. Lives here rather than beside the refresh job because both
+ * the job and `AuthProfilesManager`'s at-use-time lazy refresh gate on it — a
+ * second copy of these literals would break refresh for already-signed-in
+ * users ~1h later, invisibly. The refresh-eligibility regression test asserts
+ * both literals are still selected after the OAuth-flow consolidation.
+ */
+export const REFRESHABLE_AUTH_TYPES: ReadonlySet<string> = new Set([
+  "oauth",
+  "device-code",
+]);
+
 function buildSecretName(
   userId: string,
   agentId: string,

--- a/packages/server/src/gateway/proxy/token-refresh-job.ts
+++ b/packages/server/src/gateway/proxy/token-refresh-job.ts
@@ -3,18 +3,14 @@ import { type DbClient, getDb } from "../../db/client.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
 import type { OAuthCredentials } from "../auth/oauth/credentials.js";
 import type { AuthProfilesManager } from "../auth/settings/auth-profiles-manager.js";
-import { isOrgBucketAgentId } from "../auth/settings/user-auth-profile-store.js";
+import {
+  isOrgBucketAgentId,
+  REFRESHABLE_AUTH_TYPES,
+} from "../auth/settings/user-auth-profile-store.js";
 
 const logger = createLogger("token-refresh-job");
 
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000; // Refresh tokens expiring within 5 minutes
-
-// Profile auth types that carry a refresh token we can rotate. "oauth" =
-// Claude (authorization-code), "device-code" = ChatGPT/Codex. Exported so the
-// refresh-eligibility regression test can assert BOTH literals are still
-// selected after the OAuth-flow consolidation — a silent rename here breaks
-// refresh for already-signed-in users ~1h later, invisibly.
-export const REFRESHABLE_AUTH_TYPES = new Set(["oauth", "device-code"]);
 
 /**
  * Anything that can swap a refresh token for fresh credentials. Both the
@@ -144,7 +140,7 @@ export class TokenRefreshJob {
 
   private async doRefresh(userId: string, agentId: string): Promise<void> {
     for (const { providerId, refresher } of this.refreshableProviders) {
-      const profiles = await this.authProfilesManager.getProviderProfiles(
+      const profiles = await this.authProfilesManager.getStoredProviderProfiles(
         agentId,
         providerId,
         userId
@@ -201,7 +197,7 @@ export class TokenRefreshJob {
 
       // Re-read under the lock — another replica may have rotated this profile
       // while we waited to acquire it.
-      const profiles = await this.authProfilesManager.getProviderProfiles(
+      const profiles = await this.authProfilesManager.getStoredProviderProfiles(
         agentId,
         providerId,
         userId

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -317,11 +317,10 @@ async function lockInferenceProviderDefaults(
  *     credentials live in per-user `auth_profiles` and are fetched by
  *     `getBestProfile(agentId, providerId, …, context)`; `oauth://` joins to no
  *     `agent_secrets` row, so `readOrgSharedProviderApiKey` returns null for
- *     them. A headless Automation run carries a synthetic user id with no
- *     profile, so inheriting an OAuth row as the ORG default hands every agent
- *     in the org a model it cannot authenticate — worse than having no default,
- *     because it fails at egress instead of falling back. (The gateway
- *     transport already refuses these; this keeps the run path honest too.)
+ *     them. Runs can resolve the requesting user's or agent owner's profile,
+ *     including that owner's org bucket, but agents owned by other members
+ *     need their own sign-in. An ORG default must be usable regardless of
+ *     which member owns an agent, so personal subscriptions remain ineligible.
  *
  * {@link setInferenceProviderDefault} rejects these for the SAME reason, so an
  * explicit choice cannot reach a state automatic promotion refuses to create.
@@ -814,7 +813,7 @@ function modelRefFromDefaultRow(row: OrgDefaultModelRow | null): string | null {
  * happen under the org lock:
  *   - no flagged default at all ⇒ promote the oldest runnable provider;
  *   - a flagged default that is NOT eligible — no `capabilities.text.model`,
- *     or an `oauth://` ref whose credential only one user can read ⇒ demote it,
+ *     or an `oauth://` ref backed by a personal subscription ⇒ demote it,
  *     then promote an eligible one. Leaving it would keep returning null while
  *     the UI showed a default, which is the confusing half of the bug. The
  *     OAuth case also repairs rows written before that rule existed.
@@ -865,11 +864,10 @@ export async function getOrgDefaultModel(
  *    report success for a selection that silently reverts on the very next
  *    read — the API must not claim to have stored something it will undo.
  *
- *  - an `oauth://` row. Its credential lives in ONE user's `auth_profiles` and
- *    is fetched with `getProviderProfiles(agentId, provider, context.userId)`,
- *    so no other member of the org — and no headless Automation run, which
- *    carries a synthetic user id — can read it. An ORG-WIDE default backed by
- *    one person's token hands everyone else a model they cannot authenticate.
+ *  - an `oauth://` row. Its credential belongs to a user. Inference can resolve
+ *    that user's profile directly or through an agent-owner fallback, but
+ *    agents owned by other members still need their own sign-in. An ORG-WIDE
+ *    default backed by one person's token cannot guarantee that coverage.
  *    Being a deliberate choice does not help: the chooser is not the only one
  *    who has to run on it. Same reason automatic promotion skips these (see
  *    {@link promoteOldestRunnableProvider}); the two paths must agree, or a


### PR DESCRIPTION
## Summary
Scheduled Automations and chat-platform runs use synthetic principals, so they could not resolve the agent owner's ChatGPT subscription even though direct chat worked. Resolve the owner's agent and organization subscription profiles in the gateway, retaining the original storage owner and bucket for token refresh. Expired persisted OAuth/device-code profiles now get a refresh attempt before selection rejects them. Periodic refresh reads only the actual stored row, so inherited profiles cannot be rotated and copied into a different user or agent row.

This deliberately lets runs of an owner's agent use that owner's subscription, matching the existing owner API-key fallback. The requesting principal and tool permissions remain unchanged; durable tokens stay in the gateway, and the organization bucket follows the verified organization context. The owner lookup cache is now scoped by organization and agent.

## Test plan
- [x] Focused auth, worker-session credential and proxy tests; reviewer reports 155 passing targeted tests, plus 14 token-refresh tests.
- [x] Bug reproduced live: scheduled tasks, duplicate analysis and net worth all failed with `No provider credentials configured`, while direct ChatGPT subscription chat completed.
- [x] Additional regression: periodic refresh of an inherited owner subscription reproduced an unintended rotation (`6 pass / 1 fail`); the fix restricts refresh reads to the persisted row. Positive coverage still rotates the owner bucket.
- [x] Red → green: the new owner-refresh suite gave `1 pass / 5 fail` against the original code and `6 pass / 0 fail` after the fix. Coverage includes owner bucket lookup, direct-owner bucket refresh, expired-token recovery and organization isolation.
- [x] `make pre-pr` passed (build, typecheck, lint, file-level knip, naming and gateway/funnel checks). Final focused rerun after the periodic-refresh correction: `30 pass / 0 fail`.
- [x] GitHub CI, semantic review and UI applicability gate passed; merged as `f5b737452c65eb96636d690521954d671e31b38c`.
- [x] Exact squash revision confirmed live; production smoke passed 9/9. A fresh net-worth Automation completed subscription inference, its deterministic reaction, snapshot persistence and notification.
- [ ] Full Automation/Slack reliability: fresh runs exposed a separate queue admission/watchdog deadline mismatch and a long-running task timeout; follow-up repairs are in progress. Native Slack poll proof remains pending.

## Notes
No DB, public API or SDK changes. Organization-wide subscription-default eligibility is unchanged: other agent owners still need their own sign-in; related comments now explain that boundary. Revoked refresh grants can still fail; a failed refresh does not make an expired profile selectable. No live subscription token was expired or altered for testing.
