### PR TITLE
fix(worker): keep truncated tool traces within wire limits

### DIFF
--- a/packages/connector-worker/src/__tests__/agent-turn-tool-output.test.ts
+++ b/packages/connector-worker/src/__tests__/agent-turn-tool-output.test.ts
@@ -1,0 +1,73 @@
+/**
+ * A tool trace must fit the wire contract it rides on.
+ *
+ * The guest clips a tool result for display and appends `…`, but the marker
+ * counts against `TURN_TOOL_OUTPUT_MAX_CHARS`, so a full-width slice plus the
+ * marker was one character over. Nothing is lenient about that overshoot: the
+ * heartbeat route drops the whole streamed payload (the turn's text delta
+ * included), and the completion route answers 400, which the daemon arm turns
+ * into a FAILED turn — the model's answer thrown away over a display field.
+ *
+ * Both boundary lengths run so the local cap in the guest and the contract's
+ * `maxLength` cannot drift apart unnoticed: exactly the cap must survive
+ * untouched, and one past it must come back within the cap. The real schemas
+ * do the judging, and the model's own view of the result is asserted
+ * unclipped — the bound is on the trace, never on the turn's context.
+ */
+import { afterEach, expect, test } from 'bun:test';
+import { Value } from '@sinclair/typebox/value';
+import { CompleteAgentTurnRequestSchema, HeartbeatRequestSchema, TURN_TOOL_OUTPUT_MAX_CHARS } from '@lobu/core/contracts/worker/protocol';
+import { runAgentTurn } from '../agent-turn/guest-entry.js';
+import type { AgentTurnEvent } from '../agent-turn/types.js';
+
+const originalFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = originalFetch; });
+
+test.each([TURN_TOOL_OUTPUT_MAX_CHARS, TURN_TOOL_OUTPUT_MAX_CHARS + 1])(
+  'a %i-character tool result produces a valid streamed heartbeat without clipping model context',
+  async (length) => {
+    const fullOutput = 'x'.repeat(length);
+    const events: AgentTurnEvent[] = [];
+    let requests = 0;
+    let modelToolResult: unknown;
+    globalThis.fetch = (async (url, init) => {
+      if (String(url).includes('/mcp/')) {
+        return Response.json({ content: [{ type: 'text', text: fullOutput }] });
+      }
+      const body = JSON.parse(String(init?.body));
+      requests += 1;
+      const tool = body.messages.find((message: { role: string }) => message.role === 'tool');
+      if (tool) modelToolResult = tool.content;
+      const choice = requests === 1
+        ? { index: 0, delta: { role: 'assistant', tool_calls: [{ index: 0, id: 'synthetic-call', type: 'function', function: { name: 'large_result', arguments: '{}' } }] }, finish_reason: 'tool_calls' }
+        : { index: 0, delta: { role: 'assistant', content: 'Done.' }, finish_reason: 'stop' };
+      const chunk = { id: 'synthetic-response', object: 'chat.completion.chunk', created: 1, model: 'synthetic-model', choices: [choice] };
+      return new Response(`data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`, { headers: { 'content-type': 'text/event-stream' } });
+    }) as typeof fetch;
+
+    const result = await runAgentTurn({
+      provider: { api: 'openai-completions', provider: 'openai', modelId: 'synthetic-model', baseUrl: 'https://provider.example.test/v1', apiKey: 'synthetic-key' },
+      systemPrompt: 'Use the tool, then finish.', userMessage: 'Read it.', sessionJsonl: '',
+      tools: { gatewayUrl: 'https://gateway.example.test', definitions: [{ mcpId: 'synthetic', name: 'large_result', description: 'Read a result', inputSchema: { type: 'object', properties: {} } }] },
+    }, (event) => events.push(event));
+    const trace = events.find((event) => event.type === 'tool_call_end');
+    expect(trace?.type).toBe('tool_call_end');
+    if (trace?.type !== 'tool_call_end') throw new Error('missing tool trace');
+    expect(modelToolResult).toBe(fullOutput);
+    expect(result.text).toBe('Done.');
+    const toolEvents = [{ tool_call_id: trace.toolCallId, name: trace.name, is_error: trace.isError, output: trace.output }];
+    expect(Value.Check(HeartbeatRequestSchema, {
+      run_id: 4242, worker_id: 'synthetic-worker',
+      turn_delta: { text: 'Done.', sequence: 1 },
+      turn_tool_events: toolEvents,
+    })).toBe(true);
+    expect(Value.Check(CompleteAgentTurnRequestSchema, {
+      run_id: 4242, worker_id: 'synthetic-worker', status: 'completed',
+      text: result.text, session_jsonl: result.sessionJsonl, turn_tool_events: toolEvents,
+    })).toBe(true);
+    // Exactly the cap survives whole; one past it comes back AT the cap, with
+    // the marker as the character the clip made room for.
+    expect(trace.output.length).toBe(Math.min(length, TURN_TOOL_OUTPUT_MAX_CHARS));
+    expect(trace.output.endsWith('…')).toBe(length > TURN_TOOL_OUTPUT_MAX_CHARS);
+  },
+);

--- a/packages/connector-worker/src/agent-turn/guest-entry.ts
+++ b/packages/connector-worker/src/agent-turn/guest-entry.ts
@@ -246,8 +246,7 @@ function messageText(message: unknown): string | undefined {
  * not cosmetic: the heartbeat route drops a body that fails the schema, taking
  * the turn's text delta with it, and the completion route answers 400 — which
  * the arm reports as a FAILED turn, discarding an answer the model already
- * produced. A turn whose last tool call returns a long result hits that path
- * every time.
+ * produced if the oversized trace rides its completion.
  */
 function clip(text: string): string {
   return text.length > TOOL_EVENT_OUTPUT_CHARS ? `${text.slice(0, TOOL_EVENT_OUTPUT_CHARS - 1)}…` : text;

--- a/packages/connector-worker/src/agent-turn/guest-entry.ts
+++ b/packages/connector-worker/src/agent-turn/guest-entry.ts
@@ -37,7 +37,16 @@ import {
 /** Third-party MCP server on the other side of the gateway: generous, never forever. */
 const TOOL_CALL_TIMEOUT_MS = 120_000;
 
-/** What of a tool's output the host sees in the event stream. */
+/**
+ * What of a tool's output the host sees in the event stream.
+ *
+ * Mirrors `TURN_TOOL_OUTPUT_MAX_CHARS`, the wire contract's `maxLength` on the
+ * same field, rather than importing it: the protocol module pulls TypeBox in,
+ * and the guest bundle takes only the pure `@lobu/core` modules. The mirror is
+ * held by the tool-output test, which drives a result of exactly this length
+ * and one past it through the real schemas — a change to either number on its
+ * own turns it red.
+ */
 const TOOL_EVENT_OUTPUT_CHARS = 2_000;
 
 /** The MCP proxy's REST reply for a tool call. */
@@ -229,8 +238,19 @@ function messageText(message: unknown): string | undefined {
     .join('');
 }
 
+/**
+ * Clip a tool result down to what the trace carries, MARKER INCLUDED.
+ *
+ * The `…` counts against the cap, so the slice reserves its one character.
+ * Appending it to a full-width slice overshoots by one, and the overshoot is
+ * not cosmetic: the heartbeat route drops a body that fails the schema, taking
+ * the turn's text delta with it, and the completion route answers 400 — which
+ * the arm reports as a FAILED turn, discarding an answer the model already
+ * produced. A turn whose last tool call returns a long result hits that path
+ * every time.
+ */
 function clip(text: string): string {
-  return text.length > TOOL_EVENT_OUTPUT_CHARS ? `${text.slice(0, TOOL_EVENT_OUTPUT_CHARS)}…` : text;
+  return text.length > TOOL_EVENT_OUTPUT_CHARS ? `${text.slice(0, TOOL_EVENT_OUTPUT_CHARS - 1)}…` : text;
 }
 
 /**

--- a/packages/connector-worker/src/daemon/agent-turn.ts
+++ b/packages/connector-worker/src/daemon/agent-turn.ts
@@ -510,10 +510,10 @@ export async function executeAgentTurnRun(
     await beatInFlight;
     await drainDeltas();
     // Whatever drainDeltas could not place rides the completion instead of
-    // being dropped. A turn's LAST tool call always lands here: its trace is
-    // queued after the final beat, and the server's heartbeat publish is
-    // fenced on the run still being `running`, which the completion below
-    // ends. Taken before the request so a trace cannot be sent twice.
+    // being dropped. A trace can remain when no text delta triggered a drain
+    // or its beat could not deliver. Heartbeat publishing requires the run
+    // to remain `running`, which completion ends, so take these before the
+    // request rather than relying on a later beat.
     const trailingTraces = [...tracesInFlight, ...toolEvents];
     tracesInFlight = [];
     toolEvents = [];


### PR DESCRIPTION
## Summary
Large tool results were clipped to 2,000 characters and then given an ellipsis, exceeding the 2,000-character wire limit. The server dropped the entire heartbeat payload, including reply text, and rejected completion when it carried that trace. Reserve space for the ellipsis so display truncation cannot invalidate a turn. The model still receives the full tool result.

## Test plan
- [x] Red: real guest execution with 2,000/2,001-character tool results produced 1 pass / 1 fail against the heartbeat schema before the fix.
- [x] Green: focused guest/daemon suites passed 33 tests. Both heartbeat and completion schemas accept the result; exact-cap output remains unchanged.
- [x] Pre-review fixer inspected; full connector-worker suite passed 474 tests, with mutation checks for the original bug and cap drift.
- [x] Rebuilt isolate integration suite: 63 passed.
- [x] make pre-pr passed.
- [x] GitHub CI, semantic review (92 confidence, zero blockers), and UI applicability gate.
- [x] Squash 81607ef6bf8682ca29621385b1a7c48a0242e4f9 deployed; exact-revision production smoke passed 9/9.
- [x] Fresh hourly run now persists query_sdk tool traces for large source and entity reads; those traces were previously dropped.
- [x] Fresh contacts cloud turn completed with Astra medium after reviewing all 136 source records; reaction succeeded. This verifies large-result progress and completion on the deployed worker. Hourly catch-up completion is a separate owner-prompt verification item.

## Notes
Production hourly runs showed rejected progress payloads. The repeated ten-minute hourly timeout remains a separate live verification item; this PR does not claim that every timeout has this cause. No public API or schema change.
