### PR TITLE
fix(personal-agent): scope quote retries to the automation run

### DIFF
--- a/examples/personal-agent/__tests__/net-worth.reaction.test.ts
+++ b/examples/personal-agent/__tests__/net-worth.reaction.test.ts
@@ -450,9 +450,10 @@ describe("financial snapshot builder", () => {
 });
 
 describe("weekly net-worth reaction", () => {
-  test("reads both active sources, fetches security and FX quotes, and saves one versioned snapshot", async () => {
+  test("reads both active sources, fetches quotes under run-scoped keys, and saves one versioned snapshot per week", async () => {
     const queries: string[] = [];
     const operationInputs: Array<{
+      idempotency_key: string;
       input: { symbols: Array<Record<string, unknown>> };
     }> = [];
     const saved: Array<Record<string, unknown>> = [];
@@ -484,6 +485,7 @@ describe("weekly net-worth reaction", () => {
       },
       operations: {
         execute: async (input: {
+          idempotency_key: string;
           input: { symbols: Array<Record<string, unknown>> };
         }) => {
           operationInputs.push(input);
@@ -555,6 +557,24 @@ describe("weekly net-worth reaction", () => {
         net_worth_gbp: 1_400,
       },
     });
+    // An action idempotency key binds to the parent run that first used it, so
+    // a retry of this run must reuse its key while the next run in the same
+    // week must not. The snapshot event has no such binding and stays weekly.
+    await runNetWorthSnapshot(ctx, client);
+    await runNetWorthSnapshot(
+      { ...ctx, window: { ...ctx.window, run_id: ctx.window.run_id + 1 } },
+      client
+    );
+    expect(operationInputs.map((input) => input.idempotency_key)).toEqual([
+      "net-worth:v4:quotes:run:300:batch:1",
+      "net-worth:v4:quotes:run:300:batch:1",
+      "net-worth:v4:quotes:run:301:batch:1",
+    ]);
+    expect(saved.map((row) => row.idempotency_key)).toEqual([
+      "net-worth:v4:snapshot:week:2026-W33",
+      "net-worth:v4:snapshot:week:2026-W33",
+      "net-worth:v4:snapshot:week:2026-W33",
+    ]);
   });
 
   test("fails closed when quotes are needed but the market-quotes connection is absent", async () => {

--- a/examples/personal-agent/net-worth.reaction.ts
+++ b/examples/personal-agent/net-worth.reaction.ts
@@ -1338,7 +1338,11 @@ export default async function runNetWorthSnapshot(
         connection_id: quoteConnectionId,
         operation_key: "quote",
         input: { symbols: batch },
-        idempotency_key: `${IDEMPOTENCY_PREFIX}:quotes:week:${week}:batch:${index + 1}`,
+        // An action idempotency key binds to the parent run that first used
+        // it, so a week-scoped key 409s on the next run in the same week.
+        // Only retries of THIS run reuse the key; weekly deduplication stays
+        // on the snapshot event's own key below.
+        idempotency_key: `${IDEMPOTENCY_PREFIX}:quotes:run:${ctx.window.run_id}:batch:${index + 1}`,
         automation_source: {
           automation_id: ctx.automation.id,
           run_id: ctx.window.run_id,


### PR DESCRIPTION
## Summary
A second net-worth run in the same week reused the quote operation's weekly idempotency key, but operation keys are also bound to trusted parent-run provenance. The server correctly rejected the new run with a 409. Scope quote keys to the Automation run so retries remain idempotent and later runs can fetch quotes. Weekly snapshot and notification deduplication are unchanged.

## Test plan
- [x] Live reproduction: a completed analysis had a failed reaction with “Action idempotency key … is already bound to a different request.”
- [x] Red: 10 pass / 1 fail with the original weekly quote key.
- [x] Green: 16 focused tests passed, including same-run retry, different-run keys, and unchanged weekly snapshot keys.
- [x] Pre-review fixer inspected; example suite 315/315 passed; make pre-pr passed.
- [x] Reviewed reaction compiled and saved to the owning Automation after an exact baseline comparison.
- [x] Two fresh runs in the same week completed; both reactions succeeded, including quote execution. Cloud guest uses gpt-6-astra with medium effort.
- [x] GitHub CI, semantic review (91 confidence, zero blockers), and UI applicability gate. Merged as eb3b1e9d4d1100fa83a8686bde2b9cfc7ca46666. The live owner reaction was already compiled and verified before merge.

## Notes
Changes only the owning personal-agent example. No shared runtime, API, database, or provider-policy change. Fresh bank holdings remain dependent on the upstream browser feeds.
