### PR TITLE
fix(device-daemon): upload transcripts through the mounted gateway

### DIFF
--- a/packages/connector-worker/src/__tests__/automation-acp.test.ts
+++ b/packages/connector-worker/src/__tests__/automation-acp.test.ts
@@ -664,7 +664,7 @@ for await (const line of readline.createInterface({ input: process.stdin })) {
 
     expect(requests).toEqual([
       {
-        url: 'https://lobu.test/worker/transcript/snapshot',
+        url: 'https://lobu.test/lobu/worker/transcript/snapshot',
         authorization: 'Bearer run-scoped-token',
         body: {
           runId: 99,

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -427,7 +427,8 @@ export class WorkerClient implements ExecutorClient {
     terminalStatus: 'completed' | 'failed' | 'timeout' | 'cancelled',
     snapshotJsonl: string
   ): Promise<void> {
-    const route = '/worker/transcript/snapshot';
+    // apiUrl is the app origin; the worker gateway is mounted under /lobu.
+    const route = '/lobu/worker/transcript/snapshot';
     const response = await fetch(`${this.apiUrl}${route}`, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## Summary
Device Automation reports complete, but their terminal ACP transcript upload returns 404 because WorkerClient appends `/worker/transcript/snapshot` to the app origin. The public server mounts the worker gateway under `/lobu`.

Send the upload to `/lobu/worker/transcript/snapshot`. Keep the existing run-scoped bearer and request body; the device PAT is never used for the upload.

## Test plan
- [x] Explicit paths staged; `make pre-pr` passed (build, typecheck, knip, lint, naming, shared runtime gates).
- [x] Focused Automation ACP suite: 13 passed, 56 assertions, including the run-token boundary.
- [x] Red → green regression: the URL assertion failed with `/worker/transcript/snapshot`; it passes with `/lobu/worker/transcript/snapshot`.
- [x] Live route probe with synthetic invalid credentials: the old route returns `404 Not Found`; the fixed WorkerClient reaches `401 Unauthorized {"error":"Invalid token"}`. No transcript was written by this probe.

A signed rebuilt Mac app was installed on the development device. A fresh, data-free OpenCode Automation completed successfully in 16 seconds, with no recurrence of the prior terminal transcript-upload error. The installed daemon hash matched the signed build. This change does not alter the server API or the SDK contract.

GitHub CI passed for `fb541208e11452f02f37d7ec4f477ea777fda4e3`; `make ui-review` passed as not applicable. The required `make review` attempt on that exact commit failed without a verdict because the selected reviewer process could not complete. The PR remains unmerged.

## Review status
`make review-fix` was attempted with all configured Claude accounts. Two report weekly limits; the other reports disabled Claude Code subscription access. No semantic review verdict was obtained. Required review remains pending; do not merge past that gate.
