### PR TITLE
fix(worker): persist answers before threshold compaction

### DIFF
--- a/packages/connector-worker/src/__tests__/native-session-completion.test.ts
+++ b/packages/connector-worker/src/__tests__/native-session-completion.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, expect, test } from 'bun:test';
+import { createNativeSession, nativeSessionJsonl, promptNativeSession } from '../agent-turn/native-session.js';
+import type { AgentTurnInput } from '../agent-turn/types.js';
+
+const originalFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = originalFetch; });
+
+function response(used: number) {
+  const chunk = { id: 'synthetic-completion', object: 'chat.completion.chunk', created: 1,
+    model: 'synthetic-model', choices: [{ index: 0, delta: { role: 'assistant', content: 'Finished.' }, finish_reason: 'stop' }],
+    usage: { prompt_tokens: used, completion_tokens: 10, total_tokens: used + 10 } };
+  return new Response(`data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`, { headers: { 'content-type': 'text/event-stream' } });
+}
+
+test('persists a finished turn without waiting for threshold compaction, then compacts before resuming', async () => {
+  let release!: () => void;
+  // Every request after the answer hangs until released, so a turn that waits
+  // for its own threshold compaction never settles and this test fails.
+  const maintenance = new Promise<void>(resolve => { release = resolve; });
+  const requests: Record<string, any>[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    requests.push(JSON.parse(String(init?.body)));
+    if (requests.length > 1) await maintenance;
+    return response(requests.length === 1 ? 950 : 10);
+  }) as typeof fetch;
+  const input: AgentTurnInput = {
+    provider: { api: 'openai-completions', provider: 'openai', modelId: 'synthetic-model',
+      baseUrl: 'https://gateway.example.test/proxy', apiKey: 'synthetic-credential' },
+    systemPrompt: 'Be brief.', sessionJsonl: '', userMessage: 'Synthetic context data. '.repeat(100),
+    compaction: { enabled: true, contextWindow: 1000, reserveTokens: 100, keepRecentTokens: 1 },
+  };
+  const session = createNativeSession(input, [], () => undefined);
+  let settled = false;
+  const turn = promptNativeSession(session, input.userMessage).then(() => { settled = true; });
+  try {
+    await Promise.race([turn, new Promise(resolve => setTimeout(resolve, 5_000))]);
+    expect(settled).toBe(true);
+    expect(requests).toHaveLength(1);
+    const checkpoint = nativeSessionJsonl(session);
+    expect(checkpoint).toContain('Finished.');
+    expect(checkpoint).not.toContain('"type":"compaction"');
+    // Restored for the next prompt: the deferred compaction still has to run,
+    // just on the turn that actually needs the room.
+    expect(session.autoCompactionEnabled).toBe(true);
+    release();
+    await promptNativeSession(session, 'Continue.');
+    // Summarize, then the resumed prompt.
+    expect(requests).toHaveLength(3);
+    expect(nativeSessionJsonl(session)).toContain('"type":"compaction"');
+    expect(requests.at(-1)?.messages.at(-1)?.content).toEqual([{ type: 'text', text: 'Continue.' }]);
+  } finally {
+    release();
+    await turn;
+    session.dispose();
+  }
+});

--- a/packages/connector-worker/src/agent-turn/native-session.ts
+++ b/packages/connector-worker/src/agent-turn/native-session.ts
@@ -164,6 +164,7 @@ export async function promptNativeSession(
   let continuationPending = false;
   let checking = false;
   let finished = false;
+  const autoCompactionEnabled = session.autoCompactionEnabled;
   let timer: ReturnType<typeof setTimeout> | undefined;
   let resolve!: () => void;
   let reject!: (error: unknown) => void;
@@ -191,7 +192,19 @@ export async function promptNativeSession(
     if (event.type === 'agent_start') { started++; continuationPending = false; }
   });
   const unsubscribeSession = session.subscribe((event) => {
-    if (event.type === 'agent_end') ended++;
+    if (event.type === 'agent_end') {
+      ended++;
+      const lastAssistant = event.messages.slice().reverse().find(message => message.role === 'assistant');
+      if (lastAssistant?.stopReason === 'stop' && !session.agent.hasQueuedMessages()) {
+        // Pi checks the same threshold before the next prompt. Persist this
+        // completed answer now instead of spending the isolate's remaining
+        // execution budget summarizing a conversation that may never resume.
+        // Errors keep compaction enabled so native overflow recovery can
+        // retry, and so does a queued round: `check` below still continues it
+        // in THIS turn, and it has to fit the window like any other.
+        session.setAutoCompactionEnabled(false);
+      }
+    }
     if (event.type === 'compaction_end') {
       continuationPending = event.willRetry || (!!event.result && session.agent.hasQueuedMessages());
     }
@@ -207,6 +220,9 @@ export async function promptNativeSession(
     if (timer !== undefined) clearTimeout(timer);
     unsubscribeAgent();
     unsubscribeSession();
+    // A session takes more than one prompt — the memory flush runs its own —
+    // so hand the compaction setting back exactly as it was found.
+    session.setAutoCompactionEnabled(autoCompactionEnabled);
   }
 }
 

--- a/packages/server/src/__tests__/integration/sandbox/isolate-agent-turn.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/isolate-agent-turn.test.ts
@@ -1653,18 +1653,24 @@ describe("agent turn on the isolate lane", () => {
 		expect(second?.body).toContain("Command exited with code 126");
 	}, 120_000);
 
-	it("compacts after answering when the context has outgrown the window, with pi's own prompts", async () => {
+	it("persists the answer before threshold compaction and compacts on the next restored turn", async () => {
 		hits = [];
 		toolScript = [];
 		armFirstDeltaGate();
-		// The fake model reports 11 in + 7 out = 18 tokens; a 20-token window with a
-		// 5-token reserve is therefore over the line the moment the turn ends.
+		// The fake model reports 11 in + 7 out = 18 tokens, so a 20-token window
+		// with a 5-token reserve is over the line the moment this turn answers —
+		// and the compaction that settles it belongs to the NEXT prompt, not to the
+		// turn whose answer is already owed to the user.
 		const run = await runTurn(
 			turnJob({ compaction: { enabled: true, contextWindow: 20, reserveTokens: 5, keepRecentTokens: 4 } }),
 		);
 
 		expect(run.output.text).toBe("Hello from the isolate");
-		const entries = sessionEntries(run.output);
+		expect(sessionEntries(run.output).some((entry) => entry.type === "compaction")).toBe(false);
+		expect(hits.filter((h) => h.url === "/v1/messages")).toHaveLength(1);
+		const resumed = await runTurn(turnJob({ sessionJsonl: run.output.sessionJsonl, userMessage: "continue",
+			compaction: { enabled: true, contextWindow: 20, reserveTokens: 5, keepRecentTokens: 4 } }));
+		const entries = sessionEntries(resumed.output);
 		const compaction = entries.find((entry) => entry.type === "compaction");
 		expect(compaction).toBeDefined();
 		expect(compaction?.tokensBefore).toBe(18);
@@ -1672,22 +1678,28 @@ describe("agent turn on the isolate lane", () => {
 		// The summary came from the model, asked with pi's summarisation prompt on
 		// the same route and the same credential as the turn itself.
 		expect(compaction?.summary).toContain("Hello from the isolate");
+		// One answer, then one summary and the resumed prompt it made room for.
 		const providerCalls = hits.filter((h) => h.url === "/v1/messages");
-		expect(providerCalls.length).toBeGreaterThanOrEqual(2);
+		expect(providerCalls).toHaveLength(3);
 		const summarization = providerCalls.find((h) => h.body.includes("context summarization assistant"));
 		expect(summarization).toBeDefined();
 		expect(summarization?.body).toContain("<conversation>");
 		expect(summarization?.body).toContain("Do NOT continue the conversation");
-		// The turn's own answer was streamed; the summary was not.
+		// Each turn streamed its own answer and nothing else: the summary the
+		// second turn fetched before prompting never reached the user as text.
 		expect(run.events.filter((e) => e.type === "text_delta").map((e) => (e as { delta: string }).delta).join("")).toBe(
+			"Hello from the isolate",
+		);
+		expect(resumed.events.filter((e) => e.type === "text_delta").map((e) => (e as { delta: string }).delta).join("")).toBe(
 			"Hello from the isolate",
 		);
 	}, 120_000);
 
-	it("waits for a delayed native summary before returning the snapshot", async () => {
+	it("waits for pre-prompt compaction and preserves every steered answer", async () => {
 		hits = [];
 		toolScript = [];
 		sawFirstDelta = Promise.resolve();
+		const seed = await runTurn(turnJob({ userMessage: "saved context ".repeat(100) }));
 		let summaryFinished = false;
 		providerScript = (body, res) => {
 			if (body.includes("context summarization assistant")) {
@@ -1699,11 +1711,11 @@ describe("agent turn on the isolate lane", () => {
 			else void writeAnthropicStream(res, ["main answer"]);
 		};
 		let offered = false;
-		const run = await runTurn(turnJob({ compaction: { enabled: true, contextWindow: 20, reserveTokens: 5, keepRecentTokens: 4 } }), ['127.0.0.1'], {
+		const run = await runTurn(turnJob({ sessionJsonl: seed.output.sessionJsonl, compaction: { enabled: true, contextWindow: 20, reserveTokens: 5, keepRecentTokens: 4 } }), ['127.0.0.1'], {
 			takeSteering: () => { if (offered) return []; offered = true; return [{ runId: 7, messageId: 'compacted-input', text: 'remember this input' }]; },
 		});
 		expect(summaryFinished).toBe(true);
-		expect(sessionEntries(run.output).at(-1)).toMatchObject({ type: "compaction", summary: expect.stringContaining("delayed native summary") });
+		expect(sessionEntries(run.output).find(entry => entry.type === "compaction")).toMatchObject({ type: "compaction", summary: expect.stringContaining("delayed native summary") });
 		// TWO user messages are answered here (the steered input queues a
 		// second round), and the host delivers `text` ONCE — to Slack at
 		// completion, and to history. Both answers have to be in it: taking the
@@ -1723,11 +1735,13 @@ describe("agent turn on the isolate lane", () => {
 		sawFirstDelta = Promise.resolve();
 		const first = await runTurn(turnJob({ userMessage: "original history ".repeat(100),
 			compaction: { enabled: true, contextWindow: 20, reserveTokens: 5, keepRecentTokens: 4 } }));
-		const original = sessionEntries(first.output);
-		expect(original.at(-1)?.type).toBe("compaction");
+		const compacted = await runTurn(turnJob({ sessionJsonl: first.output.sessionJsonl, userMessage: "continue once",
+			compaction: { enabled: true, contextWindow: 20, reserveTokens: 5, keepRecentTokens: 4 } }));
+		const original = sessionEntries(compacted.output);
+		expect(original.some(entry => entry.type === "compaction")).toBe(true);
 		const custom = { type: "custom", id: "synthetic-custom", parentId: original.at(-1)!.id,
 			timestamp: new Date(0).toISOString(), customType: "synthetic.state", data: { preserved: true } };
-		const snapshot = first.output.sessionJsonl + JSON.stringify(custom) + "\n";
+		const snapshot = compacted.output.sessionJsonl + JSON.stringify(custom) + "\n";
 		hits = [];
 		const second = await runTurn(turnJob({ sessionJsonl: snapshot, userMessage: "continue" }));
 		expect(sessionEntries(second.output).slice(0, original.length + 1)).toEqual([...original, custom]);
@@ -1862,7 +1876,7 @@ describe("agent turn on the isolate lane", () => {
 		expect(sessionMessages(run.output)[2]).toMatchObject({ role: "user", content: [{ type: "text", text: "hi" }] });
 	}, 120_000);
 
-	it("captures the original exchange even when native compaction removes its user from model context", async () => {
+	it("captures the new exchange after compacting restored context", async () => {
 		hits = [];
 		toolScript = [];
 		memoryCalls = [];
@@ -1871,13 +1885,15 @@ describe("agent turn on the isolate lane", () => {
 			search_memory: { status: 200, body: { content: [] } },
 			save_memory: { status: 200, body: { content: [{ type: "text", text: "saved" }] } },
 		};
+		const seed = await runTurn(turnJob({ userMessage: "earlier context ".repeat(100) }));
 		const run = await runTurn(turnJob({
+			sessionJsonl: seed.output.sessionJsonl,
 			userMessage: "Remember this original user request",
 			memory: { mcpId: "lobu", agentId: "agent-test" },
 			tools: { gatewayUrl: `http://127.0.0.1:${port}/lobu`, definitions: [] },
 			compaction: { enabled: true, contextWindow: 20, reserveTokens: 5, keepRecentTokens: 0 },
 		}));
-		expect(sessionEntries(run.output).at(-1)?.type).toBe("compaction");
+		expect(sessionEntries(run.output).some(entry => entry.type === "compaction")).toBe(true);
 		const captures = memoryCalls.filter((call) => call.tool === "save_memory");
 		expect(captures).toHaveLength(1);
 		expect(captures[0]?.body.content).toBe("User: Remember this original user request\nAssistant: Hello from the isolate");


### PR DESCRIPTION
## Summary

A cloud turn could deliver its final answer and still fail ten minutes later because Pi started threshold compaction before the worker persisted completion. A live synthetic tool-result run reproduced that sequence.

Persist successful answers before optional threshold compaction. Pi performs the same compaction before the next prompt, including after restoring the native session. Keep overflow recovery, transient retries, queued follow-ups, and the original compaction setting intact.

## Test plan

- Regression red: blocked summary kept a finished turn unresolved (`Expected: true; Received: false`, 0 passed / 1 failed).
- Regression green: finished turn persists with maintenance blocked; the next prompt compacts before resuming.
- Connector-worker suite: 475 passed, 0 failed.
- Real Node isolate suite: 63 passed, including restored compaction, native entry identity, steering, overflow recovery, retries, and memory capture.
- Claude Opus review-fix: inspected refinements; mutation-tested disabling compaction and restoring the setting separately. Focused tests and all 63 isolate tests passed after its edits; producer suite 167 passed.
- `make pre-pr`: passed (build, typecheck, knip, naming, and gateway/write-funnel checks).
- GitHub CI: passed for `c6154e84c87d93aa567ccb24e4bcdd7ef2c88447` ([run](https://github.com/lobu-ai/lobu/actions/runs/34536860799)).

## Notes

This defers post-answer maintenance; it does not remove compaction or increase the worker timeout. Merged as `88a19c3902c4c085cb4753786eba96961d5d6f79`. Final review passed (87 confidence, zero bugs or blockers); UI review not applicable. Live verification completed on the exact squash revision.

The existing 4 MiB native-snapshot cap is unchanged. Deferring compaction can leave an older summary available for trimming for one turn; over-cap reset behavior is not covered by this fix. Memory capture after restored compaction is tested; mid-turn overflow recovery remains covered separately.


## Production verification

- Exact squash revision served by production; prod smoke: 9 passed, 0 failed.
- Synthetic cloud Astra/medium turn retained a 414,236-character tool result and finished in 24 seconds. Saved usage: 264,689 tokens, above the 255,616-token compaction threshold; its snapshot had no post-answer compaction.
- The next turn restored that conversation, compacted it (tokensBefore 264,689), and returned the exact expected marker in 12 seconds. Final context usage: 11,666 tokens.
- A normal scheduled hourly Automation and its child worker completed successfully; scheduler failure count is zero.
- Both isolated dry-run test sessions were removed after terminal completion. Append-only history was retained.
