### PR TITLE
fix(connectors): reconnect stalled WhatsApp message streams

### DIFF
--- a/packages/connectors/src/__tests__/whatsapp-web-adapter.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web-adapter.test.ts
@@ -275,6 +275,125 @@ describe("whatsAppWebAdapterProgram send_message", () => {
   });
 });
 
+describe("whatsAppWebAdapterProgram connection readiness", () => {
+  function install(socketModules: Record<string, unknown>) {
+    let now = 1_000;
+    const modules: Record<string, unknown> = {
+      WAWebCollections: { Chat: { _models: [{}] }, Msg: { _models: [] } },
+      WAWebUserPrefsMeUser: {
+        getMaybeMePnUser: () => ({ _serialized: "self@c.us" }),
+      },
+      WAWebChatLoadMessages: { loadEarlierMsgs: async () => undefined },
+      ...socketModules,
+    };
+    const globals: Record<string, any> = {};
+    new Function(
+      "globalThis",
+      "window",
+      "document",
+      "Date",
+      `(${whatsAppWebAdapterProgram.toString()})();`,
+    )(
+      globals,
+      { require: (name: string) => modules[name] ?? null },
+      { querySelector: () => null },
+      { now: () => now },
+    );
+    const invoke = (op = "probe") =>
+      globals.__owlettoWhatsAppAdapterV1.invoke({
+        op,
+        adapter_version: WHATSAPP_ADAPTER_VERSION,
+        backfill_disabled: true,
+      });
+    return {
+      invoke,
+      settle: async () => {
+        await invoke();
+        now += 501;
+        return invoke();
+      },
+    };
+  }
+
+  it("rejects a disconnected live stream even when the account is connected", async () => {
+    const page = install({
+      WAWebSocketModel: {
+        Socket: {
+          state: "CONNECTED",
+          stream: "DISCONNECTED",
+          hasSynced: true,
+        },
+      },
+    });
+    expect(await page.settle()).toMatchObject({
+      ok: false,
+      error: { state: "not_ready", reason: "stream_disconnected" },
+    });
+    expect(await page.invoke("collect")).toMatchObject({
+      ok: false,
+      error: { reason: "stream_disconnected" },
+    });
+  });
+
+  it("accepts a connected current socket after the stores settle", async () => {
+    const page = install({
+      WAWebSocketModel: {
+        Socket: {
+          state: "CONNECTED",
+          stream: "CONNECTED",
+          hasSynced: true,
+        },
+      },
+    });
+    expect(await page.settle()).toMatchObject({ ok: true });
+  });
+
+  it("does not claim readiness when connection modules disappear", async () => {
+    expect(await install({}).settle()).toMatchObject({
+      ok: false,
+      error: {
+        state: "capability_unavailable",
+        reason: "connection_state_unavailable",
+      },
+    });
+  });
+
+  it("retains readable legacy connection state", async () => {
+    expect(
+      await install({
+        WAWebSocketState: { getSocketState: () => "CONNECTED" },
+      }).settle(),
+    ).toMatchObject({ ok: true });
+  });
+
+  it("rejects unsynced or unpaired current sockets", async () => {
+    expect(
+      await install({
+        WAWebSocketModel: {
+          Socket: {
+            state: "CONNECTED",
+            stream: "CONNECTED",
+            hasSynced: false,
+          },
+        },
+      }).settle(),
+    ).toMatchObject({
+      ok: false,
+      error: { reason: "initial_sync_incomplete" },
+    });
+    expect(
+      await install({
+        WAWebSocketModel: {
+          Socket: {
+            state: "UNPAIRED",
+            stream: "DISCONNECTED",
+          },
+        },
+      }).settle(),
+    ).toMatchObject({ ok: false, error: { state: "logged_out" } });
+  });
+});
+
 /**
  * Media download, against the module shapes the LIVE build exposes
  * (captured 2026-09-02 on a paired Chrome).
@@ -692,6 +811,7 @@ describe("whatsAppWebAdapterProgram collect scaling", () => {
         Chat: { _models: [chatModel] },
         Contact: { _models: contacts },
       },
+      WAWebSocketModel: { Socket: { state: "CONNECTED", stream: "CONNECTED", hasSynced: true } },
       // `collect` is capability-gated on the history loader, and readiness
       // needs an authenticated self identity.
       WAWebChatLoadMessages: { loadEarlierMsgs: async () => undefined },

--- a/packages/connectors/src/__tests__/whatsapp-web-adapter.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web-adapter.test.ts
@@ -390,7 +390,10 @@ describe("whatsAppWebAdapterProgram connection readiness", () => {
           },
         },
       }).settle(),
-    ).toMatchObject({ ok: false, error: { state: "logged_out" } });
+    ).toMatchObject({
+      ok: false,
+      error: { state: "not_ready", reason: "connection_unpaired" },
+    });
   });
 });
 
@@ -811,9 +814,11 @@ describe("whatsAppWebAdapterProgram collect scaling", () => {
         Chat: { _models: [chatModel] },
         Contact: { _models: contacts },
       },
-      WAWebSocketModel: { Socket: { state: "CONNECTED", stream: "CONNECTED", hasSynced: true } },
       // `collect` is capability-gated on the history loader, and readiness
-      // needs an authenticated self identity.
+      // needs a live socket and an authenticated self identity.
+      WAWebSocketModel: {
+        Socket: { state: "CONNECTED", stream: "CONNECTED", hasSynced: true },
+      },
       WAWebChatLoadMessages: { loadEarlierMsgs: async () => undefined },
       WAWebUserPrefsMeUser: {
         getMaybeMePnUser: () => ({ _serialized: "me@c.us" }),

--- a/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
@@ -600,6 +600,42 @@ describe("sync over the generic chrome bridge", () => {
     }
   });
 
+  it("reports the readiness failure, not a failed reload dispatch", async () => {
+    // The reload is a recovery attempt, not a verdict. A bridge that refuses
+    // it (tab already navigating, ownership guard) must not replace the
+    // readiness error the run is actually retrying on, or a transient stall
+    // surfaces as an unclassifiable bridge failure.
+    const { dispatcher } = makeDispatcher({
+      probe: {
+        ok: false,
+        error: { state: "not_ready", reason: "stream_disconnected" },
+      },
+    });
+    const bridge = dispatcher as unknown as {
+      dispatch: (
+        action: string,
+        input: Record<string, unknown>,
+      ) => Promise<unknown>;
+    };
+    const inner = bridge.dispatch;
+    bridge.dispatch = async (action, input) => {
+      if (String(input.expression ?? "").includes("location.reload()")) {
+        throw new Error("chrome refused the reload");
+      }
+      return inner(action, input);
+    };
+    const realNow = Date.now;
+    let ticks = 0;
+    Date.now = () => realNow() + ticks++ * 40_000;
+    try {
+      await expect(
+        messagesFeed().sync(syncCtx(null, dispatcher)),
+      ).rejects.toThrow("stream_disconnected");
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
   it("marks persistent store hydration as a transient dependency failure", async () => {
     const realNow = Date.now;
     let calls = 0;

--- a/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
+++ b/packages/connectors/src/__tests__/whatsapp-web.connector.test.ts
@@ -83,6 +83,10 @@ function makeDispatcher(
       if (action === "navigate") return { tab_id: 42, current_url: input.url };
       if (action !== "evaluate") return {};
       const expression = String(input.expression ?? "");
+      if (expression.includes("location.reload()")) {
+        installed = false;
+        return { value: true };
+      }
       // Installation probe.
       if (expression.includes("a.version ===")) return { value: installed };
       const match = expression.match(/a\.invoke\((\{[\s\S]*\})\);/);
@@ -535,6 +539,67 @@ describe("sync over the generic chrome bridge", () => {
     ]);
   });
 
+  it("reloads a disconnected persistent source once before collecting", async () => {
+    const { dispatcher, calls, adapterOps } = makeDispatcher({
+      probe: () =>
+        calls.some((call) =>
+          String(call.input.expression).includes("location.reload()"),
+        )
+          ? READY
+          : {
+              ok: false,
+              error: { state: "not_ready", reason: "stream_disconnected" },
+            },
+      collect: {
+        ok: true,
+        messages: [message("reconnected")],
+        history_pages: [],
+      },
+    });
+    const realNow = Date.now;
+    let ticks = 0;
+    Date.now = () => realNow() + ticks++ * 40_000;
+    try {
+      const result = await messagesFeed().sync(syncCtx(null, dispatcher));
+      expect(result.events.map((event) => event.origin_id)).toEqual([
+        "reconnected",
+      ]);
+      expect(
+        calls.filter((call) =>
+          String(call.input.expression).includes("location.reload()"),
+        ),
+      ).toHaveLength(1);
+      expect(adapterOps.at(-1)).toBe("collect");
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  it("does not repeatedly reload or collect if reconnection fails", async () => {
+    const { dispatcher, calls, adapterOps } = makeDispatcher({
+      probe: {
+        ok: false,
+        error: { state: "not_ready", reason: "stream_disconnected" },
+      },
+    });
+    const realNow = Date.now;
+    let ticks = 0;
+    Date.now = () => realNow() + ticks++ * 40_000;
+    try {
+      await expect(
+        messagesFeed().sync(syncCtx(null, dispatcher)),
+      ).rejects.toThrow("stream_disconnected");
+      expect(
+        calls.filter((call) =>
+          String(call.input.expression).includes("location.reload()"),
+        ),
+      ).toHaveLength(1);
+      expect(adapterOps).not.toContain("collect");
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
   it("marks persistent store hydration as a transient dependency failure", async () => {
     const realNow = Date.now;
     let calls = 0;
@@ -690,7 +755,7 @@ describe("sync over the generic chrome bridge", () => {
   });
 
   it("bumps the WhatsApp connector version for readiness semantics", () => {
-    expect(connector.definition.version).toBe("1.0.1");
+    expect(connector.definition.version).toBe("1.0.2");
   });
 
   it("names the remedy when WhatsApp Web is signed out", async () => {

--- a/packages/connectors/src/whatsapp-web-adapter.js
+++ b/packages/connectors/src/whatsapp-web-adapter.js
@@ -35,7 +35,7 @@ export function whatsAppWebAdapterProgram() {
   // when this number moves: shipping a fix under the old number leaves every
   // already-open tab running the previous code with nothing to show for it.
   // Keep in lockstep with WHATSAPP_ADAPTER_VERSION in whatsapp-web-helpers.ts.
-  const ADAPTER_VERSION = 10;
+  const ADAPTER_VERSION = 11;
   const SYSTEM_TYPES = new Set([
     "gp2",
     "notification_template",
@@ -447,33 +447,54 @@ export function whatsAppWebAdapterProgram() {
         reason: "authenticated_self_identity_unavailable",
       };
     }
-    const connection = requireFirst([
-      "WAWebSocketState",
-      "WAWebConn",
-      "WAWebConnectionState",
-    ]);
+    // Verified on WhatsApp Web (2026-09-10): Socket.state was CONNECTED while
+    // Socket.stream was DISCONNECTED, then both were CONNECTED after reload.
+    // Current WhatsApp exposes account and transport state separately. An
+    // authenticated account can retain hydrated stores while its stream is
+    // disconnected; those cached messages are not a successful live sync.
+    const socket = requireFirst(["WAWebSocketModel"])?.Socket;
+    const connection =
+      socket ??
+      requireFirst(["WAWebSocketState", "WAWebConn", "WAWebConnectionState"]);
     const connectionState = String(
       connection?.getSocketState?.() ??
         connection?.state ??
         connection?.socketState ??
         ""
     ).toLowerCase();
-    if (/disconnected|unpaired|conflict|timeout/.test(connectionState)) {
+    if (!connectionState) {
+      return {
+        ready: false,
+        state: "capability_unavailable",
+        reason: "connection_state_unavailable",
+      };
+    }
+    if (!/^(connected|open|ready|syncing)$/.test(connectionState)) {
       return {
         ready: false,
         state: "not_ready",
         reason: `connection_${connectionState}`,
       };
     }
-    if (
-      connectionState &&
-      !/^(connected|open|ready|syncing)$/.test(connectionState)
-    ) {
-      return {
-        ready: false,
-        state: "not_ready",
-        reason: `connection_${connectionState}`,
-      };
+    if (socket) {
+      const stream = String(socket.stream ?? "").toLowerCase();
+      if (!stream) {
+        return {
+          ready: false,
+          state: "capability_unavailable",
+          reason: "stream_state_unavailable",
+        };
+      }
+      if (!/^(connected|open|ready)$/.test(stream)) {
+        return { ready: false, state: "not_ready", reason: `stream_${stream}` };
+      }
+      if (socket.hasSynced === false) {
+        return {
+          ready: false,
+          state: "hydrating",
+          reason: "initial_sync_incomplete",
+        };
+      }
     }
     const offlineDelivery = requireFirst([
       "WAWebOfflineDelivery",

--- a/packages/connectors/src/whatsapp-web-helpers.ts
+++ b/packages/connectors/src/whatsapp-web-helpers.ts
@@ -15,7 +15,7 @@
 
 import type { EventEnvelope } from "@lobu/connector-sdk";
 
-export const WHATSAPP_ADAPTER_VERSION = 10;
+export const WHATSAPP_ADAPTER_VERSION = 11;
 export const WHATSAPP_ORIGIN = "https://web.whatsapp.com";
 const WHATSAPP_SOURCE = "whatsapp_web";
 const RECENT_OVERLAP_SECONDS = 15 * 60;

--- a/packages/connectors/src/whatsapp_web.ts
+++ b/packages/connectors/src/whatsapp_web.ts
@@ -305,6 +305,14 @@ async function invokeAdapter<T extends object>(
 
 const LOGGED_OUT_PATTERN = /logged_out|qr_code_visible/;
 /**
+ * The one readiness verdict a reload can fix: the account is authenticated and
+ * its stores are hydrated, but the live stream is gone, so the page serves
+ * cached state indefinitely. Matched on the message rather than the error
+ * prototype -- see classifyWhatsAppReadinessFailure for why that is the
+ * reliable half of an adapter failure.
+ */
+const STALLED_STREAM_PATTERN = /WhatsApp Web not_ready: stream_disconnected/;
+/**
  * `hydrating`/`stores_settling` are the adapter's own words for "the page is
  * still coming up", so they arrive prefixed as a WhatsAppAdapterError.
  */
@@ -372,20 +380,20 @@ async function readyWhatsAppTab(
       lastError = error;
       // A persistent scrape-owned tab can keep its cached stores after its
       // stream stalls, so nothing recovers on its own. Reload it once, inside
-      // the existing readiness deadline, deferred inside the page so navigation
-      // lets the expression return before navigation starts.
-      if (
-        !reloaded &&
-        error instanceof WhatsAppAdapterError &&
-        error.message === "WhatsApp Web not_ready: stream_disconnected"
-      ) {
+      // the existing readiness deadline, and defer the reload inside the page
+      // so the expression returns before navigation tears the world down.
+      // A dispatch that fails here is not a readiness verdict of its own:
+      // swallow it and keep polling on the error that triggered the reload.
+      if (!reloaded && STALLED_STREAM_PATTERN.test(String(error))) {
         reloaded = true;
-        await dispatcher.dispatch("evaluate", {
-          tab_id: tabId,
-          expression:
-            "(() => { setTimeout(() => location.reload(), 100); return true; })()",
-          await_promise: false,
-        });
+        await dispatcher
+          .dispatch("evaluate", {
+            tab_id: tabId,
+            expression:
+              "(() => { setTimeout(() => location.reload(), 100); return true; })()",
+            await_promise: false,
+          })
+          .catch(() => undefined);
       }
       if (LOGGED_OUT_PATTERN.test(String(error))) {
         throw new Error(

--- a/packages/connectors/src/whatsapp_web.ts
+++ b/packages/connectors/src/whatsapp_web.ts
@@ -362,6 +362,7 @@ async function readyWhatsAppTab(
   const tabId = await openWhatsAppTab(dispatcher);
   const deadline = Date.now() + timeoutMs;
   let lastError: unknown = null;
+  let reloaded = false;
   do {
     try {
       await ensureAdapter(dispatcher, tabId);
@@ -369,6 +370,23 @@ async function readyWhatsAppTab(
       return tabId;
     } catch (error) {
       lastError = error;
+      // A persistent scrape-owned tab can keep its cached stores after its
+      // stream stalls, so nothing recovers on its own. Reload it once, inside
+      // the existing readiness deadline, deferred inside the page so navigation
+      // lets the expression return before navigation starts.
+      if (
+        !reloaded &&
+        error instanceof WhatsAppAdapterError &&
+        error.message === "WhatsApp Web not_ready: stream_disconnected"
+      ) {
+        reloaded = true;
+        await dispatcher.dispatch("evaluate", {
+          tab_id: tabId,
+          expression:
+            "(() => { setTimeout(() => location.reload(), 100); return true; })()",
+          await_promise: false,
+        });
+      }
       if (LOGGED_OUT_PATTERN.test(String(error))) {
         throw new Error(
           "WhatsApp Web is not signed in on the paired Chrome. Open https://web.whatsapp.com and scan the QR from WhatsApp → Settings → Linked Devices, then retry."
@@ -628,7 +646,7 @@ export default class WhatsAppWebConnector extends ConnectorRuntime<
     name: "WhatsApp",
     description:
       "Personal WhatsApp messages read from WhatsApp Web in the paired Owletto Chrome. Syncs one-to-one and group chats, progressively hydrates history, and can search, draft, send, edit, react to, and revoke messages.",
-    version: "1.0.1",
+    version: "1.0.2",
     faviconDomain: "whatsapp.com",
     // Implicit auth: the user is already signed into WhatsApp Web in the
     // paired Chrome. There is no artifact to relay — the QR is rendered by


### PR DESCRIPTION
## Summary
WhatsApp Web can retain cached chats with an authenticated account while its live message stream is disconnected. Syncs previously reported success because readiness inspected module names the current web build no longer exposes.

Read the current socket model's account and stream states, reject unreadable state, and reload a disconnected scrape-owned tab once within the existing readiness deadline. Connector 1.0.2 and adapter 11 preserve connection, feed, checkpoint and message identity. Unpaired states keep polling during hydration; the existing QR check owns the sign-in remedy.

## Test plan
- [x] Intended five WhatsApp paths staged explicitly; `make pre-pr` passed.
- [x] Focused tests: `bun test packages/connectors/src/__tests__/whatsapp-web-adapter.test.ts packages/connectors/src/__tests__/whatsapp-web.connector.test.ts`.
- [x] Pre-review fixer ran the connector suite (416 pass), compiled adapter serialization test (1 pass), typecheck, and mutation checks for both stream rejection and reconnection.
- [x] Bug reproduced live: account `CONNECTED`, stream `DISCONNECTED`, old adapter probe `ready:true`; current socket module exported `Socket` while all three old module names returned null. Reload restored stream `CONNECTED`; two subsequent scheduled syncs collected 25 and 3 messages and advanced the persisted head.

Red before the fix:
```
70 pass
5 fail
Ran 75 tests across 2 files.
```
Green after the fix, including the final review adjustment:
```
76 pass
0 fail
Ran 76 tests across 2 files.
```

## Notes
No hosted UI change. Final GitHub CI and semantic review passed; UI review was not applicable.

Production verification on 2026-09-11: squash commit `0b557f09fa077580302082481ee230331de8f374` was live, with 9 smoke checks passed and 0 failed. The existing installed WhatsApp definition was upgraded in place to 1.0.2. Three subsequent scheduled syncs ran that version successfully and each collected two messages. The task-owned worktree has been cleaned up.
