### PR TITLE
fix(agents): make follow-up suggestions optional

### DIFF
--- a/packages/core/src/__tests__/agent-policy-harden.test.ts
+++ b/packages/core/src/__tests__/agent-policy-harden.test.ts
@@ -16,6 +16,7 @@ import {
   renderBaselineAgentPolicy,
   TOOL_RULES,
 } from "../agent-policy";
+import { SUGGESTION_LIMITS } from "../suggestions";
 
 // ── renderBaselineAgentPolicy ─────────────────────────────────────────────────
 
@@ -131,6 +132,23 @@ describe("getCustomToolDescription", () => {
     const desc = getCustomToolDescription("suggest_actions");
     expect(desc).toContain("follow-up");
     expect(desc).toContain("user's next turn");
+  });
+
+  test("makes suggest_actions optional and states its real delivery contract", () => {
+    const desc = getCustomToolDescription("suggest_actions");
+    expect(desc).toMatch(/optional/i);
+    expect(desc).toMatch(/skip/i);
+    expect(desc).toMatch(/at most once/i);
+    // The card is posted at tool-call time, not attached to the terminal reply
+    // (see the /internal/suggestions/create route), so the copy must not claim
+    // the chips hang under the reply or that a reply without them is broken.
+    expect(desc).toMatch(/immediately/i);
+    expect(desc).not.toMatch(
+      /always call|every reply|dead end|under your reply/i
+    );
+    // The ceiling in the copy is the one sanitizeSuggestionPrompts enforces —
+    // above it, extra prompts are silently dropped.
+    expect(desc).toContain(`${SUGGESTION_LIMITS.maxPrompts} is the ceiling`);
   });
 
   test("registers the event presentation and scoped follow-up tools", () => {

--- a/packages/core/src/agent-policy.ts
+++ b/packages/core/src/agent-policy.ts
@@ -71,7 +71,7 @@ export const CUSTOM_TOOL_METADATA: Record<string, CustomToolMetadata> = {
   },
   suggest_actions: {
     description:
-      'ALWAYS call this once before you finish replying, unless the user explicitly said they are done. Offer 2-4 follow-up actions as tappable chips under your reply. Each `message` is sent verbatim as the user\'s next turn, so write it in the user\'s voice ("Show me the diff", not "I can show you the diff"). This is non-blocking and is how users navigate — a reply without chips is a dead end. If the obvious next step is unclear, suggest ways to go deeper on what you just discussed.',
+      'Offer optional follow-up actions as tappable chips when the user asks for suggested next steps, or when a concrete choice would help them proceed. Default to a plain text reply: skip routine answers, acknowledgements, corrections, status updates, and requests you already completed, and respect an explicit ask for no suggestions or a closed topic. Do not invent extra work, repeat actions already offered, or defer work you should do now. One useful action is enough and 4 is the ceiling — never pad the list. Call at most once per turn. Each `message` is sent verbatim as the user\'s next turn, so write it in the user\'s voice ("Show me the diff", not "I can show you the diff"). This posts immediately, independently of the final reply, so each suggestion must make sense on its own. Non-blocking; finish your reply normally.',
   },
 };
 

--- a/packages/plugin-conversations/src/__tests__/plugin.test.ts
+++ b/packages/plugin-conversations/src/__tests__/plugin.test.ts
@@ -47,4 +47,20 @@ describe("conversation plugin", () => {
       ]);
     }
   });
+
+  test("describes suggestions as optional in both the tool and its argument", () => {
+    const tool = createConversationTools({ ...params, platform: "api" }).find(
+      (candidate) => candidate.name === "suggest_actions"
+    );
+    expect(tool?.description).toMatch(/optional/i);
+    const prompts = tool?.parameters.properties.prompts;
+    expect(prompts?.description).toMatch(/optional/i);
+    expect(prompts?.description).toMatch(/single/i);
+    // The old copy made a chipless reply a failure ("call this before finishing
+    // almost every reply — chips are how users navigate"), which is what
+    // produced padded suggestions on turns that needed none. Pin it out.
+    expect(JSON.stringify(tool)).not.toMatch(
+      /always call|every reply|chips are how|dead end|under your reply/i
+    );
+  });
 });

--- a/packages/plugin-conversations/src/index.ts
+++ b/packages/plugin-conversations/src/index.ts
@@ -482,7 +482,7 @@ export function createConversationTools(
           }),
           {
             description:
-              "2-3 follow-up actions to offer the user. Call this before finishing almost every reply — chips are how users navigate. Non-blocking; the turn continues.",
+              "Follow-up actions to offer the user (1-4). Only useful, optional next steps; a single action is enough, so do not pad the list. Skip this tool when no suggestion is needed.",
           }
         ),
       }),

--- a/packages/server/src/__tests__/unit/suggest-followups.test.ts
+++ b/packages/server/src/__tests__/unit/suggest-followups.test.ts
@@ -91,6 +91,38 @@ describe("suggest-followups guardrail", () => {
 });
 
 describe("generateSuggestFollowups", () => {
+  // The prompt used to demand "2-3 things" on every reply, so the model padded
+  // turns that needed nothing. It now instructs an empty set as the default,
+  // and an empty set must survive the parse/sanitize path as [] (the callers
+  // treat [] as "post no card").
+  test("instructs an empty default and returns [] for it", async () => {
+    let systemPrompt = "";
+    const original = globalThis.fetch;
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body));
+      systemPrompt = body.messages.find(
+        (message: { role: string }) => message.role === "system"
+      ).content;
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: '{"prompts":[]}' } }],
+        })
+      );
+    }) as unknown as typeof fetch;
+    restore = () => {
+      globalThis.fetch = original;
+    };
+
+    const out = await generateSuggestFollowups(REPLY, ORG, {
+      resolveTarget: target(),
+    });
+    expect(systemPrompt).toContain('{"prompts":[]}');
+    expect(systemPrompt).toMatch(/optional/i);
+    expect(systemPrompt).toMatch(/completed requests/i);
+    expect(systemPrompt).not.toMatch(/return 2-3 things/i);
+    expect(out).toEqual([]);
+  });
+
   test("parses well-formed prompts from the model", async () => {
     restore = stubFetch(
       JSON.stringify({

--- a/packages/server/src/gateway/guardrails/suggest-followups.ts
+++ b/packages/server/src/gateway/guardrails/suggest-followups.ts
@@ -3,8 +3,11 @@
  *
  * Not a safety trip: it never blocks a reply. When an agent enables it via
  * `guardrails: ["suggest-followups"]` and a turn ends without the agent calling
- * `suggest_actions`, the gateway derives 2–3 follow-up chips from the reply
- * and publishes them through the same persist + card path the tool uses.
+ * `suggest_actions`, the gateway may derive useful optional follow-up chips
+ * from the reply and post them as their own platform card. An empty set is the
+ * default: a complete answer needs no suggestions. Chat surfaces only — the
+ * API/web path deliberately skips enrichment (see unified-thread-consumer).
+ * Chat platforms retain the cards; the interaction bridge persists click routing.
  *
  * Ordering (critical): enrichment runs ONLY after blocking output guardrails
  * (`secret-scan`, `pii-scan`, …) have passed on the terminal text. The
@@ -68,8 +71,12 @@ const DEFAULT_TIMEOUT_MS = 60_000;
 const MIN_REPLY_CHARS = 40;
 
 const SYSTEM_PROMPT = [
-  "You write follow-up action chips for a chat UI.",
-  "Given an assistant's reply, return 2-3 things the USER would plausibly want next.",
+  "You decide whether an assistant's reply needs optional follow-up action chips.",
+  'Default to {"prompts":[]}. A complete answer does not need suggestions.',
+  "Only offer a concrete next step the reply itself leaves open and that would help the user proceed.",
+  "Return no suggestions for routine answers, acknowledgements, corrections, status updates, completed requests, or a reply that closes the topic.",
+  "Do not invent extra work or add a generic offer to explore further.",
+  "When useful next steps remain, return 1-3 distinct actions. A single useful action is enough; never pad the list.",
   "",
   'Each item is {"title","message"}:',
   '- "title": a short tappable label, at most 20 characters.',


### PR DESCRIPTION
## Summary
Lobu was instructed to call `suggest_actions` before almost every reply, and the automatic follow-up prompt also demanded a fixed number of suggestions. This produced unnecessary Slack button messages even for complete answers.

Make the shared tool guidance and argument help optional, allow one useful action without filler, and let automatic enrichment return an empty set. The tool guidance also covers closure, requests for no suggestions, repeated/completed work, and the fact that suggestions post immediately as a separate interaction.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` passed.
- [x] Commit-hook checks passed.
- [x] Focused policy, plugin, enrichment, and response-delivery tests: 77 passed, 0 failed.
- [x] Bug reproduced before changing the instructions:

```text
44 pass
3 fail
- shared instruction required suggestions
- tool argument description repeated the requirement
- enrichment prompt had no explicit empty-result path
```

After changing instructions and rebuilding core:

```text
77 pass
0 fail
Ran 77 tests across 4 files.
```

- [x] Real Claude Opus 5 evaluation using the shipped tool description/schema through a local MCP harness (delivery simulated): 11/11 revised-prompt cases passed. Eight routine/closed/completed cases produced no buttons; three explicit or useful unresolved-choice cases preserved suggestions, including one requested action. The latest baseline run produced unwanted suggestions in 2 of 3 cases.

## Notes
This changes prompt guidance. Suggestions remain available and keep their existing delivery order. Existing Slack button messages remain in scrollback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Follow-up suggestions are now optional and appear only when they provide useful next steps.
  - Completed or routine requests can return no suggestions.
  - Suggestions are limited to a small number of distinct actions and are posted separately from the main reply.

- **Bug Fixes**
  - Prevented repetitive, invented, or unnecessary suggestions.
  - Improved handling of empty suggestion results so they are preserved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->