### PR TITLE
fix(server): resolve unknown Codex model capabilities

### DIFF
--- a/packages/server/src/__tests__/integration/agent-turn-producer.test.ts
+++ b/packages/server/src/__tests__/integration/agent-turn-producer.test.ts
@@ -1206,6 +1206,53 @@ describe('agent turn producer', () => {
     await toolless();
   });
 
+  it('uses provider-owned metadata for a model missing from the bundled registry', async () => {
+    const org = await createTestOrganization();
+    const metadata = vi.fn(async () => ({ contextWindow: 272000, reasoning: true, input: ['text', 'image'] as ('text' | 'image')[] }));
+    const module = Object.assign(tokenEchoingModule(), { getModelMetadata: metadata });
+    const message = messageFor(org.id);
+    message.agentOptions = { model: 'claude/synthetic-new-model' };
+    await enqueueMessage(message, { agentSettings: settingsStore, catalog: catalogFor(module), gatewayUrl: GATEWAY_URL });
+    const [run] = await agentTurnRuns();
+    expect(run.action_input.turn.compaction.context_window).toBe(272000);
+    expect(run.action_input.turn.provider.reasoning).toBe(true);
+    expect(metadata).toHaveBeenCalledWith(AGENT_ID, 'synthetic-new-model', expect.objectContaining({ organizationId: org.id, userId: 'user-turn' }));
+  });
+
+  it.each(['failure', 'invalid'])('retains registry defaults when provider metadata is %s', async (mode) => {
+    const org = await createTestOrganization();
+    const module = Object.assign(tokenEchoingModule(), { getModelMetadata: async () => {
+      if (mode === 'failure') throw new Error('Synthetic catalog failure');
+      return { contextWindow: -1, maxTokens: Number.NaN, input: [] };
+    } });
+    const message = messageFor(org.id);
+    message.agentOptions = { model: 'claude/synthetic-new-model' };
+    await enqueueMessage(message, { agentSettings: settingsStore, catalog: catalogFor(module), gatewayUrl: GATEWAY_URL });
+    const [run] = await agentTurnRuns();
+    // The producer's own DEFAULT_CONTEXT_WINDOW, unchanged by the junk answer.
+    expect(run.action_input.turn.compaction.context_window).toBe(128000);
+    expect(run.action_input.turn.provider.max_tokens).toBeUndefined();
+    expect(run.action_input.turn.provider.reasoning).toBeUndefined();
+  });
+
+  it('never asks the provider about a model the registry already carries', async () => {
+    // The lookup is a live call to the provider's own catalog on the
+    // per-message admission path; a registry hit answers the same four fields
+    // without it.
+    const org = await createTestOrganization();
+    const metadata = vi.fn(async () => ({ contextWindow: 999 }));
+    const module = Object.assign(tokenEchoingModule(), { getModelMetadata: metadata });
+    const message = messageFor(org.id);
+    message.agentOptions = { model: 'claude/claude-sonnet-4-5-20250929' };
+    await enqueueMessage(message, { agentSettings: settingsStore, catalog: catalogFor(module), gatewayUrl: GATEWAY_URL });
+    const [run] = await agentTurnRuns();
+    expect(metadata).not.toHaveBeenCalled();
+    const registryModel = getModel('anthropic' as never, 'claude-sonnet-4-5-20250929' as never) as
+      | { contextWindow?: number }
+      | undefined;
+    expect(run.action_input.turn.compaction.context_window).toBe(registryModel?.contextWindow);
+  });
+
   it('passes native tool history and provider metadata to Pi without gateway rewriting', async () => {
     const org = await createTestOrganization();
     const sql = getTestDb();

--- a/packages/server/src/gateway/auth/chatgpt/__tests__/model-metadata.test.ts
+++ b/packages/server/src/gateway/auth/chatgpt/__tests__/model-metadata.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, expect, test } from "bun:test";
+import type { ProviderCredentialContext } from "../../../embedded.js";
+import { ChatGPTOAuthModule } from "../chatgpt-oauth-module.js";
+
+const originalFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = originalFetch; });
+const token = `e30.${Buffer.from(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "synthetic-account" } })).toString("base64url")}.synthetic`;
+
+class TestModule extends ChatGPTOAuthModule {
+  credential: string | null = token;
+  seenContext?: ProviderCredentialContext;
+  constructor() { super({} as never); }
+  protected override async getCredential(_agentId: string, context?: ProviderCredentialContext): Promise<string | null> {
+    this.seenContext = context;
+    return this.credential;
+  }
+}
+
+test("reads the exact account-scoped Codex model's runtime capabilities", async () => {
+  let request: RequestInit | undefined;
+  let url = "";
+  globalThis.fetch = (async (input, init) => {
+    url = String(input); request = init;
+    return Response.json({ models: [
+      { slug: "different-model", context_window: 1000 },
+      { slug: "synthetic-new-model", context_window: 272000, input_modalities: ["text", "image"], supported_reasoning_levels: [{ effort: "medium" }] },
+    ] });
+  }) as typeof fetch;
+  const module = new TestModule();
+  const context = { organizationId: "synthetic-org", userId: "synthetic-user" };
+  expect(await module.getModelMetadata("synthetic-agent", "synthetic-new-model", context)).toEqual({ contextWindow: 272000, reasoning: true, input: ["text", "image"] });
+  expect(module.seenContext).toEqual(context);
+  expect(new URL(url).pathname).toBe("/backend-api/codex/models");
+  expect(new URL(url).searchParams.get("client_version")).toBeTruthy();
+  expect(new Headers(request?.headers).get("ChatGPT-Account-Id")).toBe("synthetic-account");
+  expect(new Headers(request?.headers).get("Authorization")).toBe(`Bearer ${token}`);
+  expect(request?.redirect).toBe("error");
+  expect(request?.signal).toBeDefined();
+});
+
+test.each([null, "not-a-jwt"])("does not fetch without account-scoped credentials: %s", async credential => {
+  const module = new TestModule(); module.credential = credential;
+  let calls = 0;
+  globalThis.fetch = (async () => { calls++; throw new Error("Must not fetch"); }) as typeof fetch;
+  expect(await module.getModelMetadata("synthetic-agent", "synthetic-model", {})).toBeUndefined();
+  expect(calls).toBe(0);
+});
+
+// A catalog that cannot be read, or reads back as junk, must leave the caller
+// on its registry defaults — including an EMPTY reasoning list, which says
+// nothing rather than "this model cannot reason".
+test.each([
+  ["network", undefined],
+  ["status", undefined],
+  ["json", undefined],
+  ["missing", undefined],
+  ["malformed", {}],
+  ["no-reasoning-levels", {}],
+] as const)("contains %s catalog failures without asserting capabilities", async (mode, expected) => {
+  globalThis.fetch = (async () => {
+    if (mode === "network") throw new Error("Synthetic transport failure");
+    if (mode === "status") return new Response("Unavailable", { status: 503 });
+    if (mode === "json") return new Response("not JSON");
+    if (mode === "missing") return Response.json({ models: [] });
+    if (mode === "no-reasoning-levels") return Response.json({ models: [{ slug: "synthetic-model", supported_reasoning_levels: [] }] });
+    return Response.json({ models: [{ slug: "synthetic-model", context_window: -1, supported_reasoning_levels: ["invalid"], input_modalities: [null] }] });
+  }) as typeof fetch;
+  expect(await new TestModule().getModelMetadata("synthetic-agent", "synthetic-model", {})).toEqual(expected);
+});

--- a/packages/server/src/gateway/auth/chatgpt/chatgpt-oauth-module.ts
+++ b/packages/server/src/gateway/auth/chatgpt/chatgpt-oauth-module.ts
@@ -1,7 +1,15 @@
-import type { ModelOption } from "@lobu/core";
+import { createLogger, type ModelOption } from "@lobu/core";
+import type { ProviderCredentialContext } from "../../embedded.js";
+import type { ProviderModelMetadata } from "../../modules/module-system.js";
 import { BaseProviderModule } from "../base-provider-module.js";
+import { extractJwtAccountId } from "../oauth/client.js";
 import type { AuthProfilesManager } from "../settings/auth-profiles-manager.js";
 import { fetchModelOptions } from "../utils/fetch-model-options.js";
+
+const logger = createLogger("chatgpt-oauth-module");
+// The Codex catalog endpoint negotiates on the CLIENT's version, not Lobu's:
+// it is the Codex CLI release whose response shape this reader parses.
+const CODEX_CATALOG_CLIENT_VERSION = "0.154.0";
 
 /**
  * ChatGPT provider module — runtime credential surface for the ChatGPT
@@ -59,5 +67,72 @@ export class ChatGPTOAuthModule extends BaseProviderModule {
           return id ? { id, label: m.title?.trim() || id } : null;
         }),
     });
+  }
+
+  /**
+   * Capabilities for a model the bundled registry has never heard of, read
+   * from the account's own Codex catalog. Answers `undefined` for every
+   * failure — no credential, no account identity, an unreachable or
+   * unparseable catalog — so the caller keeps its registry defaults.
+   */
+  async getModelMetadata(
+    agentId: string,
+    modelId: string,
+    context: ProviderCredentialContext
+  ): Promise<ProviderModelMetadata | undefined> {
+    const token = await this.getCredential(agentId, context);
+    if (!token) return undefined;
+    const accountId = extractJwtAccountId(token);
+    if (!accountId) return undefined;
+    try {
+      const response = await fetch(
+        `https://chatgpt.com/backend-api/codex/models?client_version=${CODEX_CATALOG_CLIENT_VERSION}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "ChatGPT-Account-Id": accountId,
+            originator: "codex_cli_rs",
+            Accept: "application/json",
+          },
+          signal: AbortSignal.timeout(5000),
+          redirect: "error",
+        }
+      );
+      if (!response.ok) {
+        logger.warn({ status: response.status }, "Codex model catalog unavailable");
+        return undefined;
+      }
+      const payload = await response.json() as { models?: Array<Record<string, unknown>> };
+      if (!Array.isArray(payload.models)) return undefined;
+      const model = payload.models.find(candidate => candidate?.slug === modelId);
+      if (!model) return undefined;
+      const metadata: ProviderModelMetadata = {};
+      if (typeof model.context_window === "number" && Number.isSafeInteger(model.context_window) && model.context_window > 0) {
+        metadata.contextWindow = model.context_window;
+      }
+      // An EMPTY level list is no answer, not "no reasoning": asserting
+      // `false` there makes the guest reject an effort the caller configured
+      // for a model that may well support it. Leave the field absent instead.
+      if (Array.isArray(model.supported_reasoning_levels) && model.supported_reasoning_levels.length > 0 && model.supported_reasoning_levels.every(level =>
+        level && typeof level === "object" && "effort" in level && typeof level.effort === "string"
+      )) {
+        metadata.reasoning = model.supported_reasoning_levels.some(level =>
+          level.effort !== "none" && level.effort !== "off"
+        );
+      }
+      if (Array.isArray(model.input_modalities)) {
+        const input = model.input_modalities.filter((value): value is "text" | "image" => value === "text" || value === "image");
+        if (input.length) metadata.input = input;
+      }
+      return metadata;
+    } catch (error) {
+      logger.warn(
+        // JSON parse errors can quote upstream body fragments; do not log
+        // arbitrary response or transport text from an authenticated request.
+        { category: error instanceof SyntaxError ? "invalid_json" : "transport" },
+        "Codex model catalog lookup failed; retaining registry defaults"
+      );
+      return undefined;
+    }
   }
 }

--- a/packages/server/src/gateway/modules/module-system.ts
+++ b/packages/server/src/gateway/modules/module-system.ts
@@ -23,6 +23,18 @@ export interface ProviderUpstreamConfig {
   apiKeyHeader?: "authorization" | "x-api-key";
 }
 
+/**
+ * What a provider's own catalog says about one model. Every field is optional:
+ * the module answers only what its catalog carries, and each is validated at
+ * the consumer before it can overwrite a registry value.
+ */
+export interface ProviderModelMetadata {
+  contextWindow?: number;
+  maxTokens?: number;
+  reasoning?: boolean;
+  input?: ("text" | "image")[];
+}
+
 export interface ModelProviderModule extends OrchestratorModule {
   providerId: string;
   providerDisplayName: string;
@@ -69,6 +81,17 @@ export interface ModelProviderModule extends OrchestratorModule {
   ): Record<string, string>;
   getApp?(): any;
   getModelOptions?(agentId: string, userId: string): Promise<ModelOption[]>;
+  /**
+   * Gateway-only capability lookup, consulted ONLY for a model the bundled
+   * registry does not carry — a provider that shipped a new model since this
+   * release. Never on the happy path: a registry hit answers without leaving
+   * the process.
+   */
+  getModelMetadata?(
+    agentId: string,
+    modelId: string,
+    context: ProviderCredentialContext
+  ): Promise<ProviderModelMetadata | undefined>;
   buildCredentialPlaceholder?(
     agentId: string,
     context?: ProviderCredentialContext

--- a/packages/server/src/gateway/orchestration/agent-turn-producer.ts
+++ b/packages/server/src/gateway/orchestration/agent-turn-producer.ts
@@ -493,11 +493,21 @@ function resolveTurnCompat(
  * invented here. Reasoning support is left undefined for the same reason: the
  * registry has no answer, so the guest decides from the requested effort
  * instead of being told `false` about a model that may well support it.
+ *
+ * `known` reports whether those values came from a registry entry at all,
+ * which is what decides if the provider is worth asking for live
+ * capabilities.
  */
 function resolveModelMetadata(
   registryProvider: string,
   modelId: string
-): Pick<TurnProvider, "input" | "contextWindow" | "maxTokens" | "reasoning"> {
+): {
+  known: boolean;
+  metadata: Pick<
+    TurnProvider,
+    "input" | "contextWindow" | "maxTokens" | "reasoning"
+  >;
+} {
   // `getModel` is typed over pi-ai's static registry and cannot take the
   // strings Lobu resolves at runtime without a cast; it answers undefined for
   // a model the registry does not carry.
@@ -506,17 +516,22 @@ function resolveModelMetadata(
     | undefined;
   const window = model?.contextWindow;
   return {
-    // pi enforces this one: `transformMessages` replaces every image block
-    // with a "model does not support images" placeholder when `"image"` is
-    // missing, which is what a non-vision model must get.
-    input: model?.input ? [...model.input] : ["text", "image"],
-    contextWindow:
-      typeof window === "number" && window > 0 ? window : DEFAULT_CONTEXT_WINDOW,
-    maxTokens:
-      typeof model?.maxTokens === "number" && model.maxTokens > 0
-        ? model.maxTokens
-        : null,
-    reasoning: model?.reasoning,
+    known: Boolean(model),
+    metadata: {
+      // pi enforces this one: `transformMessages` replaces every image block
+      // with a "model does not support images" placeholder when `"image"` is
+      // missing, which is what a non-vision model must get.
+      input: model?.input ? [...model.input] : ["text", "image"],
+      contextWindow:
+        typeof window === "number" && window > 0
+          ? window
+          : DEFAULT_CONTEXT_WINDOW,
+      maxTokens:
+        typeof model?.maxTokens === "number" && model.maxTokens > 0
+          ? model.maxTokens
+          : null,
+      reasoning: model?.reasoning,
+    },
   };
 }
 
@@ -654,6 +669,60 @@ async function resolveTurnProvider(
     module.providerId,
     module.getUpstreamConfig?.()?.slug
   );
+  const { known, metadata } = resolveModelMetadata(
+    protocol.registryAlias,
+    modelId
+  );
+  // Only a model the registry has never heard of is worth asking the provider
+  // about: this runs once per admitted message, and a provider lookup is a
+  // live call to the provider's catalog. A registry hit already carries the
+  // same four fields, so the common path never leaves the process.
+  if (!known && module.getModelMetadata) {
+    try {
+      const supplied = await module.getModelMetadata(
+        args.agentId,
+        modelId,
+        context
+      );
+      // Each field is validated here rather than trusted from the module: it
+      // originates in a provider's own catalog response, and a nonsense window
+      // or ceiling reaches the guest as a hard limit.
+      const contextWindow = supplied?.contextWindow;
+      const maxTokens = supplied?.maxTokens;
+      if (
+        typeof contextWindow === "number" &&
+        Number.isSafeInteger(contextWindow) &&
+        contextWindow > 0
+      ) {
+        metadata.contextWindow = contextWindow;
+      }
+      if (
+        typeof maxTokens === "number" &&
+        Number.isSafeInteger(maxTokens) &&
+        maxTokens > 0
+      ) {
+        metadata.maxTokens = maxTokens;
+      }
+      if (typeof supplied?.reasoning === "boolean") {
+        metadata.reasoning = supplied.reasoning;
+      }
+      if (
+        supplied?.input?.length &&
+        supplied.input.every(
+          (value) => value === "text" || value === "image"
+        )
+      ) {
+        metadata.input = [...supplied.input];
+      }
+    } catch {
+      // Metadata discovery must not turn a healthy inference credential into
+      // an admission failure. Keep the registry/defaults on lookup failure.
+      logger.warn(
+        { provider: module.providerId, modelId },
+        "Provider model metadata unavailable; using registry defaults"
+      );
+    }
+  }
   return {
     api: protocol.api,
     provider: protocol.registryAlias,
@@ -662,7 +731,7 @@ async function resolveTurnProvider(
     baseUrl,
     credential,
     host,
-    ...resolveModelMetadata(protocol.registryAlias, modelId),
+    ...metadata,
     ...resolveTurnCompat(
       protocol.api,
       module.getUpstreamConfig?.()?.upstreamBaseUrl


### PR DESCRIPTION
## Summary
New subscription models absent from the bundled model registry receive a 128k context fallback even when the account catalog advertises a larger window. The gateway now resolves capabilities for unknown models through the provider module; ChatGPT reads its account-scoped Codex catalog. Known registry models avoid the network lookup, and unavailable or malformed metadata retains existing defaults.

Credentials remain gateway-only. The lookup has a five-second deadline and rejects redirects; logs exclude upstream body fragments. This uses the existing worker metadata fields and adds no public API or database schema.

## Test plan
- [x] Targeted provider tests: 9 passed, including missing credentials, malformed catalogs and empty reasoning capabilities.
- [x] Agent-turn producer integration: 167 passed, including actual HTTP/isolate paths and a registry-hit guard.
- [x] Pre-review fixer completed; changes inspected.
- [x] Explicit paths staged and `make pre-pr` passed; full GitHub CI is the canonical gate per root AGENTS.md.
- [x] Red → green: provider-owned context-window regression.

Red:
```text
expected 272000, received 128000
1 failed
```
Green:
```text
agent-turn-producer.test.ts: 167 passed
model-metadata.test.ts: 9 passed
```

## Notes
A live cloud Astra worker independently showed the 128k compaction window. Post-rollout verification must inspect the account-derived window and finish a real cloud turn. A prior large catch-up completed its Automation but its child worker timed out after answering; that timeout is not yet proven to be caused or fixed by this metadata mismatch.

Post-rollout: production served squash `5dfb9b277828161eca8a0f288baf47b3ff7a3135` with ancestry verified. A real managed Automation received account-derived `context_window: 272000`, Astra medium, and its parent, worker and reaction completed. A separate tool-fed synthetic probe reproduced the post-answer timeout despite the corrected window, so that lifecycle issue remains separate work.
