### PR TITLE
fix(connectors): resume Calendar bootstrap without losing events

### DIFF
--- a/packages/connectors/src/__tests__/google_calendar.test.ts
+++ b/packages/connectors/src/__tests__/google_calendar.test.ts
@@ -76,6 +76,15 @@ function fakeHttp(pages: CalPage[]) {
   };
 }
 
+/**
+ * Checkpoint scope for the default config, spelled out on the wire rather than
+ * imported so a change to either the version or the tuple shape shows up here
+ * as the checkpoint invalidation it is.
+ */
+const SCOPE = JSON.stringify([2, 'primary', 30]);
+
+const originId = (event: { origin_id: string }) => event.origin_id;
+
 function calEvent(id: string, startIso: string) {
   return {
     id,
@@ -111,25 +120,179 @@ describe('GoogleCalendarConnector full sync', () => {
     expect(calls).toEqual([null, 'p2']);
   });
 
-  test('keeps paginating past max_results to reach the trailing sync token, but stops appending', async () => {
+  test.each(['events', 'changes'])(
+    'resumes a capped %s bootstrap without dropping unread events',
+    async (feedKey) => {
+      const connector = new GoogleCalendarConnector();
+      const { client, calls, urls } = fakeHttp([
+        // Page 1 overshoots the cap of 1 — both of its events must still land,
+        // because the cursor moves past them either way.
+        {
+          items: [
+            calEvent('a1', '2026-01-01T10:00:00Z'),
+            calEvent('a2', '2026-01-01T11:00:00Z'),
+          ],
+          nextPageToken: 'p2',
+        },
+        { items: [calEvent('b', '2026-01-02T10:00:00Z')], nextSyncToken: 'SYNC2' },
+      ]);
+      connector.client = () => client;
+      const ctx = {
+        feedKey,
+        config: { calendar_id: 'primary', max_results: 1 },
+        credentials: { accessToken: 'tok' },
+      };
+
+      // The cap stops the run after page 1, but page 1 is stored whole and its
+      // continuation is parked rather than discarded.
+      const first = await connector.sync({ ...ctx, checkpoint: {} });
+      expect(first.events.map(originId).sort()).toEqual(['a1', 'a2']);
+      expect(calls).toEqual([null]);
+      expect(first.checkpoint.sync_token).toBeUndefined();
+      expect(first.checkpoint.last_sync_at).toBeUndefined();
+      expect(first.checkpoint.pending.page_token).toBe('p2');
+
+      const second = await connector.sync({ ...ctx, checkpoint: first.checkpoint });
+      expect(second.events.map(originId)).toEqual(['b']);
+      expect(second.checkpoint.sync_token).toBe('SYNC2');
+      expect(second.checkpoint.pending).toBeUndefined();
+      expect(calls).toEqual([null, 'p2']);
+      // The resumed page must be requested against the window that minted it.
+      expect(new URL(urls[0]).searchParams.get('timeMin')).toBe(
+        new URL(urls[1]).searchParams.get('timeMin')
+      );
+    }
+  );
+
+  test('replays a legacy checkpoint once, because its window may be truncated', async () => {
     const connector = new GoogleCalendarConnector();
-    const { client } = fakeHttp([
-      { items: [calEvent('a', '2026-01-01T10:00:00Z')], nextPageToken: 'p2' },
-      { items: [calEvent('b', '2026-01-02T10:00:00Z')], nextSyncToken: 'SYNC2' },
+    const { client, urls } = fakeHttp([
+      { items: [calEvent('recovered', '2026-01-01T10:00:00Z')], nextSyncToken: 'COMPLETE' },
     ]);
     connector.client = () => client;
 
     const result = await connector.sync({
-      feedKey: 'events',
-      config: { calendar_id: 'primary', max_results: 1 }, // cap at 1 stored event
+      feedKey: 'changes',
+      config: {},
+      credentials: { accessToken: 'tok' },
+      checkpoint: { sync_token: 'LEGACY' },
+    });
+
+    expect(new URL(urls[0]).searchParams.has('syncToken')).toBe(false);
+    expect(result.events).toHaveLength(1);
+    // Rescoped, so the replay happens exactly once.
+    expect(result.checkpoint.scope).toBe(SCOPE);
+  });
+
+  test('parks an empty page that still carries a continuation', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client } = fakeHttp([{ items: [], nextPageToken: 'p2' }]);
+    connector.client = () => client;
+
+    const result = await connector.sync({
+      feedKey: 'changes',
+      config: {},
       credentials: { accessToken: 'tok' },
       checkpoint: {},
     });
 
-    // Only 1 event stored (cap), but the second page was still fetched so the
-    // trailing sync token is captured.
-    expect(result.events).toHaveLength(1);
-    expect(result.checkpoint.sync_token).toBe('SYNC2');
+    expect(result.checkpoint.pending.page_token).toBe('p2');
+    expect(result.checkpoint.last_sync_at).toBeUndefined();
+  });
+
+  test('rejects a self-referential bootstrap cursor instead of looping', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client } = fakeHttp([{ items: [], nextPageToken: 'loop' }]);
+    connector.client = () => client;
+
+    await expect(
+      connector.sync({
+        feedKey: 'changes',
+        config: {},
+        credentials: { accessToken: 'tok' },
+        checkpoint: {
+          scope: SCOPE,
+          pending: {
+            params: 'maxResults=250&singleEvents=true&showDeleted=true',
+            page_token: 'loop',
+          },
+        },
+      })
+    ).rejects.toThrow(/repeated page token/);
+  });
+
+  test('changing calendars discards the old cursors and reboots the lookback', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client, urls } = fakeHttp([
+      { items: [calEvent('other', '2026-01-01T10:00:00Z')], nextSyncToken: 'NEW' },
+    ]);
+    connector.client = () => client;
+
+    await connector.sync({
+      feedKey: 'changes',
+      config: { calendar_id: 'secondary' },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {
+        scope: SCOPE,
+        sync_token: 'WRONG',
+        pending: { params: 'maxResults=250', page_token: 'WRONG' },
+      },
+    });
+
+    const url = new URL(urls[0]);
+    expect(url.pathname).toContain('/secondary/events');
+    expect(url.searchParams.has('syncToken')).toBe(false);
+    expect(url.searchParams.has('pageToken')).toBe(false);
+    expect(url.searchParams.has('timeMin')).toBe(true);
+  });
+
+  test('a later-page provider failure fails the run instead of checkpointing it', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client } = fakeHttp([
+      { items: [calEvent('a', '2026-01-01T10:00:00Z')], nextPageToken: 'p2' },
+      { status: 503 },
+    ]);
+    connector.client = () => client;
+
+    // Throwing leaves the stored checkpoint untouched, so `p2` is retried whole
+    // rather than being recorded as reached.
+    await expect(
+      connector.sync({
+        feedKey: 'changes',
+        config: {},
+        credentials: { accessToken: 'tok' },
+        checkpoint: {},
+      })
+    ).rejects.toThrow(/503/);
+  });
+
+  test('incremental paging keeps its page size and fails closed at the safety bound', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client, urls } = fakeHttp(
+      Array.from({ length: 200 }, (_, i) => ({
+        items: [calEvent(String(i), '2026-01-01T10:00:00Z')],
+        nextPageToken: `page-${i + 1}`,
+      }))
+    );
+    connector.client = () => client;
+
+    // An incremental cursor only advances on the last page, so running out of
+    // pages has to fail rather than persist a partial batch.
+    await expect(
+      connector.sync({
+        feedKey: 'events',
+        config: { max_results: 2 },
+        credentials: { accessToken: 'tok' },
+        checkpoint: { scope: SCOPE, sync_token: 'CURRENT' },
+      })
+    ).rejects.toThrow(/page bound/);
+
+    expect(urls).toHaveLength(200);
+    // `max_results` caps the bootstrap only; it never shrinks the page size and
+    // with it the number of changes the bound can carry.
+    expect(new Set(urls.map((url) => new URL(url).searchParams.get('maxResults')))).toEqual(
+      new Set(['250'])
+    );
   });
 });
 
@@ -244,7 +407,7 @@ describe('GoogleCalendarConnector poisoned sync token recovery', () => {
       feedKey: 'events',
       config: { calendar_id: 'primary', max_results: 100 },
       credentials: { accessToken: 'tok' },
-      checkpoint: { sync_token: 'POISONED' },
+      checkpoint: { scope: SCOPE, sync_token: 'POISONED' },
     });
 
     // The poisoned token was tried once...
@@ -279,7 +442,7 @@ describe('GoogleCalendarConnector poisoned sync token recovery', () => {
         feedKey: 'events',
         config: { calendar_id: 'primary', max_results: 100 },
         credentials: { accessToken: 'tok' },
-        checkpoint: { sync_token: 'POISONED' },
+        checkpoint: { scope: SCOPE, sync_token: 'POISONED' },
       })
     ).rejects.toThrow(/insufficient authentication scopes/);
   });
@@ -297,7 +460,7 @@ describe('GoogleCalendarConnector poisoned sync token recovery', () => {
         feedKey: 'events',
         config: { calendar_id: 'primary', max_results: 100 },
         credentials: { accessToken: 'tok' },
-        checkpoint: { sync_token: 'GOOD' },
+        checkpoint: { scope: SCOPE, sync_token: 'GOOD' },
       })
     ).rejects.toThrow(/Daily Limit Exceeded/);
 
@@ -341,7 +504,7 @@ describe('GoogleCalendarConnector incremental sync', () => {
       feedKey: 'events',
       config: { calendar_id: 'primary', max_results: 100 },
       credentials: { accessToken: 'tok' },
-      checkpoint: { sync_token: 'STALE' },
+      checkpoint: { scope: SCOPE, sync_token: 'STALE' },
     });
 
     // Incremental attempt used the stale token; full sync recovered events + a
@@ -355,7 +518,7 @@ describe('GoogleCalendarConnector incremental sync', () => {
 describe('GoogleCalendarConnector source-readable events feed', () => {
   test('events supports sync and read while changes supports sync only', () => {
     const connector = new GoogleCalendarConnector();
-    expect(connector.definition.version).toBe('1.1.1');
+    expect(connector.definition.version).toBe('1.1.2');
     expect(typeof connector.definition.feeds.events.sync).toBe('function');
     expect(typeof connector.definition.feeds.events.read).toBe('function');
     expect(typeof connector.definition.feeds.changes.sync).toBe('function');
@@ -492,7 +655,7 @@ describe('GoogleCalendarConnector durable changes feed', () => {
       feedKey: 'changes',
       config: { calendar_id: 'primary', max_results: 1 },
       credentials: { accessToken: 'tok' },
-      checkpoint: { sync_token: 'OLD' },
+      checkpoint: { scope: SCOPE, sync_token: 'OLD' },
     });
 
     expect(
@@ -542,7 +705,7 @@ describe('GoogleCalendarConnector durable changes feed', () => {
         feedKey: 'changes',
         config: { calendar_id: 'primary', max_results: 100 },
         credentials: { accessToken: 'tok' },
-        checkpoint: { sync_token: 'OLD' },
+        checkpoint: { scope: SCOPE, sync_token: 'OLD' },
       })
     ).rejects.toThrow(/sync token/i);
   });

--- a/packages/connectors/src/google_calendar.ts
+++ b/packages/connectors/src/google_calendar.ts
@@ -56,7 +56,38 @@ interface CalendarEventListResponse {
 // Checkpoint
 // ---------------------------------------------------------------------------
 
+/**
+ * Leading element of `CalendarCheckpoint.scope`. Bumping it retires every
+ * stored checkpoint, because a cursor is only safe to resume when this exact
+ * code minted it. Bumped to 2 when the bootstrap became resumable: before that
+ * a capped run advanced the sync token after silently discarding the unread
+ * tail, so those tokens describe an incomplete window.
+ */
+const CHECKPOINT_SCOPE_VERSION = 2;
+
+/**
+ * Hard ceiling on pages fetched per run, shared by both traversals. At 250
+ * events/page that is 50k events — more than any reasonable calendar window,
+ * and the only bound when every item on a page is filtered out.
+ */
+const MAX_SYNC_PAGES = 200;
+
 interface CalendarCheckpoint {
+  /**
+   * Query identity this checkpoint's cursors belong to, as
+   * `[CHECKPOINT_SCOPE_VERSION, calendarId, lookbackDays]`. A checkpoint belongs
+   * to one configured feed; changing its calendar or lookback invalidates
+   * both cursors below.
+   * Absent or mismatched means "start a fresh bootstrap".
+   */
+  scope?: string;
+  /**
+   * Unfinished bootstrap: the `events.list` query as first issued (so the
+   * `timeMin`/`timeMax` window stays fixed across runs, which the page token
+   * requires) plus the token for the page still to fetch. Absent once the
+   * traversal has reached the last page.
+   */
+  pending?: { params: string; page_token: string };
   sync_token?: string;
   last_sync_at?: string;
 }
@@ -124,7 +155,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime<Record<str
     key: 'google.calendar',
     name: 'Google Calendar',
     description: 'Syncs calendar events from Google Calendar and supports creating new events.',
-    version: '1.1.1',
+    version: '1.1.2',
     faviconDomain: 'calendar.google.com',
     authSchema: {
       methods: [
@@ -219,7 +250,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime<Record<str
             max_results: {
               type: 'integer', minimum: 1, maximum: 2500, default: 100,
               description:
-                'Maximum events to persist during initial collection; incremental collections persist every change.',
+                'Soft cap on events per initial collection run: a provider page is never split, and remaining pages resume on the next run. Incremental collections persist every change.',
             },
           },
         },
@@ -429,106 +460,129 @@ export default class GoogleCalendarConnector extends ConnectorRuntime<Record<str
     const events: EventEnvelope[] = [];
     const durableChanges = ctx.feedKey === 'changes';
 
-    // No cursor-version guard: v1.1.0 changes tokens (minted without
-    // showDeleted) were retired by a one-time migration that cleared any
-    // unversioned changes checkpoint. Hosted prod carried exactly one such feed
-    // and it was already versioned, so the migration was a no-op. Self-hosted
-    // installs upgrading from that release with a v1.1.0 changes token are out
-    // of migration reach and may see Google reject the token under the current
-    // query shape; their recovery is to clear the feed checkpoint.
-    if (checkpoint.sync_token) {
+    // A checkpoint minted under a different scope (or by an older version that
+    // truncated its bootstrap) cannot be resumed: revisit the configured
+    // lookback once instead. Origin IDs are unchanged, so the replay supersedes
+    // the existing rows rather than duplicating them.
+    const scope = JSON.stringify([CHECKPOINT_SCOPE_VERSION, calendarId, lookbackDays]);
+    const resumable = checkpoint.scope === scope;
+
+    /** Traversal reached the last page: store its cursor and stamp the run. */
+    const finish = (items: EventEnvelope[], syncToken?: string): SyncResult => {
+      const result = this.buildResult(items, syncToken);
+      return { ...result, checkpoint: { ...result.checkpoint, scope } };
+    };
+
+    if (resumable && checkpoint.sync_token) {
       const result = await this.syncWithToken(
         http,
         calendarId,
         checkpoint.sync_token,
-        maxResults,
         durableChanges
       );
-      if (result) {
-        return this.buildResult(result.events, result.nextSyncToken);
-      }
+      if (result) return finish(result.events, result.nextSyncToken);
       // The stored token was rejected (see isSyncTokenRejection). Fall through
-      // to a full sync exactly once — no retry loop. The full sync below either
-      // succeeds and overwrites the checkpoint with a token minted under the
-      // current grant, or throws (the scope is genuinely missing) and the error
-      // reaches the run record instead of being swallowed.
+      // to one complete bootstrap under the current grant — no retry loop. It
+      // either succeeds and overwrites the checkpoint with a token minted under
+      // that grant, or throws and the error reaches the run record.
     }
 
-    // Full sync
+    // Bootstrap: walk the configured window, resuming a parked page if one is
+    // in scope, until the last page hands over a durable cursor.
     const timeMin = new Date();
     timeMin.setDate(timeMin.getDate() - lookbackDays);
     const timeMax = new Date();
     timeMax.setDate(timeMax.getDate() + 365); // Include future events
 
-    let nextSyncToken: string | undefined;
+    const pending = resumable ? checkpoint.pending : undefined;
+    // Google permits timeMin on the initial full sync but forbids it with
+    // syncToken. Once issued, the query is replayed verbatim on every resuming
+    // run: a page token is only valid against the window that minted it.
+    const params = pending
+      ? new URLSearchParams(pending.params)
+      : durableChanges
+        ? new URLSearchParams({
+            maxResults: '250',
+            singleEvents: 'true',
+            showDeleted: 'true',
+            timeMin: timeMin.toISOString(),
+          })
+        : new URLSearchParams({
+            maxResults: '250',
+            orderBy: 'startTime',
+            singleEvents: 'true',
+            timeMin: timeMin.toISOString(),
+            timeMax: timeMax.toISOString(),
+          });
+    const baseParams = params.toString();
 
-    // Safety bound — at 250 events/page, 200 pages = 50k events, more than
-    // any reasonable calendar window. Stops a runaway loop if the upstream
-    // ever returns a self-referential page token.
-    const MAX_PAGES = 200;
+    /**
+     * Ran out of budget mid-traversal: park the next page token and return no
+     * sync token and no `last_sync_at`, so nothing downstream can read this run
+     * as a completed window. The next scheduled run resumes from `token`.
+     */
+    const park = (token: string): SyncResult => ({
+      ...this.buildResult(events, undefined),
+      checkpoint: { scope, pending: { params: baseParams, page_token: token } },
+    });
 
-    const pages = paginateByCursor<CalendarEvent, string>(
-      async (pageToken) => {
-        // Google permits timeMin on the initial full sync but forbids it with
-        // syncToken. Other durable parameters remain stable across both paths.
-        const params = durableChanges
-          ? new URLSearchParams({
-              maxResults: '250',
-              singleEvents: 'true',
-              showDeleted: 'true',
-              timeMin: timeMin.toISOString(),
-            })
-          : new URLSearchParams({
-              maxResults: '250',
-              orderBy: 'startTime',
-              singleEvents: 'true',
-              timeMin: timeMin.toISOString(),
-              timeMax: timeMax.toISOString(),
-            });
-        if (pageToken) {
-          params.set('pageToken', pageToken);
-        }
+    let pageToken = pending?.page_token;
+    const seenTokens = new Set<string>();
+    for (let page = 0; ; page++) {
+      if (pageToken) {
+        seenTokens.add(pageToken);
+        params.set('pageToken', pageToken);
+      }
 
-        const url = `${this.BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events?${params.toString()}`;
-        const response = await http.raw(url);
+      const url = `${this.BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events?${params.toString()}`;
+      const response = await http.raw(url);
+      if (!response.ok) {
+        // No checkpoint is returned, so the parked token survives and this
+        // exact page is retried on the next run.
+        throw new Error(
+          `Calendar events.list error (${response.status}): ${await response.text()}`
+        );
+      }
 
-        if (!response.ok) {
-          throw new Error(
-            `Calendar events.list error (${response.status}): ${await response.text()}`
-          );
-        }
-
-        const data = (await response.json()) as CalendarEventListResponse;
-        // Google only returns nextSyncToken on the LAST page (no nextPageToken).
-        // Capture it whenever present so the trailing value survives; the
-        // generator keeps paging until nextPageToken is exhausted, otherwise the
-        // sync token is never obtained and every subsequent sync re-runs the full
-        // window from scratch.
-        nextSyncToken = data.nextSyncToken;
-        return { items: data.items ?? [], nextCursor: data.nextPageToken };
-      },
-      { maxPages: MAX_PAGES }
-    );
-
-    // Keep paginating past `maxResults`, just stop appending events once the cap
-    // is reached, so the trailing nextSyncToken is still captured.
-    for await (const items of pages) {
+      const data = (await response.json()) as CalendarEventListResponse;
+      const items = data.items ?? [];
+      // A provider page is atomic: `max_results` caps how much a run starts,
+      // never how much of a fetched page is stored. Dropping a page's tail
+      // would lose those events for good once the cursor moved past them.
       for (const calEvent of items) {
-        if (events.length >= maxResults) break;
         const envelope = durableChanges
           ? this.calendarEventToChangeEnvelope(calEvent)
           : this.calendarEventToEnvelope(calEvent);
         if (envelope) events.push(envelope);
       }
-    }
 
-    if (durableChanges && !nextSyncToken) {
-      throw new Error(
-        'Google Calendar changes traversal completed without a durable sync token.'
-      );
-    }
+      // Google only returns nextSyncToken on the LAST page (no nextPageToken),
+      // so the traversal has to reach it before the feed can go incremental.
+      if (!data.nextPageToken) {
+        if (durableChanges && !data.nextSyncToken) {
+          throw new Error(
+            'Google Calendar changes traversal completed without a durable sync token.'
+          );
+        }
+        return finish(events, data.nextSyncToken);
+      }
+      if (seenTokens.has(data.nextPageToken)) {
+        throw new Error('Google Calendar returned a repeated page token.');
+      }
+      pageToken = data.nextPageToken;
 
-    return this.buildResult(events, nextSyncToken);
+      // Stop once this run has collected its share, once the provider returns
+      // an empty page, or at the hard ceiling — the last of which is the only
+      // bound on a window of nothing but filtered-out items, where
+      // `events.length` never reaches the cap.
+      if (
+        events.length >= maxResults ||
+        items.length === 0 ||
+        page + 1 >= MAX_SYNC_PAGES
+      ) {
+        return park(pageToken);
+      }
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -575,23 +629,28 @@ export default class GoogleCalendarConnector extends ConnectorRuntime<Record<str
     http: HttpClient,
     calendarId: string,
     syncToken: string,
-    maxResults: number,
     durableChanges: boolean
   ): Promise<{ events: EventEnvelope[]; nextSyncToken?: string } | null> {
     const events: EventEnvelope[] = [];
     let nextSyncToken: string | undefined;
+    let unreadPage: string | undefined;
+    const seenTokens = new Set<string>();
     // The stored syncToken was rejected (410 expired, or 403 because it was
     // minted under a superseded grant) — abort and let the caller drop it and
     // fall through to a full sync. Signalled out of the generator via this flag.
     let syncTokenRejected = false;
 
-    // Same hard ceiling as the full-sync path — defensive only.
-    const MAX_PAGES = 200;
-
     const pages = paginateByCursor<CalendarEvent, string>(
       async (pageToken) => {
-        // Consume every incremental change before advancing the durable token;
-        // max_results limits only the historical bootstrap.
+        if (pageToken) {
+          if (seenTokens.has(pageToken)) {
+            throw new Error('Google Calendar returned a repeated page token.');
+          }
+          seenTokens.add(pageToken);
+        }
+        // Consume every incremental change before advancing the durable token,
+        // so the page size is fixed rather than derived from `max_results`,
+        // which limits only the historical bootstrap.
         const params = durableChanges
           ? new URLSearchParams({
               maxResults: '250',
@@ -600,7 +659,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime<Record<str
               showDeleted: 'true',
             })
           : new URLSearchParams({
-              maxResults: String(Math.max(1, Math.min(250, maxResults - events.length))),
+              maxResults: '250',
               syncToken,
             });
         if (pageToken) {
@@ -622,9 +681,10 @@ export default class GoogleCalendarConnector extends ConnectorRuntime<Record<str
         const data = (await response.json()) as CalendarEventListResponse;
         // Capture the trailing nextSyncToken; generator pages until exhausted.
         nextSyncToken = data.nextSyncToken;
+        unreadPage = data.nextPageToken;
         return { items: data.items ?? [], nextCursor: data.nextPageToken };
       },
-      { maxPages: MAX_PAGES }
+      { maxPages: MAX_SYNC_PAGES }
     );
 
     for await (const items of pages) {
@@ -637,6 +697,15 @@ export default class GoogleCalendarConnector extends ConnectorRuntime<Record<str
     }
 
     if (syncTokenRejected) return null;
+    // The generator stopped at MAX_SYNC_PAGES with a page still unread. Unlike
+    // the bootstrap there is nothing to park — an incremental cursor advances
+    // only on the last page — so fail the run and keep the stored token, rather
+    // than returning a silently partial batch.
+    if (unreadPage) {
+      throw new Error(
+        'Google Calendar incremental traversal exceeded its page bound before completing.'
+      );
+    }
     if (durableChanges && !nextSyncToken) {
       throw new Error(
         'Google Calendar incremental changes traversal completed without a durable sync token.'


### PR DESCRIPTION
## Summary
Google Calendar bootstrap fetched all pages but discarded events beyond max_results, then advanced its sync token. The next run could never recover those unchanged events.

Persist complete pages and resume unfinished bootstraps on later runs using the same query. Retire old, potentially incomplete checkpoints once and replay the configured lookback with stable origin IDs. Incremental sync fails visibly if its page bound leaves unread changes.

## Test plan
- [x] Focused regression: before fix 15 pass / 4 fail; after fix 23 pass / 0 fail.
- [x] Full connector suite: 416 pass / 0 fail; connector typecheck clean.
- [x] Mutation checks: restoring the within-page drop fails both feed variants; removing scope validation fails two recovery tests.
- [x] make review-fix completed; changes reread. make pre-pr clean. Exact two intended files committed.
- [x] GitHub CI and exact-head Codex review passed; no bugs or blockers reported.
- [x] Squash revision `db1ed9aef899f2273f065844ea8e9fd5e4334c35` deployed; production smoke: 9 passed / 0 failed.
- [x] Existing Calendar definition upgraded in place to 1.1.2. Three live feed syncs completed successfully, processing 1,224 records, with unchanged connections and OAuth grants.
- [x] Subsequent normal scheduled syncs on 1.1.2 completed successfully for the event feed (15 records) and all three changes feeds (0 new records after the recovered imports).

## Notes
Uses the existing feed config and checkpoint contract. max_results is a soft per-run bootstrap cap: an already-fetched page is persisted in full. A provider rejection of a parked page token remains a visible failure; no silent skipping or deletion. No new authorization scopes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Google Calendar synchronization now resumes incomplete initial imports instead of losing remaining pages.
  - Incremental synchronization uses consistent paging and preserves progress when limits or provider errors interrupt a run.
  - Added safeguards against repeated pagination cursors and invalid or outdated saved progress.
  - Improved handling for empty pages, calendar changes, token recovery, and expired credentials.

- **Configuration**
  - Updated the maximum-results setting description to clarify its soft-limit and resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->