### PR TITLE
fix(connectors): persist complete Gmail threads without skipping pages

### DIFF
--- a/docs/connector-authoring.md
+++ b/docs/connector-authoring.md
@@ -119,8 +119,9 @@ directly because their executable handlers live elsewhere.
   the caller without persisting them.
 - **Both** lets a connector maintain a small, searchable index while retaining
   an explicit path to source-owned detail. Gmail can sync a filtered set of
-  threads yet read any message on demand; SQL and warehouse connectors can
-  materialize selected queries while pushing ad-hoc compute to the database.
+  threads yet search the wider mailbox on demand; SQL and warehouse connectors
+  can materialize selected queries while pushing ad-hoc compute to the
+  database.
 
 `configSchema` governs the persisted feed instance across every handler.
 Top-level `required` fields are enforced for read-only, sync-only, and hybrid

--- a/docs/connector-authoring.md
+++ b/docs/connector-authoring.md
@@ -118,8 +118,8 @@ directly because their executable handlers live elsewhere.
 - **`read`** pushes filtering and pagination to the source and returns rows to
   the caller without persisting them.
 - **Both** lets a connector maintain a small, searchable index while retaining
-  an explicit path to source-owned detail. Gmail can sync selected metadata yet
-  read complete messages on demand; SQL and warehouse connectors can
+  an explicit path to source-owned detail. Gmail can sync a filtered set of
+  threads yet read any message on demand; SQL and warehouse connectors can
   materialize selected queries while pushing ad-hoc compute to the database.
 
 `configSchema` governs the persisted feed instance across every handler.

--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -16,6 +16,7 @@ beforeAll(async () => {
 
 interface FakeMessage {
   id: string;
+  body?: string;
   labelIds?: string[];
   from?: string;
   to?: string;
@@ -56,7 +57,14 @@ function fakeHttp(
       }
       const body = threadMatch
         ? toThreadResponse(byId.get(threadMatch[1]))
-        : { threads: threads.map((t) => ({ id: t.id, historyId: '1', snippet: 's' })) };
+        : (() => {
+            const start = Number(u.searchParams.get('pageToken') ?? 0);
+            const limit = Number(u.searchParams.get('maxResults') ?? 100);
+            return {
+              threads: threads.slice(start, start + limit).map((t) => ({ id: t.id, historyId: '1', snippet: 's' })),
+              ...(start + limit < threads.length ? { nextPageToken: String(start + limit) } : {}),
+            };
+          })();
       return {
         ok: true,
         status: 200,
@@ -80,6 +88,7 @@ function toThreadResponse(thread: FakeThread | undefined) {
       internalDate: String(Date.parse(m.date ?? '2026-07-01T10:00:00Z')),
       payload: {
         mimeType: 'text/plain',
+        ...(m.body ? { body: { data: Buffer.from(m.body).toString('base64url') } } : {}),
         headers: [
           { name: 'Subject', value: `subject ${thread.id}` },
           { name: 'From', value: m.from ?? 'Some One <someone@example.com>' },
@@ -150,9 +159,7 @@ test('person-building sync requests its label union and attribution headers', as
 
   expect(new URL(urls[0]).searchParams.get('q')).toContain('{label:INBOX label:SENT}');
   const threadUrl = urls.find((url) => url.includes('/threads/t-human')) ?? '';
-  for (const header of ['To', 'Cc', 'List-Id', 'Precedence']) {
-    expect(threadUrl).toContain(`metadataHeaders=${header}`);
-  }
+  expect(new URL(threadUrl).searchParams.get('format')).toBe('full');
 });
 
 describe('Gmail replied signal (promote-on-interaction)', () => {
@@ -204,7 +211,7 @@ describe('Gmail replied signal (promote-on-interaction)', () => {
 
 describe('Gmail person attribution rule', () => {
   test('bumps the connector version for the changed sync contract', () => {
-    expect(new GmailConnector().definition.version).toBe('1.0.4');
+    expect(new GmailConnector().definition.version).toBe('1.0.5');
   });
 
   test('autoCreate is gated on person_relevant, with a legacy replied rule for pre-refresh payloads', () => {
@@ -639,5 +646,131 @@ describe('Gmail write scope', () => {
       expect(actions[key]).toBeDefined();
       expect(actions[key].key).toBe(key);
     }
+  });
+});
+
+describe('complete Gmail sync input', () => {
+  const context = (checkpoint: Record<string, unknown> = {}, config: Record<string, unknown> = {}) => ({
+    feedKey: 'threads', credentials: { accessToken: 'synthetic-token' }, checkpoint, config,
+  });
+
+  test('stores full text of every reply and dates the thread by its newest message', async () => {
+    const connector = new GmailConnector();
+    const urls: string[] = [];
+    connector.createClient = () => fakeHttp([{ id: 'thread-full', messages: [
+      { id: 'first', date: '2026-07-01T10:00:00Z', body: 'Original request with details past the snippet.' },
+      { id: 'reply', date: '2026-07-02T11:00:00Z', body: 'The work is complete. Teşekkürler.' },
+    ] }], (url) => urls.push(url));
+    const result = await connector.sync(context());
+    expect(result.events[0].payload_text).toContain('Original request with details past the snippet.');
+    expect(result.events[0].payload_text).toContain('The work is complete. Teşekkürler.');
+    expect(result.events[0].occurred_at.toISOString()).toBe('2026-07-02T11:00:00.000Z');
+    expect(new URL(urls[1]).searchParams.get('format')).toBe('full');
+    expect(result.events[0].origin_id).toBe('thread-full');
+  });
+
+  test('honors the already-declared search scope instead of silently using INBOX', async () => {
+    const connector = new GmailConnector();
+    const urls: string[] = [];
+    connector.createClient = () => fakeHttp([], (url) => urls.push(url));
+    await connector.sync(context({}, { query: '-in:spam -in:trash', labels: ['INBOX', 'SENT'] }));
+    const query = new URL(urls[0]).searchParams.get('q');
+    expect(query).toContain('-in:spam -in:trash');
+    expect(query).not.toContain('label:INBOX');
+  });
+
+  test('resumes the next page without advancing past unprocessed mail', async () => {
+    const connector = new GmailConnector();
+    const urls: string[] = [];
+    connector.createClient = () => ({ raw: async (url: string) => {
+      urls.push(url);
+      const u = new URL(url);
+      const id = u.pathname.match(/\/threads\/([^/]+)$/)?.[1];
+      return { ok: true, status: 200, json: async () => id
+        ? toThreadResponse({ id, messages: [{ id: 'm-' + id, body: id }] })
+        : u.searchParams.get('pageToken') === 'page-two'
+          ? { threads: [{ id: 'older' }] }
+          : { threads: [{ id: 'newer' }], nextPageToken: 'page-two' },
+      };
+    } });
+    const prior = { last_sync_at: '2026-07-01T00:00:00Z' };
+    const first = await connector.sync(context(prior, { max_results: 1 }));
+    expect(first.checkpoint.last_sync_at).toBeUndefined();
+    expect(first.checkpoint.pending.page_token).toBe('page-two');
+    // A different lookback must not re-cut a window that is mid-walk: the stored
+    // page token only means anything against the query it was issued for.
+    const second = await connector.sync(context(first.checkpoint, { max_results: 1, lookback_days: 1 }));
+    expect(first.events.map((event) => event.origin_id)).toEqual(['newer']);
+    expect(second.events.map((event) => event.origin_id)).toEqual(['older']);
+    const lists = urls.filter((url) => !new URL(url).pathname.match(/\/threads\//)).map((url) => new URL(url));
+    expect(lists[1].searchParams.get('pageToken')).toBe('page-two');
+    expect(lists[1].searchParams.get('q')).toBe(lists[0].searchParams.get('q'));
+    expect(new Date(second.checkpoint.last_sync_at).getTime()).toBeGreaterThan(Date.parse(prior.last_sync_at));
+  });
+
+  test('keeps an empty page with a continuation token pending', async () => {
+    const connector = new GmailConnector();
+    connector.createClient = () => ({ raw: async () => ({
+      ok: true, json: async () => ({ threads: [], nextPageToken: 'continue-empty' }),
+    }) });
+    const prior = { last_sync_at: '2026-07-01T00:00:00Z' };
+    const result = await connector.sync(context(prior));
+    expect(result.events).toEqual([]);
+    expect(result.checkpoint.last_sync_at).toBeUndefined();
+    expect(result.checkpoint.pending.page_token).toBe('continue-empty');
+  });
+
+  test('rejects a repeated token instead of recording a completed window', async () => {
+    const connector = new GmailConnector();
+    connector.createClient = () => ({ raw: async () => ({
+      ok: true, json: async () => ({ threads: [], nextPageToken: 'same' }),
+    }) });
+    await expect(connector.sync(context({ schema_version: 2, scope: JSON.stringify(['label:INBOX', false]), pending: {
+      query: 'after:1 before:2 (label:INBOX)',
+      started_at: '2026-07-02T00:00:00Z', page_token: 'same',
+    } }))).rejects.toThrow('repeated page token');
+  });
+
+  test('revisits the lookback when replacing snippet checkpoints or widening the filter', async () => {
+    const connector = new GmailConnector();
+    const urls: string[] = [];
+    connector.createClient = () => fakeHttp([], (url) => urls.push(url));
+    const old = { last_sync_at: new Date(Date.now() - 60_000).toISOString() };
+    const first = await connector.sync(context(old, { lookback_days: 30 }));
+    const after = Number(new URL(urls[0]).searchParams.get('q')?.match(/after:(\d+)/)?.[1]);
+    expect(after).toBeLessThan(Date.parse(old.last_sync_at) / 1000 - 29 * 86400);
+    expect(first.checkpoint.schema_version).toBe(2);
+    await connector.sync(context(first.checkpoint, { query: '-in:spam -in:trash', lookback_days: 30 }));
+    const widenedAfter = Number(new URL(urls[1]).searchParams.get('q')?.match(/after:(\d+)/)?.[1]);
+    expect(widenedAfter).toBeLessThan(Date.parse(old.last_sync_at) / 1000 - 29 * 86400);
+  });
+
+  test('preserves a long body including actions beyond an arbitrary preview cap', async () => {
+    const connector = new GmailConnector();
+    const body = 'x'.repeat(200_000) + ' Please submit the signed agreement.';
+    connector.createClient = () => fakeHttp([{ id: 'thread-long', messages: [{ id: 'long', body }] }]);
+    const result = await connector.sync(context());
+    expect(result.events[0].payload_text).toContain(body);
+  });
+
+  test.each(['empty', 'undated'])('does not advance past malformed %s thread data', async (kind) => {
+    const connector = new GmailConnector();
+    connector.createClient = () => ({ raw: async (url: string) => ({
+      ok: true, status: 200, json: async () => url.includes('/threads/')
+        ? kind === 'empty' ? { id: kind, messages: [] }
+          : toThreadResponse({ id: kind, messages: [{ id: 'm', date: 'invalid-date' }] })
+        : { threads: [{ id: kind }] },
+    }) });
+    await expect(connector.sync(context())).rejects.toThrow(/Gmail returned/);
+  });
+
+  test('does not checkpoint past a failed thread fetch', async () => {
+    const connector = new GmailConnector();
+    connector.createClient = () => ({ raw: async (url: string) =>
+      url.includes('/threads/')
+        ? { ok: false, status: 503, text: async () => 'provider unavailable' }
+        : { ok: true, json: async () => ({ threads: [{ id: 'retry-me' }] }) },
+    });
+    await expect(connector.sync(context())).rejects.toThrow(/503/);
   });
 });

--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -32,7 +32,7 @@ interface FakeThread {
 }
 
 /**
- * Fake Gmail HTTP client: serves threads.list (one page) and threads/<id>
+ * Fake Gmail HTTP client: serves paginated threads.list and threads/<id>
  * lookups from the given fixtures. Header values come from the per-message
  * `from`/`date` fields; snippets are constant. `failThreadIds` respond 404.
  */
@@ -900,5 +900,112 @@ describe('Gmail externally stored message bodies', () => {
   test('a failed external body fetch cannot advance the sync checkpoint', async () => {
     const { connector } = setup(503);
     await expect(connector.sync(syncContext)).rejects.toThrow(/503/);
+  });
+});
+
+describe('Gmail empty MIME alternatives', () => {
+  const html = '<p>Please confirm the delivery date.</p>';
+  const context = { feedKey: 'threads', config: {}, checkpoint: {}, credentials: { accessToken: 'synthetic-token' } };
+
+  function setup(plainBody: Record<string, unknown>, attachmentStatus = 200) {
+    const connector = new GmailConnector();
+    const thread = toThreadResponse({ id: 'alternatives', messages: [{ id: 'message' }] });
+    const payload = {
+      ...thread.messages[0].payload,
+      mimeType: 'multipart/alternative',
+      parts: [
+        { mimeType: 'text/plain', body: plainBody },
+        { mimeType: 'text/html', body: { data: Buffer.from(html).toString('base64url') } },
+      ],
+    };
+    connector.createClient = () => ({ raw: async (url: string) => ({
+      ok: !url.includes('/attachments/') || attachmentStatus === 200,
+      status: attachmentStatus,
+      text: async () => 'body unavailable',
+      json: async () => url.includes('/attachments/') ? { data: '' }
+        : url.includes('/threads/') ? { ...thread, messages: [{ ...thread.messages[0], payload }] }
+        : { threads: [{ id: 'alternatives' }] },
+    }) });
+    return connector;
+  }
+
+  for (const mode of ['sync', 'get_thread']) {
+    test.each([
+      ['empty inline', { data: '', size: 0 }],
+      ['absent', {}],
+      ['whitespace', { data: Buffer.from(' \r\n').toString('base64url') }],
+      ['empty external', { attachmentId: 'empty-body', size: 0 }],
+    ] as const)(`${mode} falls back to HTML for %s plain text`, async (_name, body) => {
+      const connector = setup(body);
+      const text = mode === 'sync'
+        ? (await connector.sync(context)).events[0].payload_text
+        : (await connector.execute({ actionKey: 'get_thread', input: { thread_id: 'alternatives' }, credentials: context.credentials })).output.messages[0].body;
+      expect(text).toContain(html);
+    });
+  }
+
+  test.each([
+    ['missing nonempty body', { size: 12 }, 200],
+    ['unavailable external body', { attachmentId: 'unavailable', size: 12 }, 503],
+    ['empty external response for nonempty body', { attachmentId: 'nonempty', size: 12 }, 200],
+  ] as const)('does not checkpoint past a %s despite a readable HTML alternative', async (_name, body, status) => {
+    await expect(setup(body, status).sync(context)).rejects.toThrow(/body/);
+  });
+});
+
+describe('Gmail multipart body sections', () => {
+  const context = { feedKey: 'threads', config: {}, checkpoint: {}, credentials: { accessToken: 'synthetic-token' } };
+  const inline = (mimeType: string, text: string) => ({
+    mimeType, body: { data: Buffer.from(text).toString('base64url') },
+  });
+
+  function setup(externalStatus = 200) {
+    const connector = new GmailConnector();
+    const urls: string[] = [];
+    const thread = toThreadResponse({ id: 'mixed-body', messages: [{ id: 'mixed-message' }] });
+    const payload = {
+      ...thread.messages[0].payload,
+      mimeType: 'multipart/mixed',
+      parts: [
+        {
+          mimeType: 'multipart/alternative',
+          parts: [inline('text/html', '<p>HTML duplicate</p>'), inline('text/plain', 'Opening section.')],
+        },
+        {
+          mimeType: 'multipart/alternative',
+          parts: [inline('text/plain', ''), inline('text/html', '<p>HTML-only middle section.</p>')],
+        },
+        { mimeType: 'text/plain', body: { attachmentId: 'inline-tail' } },
+        { mimeType: 'text/plain', headers: [{ name: 'Content-Disposition', value: 'attachment' }], body: { attachmentId: 'excluded' } },
+      ],
+    };
+    connector.createClient = () => ({ raw: async (url: string) => {
+      urls.push(url);
+      return {
+        ok: !url.includes('/attachments/') || externalStatus === 200,
+        status: externalStatus,
+        text: async () => 'body unavailable',
+        json: async () => url.includes('/attachments/') ? { data: Buffer.from('Please sign the final section.').toString('base64url') }
+          : url.includes('/threads/') ? { ...thread, messages: [{ ...thread.messages[0], payload }] }
+          : { threads: [{ id: thread.id }] },
+      };
+    } });
+    return { connector, urls };
+  }
+
+  test.each(['sync', 'get_thread'])('%s retains every inline section without duplicating alternatives', async (mode) => {
+    const { connector, urls } = setup();
+    const body = mode === 'sync'
+      ? (await connector.sync(context)).events[0].payload_text
+      : (await connector.execute({ actionKey: 'get_thread', input: { thread_id: 'mixed-body' }, credentials: context.credentials })).output.messages[0].body;
+    expect(body).toContain('Opening section.\n\n<p>HTML-only middle section.</p>\n\nPlease sign the final section.');
+    expect(body).not.toContain('HTML duplicate');
+    expect(urls.filter((url) => url.includes('/attachments/'))).toEqual([
+      'https://www.googleapis.com/gmail/v1/users/me/messages/mixed-message/attachments/inline-tail',
+    ]);
+  });
+
+  test('does not checkpoint past a failed later inline section', async () => {
+    await expect(setup(503).connector.sync(context)).rejects.toThrow(/503/);
   });
 });

--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -764,6 +764,54 @@ describe('complete Gmail sync input', () => {
     await expect(connector.sync(context())).rejects.toThrow(/Gmail returned/);
   });
 
+  test('restarts the window when Gmail retires the stored page token', async () => {
+    const connector = new GmailConnector();
+    const urls: string[] = [];
+    connector.createClient = () => ({
+      raw: async (url: string) => {
+        urls.push(url);
+        const u = new URL(url);
+        const id = u.pathname.match(/\/threads\/([^/]+)$/)?.[1];
+        if (id) return { ok: true, status: 200, json: async () => toThreadResponse({ id, messages: [{ id: `m-${id}` }] }) };
+        if (u.searchParams.get('pageToken') === 'retired') {
+          return { ok: false, status: 400, text: async () => 'Invalid pageToken' };
+        }
+        return { ok: true, status: 200, json: async () => ({ threads: [{ id: 'first-page' }] }) };
+      },
+    });
+    const result = await connector.sync(
+      context({
+        schema_version: 2,
+        scope: JSON.stringify(['label:INBOX', false]),
+        pending: { query: 'after:1 before:2 (label:INBOX)', started_at: '2026-07-02T00:00:00Z', page_token: 'retired' },
+      })
+    );
+    // Same window, first page — not a fresh window, and not a wedged run.
+    const lists = urls.filter((url) => !url.includes('/threads/'));
+    expect(lists).toHaveLength(2);
+    expect(new URL(lists[1]).searchParams.get('pageToken')).toBeNull();
+    expect(new URL(lists[1]).searchParams.get('q')).toBe('after:1 before:2 (label:INBOX)');
+    expect(result.events.map((event) => event.origin_id)).toEqual(['first-page']);
+    expect(result.checkpoint.last_sync_at).toBe('2026-07-02T00:00:00Z');
+    expect(result.checkpoint.pending).toBeUndefined();
+  });
+
+  test('propagates a non-cursor list failure instead of restarting the window', async () => {
+    const connector = new GmailConnector();
+    connector.createClient = () => ({
+      raw: async () => ({ ok: false, status: 429, text: async () => 'rate limited' }),
+    });
+    await expect(
+      connector.sync(
+        context({
+          schema_version: 2,
+          scope: JSON.stringify(['label:INBOX', false]),
+          pending: { query: 'after:1 before:2 (label:INBOX)', started_at: '2026-07-02T00:00:00Z', page_token: 'live' },
+        })
+      )
+    ).rejects.toThrow(/429/);
+  });
+
   test('does not checkpoint past a failed thread fetch', async () => {
     const connector = new GmailConnector();
     connector.createClient = () => ({ raw: async (url: string) =>
@@ -772,5 +820,85 @@ describe('complete Gmail sync input', () => {
         : { ok: true, json: async () => ({ threads: [{ id: 'retry-me' }] }) },
     });
     await expect(connector.sync(context())).rejects.toThrow(/503/);
+  });
+});
+
+describe('Gmail externally stored message bodies', () => {
+  const BODY = 'Full body: please sign the agreement.';
+  const syncContext = {
+    feedKey: 'threads',
+    config: {},
+    checkpoint: {},
+    credentials: { accessToken: 'synthetic-token' },
+  };
+
+  function setup(attachmentStatus = 200) {
+    const connector = new GmailConnector();
+    const urls: string[] = [];
+    connector.createClient = () => ({
+      raw: async (url: string) => {
+        urls.push(url);
+        const attachment = url.includes('/attachments/');
+        return {
+          ok: !attachment || attachmentStatus === 200,
+          status: attachment ? attachmentStatus : 200,
+          text: async () => 'body fetch failed',
+          json: async () => {
+            if (attachment) return { data: Buffer.from(BODY).toString('base64url') };
+            if (!url.includes('/threads/')) return { threads: [{ id: 'thread-body' }] };
+            return {
+              id: 'thread-body',
+              messages: [
+                {
+                  id: 'message-body',
+                  internalDate: '1783558800000',
+                  snippet: 'Short preview',
+                  payload: {
+                    mimeType: 'multipart/mixed',
+                    headers: [],
+                    parts: [
+                      // An attached text file sits beside the body in the same
+                      // container and must not be mistaken for it.
+                      { mimeType: 'text/plain', filename: 'notes.txt', body: { attachmentId: 'excluded-file' } },
+                      {
+                        mimeType: 'multipart/alternative',
+                        parts: [{ mimeType: 'text/plain', body: { attachmentId: 'body-ref', size: 43 } }],
+                      },
+                    ],
+                  },
+                },
+              ],
+            };
+          },
+        };
+      },
+    });
+    return { connector, urls };
+  }
+
+  test.each(['sync', 'get_thread'])(
+    '%s retrieves the text body reference without treating an attached file as the body',
+    async (mode) => {
+      const { connector, urls } = setup();
+      const body =
+        mode === 'sync'
+          ? (await connector.sync(syncContext)).events[0].payload_text
+          : (
+              await connector.execute({
+                actionKey: 'get_thread',
+                input: { thread_id: 'thread-body' },
+                credentials: { accessToken: 'synthetic-token' },
+              })
+            ).output.messages[0].body;
+      expect(body).toContain(BODY);
+      expect(urls.filter((url) => url.includes('/attachments/'))).toEqual([
+        'https://www.googleapis.com/gmail/v1/users/me/messages/message-body/attachments/body-ref',
+      ]);
+    }
+  );
+
+  test('a failed external body fetch cannot advance the sync checkpoint', async () => {
+    const { connector } = setup(503);
+    await expect(connector.sync(syncContext)).rejects.toThrow(/503/);
   });
 });

--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -1009,3 +1009,103 @@ describe('Gmail multipart body sections', () => {
     await expect(setup(503).connector.sync(context)).rejects.toThrow(/503/);
   });
 });
+
+describe('Gmail MIME syntax', () => {
+  const context = { feedKey: 'threads', config: {}, checkpoint: {}, credentials: { accessToken: 'synthetic-token' } };
+  const inline = (mimeType: string, text: string) => ({
+    mimeType, body: { data: Buffer.from(text).toString('base64url') },
+  });
+
+  for (const mode of ['sync', 'get_thread']) {
+    test.each([
+      ['plain body', inline('TEXT/PLAIN', 'Complete body.')],
+      ['HTML body', inline('Text/Html', 'Complete body.')],
+      ['alternative preference', {
+        mimeType: 'Multipart/Alternative',
+        parts: [inline('text/html', 'Unwanted duplicate.'), inline('TEXT/PLAIN', 'Complete body.')],
+      }],
+      ['attachment whitespace', {
+        mimeType: 'multipart/mixed',
+        parts: [
+          inline('text/plain', 'Complete body.'),
+          { ...inline('text/plain', 'Unwanted attachment.'), headers: [{ name: 'Content-Disposition', value: ' ATTACHMENT \r\n\t; size=20' }] },
+        ],
+      }],
+      ['named inline body', {
+        ...inline('text/plain', 'Complete body.'),
+        filename: 'body.txt',
+        headers: [{ name: 'Content-Disposition', value: 'INLINE; filename="body.txt"' }],
+      }],
+      ['named inline multipart', {
+        mimeType: 'multipart/mixed', filename: 'body.mime',
+        headers: [{ name: 'Content-Disposition', value: 'inline; filename="body.mime"' }],
+        parts: [inline('text/plain', 'Complete body.')],
+      }],
+      ['unknown attachment disposition', {
+        mimeType: 'multipart/mixed',
+        parts: [
+          inline('text/plain', 'Complete body.'),
+          { ...inline('text/plain', 'Unwanted attachment.'), headers: [{ name: 'Content-Disposition', value: 'x-archive' }] },
+        ],
+      }],
+    ])(`${mode} handles valid MIME syntax in %s`, async (_name, payload) => {
+      const connector = new GmailConnector();
+      const thread = toThreadResponse({ id: 'mime-thread', messages: [{ id: 'mime-message' }] });
+      connector.createClient = () => ({ raw: async (url: string) => ({
+        ok: true,
+        json: async () => url.includes('/threads/')
+          ? { ...thread, messages: [{ ...thread.messages[0], payload }] }
+          : { threads: [{ id: thread.id }] },
+      }) });
+      const body = mode === 'sync'
+        ? (await connector.sync(context)).events[0].payload_text
+        : (await connector.execute({ actionKey: 'get_thread', input: { thread_id: thread.id }, credentials: context.credentials })).output.messages[0].body;
+      expect(body).toContain('Complete body.');
+      expect(body).not.toContain('Unwanted');
+    });
+  }
+});
+
+describe('Gmail MIME body charset', () => {
+  const context = { feedKey: 'threads', config: {}, checkpoint: {}, credentials: { accessToken: 'synthetic-token' } };
+
+  function setup(bytes: Buffer, contentType: string | undefined, external: boolean) {
+    const connector = new GmailConnector();
+    const thread = toThreadResponse({ id: 'encoded-thread', messages: [{ id: 'encoded-message' }] });
+    const payload = {
+      mimeType: 'text/plain',
+      headers: contentType ? [{ name: 'cOnTeNt-TyPe', value: contentType }] : [],
+      body: external ? { attachmentId: 'encoded-body', size: bytes.length }
+        : { data: bytes.toString('base64url'), size: bytes.length },
+    };
+    connector.createClient = () => ({ raw: async (url: string) => ({
+      ok: true,
+      json: async () => url.includes('/attachments/') ? { data: bytes.toString('base64url') }
+        : url.includes('/threads/') ? { ...thread, messages: [{ ...thread.messages[0], payload }] }
+        : { threads: [{ id: thread.id }] },
+    }) });
+    return connector;
+  }
+
+  for (const external of [false, true]) {
+    for (const mode of ['sync', 'get_thread']) {
+      test.each([
+        ['Latin-1', Buffer.from('café à Noël', 'latin1'), 'text/plain; CHARSET="ISO-8859-1"', 'café à Noël'],
+        ['default UTF-8', Buffer.from('İstanbul — teşekkürler'), undefined, 'İstanbul — teşekkürler'],
+      ] as const)(`${mode} decodes %s ${external ? 'external' : 'inline'} bytes`, async (_name, bytes, contentType, expected) => {
+        const connector = setup(bytes, contentType, external);
+        const body = mode === 'sync'
+          ? (await connector.sync(context)).events[0].payload_text
+          : (await connector.execute({ actionKey: 'get_thread', input: { thread_id: 'encoded-thread' }, credentials: context.credentials })).output.messages[0].body;
+        expect(body).toContain(expected);
+        expect(body).not.toContain('\uFFFD');
+      });
+    }
+    test.each([
+      ['invalid UTF-8', Buffer.from([0xc3, 0x28]), 'text/plain; charset=utf-8'],
+      ['unsupported charset', Buffer.from('body'), 'text/plain; charset=unknown-charset'],
+    ] as const)(`does not checkpoint past %s ${external ? 'external' : 'inline'} bytes`, async (_name, bytes, contentType) => {
+      await expect(setup(bytes, contentType, external).sync(context)).rejects.toThrow();
+    });
+  }
+});

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -12,7 +12,6 @@ import {
   createHttpClient,
   type EventEnvelope,
   type HttpClient,
-  paginateByCursor,
   type FeedReadContext,
   type FeedReadResult,
   type RuntimeConnectorDefinition,
@@ -63,11 +62,24 @@ interface GmailThreadGetResponse {
 // ---------------------------------------------------------------------------
 
 interface GmailCheckpoint {
+  /** Bumped when the shape below changes; a mismatch re-runs the lookback. */
+  schema_version?: number;
+  /** Serialized search + person filter the two fields below were produced under. */
+  scope?: string;
   last_sync_at?: string;
+  /** Set while a window is only part-walked: the run hit `max_results`, or a page came back empty with a cursor. */
+  pending?: {
+    query: string;
+    started_at: string;
+    page_token: string;
+  };
 }
 
 interface GmailConfig {
-  /** Gmail search scope shared by sync and direct source reads. */
+  /**
+   * Gmail search scope shared by sync and direct source reads. Takes precedence
+   * over `labels` and `label` when set.
+   */
   query?: string;
   label?: string;
   /** Non-empty labels to union in the sync query. Overrides `label`. */
@@ -106,7 +118,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     name: 'Gmail',
     description:
       'Syncs Gmail threads, live-reads matching messages, and supports sending, drafts, and replies.',
-    version: '1.0.4',
+    version: '1.0.5',
     faviconDomain: 'mail.google.com',
     authSchema: {
       methods: [
@@ -148,7 +160,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
             query: {
               type: 'string',
               description:
-                'Optional Gmail search scope for sync and source reads, e.g. "label:INBOX newer_than:30d".',
+                'Optional Gmail search scope for sync and source reads, e.g. "label:INBOX newer_than:30d". Takes precedence over `labels` and `label`.',
             },
             label: {
               type: 'string',
@@ -159,7 +171,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
               type: 'array',
               items: { type: 'string' },
               description:
-                'Non-empty labels to union in the sync query, e.g. ["INBOX", "SENT"]. Overrides `label` so outbound-initiated threads are covered.',
+                'Non-empty labels to union in the sync query, e.g. ["INBOX", "SENT"]. Overrides `label` so outbound-initiated threads are covered; ignored when `query` is set.',
             },
             max_results: {
               type: 'integer',
@@ -387,139 +399,120 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     const lookbackDays = ctx.config.lookback_days ?? 30;
     const humanSendersOnly = ctx.config.human_senders_only === true;
 
-    const checkpoint = ctx.checkpoint ?? {}
-
-    // Determine the "after" date for the query
-    const afterDate = checkpoint.last_sync_at
+    const checkpoint = ctx.checkpoint ?? {};
+    const scope = ctx.config.query?.trim() || (labels.length > 0
+      ? `{${labels.map((l) => `label:${l}`).join(' ')}}`
+      : `label:${label}`);
+    // Old checkpoints describe snippet-only input. Revisit the configured
+    // lookback once when upgrading or changing the source filter, preserving
+    // thread origin IDs so ingestion supersedes rather than duplicates rows.
+    const scopeKey = JSON.stringify([scope, humanSendersOnly]);
+    const resumable = checkpoint.schema_version === 2 && checkpoint.scope === scopeKey;
+    const pending = resumable ? checkpoint.pending : undefined;
+    const windowStart = pending?.started_at ?? syncStartedAt.toISOString();
+    const afterDate = resumable && checkpoint.last_sync_at
       ? new Date(checkpoint.last_sync_at)
-      : (() => {
-          const d = new Date();
-          d.setDate(d.getDate() - lookbackDays);
-          return d;
-        })();
-
-    // Gmail's `after:` accepts a Unix timestamp (epoch seconds) for second-level
-    // precision. Using `YYYY/MM/DD` (day granularity, host timezone) meant every
-    // sync within the same day re-fetched the whole day's threads as duplicates.
-    const afterEpochSeconds = Math.floor(afterDate.getTime() / 1000);
-    // `labels` unions multiple labels (e.g. INBOX + SENT) so outbound-initiated
-    // threads — often the strongest "this is a real contact" signal — are covered.
-    const query =
-      labels.length > 0
-        ? `after:${afterEpochSeconds} {${labels.map((l) => `label:${l}`).join(' ')}}`
-        : `after:${afterEpochSeconds} label:${label}`;
-
+      : new Date(syncStartedAt.getTime() - lookbackDays * 24 * 60 * 60_000);
+    // Keep the search window fixed across capped runs. Its second-level overlap
+    // covers messages arriving on the boundary; origin_id makes that replay safe.
+    const after = Math.floor(afterDate.getTime() / 1000) - 1;
+    const before = Math.ceil(Date.parse(windowStart) / 1000);
+    const query = pending?.query ?? `after:${after} before:${before} (${scope})`;
+    let pageToken = pending?.page_token;
     const http = this.createClient(token);
     const events: EventEnvelope[] = [];
     // Bounds the threads FETCHED per run (each is an API call), independent of
     // how many survive the person filter — a narrow feed must not scan the whole
-    // lookback just because most threads are rejected.
+    // window just because most threads are rejected. It also sizes each list
+    // page, so a page can never push the run past the cap.
     let inspected = 0;
 
-    const pages = paginateByCursor<NonNullable<GmailThreadListResponse['threads']>[number], string>(
-      async (pageToken) => {
-        const params = new URLSearchParams({
-          q: query,
-          maxResults: String(Math.min(100, maxResults - inspected)),
-        });
-        if (pageToken) {
-          params.set('pageToken', pageToken);
-        }
-
-        const listUrl = `${this.BASE_URL}/threads?${params.toString()}`;
-        const listResponse = await http.raw(listUrl);
-
-        if (!listResponse.ok) {
-          throw new Error(
-            `Gmail threads.list error (${listResponse.status}): ${await listResponse.text()}`
-          );
-        }
-
-        const listData = (await listResponse.json()) as GmailThreadListResponse;
-        return { items: listData.threads ?? [], nextCursor: listData.nextPageToken };
-      },
-      { delayMs: this.RATE_LIMIT_MS }
-    );
-
-    for await (const threads of pages) {
-      if (threads.length === 0) break;
-
-      // Fetch each thread with metadata format
+    do {
+      const params = new URLSearchParams({
+        q: query,
+        maxResults: String(Math.min(100, maxResults - inspected)),
+      });
+      if (pageToken) params.set('pageToken', pageToken);
+      const listResponse = await http.raw(`${this.BASE_URL}/threads?${params.toString()}`);
+      if (!listResponse.ok) {
+        throw new Error(`Gmail threads.list error (${listResponse.status}): ${await listResponse.text()}`);
+      }
+      const listData = (await listResponse.json()) as GmailThreadListResponse;
+      const threads = listData.threads ?? [];
       for (const threadStub of threads) {
+        inspected++;
         try {
-          // Count the GET attempt up front so failed/empty/malformed responses
-          // also consume max_results — the cap bounds API calls, not just events.
-          inspected++;
-          const threadUrl = `${this.BASE_URL}/threads/${threadStub.id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Cc&metadataHeaders=Date&metadataHeaders=List-Id&metadataHeaders=Precedence`;
-          const threadResponse = await http.raw(threadUrl);
-
-          if (!threadResponse.ok) continue;
-
-          const thread = (await threadResponse.json()) as GmailThreadGetResponse;
-
-          if (!thread.messages || thread.messages.length === 0) continue;
-
-          const firstMessage = thread.messages[0];
-          const attribution = this.resolvePersonAttribution(
-            thread.messages,
-            humanSendersOnly
-          );
-          const subject = this.getHeader(firstMessage, 'Subject') || '(no subject)';
-          const dateHeader = this.getHeader(firstMessage, 'Date');
-          const occurredAt = dateHeader
-            ? new Date(dateHeader)
-            : new Date(parseInt(firstMessage.internalDate, 10));
-
-          if (Number.isNaN(occurredAt.getTime())) continue;
-
-          // Under human_senders_only the sync is deliberately narrow — only
-          // person-relevant threads are persisted (everything else stays a live
-          // read), so the DB only holds the high-signal set that drives person
-          // building.
+          const response = await http.raw(`${this.BASE_URL}/threads/${threadStub.id}?format=full`);
+          // A thread deleted between list and get has nothing left to sync.
+          // Other failures must fail the run so the same window is retried
+          // rather than checkpointed as complete.
+          if (response.status === 404) continue;
+          if (!response.ok) {
+            throw new Error(`Gmail threads.get error (${response.status}): ${await response.text()}`);
+          }
+          const thread = (await response.json()) as GmailThreadGetResponse;
+          if (!thread.messages?.length) throw new Error('Gmail returned a thread without messages');
+          const messages = [...thread.messages].sort((a, b) => Number(a.internalDate) - Number(b.internalDate));
+          const firstMessage = messages[0];
+          const latestMessage = messages[messages.length - 1];
+          const occurredAt = new Date(Number(latestMessage.internalDate));
+          if (Number.isNaN(occurredAt.getTime())) throw new Error('Gmail returned an invalid message date');
+          const attribution = this.resolvePersonAttribution(messages, humanSendersOnly);
           if (humanSendersOnly && !attribution.personRelevant) continue;
-
-          const event: EventEnvelope = {
+          events.push({
             origin_id: thread.id,
-            title: subject,
-            payload_text: firstMessage.snippet || '',
+            title: this.getHeader(firstMessage, 'Subject') || '(no subject)',
+            payload_text: messages
+              .map((message) => {
+                const body = this.extractBody(message.payload) || message.snippet || '';
+                return [
+                  `Message: ${message.id}`,
+                  `From: ${this.getHeader(message, 'From') || 'Unknown'}`,
+                  `To: ${this.getHeader(message, 'To') || ''}`,
+                  `Date: ${this.getHeader(message, 'Date') || new Date(Number(message.internalDate)).toISOString()}`,
+                  '',
+                  body,
+                ].join('\n');
+              })
+              .join('\n\n---\n\n'),
             author_name: attribution.from,
             source_url: `https://mail.google.com/mail/u/0/#inbox/${thread.id}`,
             occurred_at: occurredAt,
             origin_type: 'thread',
             metadata: {
-              message_count: thread.messages.length,
-              label_ids: firstMessage.labelIds ?? [],
-              snippet: firstMessage.snippet,
+              message_count: messages.length,
+              label_ids: [...new Set(messages.flatMap((message) => message.labelIds ?? []))],
+              snippet: latestMessage.snippet,
               replied: attribution.replied,
               person_relevant: attribution.personRelevant,
               ...(attribution.fromEmail ? { from_email: attribution.fromEmail } : {}),
               ...(attribution.fromName ? { from_name: attribution.fromName } : {}),
             },
-          };
-
-          events.push(event);
-        } catch {
-          /* skip individual thread failures */
+          });
         } finally {
-          // Filtering must not remove the per-thread API delay: a narrow feed
-          // can reject most fetched threads and still has to respect Gmail.
-          // The cap check lives here too — a `continue` in the try (failed or
-          // filtered thread) must still consume max_results and halt.
           await sleep(this.RATE_LIMIT_MS);
-          if (inspected >= maxResults) break;
         }
       }
+      if (listData.nextPageToken && listData.nextPageToken === pageToken) {
+        throw new Error('Gmail returned a repeated page token');
+      }
+      pageToken = listData.nextPageToken;
+      // An empty page with a cursor is still incomplete. Persist its cursor
+      // rather than advance the window or spin on empty provider responses.
+      if (threads.length === 0) break;
+    } while (pageToken && inspected < maxResults);
 
-      if (inspected >= maxResults) break;
-    }
-
-    // Sort by occurred_at descending
     events.sort((a, b) => b.occurred_at.getTime() - a.occurred_at.getTime());
-
-    const newCheckpoint: GmailCheckpoint = {
-      // Keep events that arrive while this sync is running inside the next window.
-      last_sync_at: syncStartedAt.toISOString(),
-    };
+    // A part-walked window keeps the previous `last_sync_at`: it may not advance
+    // until the whole window has been walked, or the unread tail is skipped.
+    const newCheckpoint: GmailCheckpoint = pageToken
+      ? {
+          schema_version: 2,
+          scope: scopeKey,
+          ...(resumable && checkpoint.last_sync_at ? { last_sync_at: checkpoint.last_sync_at } : {}),
+          pending: { query, started_at: windowStart, page_token: pageToken },
+        }
+      : { schema_version: 2, scope: scopeKey, last_sync_at: windowStart };
 
     return {
       events,

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -1113,17 +1113,20 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     http: HttpClient,
     messageId: string
   ): Promise<string> {
-    // Text files attached to a message are not its body.
-    const disposition = payload.headers?.find((h) => h.name.toLowerCase() === 'content-disposition')?.value;
-    if (payload.filename || /^attachment(?:;|$)/i.test(disposition ?? '')) return '';
+    const disposition = payload.headers?.find((h) => h.name.toLowerCase() === 'content-disposition')
+      ?.value.split(';', 1)[0].trim().toLowerCase();
+    // Explicit inline parts can have filenames. Other declared dispositions
+    // (including extensions) are attachments; otherwise use the filename hint.
+    if (disposition !== 'inline' && (disposition || payload.filename)) return '';
+    const mimeType = payload.mimeType.toLowerCase();
     if (payload.parts?.length) {
       // Only multipart/alternative contains equivalent versions. Mixed parts
       // are separate sections and must all be retained in their original order.
-      const isAlternative = payload.mimeType === 'multipart/alternative';
+      const isAlternative = mimeType === 'multipart/alternative';
       const parts = isAlternative
         ? [
-            ...payload.parts.filter((part) => part.mimeType === 'text/plain'),
-            ...payload.parts.filter((part) => part.mimeType !== 'text/plain'),
+            ...payload.parts.filter((part) => part.mimeType.toLowerCase() === 'text/plain'),
+            ...payload.parts.filter((part) => part.mimeType.toLowerCase() !== 'text/plain'),
           ]
         : payload.parts;
       const sections: string[] = [];
@@ -1135,10 +1138,10 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       }
       return sections.join('\n\n');
     }
-    if (payload.mimeType !== 'text/plain' && payload.mimeType !== 'text/html') return '';
+    if (mimeType !== 'text/plain' && mimeType !== 'text/html') return '';
     let text = '';
     if (payload.body?.data) {
-      text = this.base64UrlDecode(payload.body.data);
+      text = this.base64UrlDecode(payload.body.data, payload);
     } else if (payload.body?.attachmentId) {
       // Gmail may externalize the body itself, even under format=full. A
       // failed fetch must not silently replace that body with its alternative.
@@ -1146,16 +1149,21 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       if (!response.ok) throw new Error(`Gmail message body error (${response.status}): ${await response.text()}`);
       const body = (await response.json()) as { data?: string };
       if (typeof body.data !== 'string') throw new Error('Gmail returned a message body without data');
-      text = this.base64UrlDecode(body.data);
+      text = this.base64UrlDecode(body.data, payload);
     }
     if (!text && payload.body?.size) throw new Error('Gmail returned a nonempty message body without data');
     // An empty plain-text alternative must not hide a readable HTML body.
     return text.trim() ? text : '';
   }
 
-  private base64UrlDecode(data: string): string {
+  private base64UrlDecode(data: string, payload: GmailMessagePayload): string {
     const padded = data.replace(/-/g, '+').replace(/_/g, '/');
-    return Buffer.from(padded, 'base64').toString('utf-8');
+    const contentType = payload.headers?.find((header) => header.name.toLowerCase() === 'content-type')?.value;
+    const charset = contentType?.match(/;\s*charset\s*=\s*(?:"([^"]*)"|'([^']*)'|([^;\s]+))/i);
+    const encoding = (charset?.[1] ?? charset?.[2] ?? charset?.[3] ?? 'utf-8').trim();
+    // MIME bodies contain bytes in the part's declared charset. Invalid bytes
+    // or unsupported labels must fail the read instead of persisting corruption.
+    return new TextDecoder(encoding, { fatal: true }).decode(Buffer.from(padded, 'base64'));
   }
 
   private base64UrlEncode(str: string): string {

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -444,8 +444,8 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       const listResponse = await http.raw(`${this.BASE_URL}/threads?${params.toString()}`);
       if (!listResponse.ok) {
         const detail = await listResponse.text();
-        // Gmail answers a retired pageToken with 400; 404 covers the same
-        // condition. Anything else (auth, quota, outage) must still fail the run.
+        // Retry a stored cursor once on 400/404. Auth, quota and server errors
+        // must still fail the run without restarting pagination.
         if (staleCursorRecoverable && (listResponse.status === 400 || listResponse.status === 404)) {
           staleCursorRecoverable = false;
           pageToken = undefined;
@@ -1113,31 +1113,44 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     http: HttpClient,
     messageId: string
   ): Promise<string> {
-    const textParts: GmailMessagePayload[] = [];
-    const visit = (part: GmailMessagePayload) => {
-      // Text files attached to a message are not its body. Descend through
-      // MIME containers, choosing plain text over the equivalent HTML part.
-      const disposition = part.headers?.find((h) => h.name.toLowerCase() === 'content-disposition')?.value;
-      if (part.filename || /^attachment(?:;|$)/i.test(disposition ?? '')) return;
-      if (part.mimeType === 'text/plain' || part.mimeType === 'text/html') textParts.push(part);
-      for (const child of part.parts ?? []) visit(child);
-    };
-    visit(payload);
-    const part = textParts.find((item) => item.mimeType === 'text/plain') ?? textParts[0];
-    if (!part) return '';
-    if (part.body?.data) return this.base64UrlDecode(part.body.data);
-    const attachmentId = part.body?.attachmentId;
-    if (attachmentId) {
+    // Text files attached to a message are not its body.
+    const disposition = payload.headers?.find((h) => h.name.toLowerCase() === 'content-disposition')?.value;
+    if (payload.filename || /^attachment(?:;|$)/i.test(disposition ?? '')) return '';
+    if (payload.parts?.length) {
+      // Only multipart/alternative contains equivalent versions. Mixed parts
+      // are separate sections and must all be retained in their original order.
+      const isAlternative = payload.mimeType === 'multipart/alternative';
+      const parts = isAlternative
+        ? [
+            ...payload.parts.filter((part) => part.mimeType === 'text/plain'),
+            ...payload.parts.filter((part) => part.mimeType !== 'text/plain'),
+          ]
+        : payload.parts;
+      const sections: string[] = [];
+      for (const part of parts) {
+        const text = await this.extractBody(part, http, messageId);
+        if (!text) continue;
+        if (isAlternative) return text;
+        sections.push(text);
+      }
+      return sections.join('\n\n');
+    }
+    if (payload.mimeType !== 'text/plain' && payload.mimeType !== 'text/html') return '';
+    let text = '';
+    if (payload.body?.data) {
+      text = this.base64UrlDecode(payload.body.data);
+    } else if (payload.body?.attachmentId) {
       // Gmail may externalize the body itself, even under format=full. A
-      // failed fetch must not silently replace that body with its snippet.
-      const response = await http.raw(`${this.BASE_URL}/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}`);
+      // failed fetch must not silently replace that body with its alternative.
+      const response = await http.raw(`${this.BASE_URL}/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(payload.body.attachmentId)}`);
       if (!response.ok) throw new Error(`Gmail message body error (${response.status}): ${await response.text()}`);
       const body = (await response.json()) as { data?: string };
       if (typeof body.data !== 'string') throw new Error('Gmail returned a message body without data');
-      return this.base64UrlDecode(body.data);
+      text = this.base64UrlDecode(body.data);
     }
-    if (part.body?.size) throw new Error('Gmail returned a nonempty message body without data');
-    return '';
+    if (!text && payload.body?.size) throw new Error('Gmail returned a nonempty message body without data');
+    // An empty plain-text alternative must not hide a readable HTML body.
+    return text.trim() ? text : '';
   }
 
   private base64UrlDecode(data: string): string {

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -34,9 +34,11 @@ interface GmailMessage {
 }
 
 interface GmailMessagePayload {
-  headers: GmailHeader[];
+  /** Present on the top-level payload; nested MIME parts may omit it. */
+  headers?: GmailHeader[];
   mimeType: string;
-  body?: { data?: string; size?: number };
+  filename?: string;
+  body?: { data?: string; size?: number; attachmentId?: string };
   parts?: GmailMessagePayload[];
 }
 
@@ -419,15 +421,21 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     const before = Math.ceil(Date.parse(windowStart) / 1000);
     const query = pending?.query ?? `after:${after} before:${before} (${scope})`;
     let pageToken = pending?.page_token;
+    // A stored cursor outlives the run that issued it and Gmail may retire it.
+    // Rejecting it forever would wedge the feed behind a checkpoint only a human
+    // could clear, so the first request of the run — the only one using a cursor
+    // from a previous run — may fall back to re-walking the same window from its
+    // first page. `origin_id` makes that replay a supersede, not a duplicate.
+    let staleCursorRecoverable = pageToken !== undefined;
     const http = this.createClient(token);
     const events: EventEnvelope[] = [];
-    // Bounds the threads FETCHED per run (each is an API call), independent of
-    // how many survive the person filter — a narrow feed must not scan the whole
-    // window just because most threads are rejected. It also sizes each list
-    // page, so a page can never push the run past the cap.
+    // Bounds the threads FETCHED per run (each costs at least one API call),
+    // independent of how many survive the person filter — a narrow feed must not
+    // scan the whole window just because most threads are rejected. It also sizes
+    // each list page, so a page can never push the run past the cap.
     let inspected = 0;
 
-    do {
+    for (;;) {
       const params = new URLSearchParams({
         q: query,
         maxResults: String(Math.min(100, maxResults - inspected)),
@@ -435,8 +443,17 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       if (pageToken) params.set('pageToken', pageToken);
       const listResponse = await http.raw(`${this.BASE_URL}/threads?${params.toString()}`);
       if (!listResponse.ok) {
-        throw new Error(`Gmail threads.list error (${listResponse.status}): ${await listResponse.text()}`);
+        const detail = await listResponse.text();
+        // Gmail answers a retired pageToken with 400; 404 covers the same
+        // condition. Anything else (auth, quota, outage) must still fail the run.
+        if (staleCursorRecoverable && (listResponse.status === 400 || listResponse.status === 404)) {
+          staleCursorRecoverable = false;
+          pageToken = undefined;
+          continue;
+        }
+        throw new Error(`Gmail threads.list error (${listResponse.status}): ${detail}`);
       }
+      staleCursorRecoverable = false;
       const listData = (await listResponse.json()) as GmailThreadListResponse;
       const threads = listData.threads ?? [];
       for (const threadStub of threads) {
@@ -459,22 +476,21 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
           if (Number.isNaN(occurredAt.getTime())) throw new Error('Gmail returned an invalid message date');
           const attribution = this.resolvePersonAttribution(messages, humanSendersOnly);
           if (humanSendersOnly && !attribution.personRelevant) continue;
+          const messageTexts: string[] = [];
+          for (const message of messages) {
+            const body = await this.extractBody(message.payload, http, message.id) || message.snippet || '';
+            messageTexts.push([
+              `Message: ${message.id}`,
+              `From: ${this.getHeader(message, 'From') || 'Unknown'}`,
+              `To: ${this.getHeader(message, 'To') || ''}`,
+              `Date: ${this.getHeader(message, 'Date') || new Date(Number(message.internalDate)).toISOString()}`,
+              '', body,
+            ].join('\n'));
+          }
           events.push({
             origin_id: thread.id,
             title: this.getHeader(firstMessage, 'Subject') || '(no subject)',
-            payload_text: messages
-              .map((message) => {
-                const body = this.extractBody(message.payload) || message.snippet || '';
-                return [
-                  `Message: ${message.id}`,
-                  `From: ${this.getHeader(message, 'From') || 'Unknown'}`,
-                  `To: ${this.getHeader(message, 'To') || ''}`,
-                  `Date: ${this.getHeader(message, 'Date') || new Date(Number(message.internalDate)).toISOString()}`,
-                  '',
-                  body,
-                ].join('\n');
-              })
-              .join('\n\n---\n\n'),
+            payload_text: messageTexts.join('\n\n---\n\n'),
             author_name: attribution.from,
             source_url: `https://mail.google.com/mail/u/0/#inbox/${thread.id}`,
             occurred_at: occurredAt,
@@ -500,7 +516,8 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       // An empty page with a cursor is still incomplete. Persist its cursor
       // rather than advance the window or spin on empty provider responses.
       if (threads.length === 0) break;
-    } while (pageToken && inspected < maxResults);
+      if (!pageToken || inspected >= maxResults) break;
+    }
 
     events.sort((a, b) => b.occurred_at.getTime() - a.occurred_at.getTime());
     // A part-walked window keeps the previous `last_sync_at`: it may not advance
@@ -902,13 +919,16 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
         ? this.getHeader(thread.messages[0], 'Subject') || '(no subject)'
         : '(no subject)';
 
-    const messages = thread.messages.map((msg) => ({
-      id: msg.id,
-      from: this.getHeader(msg, 'From') || 'Unknown',
-      date: this.getHeader(msg, 'Date') || '',
-      snippet: msg.snippet,
-      body: this.extractBody(msg.payload),
-    }));
+    const messages = [];
+    for (const msg of thread.messages) {
+      messages.push({
+        id: msg.id,
+        from: this.getHeader(msg, 'From') || 'Unknown',
+        date: this.getHeader(msg, 'Date') || '',
+        snippet: msg.snippet,
+        body: await this.extractBody(msg.payload, http, msg.id),
+      });
+    }
 
     return {
       success: true,
@@ -1062,7 +1082,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
   }
 
   private getHeader(message: GmailMessage, name: string): string | undefined {
-    const header = message.payload.headers.find((h) => h.name.toLowerCase() === name.toLowerCase());
+    const header = message.payload.headers?.find((h) => h.name.toLowerCase() === name.toLowerCase());
     return header?.value;
   }
 
@@ -1088,34 +1108,35 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     return { name: trimmed, email: null };
   }
 
-  private extractBody(payload: GmailMessagePayload): string {
-    // Try to get body from payload.body.data directly
-    if (payload.body?.data) {
-      return this.base64UrlDecode(payload.body.data);
+  private async extractBody(
+    payload: GmailMessagePayload,
+    http: HttpClient,
+    messageId: string
+  ): Promise<string> {
+    const textParts: GmailMessagePayload[] = [];
+    const visit = (part: GmailMessagePayload) => {
+      // Text files attached to a message are not its body. Descend through
+      // MIME containers, choosing plain text over the equivalent HTML part.
+      const disposition = part.headers?.find((h) => h.name.toLowerCase() === 'content-disposition')?.value;
+      if (part.filename || /^attachment(?:;|$)/i.test(disposition ?? '')) return;
+      if (part.mimeType === 'text/plain' || part.mimeType === 'text/html') textParts.push(part);
+      for (const child of part.parts ?? []) visit(child);
+    };
+    visit(payload);
+    const part = textParts.find((item) => item.mimeType === 'text/plain') ?? textParts[0];
+    if (!part) return '';
+    if (part.body?.data) return this.base64UrlDecode(part.body.data);
+    const attachmentId = part.body?.attachmentId;
+    if (attachmentId) {
+      // Gmail may externalize the body itself, even under format=full. A
+      // failed fetch must not silently replace that body with its snippet.
+      const response = await http.raw(`${this.BASE_URL}/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}`);
+      if (!response.ok) throw new Error(`Gmail message body error (${response.status}): ${await response.text()}`);
+      const body = (await response.json()) as { data?: string };
+      if (typeof body.data !== 'string') throw new Error('Gmail returned a message body without data');
+      return this.base64UrlDecode(body.data);
     }
-
-    // Search through parts for text/plain or text/html
-    if (payload.parts) {
-      for (const part of payload.parts) {
-        if (part.mimeType === 'text/plain' && part.body?.data) {
-          return this.base64UrlDecode(part.body.data);
-        }
-      }
-      // Fallback to text/html if no plain text
-      for (const part of payload.parts) {
-        if (part.mimeType === 'text/html' && part.body?.data) {
-          return this.base64UrlDecode(part.body.data);
-        }
-      }
-      // Recurse into nested parts (e.g. multipart/alternative inside multipart/mixed)
-      for (const part of payload.parts) {
-        if (part.parts) {
-          const nested = this.extractBody(part);
-          if (nested) return nested;
-        }
-      }
-    }
-
+    if (part.body?.size) throw new Error('Gmail returned a nonempty message body without data');
     return '';
   }
 


### PR DESCRIPTION
## Summary
Gmail sync stored only the first message snippet, ignored its declared query setting, and advanced the time checkpoint after capped or failed thread reads. Replies and unread pages could never reach downstream task extraction.

Persist every reply body, including bodies Gmail stores behind attachment IDs, and date threads by the latest message. Skip empty MIME alternatives, preserve every separate inline section, honor MIME capitalization and inline disposition, decode the declared body charset, and reject unreadable nonempty bodies before advancing the checkpoint. Honor the existing query setting, preserve a fixed window and continuation cursor between capped runs, recover rejected stored cursors once, and fail visibly on incomplete reads. Replay old snippet checkpoints through the configured lookback with stable thread origin IDs.

## Test plan
- [x] Original regressions: 29 pass / 4 fail before; complete-body and paging cases pass after.
- [x] External body regressions: 39 pass / 3 fail before; 44 pass / 0 fail after cursor recovery and body fixes.
- [x] Earlier full connector suite: 424 pass / 0 fail. Relevant server source-read/catalog suites: 16 pass.
- [x] MIME regression: 46 pass / 9 fail before the empty-alternative fix. Three additional mixed-section regressions failed before the section fix. At that stage Gmail: 58 pass / 0 fail; source-read suite: 12 pass.
- [x] Codex reproduced the MIME loss, and the subsequent Codex pre-review fixer completed. Final local pre-PR gates passed.
- [x] Charset regression: 62 pass / 8 fail before; 70 pass / 0 fail after. MIME syntax regressions: 0 pass / 8 fail, then 8 pass / 6 fail before their fixes. Final Gmail suite: 84 pass / 0 fail; worker decoder tests: 7 pass.
- [x] The production Gmail decoder passed four checks through the real worker prelude, including Latin-1, UTF-8, invalid bytes, and an unsupported charset. Final Codex pre-review fixer and local pre-PR gates passed.
- [x] make review-fix completed and edits reread; make pre-pr clean; exact three intended files committed.
- [x] GitHub CI passed after retrying an unrelated network-bound CLI scaffold timeout; exact-head Codex review reported 0 bugs / 0 blockers (88 confidence), with 84 Gmail tests and worker-prelude probes passing. All ten required checks passed before squash merge.
- [x] Squash revision `d907d79ab1adbc8cf590398f4b86d66cb22bb3f9` is live; expected-revision gate and production smoke passed (9 passed / 0 failed).
- [x] Live normal scheduled import and persisted-cursor continuation after rollout.
  - Existing feed upgraded in place to 1.0.5. First normal scheduled run completed successfully on 2026-09-11 at 03:43 UTC: 500 threads, 23 multi-message threads, and 240 threads outside the inbox. Stored bodies totalled about 5.4 million characters; the schema-version-2 checkpoint retained the unfinished window and continuation cursor. The configured one-year backfill remains in progress; a subsequent batch was triggered through the existing feed operation.
  - The continuation completed at 03:48 UTC with another 500 threads, retaining the same fixed historical window and advancing its page cursor. The normal half-hour schedule remains active. The configured one-year backfill is not yet complete.
  - Downstream Automation processing completed on 216 events from the first imported arrivals, with six task creations and two existing task action/rationale updates verified in persisted entities. The remaining imported arrivals await the next normal hourly window.

## Notes
No new OAuth scopes or public operations. Binary file attachments are not decoded as message bodies. Provider or malformed-body failures keep the previous checkpoint rather than silently skipping input. HTML-only mail retains its HTML text. Old feeds rebuild only their configured lookback, not unlimited history.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gmail synchronization now stores complete message bodies, including externally stored attachment content.
  * Gmail sync supports resumable processing across pages and recovers when pagination tokens become invalid.
  * Sync scope consistently honors configured queries and labels.
  * Multipart messages now preserve relevant content while prioritizing plain text and excluding attached files.

* **Bug Fixes**
  * Improved handling of malformed or unavailable Gmail threads and message content.

* **Documentation**
  * Updated the hybrid sync/read feed example to clarify Gmail’s filtering and on-demand search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
