### PR TITLE
fix(runtime): preserve cloud turn admission deadlines

### DIFF
--- a/charts/lobu/Chart.yaml
+++ b/charts/lobu/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lobu
 description: Lobu Platform - Never forget anything. User content analysis with AI.
 type: application
-version: 19.2.4
+version: 19.2.5
 appVersion: 19.2.0
 keywords:
   - lobu

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -200,6 +200,11 @@ worker:
 
   env:
     POLL_INTERVAL_MS: "10000"
+    # Let independent agent turns and connector reads overlap: the poll loop
+    # defaults to ONE slot, so a long Automation holds up every other run on
+    # the fleet worker until it finishes. Two leaves headroom for the Node
+    # host beyond the two 512MB isolate heaps, even at the 2Gi request floor.
+    WORKER_MAX_CONCURRENT_JOBS: "2"
     # Tag Sentry events from the worker/embeddings deployment as production.
     ENVIRONMENT: production
 

--- a/packages/server/src/config/intervals.ts
+++ b/packages/server/src/config/intervals.ts
@@ -57,7 +57,12 @@ export const intervals = {
    *  120s leaves room for the 30s worker heartbeat to miss ~3 ticks before
    *  the reaper writes the row off — a real worker stutter (GC pause, network
    *  blip) gets a grace window, but a crashed worker frees the feed within
-   *  a couple of minutes instead of five. */
+   *  a couple of minutes instead of five.
+   *
+   *  Doubles as the `agent_turn` CLAIM horizon (`sweepStaleAgentTurnRuns`): a
+   *  claim-eligible turn still pending this long never started, so lowering
+   *  this also shortens the pre-admission window `armTurnTimeout` grants a
+   *  queued turn. */
   get runsReaperStaleAfterSeconds(): number {
     return parseEnvInt('RUNS_REAPER_STALE_AFTER_SECONDS', 120);
   },
@@ -100,11 +105,13 @@ export const intervals = {
     return parseEnvInt('WORKER_KILL_TIMEOUT_MS', 5_000);
   },
 
-  /** Default turn-liveness deadline. Comfortably exceeds the worker's 20s
-   *  status_update interval so a live worker (which extends the deadline on
-   *  every status_update — plus on the 30s SSE-ping ACK and delivery receipts)
-   *  is never falsely failed; a silent/dead worker lapses within this window of
-   *  its last worker-driven signal. */
+  /** Turn-liveness deadline while the turn EXECUTES. Comfortably exceeds the
+   *  worker's 20s status_update interval so a live worker (which extends the
+   *  deadline on every status_update — plus on the 30s SSE-ping ACK and
+   *  delivery receipts) is never falsely failed; a silent/dead worker lapses
+   *  within this window of its last worker-driven signal. `armTurnTimeout`
+   *  adds `runsReaperStaleAfterSeconds` on top, because a turn still waiting
+   *  for a worker slot has nothing that could signal liveness yet. */
   get turnDefaultDeadlineMs(): number {
     return parseEnvInt('TURN_DEFAULT_DEADLINE_MS', 60_000);
   },

--- a/packages/server/src/gateway/__tests__/agent-turn-marker-discharge.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-turn-marker-discharge.test.ts
@@ -2,14 +2,16 @@
  * The turn-liveness marker's two obligations on the isolate lane.
  *
  * `MessageConsumer` arms one marker per dispatched turn — the client's only
- * promise of a terminal event — with a fixed `TURN_DEFAULT_DEADLINE_MS` (60s)
- * deadline, and `sweepExpiredTurns` turns a lapsed marker into a terminal
- * WORKER_UNRESPONSIVE. Two things therefore have to happen, and the
- * subprocess lane did both from `/worker/response`, a route this lane never
- * calls:
+ * promise of a terminal event — covering the worker-claim horizon plus one
+ * `TURN_DEFAULT_DEADLINE_MS` (60s) execution window, and `sweepExpiredTurns`
+ * turns a lapsed marker into a terminal WORKER_UNRESPONSIVE. The first
+ * heartbeat extension drops it to that 60s execution deadline. Two things
+ * therefore have to happen, and the subprocess lane did both from
+ * `/worker/response`, a route this lane never calls:
  *
  *  1. WHILE the turn runs, each heartbeat pushes the deadline forward.
- *     Without it any turn over 60s was failed mid-flight while working.
+ *     Without it a turn outliving its marker's deadline was failed mid-flight
+ *     while working.
  *  2. AT terminal delivery, the marker is retired in the reply's own
  *     transaction. Without it heartbeats stop, the deadline lapses, and the
  *     sweep publishes a second, contradictory error to a user who already
@@ -27,11 +29,13 @@ import { getDb } from "../../db/client.js";
 import { RunsQueue } from "../infrastructure/queue/runs-queue.js";
 import {
   armTurnTimeout,
+  extendTurnDeadlines,
   sweepExpiredTurns,
 } from "../orchestration/turn-liveness.js";
 import {
   extendHeartbeatedTurnMarker,
   insertAgentTurnResponse,
+  releaseNextAgentTurn,
 } from "../../runs/agent-turn-inputs.js";
 import { generateDeploymentName } from "../orchestration/deployment-identity.js";
 import {
@@ -102,6 +106,47 @@ beforeEach(async () => {
 });
 
 describe("isolate-lane heartbeat vs the turn-liveness marker", () => {
+  test("a released follower gets a fresh admission window after owner heartbeats", async () => {
+    const conversationId = "conv-follower";
+    const messageId = "m-follower";
+    const deploymentName = generateDeploymentName(identity(conversationId));
+    await armTurnTimeout(queue, {
+      messageId,
+      channelId: CHANNEL,
+      conversationId,
+      userId: USER,
+      platform: "api",
+      deploymentName,
+      organizationId: ORG,
+    });
+
+    // The follower's own run row, blocked behind the owner it shares a
+    // conversation — and therefore a deployment — with.
+    await getDb()`
+      INSERT INTO public.runs (organization_id, run_type, status, action_input)
+      VALUES (${ORG}, 'agent_turn', 'pending',
+        ${getDb().json(nativeRun(conversationId, messageId).action_input as never)})`;
+
+    // Every owner heartbeat extends the WHOLE deployment, so it also collapses
+    // the queued follower's marker to the 60s execution deadline.
+    await extendTurnDeadlines(deploymentName);
+
+    await getDb().begin(async (tx) => {
+      await releaseNextAgentTurn(
+        tx as never,
+        nativeRun(conversationId, "m-owner") as never,
+      );
+    });
+
+    // 90s later the follower still has not been claimed: inside the admission
+    // window the release restored, outside the execution deadline it had.
+    await getDb()`
+      UPDATE public.runs SET run_at = run_at - interval '90 seconds'
+      WHERE run_type = 'internal' AND queue_name = 'internal:turn_timeout'`;
+    expect(await sweepExpiredTurns()).toBe(0);
+    expect(await armedMarkers()).toBe(1);
+  });
+
   test("a heartbeating long turn keeps its marker alive past the deadline", async () => {
     const conversationId = "conv-long";
     const messageId = "m-long";

--- a/packages/server/src/gateway/__tests__/turn-liveness.test.ts
+++ b/packages/server/src/gateway/__tests__/turn-liveness.test.ts
@@ -181,6 +181,30 @@ async function durableInput(
 }
 
 describe("turn-liveness", () => {
+  test("a queued turn remains live throughout worker admission, then uses the heartbeat deadline", async () => {
+    await armTurnTimeout(queue, routing("dep-queued", "m-queued"));
+    // A busy worker may claim later than the 60s execution deadline and still
+    // be inside the 120s claim horizon the reaper grants a pending
+    // agent_turn — and nothing can heartbeat a turn that is not claimed yet,
+    // so the marker must survive this age on the arming deadline alone.
+    await getDb()`
+      UPDATE public.runs SET run_at = run_at - interval '90 seconds'
+      WHERE queue_name = ${TURN_TIMEOUT_QUEUE}
+    `;
+    expect(await sweepExpiredTurns()).toBe(0);
+    expect(await markerCount("dep-queued")).toBe(1);
+
+    // The first worker-driven signal collapses the marker to the execution
+    // deadline, so the same 90s of silence now lapses it — exactly once.
+    await extendTurnDeadlines("dep-queued");
+    await getDb()`
+      UPDATE public.runs SET run_at = run_at - interval '90 seconds'
+      WHERE queue_name = ${TURN_TIMEOUT_QUEUE}
+    `;
+    expect(await sweepExpiredTurns()).toBe(1);
+    expect(await sweepExpiredTurns()).toBe(0);
+  });
+
   test("durable inputs replay while live and complete atomically with the terminal reply", async () => {
     await armTurnTimeout(queue, routing("dep-durable", "m-durable"));
     const { organizationId, storedPayload } = await durableInput(

--- a/packages/server/src/gateway/orchestration/agent-turn-producer.ts
+++ b/packages/server/src/gateway/orchestration/agent-turn-producer.ts
@@ -118,7 +118,7 @@ const compactionDefaults = SettingsManager.inMemory().getCompactionSettings();
  *
  * This lane is the only execution path, and `handleMessage` arms the
  * turn-liveness marker BEFORE enqueueing, so a bare `return` here leaves the
- * client waiting out `TURN_DEFAULT_DEADLINE_MS` for a generic
+ * client waiting out that marker's whole deadline for a generic
  * `WORKER_UNRESPONSIVE`. That names the wrong cause and offers no fix. The
  * producer therefore reports the reason and the caller — which owns the marker
  * it armed — discharges it into a terminal error carrying that reason's own

--- a/packages/server/src/gateway/orchestration/turn-liveness.ts
+++ b/packages/server/src/gateway/orchestration/turn-liveness.ts
@@ -71,8 +71,10 @@ const TURN_TIMEOUT_QUEUE = "internal:turn_timeout";
  *  so the UnifiedThreadResponseConsumer wakes immediately on an emitted error. */
 const THREAD_RESPONSE_CHANNEL = "runs_lobu:thread_response";
 
-// Default turn deadline and sweep cadence live in config/intervals.ts
+// The execution deadline and sweep cadence live in config/intervals.ts
 // (`turnDefaultDeadlineMs` / `turnLivenessSweepIntervalMs`), env-overridable.
+// A turn that has not started yet carries the worker-claim horizon on top —
+// see {@link admissionDeadlineMs}.
 
 /** Routing needed to build the terminal `thread_response{error}` for a turn,
  *  stored as the marker's `action_input`. */
@@ -137,6 +139,29 @@ function turnMarkerKey(deploymentName: string, messageId: string): string {
 }
 
 /**
+ * Marker deadline for a turn that has not started executing yet: the reaper's
+ * claim horizon plus one execution window.
+ *
+ * Arming happens BEFORE admission, and a run still waiting for a worker slot
+ * has nothing that could heartbeat it — so on the bare execution deadline a
+ * turn queued behind a busy worker was failed as WORKER_UNRESPONSIVE before any
+ * worker had looked at it. That wait is already bounded elsewhere:
+ * `sweepStaleAgentTurnRuns` terminalizes a claim-eligible `agent_turn` still
+ * `pending` after `runsReaperStaleAfterSeconds` as WORKER_STARTUP_FAILED, and
+ * that delivery discharges this marker. So the marker only has to outlast that
+ * claim horizon by one execution window to stay the backstop instead of the
+ * first thing to fire — and the client gets the precise "never started" code
+ * rather than the generic unresponsive-worker one. Once the worker heartbeats,
+ * {@link extendTurnDeadlines} drops the marker to the shorter execution
+ * deadline.
+ */
+function admissionDeadlineMs(): number {
+  return (
+    intervals.runsReaperStaleAfterSeconds * 1000 + intervals.turnDefaultDeadlineMs
+  );
+}
+
+/**
  * Arm the turn-liveness marker at dispatch. Idempotent per (deployment,
  * messageId) via the partial-unique `idempotency_key`, so a re-dispatched
  * message doesn't double-arm.
@@ -151,13 +176,36 @@ function turnMarkerKey(deploymentName: string, messageId: string): string {
 export async function armTurnTimeout(
   queue: IMessageQueue,
   routing: TurnRouting,
-  deadlineMs: number = intervals.turnDefaultDeadlineMs
+  deadlineMs: number = admissionDeadlineMs()
 ): Promise<void> {
   await queue.createQueue(TURN_TIMEOUT_QUEUE);
   await queue.send(TURN_TIMEOUT_QUEUE, routing, {
     delayMs: deadlineMs,
     singletonKey: turnMarkerKey(routing.deploymentName, routing.messageId),
   });
+}
+
+/**
+ * Restart a released follower's admission clock, in the same transaction as the
+ * queue handoff that made it claimable (`releaseNextAgentTurn`).
+ *
+ * A queued follower shares its deployment with the owner blocking it, so every
+ * owner heartbeat collapsed its marker to the execution deadline. That is
+ * harmless while the owner keeps beating, but it leaves the follower only that
+ * window to be claimed once the owner is gone — and a blocked follower is not
+ * claim-eligible, so `sweepStaleAgentTurnRuns` never covered it either.
+ */
+export async function resetTurnAdmissionDeadline(
+  sql: DbClient,
+  deploymentName: string,
+  messageId: string
+): Promise<void> {
+  const deadlineSec = Math.ceil(admissionDeadlineMs() / 1000);
+  await sql`UPDATE public.runs
+    SET run_at = now() + (${deadlineSec}::int * interval '1 second')
+    WHERE idempotency_key = ${turnMarkerKey(deploymentName, messageId)}
+      AND status = 'pending' AND run_type = 'internal'
+      AND queue_name = ${TURN_TIMEOUT_QUEUE}`;
 }
 
 /**
@@ -229,7 +277,8 @@ export async function extendTurnDeadlines(
  * `Retry-After`) and a later attempt on the same turn may well succeed. Failing
  * the turn here would kill turns that were about to work. Instead we only
  * withdraw the *extension* — the turn keeps whatever deadline it already had
- * (at most `turnDefaultDeadlineMs` from the last extension), which normally
+ * (at most `turnDefaultDeadlineMs` from its last extension, or the longer
+ * arming deadline when no extension has landed yet), which normally
  * outlasts the SDK's short `Retry-After` backoff. If a retry succeeds the
  * worker resumes real progress and {@link clearTurnProviderFailed} re-arms
  * extension; if none does, the marker lapses and `sweepExpiredTurns` emits a

--- a/packages/server/src/runs/agent-turn-inputs.ts
+++ b/packages/server/src/runs/agent-turn-inputs.ts
@@ -4,7 +4,7 @@ import { AGENT_TURN_INPUT_MAX, type AgentTurnPollPayload, type HeartbeatResponse
 import { CURRENT_SESSION_VERSION } from '@mariozechner/pi-coding-agent';
 import { getDb, type DbClient } from '../db/client';
 import type { TurnReply } from '../gateway/orchestration/agent-turn-producer';
-import { dischargeTurnMarkers, extendTurnDeadlines, insertThreadResponseRow } from '../gateway/orchestration/turn-liveness';
+import { dischargeTurnMarkers, extendTurnDeadlines, insertThreadResponseRow, resetTurnAdmissionDeadline } from '../gateway/orchestration/turn-liveness';
 import { generateDeploymentName } from '../gateway/orchestration/deployment-identity';
 
 export interface NativeTurnRun {
@@ -69,13 +69,20 @@ export function agentTurnClaimEligible(sql: DbClient) {
 
 /** Called only under the conversation lock, after the owning terminal transition. */
 export async function releaseNextAgentTurn(sql: DbClient, run: NativeTurnRun) {
-  await sql`UPDATE runs SET run_at = now() WHERE id = (
+  const [next] = await sql<NativeTurnRun>`UPDATE runs SET run_at = now() WHERE id = (
     SELECT id FROM runs WHERE run_type = 'agent_turn' AND status = 'pending'
       AND organization_id = ${run.organization_id}
       AND action_input->'turn'->>'agent_id' = ${run.action_input?.turn?.agent_id ?? null}
       AND action_input->'turn'->>'conversation_id' = ${run.action_input?.turn?.conversation_id ?? null}
     ORDER BY id LIMIT 1
-  )`;
+  ) RETURNING id, organization_id, action_input`;
+  // The follower becomes claimable from now, so its liveness marker — which the
+  // owner's heartbeats collapsed to the execution deadline — needs its
+  // admission window back, in this transaction.
+  const deployment = next && turnMarkerDeployment(next);
+  if (deployment && next.action_input?.turn?.message_id) {
+    await resetTurnAdmissionDeadline(sql, deployment, next.action_input.turn.message_id);
+  }
 }
 
 export function nativeSessionBase(snapshot: string): NativeTurnRun['run_metadata'] {
@@ -159,9 +166,10 @@ export async function pendingAgentTurnInputs(sql: DbClient, owner: NativeTurnRun
 
 /**
  * Derive the turn-liveness marker's deployment name from a native turn's
- * envelope. Single source for the two sites that need it — the terminal
- * discharge and the heartbeat extension — so neither can drift from the
- * arming site in `MessageConsumer`.
+ * envelope. Single source for the sites that need it — the terminal discharge,
+ * the heartbeat extension, and the queue handoff that re-arms the next turn's
+ * admission window — so none can drift from the arming site in
+ * `MessageConsumer`.
  */
 function turnMarkerDeployment(run: NativeTurnRun): string | null {
   const envelope = run.action_input;
@@ -182,7 +190,7 @@ function turnMarkerDeployment(run: NativeTurnRun): string | null {
  *
  * The isolate lane's heartbeat refreshes `runs.last_heartbeat_at`, which the
  * run reaper reads — but the marker carries its OWN `run_at`, and without this
- * a turn running longer than `TURN_DEFAULT_DEADLINE_MS` collects a spurious
+ * a turn running longer than that marker's deadline collects a spurious
  * terminal error while it is still working. Never throws: a heartbeat ACK must
  * not fail on a liveness bookkeeping error.
  */

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -326,7 +326,7 @@ export async function heartbeat(c: Context<{ Bindings: Env }>) {
 		// TURN marker too, not just `runs.last_heartbeat_at`. There are two
 		// independent deadlines: the run reaper reads the heartbeat column, while
 		// the marker carries its own `run_at`. Refreshing only the column let any
-		// turn longer than TURN_DEFAULT_DEADLINE_MS (60s) collect a spurious
+		// turn outliving that marker's deadline collect a spurious
 		// WORKER_UNRESPONSIVE mid-flight, while it was still working. The
 		// subprocess lane extended the marker from `/worker/response`, a route the
 		// isolate lane does not use. `extendTurnDeadlines` never throws and skips a


### PR DESCRIPTION
## Summary
Cloud turns queued behind busy workers could receive a worker-unresponsive error after 60 seconds even though their worker-claim window lasted 120 seconds. Initial turns and released conversation followers now retain the admission window before the execution heartbeat deadline applies. The follower reset shares the existing queue handoff transaction.

Allow two concurrent jobs per fleet worker so a long Automation does not occupy its only execution slot, while retaining memory headroom on 2 GiB deployments.

## Test plan
- [x] Live reproduction: an Automation was failed before its cloud worker executed; a Slack turn exhausted its claim window while the two production slots were occupied.
- [x] Initial regression: 26 pass / 1 fail before the fix. Released-follower regression: 2 pass / 1 fail before its correction.
- [x] Focused deadline and marker suites: 30 pass / 0 fail. Helm template renders the existing concurrency setting.
- [x] Final pre-review fixer inspected; focused tests rerun.
- [x] make pre-pr passed.
- [x] GitHub CI, semantic review (88 confidence, zero blockers), and UI applicability check.
- [x] Squash b0123b4cb97e35a972241a5a200814ba64b0126a deployed; production smoke 9/9 passed. Worker concurrency read back as 2.
- [x] Live contacts replay completed with successful save, notification, and reaction. Three simultaneous cloud jobs were observed; app and worker RSS remained about 713 MiB and 243 MiB.

## Notes
No database schema or public API changes. Queue and execution waits remain bounded. Production overlap and memory behavior were verified after rollout.

Existing limitation: followers from different users in the same conversation have different deployment markers; a sufficiently long blocked wait can still expire. This change does not alter that identity contract.
