### PR TITLE
fix(automations): credit a reaction's own writes to the acting Automation

### DIFF
--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -54,9 +54,10 @@ Each Automation therefore carries one durable arrival mark,
 `automations.next_window_start`, and a run covers `[mark, now - settle)`. The
 mark advances only when a window completes, including a legitimate zero-source
 result; failed, timed-out, abandoned, and lease-expired attempts leave it where
-it is, so the same arrivals stay claimable. There is no backlog of periods to
-walk: one run covers a whole outage, however long, and the next one starts
-caught up.
+it is, so the same arrivals stay claimable. There is no backlog of calendar
+periods to walk: one window spans the uncompleted arrival range. Completing it
+still requires reading its governed inputs within the source and execution
+limits described below.
 
 The cadence still decides WHEN a run fires; it no longer shapes what the run
 covers. `settle` is `AUTOMATION_ARRIVAL_SETTLE_MS` (default 60s): `created_at` is
@@ -368,68 +369,77 @@ Do not model these as if Lobu already had a general workflow instance engine:
 - unbounded loops, recursion, parallel maps, or reusable subflows;
 - end-to-end exactly-once guarantees across third-party side effects.
 
-Those features need an explicit workflow-instance identity and step-state
-model. Adding them before a real use case would duplicate the existing run and
-event primitives; pretending event chaining already provides them would be
-equally misleading.
+Some use cases can be composed from entity state, declared outputs, connector
+actions, and scheduled reconciliation. That does not give a reaction a saved
+instruction pointer or make these workflow guarantees automatic. Add a new
+execution contract only when a concrete use case needs guarantees the existing
+primitives cannot provide.
 
 ## Convergence: did this subject get handled?
 
-The sections above describe what STARTS a run and what a completed run persists.
-This one answers the question that follows in production — "has this Automation
-acted on this subject yet, and did it work" — because the answer is not obvious
-and the wrong table is the tempting one.
+Use durable stage state to decide whether a subject needs more work. The audit
+records below help explain what happened, but a recorded attempt is not itself
+proof that a stage succeeded.
 
-**Declared outputs: `change_set` events.** Every completed window whose outputs
-touched entities writes one `change_set` event, idempotency-keyed
-`automation:{id}:run:{run}:change_set`. It links every entity the run created or
-updated through `entity_ids`, and `metadata.changes` carries the per-entity
-array (`entityId`, `name`, `kind` of `created|updated|denied`). `events` is a
-queryable source, so an Automation can already ask which subjects a process has
-touched and when, with no new surface:
+**Declared outputs: `change_set` events.** A completed window with recorded
+entity changes writes one `change_set` event, idempotency-keyed
+`automation:{id}:run:{run}:change_set`. `metadata.changes` carries the per-entity
+array (`entityId`, `name`, `kind` of `created|updated|denied`). Its `entity_ids`
+can include an existing entity whose change was denied, so inspect each change's
+`kind` before treating it as an applied write. A denied create has no entity to
+link. These events are queryable audit evidence; they do not record the outcome
+of a later reaction or external connector action.
+
+For a bounded audit read, select the changes as well as the linked entities:
 
 ```sql
-SELECT e.entity_ids, e.created_at
+SELECT e.entity_ids, e.metadata, e.created_at
 FROM events e
 WHERE e.semantic_type = 'change_set' AND e.automation_id = $1
+ORDER BY e.created_at DESC, e.id DESC
+LIMIT 100
 ```
 
 **Effects: `automation_reactions`.** Entity writes are not the whole story — a
 run that called a connector, sent a notification, or saved knowledge records a
 row per tool call (`reaction_type`, `tool_name`, `tool_args`, `tool_result`,
 `entity_id`, `source_run_id`). `entity_id` is populated by the surfaces that
-know their subject; `manage_operations` and `notify` record the call without one.
+know their subject; `manage_operations`, `notify`, and the per-attempt
+`script_execution` wrapper record the call without one.
 
 Two things to know before relying on it:
 
-- It is NOT in `QUERYABLE_SCHEMA`, so an Automation cannot read it yet. Until it
-  is, per-subject convergence is answerable from `change_set` events but not
-  from the effect log.
-- The direct-write surfaces pass no `runId`, so they take the fire-and-forget
-  insert with no dedupe predicate. A retried reaction task re-runs the script
-  and appends another row for the same subject. Latest-row queries are fine;
-  exact counts are not.
+- It is not in `QUERYABLE_SCHEMA`, so it cannot be selected as an Automation SQL
+  source. Record the stage outcome in the subject's entity state or a declared
+  output when another Automation needs to reconcile it.
+- `manage_entity`, `save_memory`, and the script wrapper pass no `runId`, so
+  they take the fire-and-forget insert with no dedupe predicate. A retried
+  reaction task re-runs the script and can append another row for the same
+  subject, and a failed insert is logged rather than retried, so a row can be
+  missing too. Do not use this table as an exactly-once completion ledger. Where
+  a `tool_result` is recorded, inspect it for deferral or failure.
 
-**Attribution is stamped, never declared.** A reaction's session carries
+**Attribution prefers the trusted session.** A reaction's session carries
 `ctx.actingAutomationId` / `ctx.actingRunId`, stamped by the reaction executor.
-Every write surface resolves credit through `resolveAutomationAttribution`,
-which prefers that stamped pair and credits nobody for a declared
-`automation_source` naming another organization's Automation. A surface must
-resolve UNCONDITIONALLY: a reaction declares nothing, so gating the call on the
-declaration silently records the write against no Automation — and drops
-`entity_id` with it. `save_content` and `manage_entity` did exactly that, which
-is why `entity_id` was populated on 0.17% of production rows.
+`save_content` and `manage_entity` resolve credit through
+`resolveAutomationAttribution`, which prefers that stamped pair. Without it, a
+declared `automation_source` is accepted only when the Automation belongs to the
+organization and owns the declared Automation run. Resolve attribution even
+when no source argument was supplied: reactions normally declare nothing, so
+gating on that argument omits their effect records and subject attribution.
 
-**Long-running processes: sweep, do not sleep.** Lobu has no workflow instance,
-so a process that spans days is not a suspended program — it is durable state
-plus a schedule that reconciles it. Model the subject as an entity, record each
-stage's outcome durably, and let a scheduled Automation select the subjects that
-have not reached the next stage yet. This is more robust than a parked timer,
-not a workaround for lacking one: the arrival mark means one run covers an
-outage of any length, there are no orphaned timers to leak, and editing the
-Automation changes the next sweep instead of stranding in-flight instances. The
-primitives it needs — a stable entity key, a durable per-stage record, and an
-idempotency key on the external call — all exist today.
+**Long-running processes: reconcile durable state.** Model the subject as an
+entity, record each stage's outcome and due time durably, and let a scheduled
+Automation select due subjects that have not reached the next stage. Such a
+source must include still-pending subjects from earlier windows, not just newly
+arrived events. Keep the source bounded and make repeated external actions safe
+under the connector/provider's actual idempotency semantics.
+
+This composes with event-triggered stages without a suspended program. Timing
+is limited by the schedule and execution capacity; admission policies, failures,
+and auto-pause can delay progress. The arrival cursor preserves an uncompleted
+input range, but does not guarantee an arbitrary backlog fits one run. Changed
+definitions also require considering the durable state left by earlier stages.
 
 ## Implementation source map
 
@@ -448,7 +458,7 @@ map when changing the system:
 | Exact governed input reads | `packages/server/src/tools/get_content/` |
 | Automation notification routing | `packages/server/src/automations/delivery-target.ts`, `packages/server/src/notifications/service.ts` |
 | Write attribution (stamped vs declared) | `packages/server/src/automations/automation-source.ts`, `packages/server/src/utils/acting-automation-context.ts` |
-| Per-subject convergence | `manage_automations/complete-window.ts` (`change_set`), `packages/server/src/utils/automation-reactions.ts` |
+| Per-subject convergence | `packages/server/src/tools/admin/manage_automations/complete-window.ts` (`change_set`), `packages/server/src/utils/automation-reactions.ts` |
 | Server/device dispatch | `packages/server/src/automations/automation.ts`, `packages/server/src/worker-api/poll.ts`, Owletto Mac `AutomationDispatcher.swift` |
 | Web authoring and projection | Owletto `automation-trigger-editor.tsx`, `lib/automations/model.ts` |
 | Generated public client | `packages/client/src/generated/` |

--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -373,6 +373,64 @@ model. Adding them before a real use case would duplicate the existing run and
 event primitives; pretending event chaining already provides them would be
 equally misleading.
 
+## Convergence: did this subject get handled?
+
+The sections above describe what STARTS a run and what a completed run persists.
+This one answers the question that follows in production — "has this Automation
+acted on this subject yet, and did it work" — because the answer is not obvious
+and the wrong table is the tempting one.
+
+**Declared outputs: `change_set` events.** Every completed window whose outputs
+touched entities writes one `change_set` event, idempotency-keyed
+`automation:{id}:run:{run}:change_set`. It links every entity the run created or
+updated through `entity_ids`, and `metadata.changes` carries the per-entity
+array (`entityId`, `name`, `kind` of `created|updated|denied`). `events` is a
+queryable source, so an Automation can already ask which subjects a process has
+touched and when, with no new surface:
+
+```sql
+SELECT e.entity_ids, e.created_at
+FROM events e
+WHERE e.semantic_type = 'change_set' AND e.automation_id = $1
+```
+
+**Effects: `automation_reactions`.** Entity writes are not the whole story — a
+run that called a connector, sent a notification, or saved knowledge records a
+row per tool call (`reaction_type`, `tool_name`, `tool_args`, `tool_result`,
+`entity_id`, `source_run_id`). `entity_id` is populated by the surfaces that
+know their subject; `manage_operations` and `notify` record the call without one.
+
+Two things to know before relying on it:
+
+- It is NOT in `QUERYABLE_SCHEMA`, so an Automation cannot read it yet. Until it
+  is, per-subject convergence is answerable from `change_set` events but not
+  from the effect log.
+- The direct-write surfaces pass no `runId`, so they take the fire-and-forget
+  insert with no dedupe predicate. A retried reaction task re-runs the script
+  and appends another row for the same subject. Latest-row queries are fine;
+  exact counts are not.
+
+**Attribution is stamped, never declared.** A reaction's session carries
+`ctx.actingAutomationId` / `ctx.actingRunId`, stamped by the reaction executor.
+Every write surface resolves credit through `resolveAutomationAttribution`,
+which prefers that stamped pair and credits nobody for a declared
+`automation_source` naming another organization's Automation. A surface must
+resolve UNCONDITIONALLY: a reaction declares nothing, so gating the call on the
+declaration silently records the write against no Automation — and drops
+`entity_id` with it. `save_content` and `manage_entity` did exactly that, which
+is why `entity_id` was populated on 0.17% of production rows.
+
+**Long-running processes: sweep, do not sleep.** Lobu has no workflow instance,
+so a process that spans days is not a suspended program — it is durable state
+plus a schedule that reconciles it. Model the subject as an entity, record each
+stage's outcome durably, and let a scheduled Automation select the subjects that
+have not reached the next stage yet. This is more robust than a parked timer,
+not a workaround for lacking one: the arrival mark means one run covers an
+outage of any length, there are no orphaned timers to leak, and editing the
+Automation changes the next sweep instead of stranding in-flight instances. The
+primitives it needs — a stable entity key, a durable per-stage record, and an
+idempotency key on the external call — all exist today.
+
 ## Implementation source map
 
 The earlier model was hard to audit because no document connected these
@@ -389,6 +447,8 @@ map when changing the system:
 | Atomic output-to-task handoff | `packages/server/src/tools/admin/manage_automations/complete-window.ts` |
 | Exact governed input reads | `packages/server/src/tools/get_content/` |
 | Automation notification routing | `packages/server/src/automations/delivery-target.ts`, `packages/server/src/notifications/service.ts` |
+| Write attribution (stamped vs declared) | `packages/server/src/automations/automation-source.ts`, `packages/server/src/utils/acting-automation-context.ts` |
+| Per-subject convergence | `manage_automations/complete-window.ts` (`change_set`), `packages/server/src/utils/automation-reactions.ts` |
 | Server/device dispatch | `packages/server/src/automations/automation.ts`, `packages/server/src/worker-api/poll.ts`, Owletto Mac `AutomationDispatcher.swift` |
 | Web authoring and projection | Owletto `automation-trigger-editor.tsx`, `lib/automations/model.ts` |
 | Generated public client | `packages/client/src/generated/` |

--- a/packages/server/src/__tests__/integration/authz/entity-row-validation.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-row-validation.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { upsertEntityApprovalPolicy } from "../../../authz/entity-policy";
 import { compileEntityRule } from "../../../authz/entity-rule-executor";
 import type { Env } from "../../../index";
 import { applyEntityChangeProposal } from "../../../tools/admin/entity-field-approval";
@@ -633,6 +634,71 @@ describe("entity row validation at the physical writer", () => {
 			expect(proposal.operation).toBe("delete");
 			expect(proposal.reason).toEqual(expect.stringMatching(/second pair of eyes/));
 			expect(await readDeletedAt(doc.id)).toBeNull();
+		}, 60_000);
+
+		/**
+		 * The card records the VERIFIED Automation, never the declared one.
+		 *
+		 * The two halves of a declaration are verified TOGETHER — the Automation
+		 * must own the run — so a real Automation paired with a foreign run fails
+		 * verification whole. A fabricated Automation id cannot reach this branch
+		 * at all: `resolveActingPrincipal` turns it into an unresolved automation
+		 * principal and the mutation gate denies first (`entity-policy.ts`), which
+		 * is why this case declares a REAL Automation. Recording the declared id
+		 * here would credit a card, and its approval run, to an Automation that
+		 * never asked for either.
+		 */
+		it("credits no Automation when the declared delete source is unverified", async () => {
+			const sql = getTestDb();
+			const { org, user, doc } = await seedEscalatingDoc();
+			// `delete` defaults to `approval`, which defers through the GATE's own
+			// card — a different mint that already carried the verified id. Allow
+			// the delete so the gate passes and the ROW RULE is what escalates,
+			// which is the branch under test. The Automation below is seeded with
+			// no managed agent, so no owner policy folds in on top of this one.
+			await upsertEntityApprovalPolicy(org.id, {
+				resourceClass: "entity",
+				principalKind: "automation",
+				deleteMode: "auto",
+			});
+			const [automation] = await sql<{ id: number }[]>`
+				WITH next_id AS (SELECT nextval('automations_id_seq')::integer AS id)
+				INSERT INTO automations (
+					id, automation_group_id, organization_id, managed_agent_id,
+					created_by, name, slug
+				)
+				SELECT id, id, ${org.id}, NULL, ${user.id},
+					'Unrelated Automation', 'unrelated-automation'
+				FROM next_id
+				RETURNING id
+			`;
+
+			const res = (await manageEntity(
+				{
+					action: "delete",
+					entity_id: doc.id,
+					// Real Automation, a run it does not own: the join in
+					// `verifiedAutomationSource` finds nothing and discards both halves.
+					automation_source: {
+						automation_id: Number(automation.id),
+						run_id: 987_654_321,
+					},
+				},
+				TEST_ENV,
+				ctxFor(org.id, { userId: user.id }),
+			)) as { approval_queued?: boolean; approval_run_id?: number };
+
+			expect(res.approval_queued).toBe(true);
+			const proposal = await readRunActionInput(
+				org.id,
+				res.approval_run_id ?? -1,
+			);
+			expect(proposal.automation_id).toBeNull();
+			const [run] = await sql<{ automation_id: number | null }[]>`
+				SELECT automation_id FROM runs
+				WHERE id = ${res.approval_run_id ?? -1} AND organization_id = ${org.id}
+			`;
+			expect(run.automation_id).toBeNull();
 		}, 60_000);
 
 		it("delays delete cleanup until the approval replay", async () => {

--- a/packages/server/src/__tests__/integration/automations/reaction-crash-safety.test.ts
+++ b/packages/server/src/__tests__/integration/automations/reaction-crash-safety.test.ts
@@ -267,6 +267,75 @@ describe("automation reaction crash safety", () => {
 		expect(logged[1].tool_args).toEqual({ attempt: 2 });
 	});
 
+	/**
+	 * The end-to-end claim, through the REAL executor rather than a simulated
+	 * session: reaction-executor stamps `actingAutomationId`, the sandbox SDK
+	 * carries it, `manage_entity` resolves it, and the row names the subject.
+	 *
+	 * `automation-source-surface` proves the two write surfaces resolve without a
+	 * declaration, but it builds the acting session by hand. Only this path
+	 * proves the executor actually stamps what those surfaces now read — the
+	 * link that made `entity_id` 2-of-1143 rows in production.
+	 */
+	it("records the subject a real reaction acted on, end to end", async () => {
+		// The subject is resolved here and inlined, so the assertion depends only
+		// on the attribution chain and not on how `ctx.entities` is hydrated.
+		const seedSql = getTestDb();
+		const script = (entityId: number) =>
+			`export default async function reaction(ctx, client) {
+        await client.entities.update({
+          entity_id: ${entityId},
+          metadata: { provisioning_status: 'provisioned' },
+        });
+      }`;
+		const { sql, automationId, runId, api } = await seedRunnableWindow(
+			script(0),
+		);
+		const [subject] = await seedSql<{ id: number }>`
+      SELECT id FROM entities WHERE name = 'Reaction Entity' ORDER BY id DESC LIMIT 1
+    `;
+		await api.automations.setReactionScript({
+			automation_id: String(automationId),
+			reaction_script: script(Number(subject.id)),
+		});
+
+		await completeWindow(api, automationId, runId, { summary: "Provisioned." });
+		const [task] = await reactionTasks(sql, runId);
+		const payload = (task.action_input as { payload: AutomationReactionTaskPayload })
+			.payload;
+		const outcome = await runAutomationReactionTask(
+			payload,
+			{} as Env,
+			Number(task.id),
+			1,
+		);
+		expect(outcome.status).toBe("success");
+
+		const logged = await sql<{
+			reaction_type: string;
+			entity_id: number | string | null;
+			automation_id: number | string;
+		}>`
+      SELECT reaction_type, entity_id, automation_id
+      FROM automation_reactions WHERE source_run_id = ${runId}
+      ORDER BY reaction_type
+    `;
+		expect(logged.map((row) => String(row.reaction_type))).toEqual([
+			"entity_updated",
+			"script_execution",
+		]);
+		// The subject, which is the whole point of the row.
+		expect(Number(logged[0].entity_id)).toBe(Number(subject.id));
+		expect(Number(logged[0].automation_id)).toBe(automationId);
+
+		// And the write itself landed on the entity, so the row is not crediting
+		// a mutation that silently did nothing.
+		const [updated] = await sql<{ metadata: Record<string, unknown> }>`
+      SELECT metadata FROM entities WHERE id = ${subject.id}
+    `;
+		expect(updated.metadata).toMatchObject({ provisioning_status: "provisioned" });
+	});
+
 	it("does not queue a second reaction when the completion is replayed", async () => {
 		const { sql, automationId, runId, api } = await seedRunnableWindow(
 			"export default async function reaction() { return; }",

--- a/packages/server/src/__tests__/integration/automations/reaction-crash-safety.test.ts
+++ b/packages/server/src/__tests__/integration/automations/reaction-crash-safety.test.ts
@@ -250,14 +250,21 @@ describe("automation reaction crash safety", () => {
 		expect(seen.window_start).toBeTruthy();
 		expect(seen.window_end).toBeTruthy();
 
-		// The run is logged where get_automation already surfaces it.
+		// The run is logged where get_automation already surfaces it. TWO rows: the
+		// script wrapper, and the `knowledge.save` the script itself performed.
+		// That save declares no `automation_source` and is credited from the
+		// stamped acting session instead, so the write that actually touched the
+		// workspace is recorded rather than attributed to nobody.
 		const logged = await sql`
       SELECT reaction_type, tool_args
       FROM automation_reactions WHERE source_run_id = ${runId}
+      ORDER BY reaction_type
     `;
-		expect(logged.length).toBe(1);
-		expect(String(logged[0].reaction_type)).toBe("script_execution");
-		expect(logged[0].tool_args).toEqual({ attempt: 2 });
+		expect(logged.map((row) => String(row.reaction_type))).toEqual([
+			"content_saved",
+			"script_execution",
+		]);
+		expect(logged[1].tool_args).toEqual({ attempt: 2 });
 	});
 
 	it("does not queue a second reaction when the completion is replayed", async () => {

--- a/packages/server/src/__tests__/integration/automations/reaction-crash-safety.test.ts
+++ b/packages/server/src/__tests__/integration/automations/reaction-crash-safety.test.ts
@@ -93,7 +93,7 @@ async function seedRunnableWindow(reactionScript: string) {
     WHERE id = ${queued.runId}
   `;
 
-	return { sql, workspace, api, automationId, runId: queued.runId };
+	return { sql, workspace, entity, api, automationId, runId: queued.runId };
 }
 
 /**
@@ -274,13 +274,14 @@ describe("automation reaction crash safety", () => {
 	 *
 	 * `automation-source-surface` proves the two write surfaces resolve without a
 	 * declaration, but it builds the acting session by hand. Only this path
-	 * proves the executor actually stamps what those surfaces now read — the
-	 * link that made `entity_id` 2-of-1143 rows in production.
+	 * proves the executor actually stamps what those surfaces now read — the link
+	 * whose absence left `entity_id` set on 2 of 1143 production rows.
 	 */
 	it("records the subject a real reaction acted on, end to end", async () => {
-		// The subject is resolved here and inlined, so the assertion depends only
-		// on the attribution chain and not on how `ctx.entities` is hydrated.
-		const seedSql = getTestDb();
+		// The subject is inlined into the script, so the assertion depends only on
+		// the attribution chain and not on how `ctx.entities` is hydrated. The
+		// entity only exists once the seed has run, hence the placeholder id the
+		// second `setReactionScript` replaces before the window completes.
 		const script = (entityId: number) =>
 			`export default async function reaction(ctx, client) {
         await client.entities.update({
@@ -288,15 +289,12 @@ describe("automation reaction crash safety", () => {
           metadata: { provisioning_status: 'provisioned' },
         });
       }`;
-		const { sql, automationId, runId, api } = await seedRunnableWindow(
+		const { sql, entity, automationId, runId, api } = await seedRunnableWindow(
 			script(0),
 		);
-		const [subject] = await seedSql<{ id: number }>`
-      SELECT id FROM entities WHERE name = 'Reaction Entity' ORDER BY id DESC LIMIT 1
-    `;
 		await api.automations.setReactionScript({
 			automation_id: String(automationId),
-			reaction_script: script(Number(subject.id)),
+			reaction_script: script(entity.id),
 		});
 
 		await completeWindow(api, automationId, runId, { summary: "Provisioned." });
@@ -325,13 +323,13 @@ describe("automation reaction crash safety", () => {
 			"script_execution",
 		]);
 		// The subject, which is the whole point of the row.
-		expect(Number(logged[0].entity_id)).toBe(Number(subject.id));
+		expect(Number(logged[0].entity_id)).toBe(entity.id);
 		expect(Number(logged[0].automation_id)).toBe(automationId);
 
 		// And the write itself landed on the entity, so the row is not crediting
 		// a mutation that silently did nothing.
 		const [updated] = await sql<{ metadata: Record<string, unknown> }>`
-      SELECT metadata FROM entities WHERE id = ${subject.id}
+      SELECT metadata FROM entities WHERE id = ${entity.id}
     `;
 		expect(updated.metadata).toMatchObject({ provisioning_status: "provisioned" });
 	});

--- a/packages/server/src/__tests__/integration/tools/automation-source-surface.test.ts
+++ b/packages/server/src/__tests__/integration/tools/automation-source-surface.test.ts
@@ -196,7 +196,9 @@ describe('write surfaces credit a stamped acting Automation with no declaration'
       name: 'Ada',
     })) as { entity: { id: number } };
 
-    // Exactly what `reaction-executor.ts` builds: the stamped pair, no argument.
+    // The half of a reaction session these surfaces read: the stamped pair with
+    // no declaration. The full session `reaction-executor.ts` builds (no user,
+    // system scopes) runs end to end in `reaction-crash-safety`.
     const reaction = org.api.withAuth({
       actingAutomationId: org.automationId,
       actingRunId: org.runId,

--- a/packages/server/src/__tests__/integration/tools/automation-source-surface.test.ts
+++ b/packages/server/src/__tests__/integration/tools/automation-source-surface.test.ts
@@ -12,11 +12,12 @@
  * pairs the forged declaration with an owned one, so a change that disabled
  * reaction tracking outright cannot make these pass by writing nothing.
  *
- * Only the cross-org case is asserted here. A NONEXISTENT id is invisible at
- * this surface: the composite foreign key already rejected the insert and the
- * call site swallows the error, so the row count was zero before this change
- * too. Asserting it here would pass either way — `automation-source-attribution`
- * covers that case where the difference is actually observable.
+ * Of the unowned declarations, only the cross-org case is asserted here. A
+ * NONEXISTENT id is invisible at this surface: the composite foreign key
+ * already rejected the insert and the call site swallows the error, so the row
+ * count was zero before this change too. Asserting it here would pass either
+ * way — `automation-source-attribution` covers that case where the difference
+ * is actually observable.
  */
 import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
@@ -57,12 +58,15 @@ async function orgWithAutomationAndRun(name: string, slug: string) {
   };
 }
 
-async function reactionRows(organizationId: string) {
+/** Every reaction row this org recorded, with the subject it acted on. */
+async function subjectRows(organizationId: string) {
   const rows = await getTestDb()<{
     automation_id: number | string;
     source_run_id: number | string;
+    reaction_type: string;
+    entity_id: number | string | null;
   }>`
-    SELECT automation_id, source_run_id
+    SELECT automation_id, source_run_id, reaction_type, entity_id
     FROM automation_reactions
     WHERE organization_id = ${organizationId}
     ORDER BY id
@@ -70,7 +74,15 @@ async function reactionRows(organizationId: string) {
   return rows.map((row) => ({
     automation_id: Number(row.automation_id),
     run_id: Number(row.source_run_id),
+    reaction_type: row.reaction_type,
+    entity_id: row.entity_id === null ? null : Number(row.entity_id),
   }));
+}
+
+/** The credit alone, for cases where the subject is not what is under test. */
+async function reactionRows(organizationId: string) {
+  const rows = await subjectRows(organizationId);
+  return rows.map(({ automation_id, run_id }) => ({ automation_id, run_id }));
 }
 
 describe('write surfaces refuse an unowned automation_source', () => {
@@ -154,5 +166,78 @@ describe('write surfaces refuse an unowned automation_source', () => {
       { automation_id: attacker.automationId, run_id: attacker.runId },
     ]);
     await expect(reactionRows(victim.organizationId)).resolves.toEqual([]);
+  });
+});
+
+/**
+ * The trusted half of the rule, which the cross-org cases above cannot reach.
+ *
+ * `resolveAutomationAttribution` already prefers `ctx.actingAutomationId` over
+ * any declaration, but `manage_entity` and `save_content` only CALL it when the
+ * caller supplied `automation_source`. A reaction's own session carries the
+ * stamped id and no declaration, so both surfaces credited nobody and wrote no
+ * row at all — which is why `automation_reactions` cannot answer what a
+ * reaction acted on.
+ *
+ * `entity_id` is asserted, not just the credit: the subject is the whole point
+ * of the row. A fix that recorded attribution but dropped the entity would pass
+ * a credit-only assertion and still leave the table useless.
+ */
+describe('write surfaces credit a stamped acting Automation with no declaration', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('credits manage_entity and records the subject when a reaction declares nothing', async () => {
+    const org = await orgWithAutomationAndRun('Acting Entity', 'a-entity');
+    await org.api.entity_schema.createType({ slug: 'employee', name: 'Employee' });
+    const created = (await org.api.entities.create({
+      type: 'employee',
+      name: 'Ada',
+    })) as { entity: { id: number } };
+
+    // Exactly what `reaction-executor.ts` builds: the stamped pair, no argument.
+    const reaction = org.api.withAuth({
+      actingAutomationId: org.automationId,
+      actingRunId: org.runId,
+    });
+    await reaction.entities.manage({
+      action: 'update',
+      entity_id: created.entity.id,
+      metadata: { provisioning_status: 'provisioned' },
+    });
+
+    await expect(subjectRows(org.organizationId)).resolves.toEqual([
+      {
+        automation_id: org.automationId,
+        run_id: org.runId,
+        reaction_type: 'entity_updated',
+        entity_id: created.entity.id,
+      },
+    ]);
+  });
+
+  it('credits save_memory when a reaction declares nothing', async () => {
+    const org = await orgWithAutomationAndRun('Acting Save', 'a-save');
+    const reaction = org.api.withAuth({
+      actingAutomationId: org.automationId,
+      actingRunId: org.runId,
+    });
+
+    await reaction.knowledge.save({
+      semantic_type: 'note',
+      metadata: {},
+      title: 'Stamped credit',
+      content: 'Attributed from the acting session, not a declaration.',
+    });
+
+    await expect(subjectRows(org.organizationId)).resolves.toEqual([
+      {
+        automation_id: org.automationId,
+        run_id: org.runId,
+        reaction_type: 'content_saved',
+        entity_id: null,
+      },
+    ]);
   });
 });

--- a/packages/server/src/__tests__/setup/test-mcp-client.ts
+++ b/packages/server/src/__tests__/setup/test-mcp-client.ts
@@ -82,6 +82,11 @@ export interface TestClientAuth {
   /** True when the MCP URL pinned an org slug (e.g. `/mcp/acme`). When the
    * direct-handler client is used, set this to mirror the wire intent. */
   scopedToOrg?: boolean;
+  /** Trusted acting-Automation identity, as the reaction executor stamps it
+   * (`automations/reaction-executor.ts`). Set these to exercise a reaction's
+   * own session, which carries no caller-declared `automation_source`. */
+  actingAutomationId?: number;
+  actingRunId?: number;
 }
 
 const DEFAULT_TEST_ENV: Env = {
@@ -229,6 +234,8 @@ export class TestApiClient {
       // Match production: only OAuth tokens issued without an org-pin can do
       // cross-org reads via `client.org()`.
       allowCrossOrg: tokenType === 'oauth' && !scopedToOrg,
+      actingAutomationId: auth.actingAutomationId ?? null,
+      actingRunId: auth.actingRunId ?? null,
     };
     return new TestApiClient({ ...DEFAULT_TEST_ENV, ...env }, ctx);
   }
@@ -257,6 +264,8 @@ export class TestApiClient {
       tokenType,
       scopedToOrg,
       allowCrossOrg: tokenType === 'oauth' && !scopedToOrg,
+      actingAutomationId: overrides.actingAutomationId ?? this.ctx.actingAutomationId ?? null,
+      actingRunId: overrides.actingRunId ?? this.ctx.actingRunId ?? null,
     };
     return new TestApiClient(this.env, ctx);
   }

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -1757,8 +1757,11 @@ async function handleDelete(
 			entity_id: entityId,
 			force_delete_tree: force,
 			current,
-			automation_id:
-				ctx.actingAutomationId ?? args.automation_source?.automation_id ?? null,
+			// The VERIFIED id, not an inline merge of the declared one. `runId`
+			// below already comes from this resolution, so the raw merge could
+			// pair a verified run with a declared Automation that failed
+			// verification — a worse pairing than either half alone.
+			automation_id: deleteAttribution.automationId,
 			attribution,
 			reason: err.verdict.reason,
 		}, deleteAttribution.runId);

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -332,12 +332,17 @@ async function trackEntityReaction(
 	result: ManageEntityResult,
 	ctx: ToolContext,
 ): Promise<void> {
-	const reactionAttribution = args.automation_source
-		? await resolveAutomationAttribution(ctx, args.automation_source)
-		: null;
+	// Resolved unconditionally, like every other call site in this file: a
+	// reaction session stamps `ctx.actingAutomationId` and declares no
+	// `automation_source`, so gating on the declaration dropped its credit —
+	// and with it `entity_id`, the only per-subject signal this table carries.
+	const reactionAttribution = await resolveAutomationAttribution(
+		ctx,
+		args.automation_source,
+	);
 	// A reaction record is keyed by the producing run.
 	if (
-		reactionAttribution?.automationId == null ||
+		reactionAttribution.automationId == null ||
 		reactionAttribution.runId == null ||
 		!("action" in result)
 	) {

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -680,14 +680,15 @@ async function saveContentImpl(
     inserted ? 'Content saved via save_memory' : 'Content save replay returned existing event'
   );
 
-  // Track automation reaction if attribution source is provided.
-  // The declared source is caller input: resolve it through the shared rule so a
-  // reaction session's own identity wins and an id belonging to another
-  // organization credits nobody.
-  const reactionAttribution =
-    inserted && args.automation_source
-      ? await resolveAutomationAttribution(ctx, args.automation_source)
-      : null;
+  // Track the automation reaction. The declared source is caller input; the
+  // shared rule prefers a reaction session's own stamped identity over it and
+  // credits nobody for an id belonging to another organization. Resolve it
+  // whenever a row was inserted, not only when a source was declared: a
+  // reaction carries the stamped pair and declares nothing, so gating on the
+  // declaration left its write recorded against no Automation at all.
+  const reactionAttribution = inserted
+    ? await resolveAutomationAttribution(ctx, args.automation_source)
+    : null;
   if (reactionAttribution?.automationId != null && reactionAttribution.runId != null) {
     await trackAutomationReaction({
       organizationId: ctx.organizationId,


### PR DESCRIPTION
## Summary

- Reaction sessions stamp the acting Automation and run on their tool context. `save_content` and `manage_entity` previously skipped attribution unless a caller also supplied `automation_source`, so these writes produced no corresponding effect records. Both now use the existing resolver unconditionally when recording a write; trusted session attribution wins, and off-session declarations still require verification.
- Deferred entity-delete proposals now use the verified Automation ID, preventing an invalid Automation/run declaration from attributing an approval card to that Automation.
- Document the distinction between attempted and applied changes, the effect log's limits, and scheduled reconciliation over durable stage state. No new database or public API contract.

## Test plan

- [x] Final diff staged by explicit paths; `make pre-pr` and commit-hook Biome/typecheck passed.
- [x] Pre-review Opus pass reran the 48 focused integration tests and reported 135 related tests passing; 28 additional source unit tests passed.
- [x] Integration regressions through both write handlers and the real reaction executor; cross-organization declaration controls retained.
- [x] Mutation proof for all three production changes, restoring the old code one site at a time.
- [x] Booted-server E2E against isolated Postgres: a real reaction wrote `onboarding_stage: account-created` on an unowned field and recorded its subject; ordinary user-session entity and knowledge writes recorded zero Automation reactions. Server, test database, and temporary token were cleaned up.

Red / green evidence from the implementation session:

```text
Original attribution guards:
  credits manage_entity ... expected [] to deeply equal [ { automation_id: ... } ]
  credits save_memory ... expected [] to deeply equal [ { automation_id: ... } ]
  Tests 2 failed | 2 passed (4)

Restore manage_entity guard only: Tests 1 failed | 3 passed (4)
Restore save_content guard only:  Tests 1 failed | 3 passed (4)
Restore unverified delete ID:     expected 1 to be null
                                 Tests 1 failed | 34 passed (35)

Fix restored, three touched suites:
  Test Files 3 passed (3)
  Tests 48 passed (48)
```

## Notes

The effect log is best effort for these direct writes and does not deduplicate retries. It is not an exactly-once completion ledger or an Automation SQL source. `change_set` audit records include denied changes; inspect the per-change outcome and persist business stage state before using it to decide what remains due. This change does not add suspended workflow execution or third-party exactly-once guarantees.

## Deployment verification

- Merged as `eab0e3f0e38305fa17d03b6960286e7d7cdcb507` after all ten required checks passed. Final Opus review: zero bugs and blockers; CI green on `b0a1aaf106802e8a157bb471cb31f7761bcf0fb2`.
- Production serves the exact squash commit. The ancestry gate and all **9 production smoke checks passed**, including readiness, web assets, MCP authorization, OAuth discovery, TLS, and the rendered MCP App.
- No new reaction effect rows were observed after deployment at verification time. The next scheduled reaction using the changed write surfaces is due at **2026-09-11 05:00 UTC / 06:00 Europe/London**. Production deployment and health are verified; that naturally scheduled behavior remains unobserved. The functional proof remains the real-server E2E and regression suites above.

<details>
<summary>Production smoke output</summary>

```text
================================================================
 prod smoke — https://app.lobu.ai
================================================================

== health ==
  ok   — /health status=ok
       version=1.6.0 revision=eab0e3f0e38305fa17d03b6960286e7d7cdcb507 environment=production

== readiness ==
  ok   — /health/ready 200 — pod can reach the database

== rollout ==
  ok   — eab0e3f0e383 is live (deployed eab0e3f0e383)

== web UI + referenced assets ==
  ok   — GET / served HTML (3287 bytes)
  ok   — all 2 referenced assets returned 200

== MCP mount ==
  ok   — /mcp challenged an anonymous call (HTTP 401)

== OAuth discovery ==
  ok   — /.well-known/oauth-authorization-server serves an issuer

== TLS ==
  ok   — TLS certificate valid for 74 more days

== rendered MCP App ==
ok — MCP App error
ok — MCP App missing + late recovery
ok — MCP App cancelled
ok — MCP App stalled-handshake
MCP App smoke PASSED
  ok   — MCP App failures are visible and late results recover without replay

  prod smoke: 9 passed, 0 failed
RESULT: prod smoke PASSED
```

</details>
