### PR TITLE
fix(automations): honor reasoning effort on cloud turns

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -7183,6 +7183,10 @@ export type PostApiV1AgentsByAgentIdMessagesData = {
     message?: string;
     messageId?: string;
     /**
+     * Reasoning effort for this turn on the cloud lane (an Automation dispatches its `execution_config.effort` here). The runtime rejects a level the selected model cannot serve.
+     */
+    effort?: string;
+    /**
      * Optional per-message model override (a `provider/model` ref or "auto"). Wins over the agent/org default. Used by Automation dispatch.
      */
     model?: string;

--- a/packages/connector-worker/src/__tests__/agent-turn-arm.test.ts
+++ b/packages/connector-worker/src/__tests__/agent-turn-arm.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import {
+  type AgentTurnPollPayload,
   type PollResponse,
   TURN_DELTA_MAX_CHARS,
 } from "@lobu/core/contracts/worker/protocol";
@@ -191,7 +192,9 @@ describe("executeAgentTurnRun", () => {
       },
     };
 
-    await executeAgentTurnRun(fakeClient(reported) as never, turnJob(), {}, cfgWith(executor));
+    const job = turnJob();
+    (job.payload as AgentTurnPollPayload).turn.effort = "medium";
+    await executeAgentTurnRun(fakeClient(reported) as never, job, {}, cfgWith(executor));
 
     expect(seen?.mode).toBe("agent_turn");
     if (seen?.mode !== "agent_turn") throw new Error("expected an agent_turn job");
@@ -203,6 +206,7 @@ describe("executeAgentTurnRun", () => {
     });
     expect(seen.turn.sessionJsonl).toBe(SESSION_JSONL);
     expect(seen.turn.systemPrompt).toBe("be brief");
+    expect(seen.turn.effort).toBe("medium");
     expect(seen.turn.userMessage).toBe("hello");
     // A turn without tools reaches the guest without a manifest, not with an
     // empty one: the guest builds its tool list off the field's presence.

--- a/packages/connector-worker/src/__tests__/native-session-compat.test.ts
+++ b/packages/connector-worker/src/__tests__/native-session-compat.test.ts
@@ -5,7 +5,87 @@ import type { AgentTurnInput } from '../agent-turn/types.js';
 const originalFetch = globalThis.fetch;
 afterEach(() => { globalThis.fetch = originalFetch; });
 
+/** Minimal terminal SSE bodies — enough for each adapter to finish a turn. */
+const sse = (events: unknown[], named = false) =>
+  events.map((event) => `${named ? `event: ${(event as { type: string }).type}\n` : ''}data: ${JSON.stringify(event)}\n\n`).join('');
+const anthropicStream = () => sse([
+  { type: 'message_start', message: { id: 'synthetic', type: 'message', role: 'assistant', model: 'reasoning-model', content: [], stop_reason: null, usage: { input_tokens: 1, output_tokens: 0 } } },
+  { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+  { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Done.' } },
+  { type: 'content_block_stop', index: 0 },
+  { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 2 } },
+  { type: 'message_stop' },
+], true);
+const responsesStream = () => sse([
+  { type: 'response.completed', response: { id: 'synthetic', status: 'completed', output: [], usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } } },
+]);
+const completionsStream = () => `${sse([
+  { id: 'synthetic', object: 'chat.completion.chunk', created: 1, model: 'reasoning-model',
+    choices: [{ index: 0, delta: { role: 'assistant', content: 'Done.' }, finish_reason: 'stop' }] },
+])}data: [DONE]\n\n`;
+
 describe('native session provider compatibility', () => {
+  test.each(['medium', 'high'])('sends %s effort for a new Codex model absent from the registry', async (effort) => {
+    const requests: Record<string, any>[] = [];
+    globalThis.fetch = (async (_url, init) => {
+      requests.push(JSON.parse(String(init?.body)));
+      const response = { id: 'synthetic-codex-response', status: 'completed', output: [],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } };
+      return new Response(`data: ${JSON.stringify({ type: 'response.completed', response })}\n\n`,
+        { headers: { 'content-type': 'text/event-stream' } });
+    }) as typeof fetch;
+    const input: AgentTurnInput = {
+      provider: { api: 'openai-codex-responses', provider: 'openai-codex', modelId: 'synthetic-new-model',
+        baseUrl: 'https://gateway.example.test/proxy/chatgpt', apiKey: 'synthetic-credential' },
+      effort, systemPrompt: 'Be brief.', sessionJsonl: '', userMessage: 'Say done.',
+    };
+    const session = createNativeSession(input, [], () => undefined);
+    try {
+      await promptNativeSession(session, input.userMessage);
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.reasoning?.effort).toBe(effort);
+    } finally { session.dispose(); }
+  });
+
+  test('rejects unsupported effort instead of silently turning reasoning off', () => {
+    const input = { provider: { modelId: 'synthetic-model' }, effort: 'unsupported' } as AgentTurnInput;
+    expect(() => createNativeSession(input, [], () => undefined)).toThrow('Unsupported cloud reasoning effort');
+    expect(() => createNativeSession({ ...input, effort: 'medium', provider: { ...input.provider, reasoning: false } }, [], () => undefined))
+      .toThrow('does not support reasoning effort');
+  });
+
+  // Every wire protocol, because only `streamSimple` reads the thinking level
+  // and each lane registers its own: a lane wired to the plain `stream` fn
+  // still typechecks and still drops the effort. Each provider names it
+  // differently, so assert the shape that provider actually sends.
+  const EFFORT_LANES = [
+    { api: 'anthropic-messages', provider: 'anthropic', body: anthropicStream(),
+      assert: (request: Record<string, any>) => expect(request.thinking).toMatchObject({ type: 'enabled' }) },
+    { api: 'openai-responses', provider: 'openai', body: responsesStream(),
+      assert: (request: Record<string, any>) => expect(request.reasoning?.effort).toBe('medium') },
+    { api: 'openai-completions', provider: 'openai', body: completionsStream(),
+      assert: (request: Record<string, any>) => expect(request.reasoning_effort).toBe('medium') },
+  ] as const;
+
+  test.each(EFFORT_LANES)('sends configured medium effort over $api', async (lane) => {
+    const requests: Record<string, any>[] = [];
+    globalThis.fetch = (async (_url, init) => {
+      requests.push(JSON.parse(String(init?.body)));
+      return new Response(lane.body, { headers: { 'content-type': 'text/event-stream' } });
+    }) as typeof fetch;
+    const input = {
+      provider: { api: lane.api, provider: lane.provider, modelId: 'reasoning-model',
+        baseUrl: 'https://gateway.example.test/proxy/reasoning', apiKey: 'synthetic-credential', reasoning: true },
+      effort: 'medium', systemPrompt: 'Be brief.', sessionJsonl: '', userMessage: 'Say done.',
+    } as AgentTurnInput;
+    const session = createNativeSession(input, [], () => undefined);
+    try {
+      await promptNativeSession(session, input.userMessage);
+      expect(requests).toHaveLength(1);
+      lane.assert(requests[0] ?? {});
+    } finally { session.dispose(); }
+  });
+
   test.each([false, true])('uses supportsStore=%s for prompts and compaction', async (supportsStore) => {
     const requests: Record<string, unknown>[] = [];
     globalThis.fetch = (async (_url, init) => {

--- a/packages/connector-worker/src/agent-turn/native-session.ts
+++ b/packages/connector-worker/src/agent-turn/native-session.ts
@@ -1,9 +1,9 @@
-import { Agent, type AgentTool } from '@mariozechner/pi-agent-core';
+import { Agent, type AgentTool, type ThinkingLevel } from '@mariozechner/pi-agent-core';
 import { registerApiProvider, streamSimple, type Api, type Model } from '@mariozechner/pi-ai';
-import { streamAnthropic } from '@mariozechner/pi-ai/anthropic';
-import { streamOpenAICompletions } from '@mariozechner/pi-ai/openai-completions';
-import { streamOpenAICodexResponses } from '@mariozechner/pi-ai/openai-codex-responses';
-import { streamOpenAIResponses } from '@mariozechner/pi-ai/openai-responses';
+import { streamAnthropic, streamSimpleAnthropic } from '@mariozechner/pi-ai/anthropic';
+import { streamOpenAICompletions, streamSimpleOpenAICompletions } from '@mariozechner/pi-ai/openai-completions';
+import { streamOpenAICodexResponses, streamSimpleOpenAICodexResponses } from '@mariozechner/pi-ai/openai-codex-responses';
+import { streamOpenAIResponses, streamSimpleOpenAIResponses } from '@mariozechner/pi-ai/openai-responses';
 import { AgentSession, SessionManager, SettingsManager, convertToLlm, CURRENT_SESSION_VERSION, type ModelRegistry } from '@mariozechner/pi-coding-agent';
 import { createLobuResourceLoader, type TransientTurnContextLookup } from '@lobu/plugin-toolkit/pi-resources';
 import { SESSION_PATH, withSessionSnapshot } from './pi-session-fs.js';
@@ -15,6 +15,21 @@ export function createNativeSession(
   tools: AgentTool[],
   getTransientContext: TransientTurnContextLookup
 ): AgentSession {
+  // Exhaustive over Pi's `ThinkingLevel`, so a level added or renamed upstream
+  // fails the build here instead of silently 400ing at the provider.
+  const levels: Record<ThinkingLevel, true> = {
+    off: true, minimal: true, low: true, medium: true, high: true, xhigh: true,
+  };
+  const effort = input.effort?.trim() || 'off';
+  if (!Object.hasOwn(levels, effort)) {
+    throw new Error(`Unsupported cloud reasoning effort: ${effort}. Supported values: ${Object.keys(levels).join(', ')}.`);
+  }
+  // Rejecting is the honest answer: silently downgrading to 'off' would bill a
+  // configured reasoning turn as a plain one with no signal that it happened.
+  if (effort !== 'off' && input.provider.reasoning === false) {
+    throw new Error(`Model ${input.provider.modelId} does not support reasoning effort.`);
+  }
+  const thinkingLevel = effort as ThinkingLevel;
   const manager = SessionManager.inMemory('/workspace');
   if (input.sessionJsonl) {
     // Pi's file reader tolerates malformed lines for crash recovery. A gateway
@@ -43,7 +58,9 @@ export function createNativeSession(
     // `claude-sonnet-4` reports `reasoning:true, maxTokens:64000` upstream and
     // was described to the adapter as `false`/8192, capping every long answer
     // on this lane at an eighth of what the model allows.
-    reasoning: input.provider.reasoning ?? false,
+    // For a model absent from the registry, an explicit effort is the user's
+    // request to try reasoning; known non-reasoning models are rejected above.
+    reasoning: input.provider.reasoning ?? (thinkingLevel !== 'off'),
     input: input.provider.input ?? ['text'],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: input.compaction?.contextWindow ?? 200_000,
@@ -57,8 +74,14 @@ export function createNativeSession(
   // One registration per wire protocol. `openai-responses` is NOT a fallback
   // for completions: official OpenAI is promoted to Responses so reasoning
   // models can use tools, and the two speak different request shapes.
+  //
+  // `streamSimple` is the variant that reads `options.reasoning`, so it — not
+  // the plain `stream` fn, which takes the narrower `StreamOptions` — is what
+  // turns `thinkingLevel` into the provider's own effort field. Registering
+  // `stream` for both slots typechecks (a wider parameter is assignable) and
+  // silently drops every configured effort, so each slot takes its own fn.
   if (input.provider.api === 'anthropic-messages') {
-    registerApiProvider({ api: 'anthropic-messages', stream: streamAnthropic, streamSimple: streamAnthropic });
+    registerApiProvider({ api: 'anthropic-messages', stream: streamAnthropic, streamSimple: streamSimpleAnthropic });
   } else if (input.provider.api === 'openai-codex-responses') {
     // pi-ai extracts an account id before invoking fetch. This inert JWT is
     // only adapter input: the isolate host replaces Authorization with the
@@ -70,11 +93,13 @@ export function createNativeSession(
     const placeholder = `e30.${btoa(JSON.stringify({ 'https://api.openai.com/auth': { chatgpt_account_id: 'lobu-proxy' } }))}.placeholder`;
     const stream: typeof streamOpenAICodexResponses = (model, context, options) =>
       streamOpenAICodexResponses(model, context, { ...options, apiKey: placeholder, transport: 'sse' });
-    registerApiProvider({ api: 'openai-codex-responses', stream, streamSimple: stream });
+    const simple: typeof streamSimpleOpenAICodexResponses = (model, context, options) =>
+      streamSimpleOpenAICodexResponses(model, context, { ...options, apiKey: placeholder, transport: 'sse' });
+    registerApiProvider({ api: 'openai-codex-responses', stream, streamSimple: simple });
   } else if (input.provider.api === 'openai-responses') {
-    registerApiProvider({ api: 'openai-responses', stream: streamOpenAIResponses, streamSimple: streamOpenAIResponses });
+    registerApiProvider({ api: 'openai-responses', stream: streamOpenAIResponses, streamSimple: streamSimpleOpenAIResponses });
   } else {
-    registerApiProvider({ api: 'openai-completions', stream: streamOpenAICompletions, streamSimple: streamOpenAICompletions });
+    registerApiProvider({ api: 'openai-completions', stream: streamOpenAICompletions, streamSimple: streamSimpleOpenAICompletions });
   }
   const context = manager.buildSessionContext();
   if (context.model?.provider !== model.provider || context.model?.modelId !== model.id) {
@@ -94,15 +119,7 @@ export function createNativeSession(
   } as unknown as ModelRegistry;
   let session: AgentSession;
   const agent = new Agent({
-    // `thinkingLevel` stays off even for a reasoning-capable model, and that is
-    // now a choice rather than a side effect of the model metadata: Pi's own
-    // `Agent` default is also `'off'` (only `AgentSession` picks a level), and
-    // nothing in Lobu configures one per agent or per turn. Turning it on would
-    // be a new product decision and a spend change, not a restored regression —
-    // so it needs a configured level to read, not a default invented here. The
-    // model's `reasoning` flag is still carried honestly above, because that is
-    // what the adapter inspects to shape the request.
-    initialState: { model, messages: context.messages, thinkingLevel: 'off' },
+    initialState: { model, messages: context.messages, thinkingLevel },
     // Keep native custom/summary conversion. Pi stores an empty text block for
     // image-only prompts; omit it only on the wire, where OpenAI rejects it.
     convertToLlm: (messages) => convertToLlm(messages).map((message) =>

--- a/packages/connector-worker/src/agent-turn/types.ts
+++ b/packages/connector-worker/src/agent-turn/types.ts
@@ -210,6 +210,8 @@ export const MAX_TOOL_CALLS_PER_TURN = 50;
 /** Everything a single turn needs. */
 export interface AgentTurnInput {
   provider: AgentTurnProvider;
+  /** Pi `ThinkingLevel` for this turn. Absent leaves thinking off. */
+  effort?: string;
   systemPrompt: string;
   /** Native Pi session JSONL; empty for a new conversation. */
   sessionJsonl: string;

--- a/packages/connector-worker/src/daemon/agent-turn.ts
+++ b/packages/connector-worker/src/daemon/agent-turn.ts
@@ -306,6 +306,7 @@ export async function executeAgentTurnRun(
             ...(turn.provider.input ? { input: turn.provider.input } : {}),
           },
           systemPrompt: turn.system_prompt,
+          ...(turn.effort ? { effort: turn.effort } : {}),
           sessionJsonl: turn.session_jsonl,
           userMessage: turn.message_text,
           ...(turn.ephemeral_context ? { ephemeralContext: turn.ephemeral_context } : {}),

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -433,6 +433,14 @@ export const AgentTurnPollPayloadSchema = Type.Object({
       )
     ),
     system_prompt: Type.String(),
+    /**
+     * Explicit per-turn reasoning effort, resolved from the Automation's
+     * `execution_config.effort` or the send-message body. Absent leaves the
+     * guest's thinking off, which is what every turn on this lane got before
+     * the field existed; the guest rejects a level it does not know or that
+     * `provider.reasoning: false` says the model cannot serve.
+     */
+    effort: Type.Optional(Type.String()),
     /** Native Pi session JSONL, read after this conversation's claim is admitted. */
     session_jsonl: Type.String(),
     provider: Type.Object({
@@ -470,9 +478,8 @@ export const AgentTurnPollPayloadSchema = Type.Object({
       /**
        * pi-ai's `Model.reasoning`: whether this model supports extended
        * thinking. The guest builds its `Model` from this envelope and has no
-       * registry to consult, so an absent value means "not reasoning-capable"
-       * — which is what every agent on this lane silently got before the
-       * field existed, registry-capable models included.
+       * registry to consult. Absent means the model is unknown: reasoning
+       * stays off unless the caller explicitly requests an effort level.
        */
       reasoning: Type.Optional(Type.Boolean()),
       /**

--- a/packages/server/src/__tests__/integration/agent-turn-producer.test.ts
+++ b/packages/server/src/__tests__/integration/agent-turn-producer.test.ts
@@ -2903,12 +2903,16 @@ describe('agent turn producer', () => {
     expect(turn.provider.reasoning).toBe(true);
   });
 
-  it("omits the output ceiling for a model the registry does not carry", async () => {
-    // `claude-opus-4-8` is not in pi-ai's registry, so there is no ceiling to
-    // state — and an absent field is how the envelope says "let the adapter
-    // apply its own default" instead of inventing a number on either side.
+  it("preserves explicit effort without inventing capabilities for an unknown model", async () => {
+    // `claude-opus-4-8` is not in pi-ai's registry, so there is no ceiling and
+    // no reasoning flag to state — and an absent field is how the envelope says
+    // "let the adapter decide" instead of inventing an answer on either side.
+    // Claiming `reasoning: false` here would make the guest reject the effort
+    // the caller configured, for a model that very likely supports it.
     const org = await createTestOrganization();
-    await enqueueMessage(messageFor(org.id), {
+    const message = messageFor(org.id);
+    message.agentOptions = { ...message.agentOptions, effort: 'medium' };
+    await enqueueMessage(message, {
       agentSettings: settingsStore,
       catalog: catalogFor(claudeModule()),
       gatewayUrl: GATEWAY_URL,
@@ -2916,11 +2920,12 @@ describe('agent turn producer', () => {
 
     const [run] = await agentTurnRuns();
     const turn = (run?.action_input as {
-      turn: { provider: { model_id: string; reasoning?: boolean; max_tokens?: number } };
+      turn: { effort?: string; provider: { model_id: string; reasoning?: boolean; max_tokens?: number } };
     }).turn;
     expect(turn.provider.model_id).toBe('claude-opus-4-8');
     expect(turn.provider.max_tokens).toBeUndefined();
-    expect(turn.provider.reasoning).toBe(false);
+    expect(turn.provider.reasoning).toBeUndefined();
+    expect(turn.effort).toBe('medium');
   });
 
   it('carries ephemeralContext on the turn-scoped channel, NOT the durable message', async () => {

--- a/packages/server/src/__tests__/integration/automations/automation-model-namespace.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automation-model-namespace.test.ts
@@ -1,10 +1,11 @@
 /**
  * `execution_config.model` is ONE stored field with TWO resolution namespaces
- * (see the comment on `getAutomationModelOverride`): a device-pinned Automation
- * hands the ref verbatim to a local CLI as `--model`, while a server-dispatched
- * one resolves it against the org's model providers. Nothing checked which
- * lane a ref belonged to, so both directions failed silently at run time. In
- * prod on 2026-08-19 both happened within eight minutes:
+ * (see the comment on `getAutomationInferenceOverrides`): a device-pinned
+ * Automation hands the ref verbatim to a local CLI as `--model`, while a
+ * server-dispatched one resolves it against the org's model providers.
+ * Nothing checked which lane a ref belonged to, so both directions failed
+ * silently at run time. In prod on 2026-08-19 both happened within eight
+ * minutes:
  *
  *   15:01  #71 (device)  opencode: ProviderModelNotFoundError deepseek/deepseek-v4-flash
  *   15:09  #5  (server)  OpenRouter 400: opencode-go/deepseek-v4-flash is not a valid model ID

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -1261,25 +1261,32 @@ async function claimAutomationRun(
 }
 
 /**
- * Read an automation's optional per-automation model override from
- * `automations.execution_config.model` (a `provider/model` ref or "auto"). This is
- * the SAME field the device-worker lane already reads as the CLI `--model` flag
- * (AutomationExecutionConfigSchema.model), so the server-side dispatch lane and the
- * device lane share one storage location. Returns undefined when unset so the
- * caller falls through to the agent/org default.
+ * Read an automation's optional per-automation inference overrides from
+ * `automations.execution_config` (`model`, a `provider/model` ref or "auto",
+ * and `effort`, a reasoning level). These are the SAME fields the device-worker
+ * lane already reads as the CLI's `--model` / effort flags
+ * (AutomationExecutionConfigSchema), so the server-side dispatch lane and the
+ * device lane share one storage location.
+ *
+ * Each field is omitted when unset, so the caller falls through to the
+ * agent/org default for the model and leaves reasoning off for the effort.
  */
-async function getAutomationModelOverride(
+async function getAutomationInferenceOverrides(
 	sql: DbClient,
 	automationId: number
-): Promise<string | undefined> {
+): Promise<{ model?: string; effort?: string }> {
 	const rows = await sql`
-    SELECT execution_config->>'model' AS model
+    SELECT execution_config->>'model' AS model, execution_config->>'effort' AS effort
     FROM automations
     WHERE id = ${automationId}
     LIMIT 1
   `;
 	const model = rows[0]?.model as string | null | undefined;
-	return typeof model === "string" && model.trim() ? model.trim() : undefined;
+	const effort = rows[0]?.effort as string | null | undefined;
+	return {
+		...(typeof model === "string" && model.trim() ? { model: model.trim() } : {}),
+		...(typeof effort === "string" && effort.trim() ? { effort: effort.trim() } : {}),
+	};
 }
 
 export async function ensureAutomationAgentExists(
@@ -1425,11 +1432,13 @@ async function dispatchAutomationRun(
 		}
 	}
 
-	// Per-automation model override lives in automations.execution_config.model (a
-	// `provider/model` ref or "auto"). When set it rides the dispatch message so
-	// agent.ts reads it into baseOptions.model and it wins the layered fallback
-	// (automation → agent → org default); when absent the agent/org default resolves.
-	const automationModel = await getAutomationModelOverride(sql, run.automation_id);
+	// Per-automation inference overrides live in automations.execution_config
+	// (`model`: a `provider/model` ref or "auto"; `effort`: a reasoning level).
+	// When set they ride the dispatch message so agent.ts reads them into
+	// baseOptions and the model wins the layered fallback (automation → agent →
+	// org default); when absent the agent/org default resolves and the turn
+	// keeps reasoning off.
+	const inferenceOverrides = await getAutomationInferenceOverrides(sql, run.automation_id);
 	const automationInstructions = await getAutomationInstructions(
 		sql,
 		run.automation_id,
@@ -1503,7 +1512,7 @@ async function dispatchAutomationRun(
 			headers,
 			body: JSON.stringify({
 				messageId,
-				...(automationModel ? { model: automationModel } : {}),
+				...inferenceOverrides,
 				content: buildDispatchMessage({
 					automationId: run.automation_id,
 					runId: run.id,

--- a/packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-automation-message-e2e.test.ts
@@ -358,6 +358,9 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
 
   test("workspace-stamped channel and DM events persist, activate once, and reply", async () => {
     const sql = getDb();
+    await sql`UPDATE automations SET execution_config = '{"effort":"medium"}'::jsonb
+      WHERE organization_id = 'org-slack-grid-e2e'
+        AND triggers->0->'match'->>'channel_id' = ${CHANNEL_ID}`;
     const channelTs = "1787292000.000821";
     const channelPayload = slackEvent({
       eventId: "Ev_GRID_CHANNEL_20260821",
@@ -382,6 +385,7 @@ describe("Slack Enterprise Grid event -> chat Automation -> Slack reply", () => 
         agentId: "agent-slack-grid-e2e",
         organizationId: "org-slack-grid-e2e",
         messageText: "LOBU_SLACK_E2E_20260821 integration channel",
+        agentOptions: { effort: "medium" },
         platformMetadata: {
           automationId: expect.any(Number),
           teamId: WORKSPACE_TEAM_ID,

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -1552,6 +1552,14 @@ export class MessageHandlerBridge {
         agentSettingsStore,
         organizationId
       );
+      // Cloud only. A device turn already carries the whole executionConfig —
+      // effort included — inside `deviceExecutionConfig` below, and its CLI
+      // reads it from there; a second copy at the top level would be a
+      // duplicate the device lane never consults.
+      const effort = executionConfig?.effort;
+      if (!executionTarget && typeof effort === "string" && effort.trim()) {
+        agentOptions.effort = effort.trim();
+      }
 
       if (executionTarget) {
         // No override means the local CLI's own default, never a cloud model.

--- a/packages/server/src/gateway/orchestration/agent-turn-producer.ts
+++ b/packages/server/src/gateway/orchestration/agent-turn-producer.ts
@@ -436,8 +436,8 @@ interface TurnProvider {
   contextWindow: number;
   /** pi-ai's `Model.maxTokens`: the output ceiling this model actually allows. */
   maxTokens: number | null;
-  /** pi-ai's `Model.reasoning`: whether the model supports extended thinking. */
-  reasoning: boolean;
+  /** Registry reasoning support; undefined means the model is unknown. */
+  reasoning: boolean | undefined;
 }
 
 /**
@@ -490,7 +490,9 @@ function resolveTurnCompat(
  * Unknown models keep the retired subprocess lane's rules: `["text","image"]`
  * (it built a dynamic entry declaring both), a finite default window, and no
  * output ceiling — the adapter's own default is a better answer than a number
- * invented here.
+ * invented here. Reasoning support is left undefined for the same reason: the
+ * registry has no answer, so the guest decides from the requested effort
+ * instead of being told `false` about a model that may well support it.
  */
 function resolveModelMetadata(
   registryProvider: string,
@@ -514,7 +516,7 @@ function resolveModelMetadata(
       typeof model?.maxTokens === "number" && model.maxTokens > 0
         ? model.maxTokens
         : null,
-    reasoning: model?.reasoning === true,
+    reasoning: model?.reasoning,
   };
 }
 
@@ -1044,11 +1046,21 @@ export async function enqueueAgentTurn(
           workingDirectory: "/workspace",
         })
       : "";
+    // Trimmed like the model ref above: an empty string is "unset", not a
+    // level to hand the guest.
+    const effortForTurn =
+      typeof data.agentOptions?.effort === "string"
+        ? data.agentOptions.effort.trim()
+        : "";
     const turn: TurnEnvelope = {
       agent_id: data.agentId,
       conversation_id: data.conversationId,
       message_id: data.messageId,
       message_text: (data.messageText ?? "").slice(0, TURN_MESSAGE_CHARS),
+      // Reasoning effort, only when the caller configured one. Absent leaves
+      // the guest's thinking off, which is what every turn got before the
+      // field existed; the guest rejects a level the model cannot serve.
+      ...(effortForTurn ? { effort: effortForTurn } : {}),
       // Turn-scoped context both producers already populate and clamp to
       // 2 KiB. It reaches the model through the guest's transient channel, so
       // it is never persisted into the replayed user message.
@@ -1114,7 +1126,10 @@ export async function enqueueAgentTurn(
         // Omitted for an unknown model, so the guest falls back to the
         // adapter's own ceiling instead of a number invented on either side.
         ...(provider.maxTokens !== null ? { max_tokens: provider.maxTokens } : {}),
-        reasoning: provider.reasoning,
+        // Likewise omitted for an unknown model: the guest reads an absent
+        // value as "no registry answer" and lets an explicit effort decide,
+        // rather than asserting a capability nothing here knows.
+        ...(provider.reasoning !== undefined ? { reasoning: provider.reasoning } : {}),
         ...(provider.compat ? { compat: provider.compat } : {}),
       },
       ...(tools ? { tools } : {}),

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -196,6 +196,12 @@ const SendMessageRequestSchema = Type.Object(
       Type.String({ description: "Message content (alias for content)" }),
     ),
     messageId: Type.Optional(Type.String()),
+    effort: Type.Optional(
+      Type.String({
+        description:
+          "Reasoning effort for this turn on the cloud lane (an Automation dispatches its `execution_config.effort` here). The runtime rejects a level the selected model cannot serve.",
+      }),
+    ),
     model: Type.Optional(
       Type.String({
         description:
@@ -1457,6 +1463,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
         message: formData.get("message") as string | null,
         messageId: formData.get("messageId") as string | null,
         model: formData.get("model") as string | null,
+        effort: formData.get("effort") as string | null,
         platform: formData.get("platform") as string | null,
       };
 
@@ -1710,9 +1717,15 @@ export function createAgentApi(config: AgentApiConfig): Hono {
         typeof body.model === "string" && body.model.trim()
           ? body.model.trim()
           : undefined;
+      // Same trim rule as the model override: an empty string is "unset".
+      const automationEffort =
+        typeof body.effort === "string" && body.effort.trim()
+          ? body.effort.trim()
+          : undefined;
       const baseOptions: Record<string, any> = {
         provider: session.provider || "claude",
         model: automationModel ?? session.model,
+        ...(automationEffort ? { effort: automationEffort } : {}),
         nixConfig: session.nixConfig,
       };
       const agentOptions = await resolveAgentOptions(

--- a/packages/server/src/tools/admin/automation-execution-config.ts
+++ b/packages/server/src/tools/admin/automation-execution-config.ts
@@ -65,7 +65,7 @@ export function assertValidExecutionConfig(value: unknown, caller: ExecutionConf
  * Reject a model ref that names a provider this org has not registered.
  *
  * `execution_config.model` is ONE stored field with TWO resolution namespaces
- * (see `getAutomationModelOverride` in automations/automation.ts). A
+ * (see `getAutomationInferenceOverrides` in automations/automation.ts). A
  * device-pinned Automation passes the ref verbatim to a local CLI as `--model`,
  * so it must name a provider THAT CLI has registered; a server-dispatched one
  * resolves it against the org's model providers — registry modules with a


### PR DESCRIPTION
## Summary
Automation effort values were saved but dropped on the cloud path, and the native provider registrations passed simple reasoning options directly to raw adapters without translating them. Carry explicit effort through scheduled dispatch, chat routing, the worker envelope and native execution. Use each provider's simple adapter so the selected level reaches the request.

An unknown model remains distinct from a known non-reasoning model: an explicit effort can be tried for a new model absent from the bundled catalog. Unsupported cloud levels and known non-reasoning models report an error instead of silently discarding the setting. Unset effort preserves thinking off.

## Test plan
- [x] Red: the provider-request regression received no reasoning effort when medium was configured (2 pass / 1 fail).
- [x] Worker/native tests: 39 pass / 0 fail, including Codex medium/high requests and invalid-effort rejection.
- [x] Slack webhook/routing tests: 26 pass / 0 fail, preserving device settings and carrying cloud effort.
- [x] Cloud producer integration suite: 170 tests passed, including real HTTP/isolate coverage.
- [x] Pre-review fixer inspected; make pre-pr passed. Additional bridge/config suites passed (110 tests). Client regenerated from the booted server; staged pre-pr passed again.
- [x] GitHub CI, semantic review (88 confidence, zero blockers), and UI applicability check.
- [x] Squash 6bf40668f7695ef08537f948e0ed5d10f5c8a210 is an ancestor of deployed 07dd276dfe46b165316bb719c95b8f1f767cc758. Live Astra medium net-worth turns completed, including successful reactions.
- [x] Production smoke assertions passed; the browser harness hung during cleanup and was terminated. The script exit was unsuccessful, so this is not a 9/9 smoke claim.

## Notes
Adds optional string effort to the per-message API and internal worker envelope. Device effort remains runtime-specific. No database migration or new persisted setting.
