### PR TITLE
fix(automations): keep derived entity names in sync

### DIFF
--- a/packages/server/src/__tests__/integration/authz/entity-approval-atomic-apply.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-approval-atomic-apply.test.ts
@@ -240,9 +240,8 @@ describe("an escalated card applies atomically or not at all", () => {
 		const { org, user, agent, invoice } = await seed();
 		const agentCtx = ctxFor(org.id, { agentId: agent.agentId });
 
-		// A card mixing an ATTRIBUTE key with metadata runs through two writers:
-		// `mergeEntityFields` first, then `patchEntityRows`. Staleness discovered by
-		// the second must still unwind the first.
+		// Attribute and metadata staleness must govern the whole approved unit,
+		// including when only the name changed after the proposal was queued.
 		const result = await updateEntity(
 			invoice.id,
 			{ name: "INV-RENAMED", metadata: { amount: 90000 } },
@@ -276,6 +275,42 @@ describe("an escalated card applies atomically or not at all", () => {
 		expect(await readName(invoice.id)).toBe("INV-HUMAN");
 		// Asserting only the name would pass with the metadata half committed.
 		expect((await readMetadata(invoice.id)).amount).toBe(1000);
+	}, 60_000);
+
+	it.each([false, true])("validates an approved metadata/name transition together (stale name: %s)", async (stale) => {
+		const { org, user, agent, invoice } = await seed();
+		const sql = getTestDb();
+		const compiled = await compileEntityRule(`export default (row) => {
+  if (row.op === "update" && row.changed("vendor")) {
+    if (row.next.$name !== row.next.vendor) row.deny("vendor and display name must change together");
+    row.escalate(["vendor"], "review the vendor change");
+  }
+};`);
+		await sql`UPDATE entity_types SET rules_compiled = ${compiled}
+      WHERE organization_id = ${org.id} AND slug = 'invoice'`;
+		const agentCtx = ctxFor(org.id, { agentId: agent.agentId });
+		const result = await updateEntity(invoice.id, {
+			name: "ACME", metadata: { vendor: "ACME" },
+		}, TEST_ENV, agentCtx);
+		expect(result.deferred).toBeTruthy();
+		await result.deferred?.queue(agentCtx, TEST_ENV);
+		const proposal = await persistedProposal(org.id);
+		expect(proposal.fields).toEqual({ vendor: "ACME", $name: "ACME" });
+		if (stale) {
+			await updateEntity(invoice.id, { name: "Human label" }, TEST_ENV,
+				ctxFor(org.id, { userId: user.id }));
+		}
+		const applied = await applyEntityFieldChangeProposal(
+			proposal as Parameters<typeof applyEntityFieldChangeProposal>[0], user.id,
+		);
+		expect(await readName(invoice.id)).toBe(stale ? "Human label" : "ACME");
+		expect((await readMetadata(invoice.id)).vendor).toBe(stale ? null : "ACME");
+		if (stale) {
+			expect(applied.changed).toBe(false);
+			expect(applied.stale.$name).toBeDefined();
+		} else {
+			expect(applied.applied.$name).toEqual({ old: "INV-ATOMIC", new: "ACME" });
+		}
 	}, 60_000);
 
 	it("CONTROL: a hold card with no escalation still applies its live fields", async () => {

--- a/packages/server/src/__tests__/integration/authz/entity-approval-hold-vs-rule.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-approval-hold-vs-rule.test.ts
@@ -414,12 +414,8 @@ describe("approval hold vs a frozen-state rule", () => {
 		const { org, user, agent, invoice } = await seed();
 		const agentCtx = ctxFor(org.id, { agentId: agent.agentId });
 
-		// `applyEntityFieldChangeProposal` splits a card in two: metadata goes
-		// through `mergeEntityFields`, reserved `$name`/`$parent_id`/`$content` go
-		// through `patchEntityRows`. Both revalidate, so both need the
-		// approved-write signal — the first cut set it on the metadata half only,
-		// and a card mixing the two rolled back whole (the attribute half threw
-		// inside the same transaction, taking the metadata half with it).
+		// Metadata and reserved attributes share one approved patch so the rule
+		// sees the complete transition and its covered escalation is waived.
 		const result = await updateEntity(
 			invoice.id,
 			{ name: "INV-RENAMED", metadata: { amount: 90000 } },

--- a/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
@@ -20,6 +20,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import type { DbClient } from '../../../db/client';
 import type { Env } from '../../../index';
 import type { AuthContext } from '../../../tools/execute';
+import type { EntityOutput } from '../../../types/automations';
 import { executeTool } from '../../../tools/execute';
 import { createAutomationRun } from '../../../runs/queue-service';
 import { computePendingWindow } from '../../../utils/window-utils';
@@ -126,7 +127,7 @@ function ownerAuthCtx(orgId: string, userId: string): AuthContext {
   };
 }
 
-async function setupKeyedAutomation() {
+async function setupKeyedAutomation(outputs: Record<string, EntityOutput> = OUTPUTS) {
   const sql = getTestDb();
   const dbClient = sql as unknown as DbClient;
   const workspace = await TestWorkspace.create({ name: 'Keyed Promotion Org' });
@@ -158,7 +159,7 @@ async function setupKeyedAutomation() {
     slug: 'keyed-automation',
     name: 'Keyed Automation',
     prompt: 'Extract problems for {{entities}}.',
-    outputs: OUTPUTS,
+    outputs,
     triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
     managed_agent_id: agent.agentId,
   })) as { automation_id: string };
@@ -789,6 +790,190 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     `;
     expect(claims).toHaveLength(1);
     expect(Number(claims[0].entity_id)).toBe(Number(rows[0].id));
+  });
+
+  it('updates a derived display name without changing the stable identity or slug', async () => {
+    const ctx = await setupKeyedAutomation({
+      problems: { entity: 'topic', key: ['category'], name: ['name'] },
+    });
+    const first = await nextCompletion(ctx);
+    await completeWithToken(ctx, first.token, first.runId, {
+      problems: [{ category: 'Stability', name: 'Investigate the crash' }],
+    });
+    const [before] = await ctx.sql`
+      SELECT e.id, e.name, e.slug, e.metadata, ei.identifier
+      FROM entities e JOIN entity_identities ei ON ei.entity_id = e.id
+      WHERE ei.organization_id = ${ctx.workspace.org.id} AND ei.namespace = 'automation_key'
+    `;
+    expect(before.name).toBe('Investigate the crash');
+
+    const rule = await compileEntityRule(`export default (row) => {
+      if (row.op === "update" && row.next.$name !== row.next.name) {
+        row.deny("display name and extracted name must stay consistent");
+      }
+    };`);
+    await ctx.sql`UPDATE entity_types SET rules_compiled = ${rule}
+      WHERE organization_id = ${ctx.workspace.org.id} AND slug = 'topic'`;
+
+    const next = await nextCompletion(ctx);
+    await completeWithToken(ctx, next.token, next.runId, {
+      problems: [{ category: 'Stability', name: 'Deploy the verified crash fix' }],
+    });
+    const rows = await ctx.sql`
+      SELECT e.id, e.name, e.slug, e.metadata, ei.identifier
+      FROM entities e JOIN entity_identities ei ON ei.entity_id = e.id
+      WHERE ei.organization_id = ${ctx.workspace.org.id} AND ei.namespace = 'automation_key'
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].metadata.name).toBe('Deploy the verified crash fix');
+    expect(rows[0].name).toBe('Deploy the verified crash fix');
+    expect(rows[0].id).toBe(before.id);
+    expect(rows[0].slug).toBe(before.slug);
+    expect(rows[0].identifier).toBe(before.identifier);
+  });
+
+  it.each(['deny', 'escalate'] as const)('leaves an unchanged promotion untouched under an update %s rule', async (verdict) => {
+    const ctx = await setupKeyedAutomation({
+      problems: { entity: 'topic', key: ['category'], name: ['name'] },
+    });
+    const extracted = { problems: [{ category: 'Stability', name: 'Investigate the crash' }] };
+    const first = await nextCompletion(ctx);
+    await completeWithToken(ctx, first.token, first.runId, extracted);
+    const [before] = await ctx.sql`
+      SELECT e.id, e.updated_at FROM entities e
+      JOIN entity_identities ei ON ei.entity_id = e.id
+      WHERE ei.organization_id = ${ctx.workspace.org.id} AND ei.namespace = 'automation_key'
+    `;
+    const rule = await compileEntityRule(`export default (row) => {
+      if (row.op === "update") {
+        ${verdict === 'deny' ? 'row.deny("frozen topic");' : 'row.escalate(["name"], "review topic edits");'}
+      }
+    };`);
+    await ctx.sql`UPDATE entity_types SET rules_compiled = ${rule}
+      WHERE organization_id = ${ctx.workspace.org.id} AND slug = 'topic'`;
+
+    const next = await nextCompletion(ctx);
+    await completeWithToken(ctx, next.token, next.runId, extracted);
+    const [after] = await ctx.sql`SELECT updated_at FROM entities WHERE id = ${before.id}`;
+    expect(after.updated_at).toEqual(before.updated_at);
+    const cards = await ctx.sql`
+      SELECT id FROM runs WHERE organization_id = ${ctx.workspace.org.id}
+        AND action_key = 'entity_field_change' AND approval_status = 'pending'
+    `;
+    expect(cards).toEqual([]);
+    const changes = await ctx.sql`
+      SELECT id FROM current_event_records WHERE organization_id = ${ctx.workspace.org.id}
+        AND run_id = ${next.runId} AND semantic_type = 'change_set'
+    `;
+    expect(changes).toEqual([]);
+  });
+
+  it('preserves a customized display name while updating its extracted fields', async () => {
+    const ctx = await setupKeyedAutomation({
+      problems: { entity: 'topic', key: ['category'], name: ['name'] },
+    });
+    const first = await nextCompletion(ctx);
+    await completeWithToken(ctx, first.token, first.runId, {
+      problems: [{ category: 'Stability', name: 'Investigate the crash' }],
+    });
+    const [created] = await ctx.sql`
+      SELECT entity_id FROM entity_identities
+      WHERE organization_id = ${ctx.workspace.org.id} AND namespace = 'automation_key'
+    `;
+    await ctx.workspace.owner.entities.update({ entity_id: Number(created.entity_id), name: 'My custom label' });
+    const [before] = await ctx.sql`SELECT name, slug FROM entities WHERE id = ${created.entity_id}`;
+    const next = await nextCompletion(ctx);
+    await completeWithToken(ctx, next.token, next.runId, {
+      problems: [{ category: 'Stability', name: 'Deploy the crash fix' }],
+    });
+    const [after] = await ctx.sql`SELECT name, slug, metadata FROM entities WHERE id = ${created.entity_id}`;
+    expect(after.metadata.name).toBe('Deploy the crash fix');
+    expect(after.name).toBe('My custom label');
+    expect(after.slug).toBe(before.slug);
+  });
+
+  it('holds a human-owned naming field and applies its name together on approval', async () => {
+    const ctx = await setupKeyedAutomation({
+      problems: { entity: 'topic', key: ['category'], name: ['name'] },
+    });
+    const first = await nextCompletion(ctx);
+    await completeWithToken(ctx, first.token, first.runId, {
+      problems: [{ category: 'Stability', name: 'Investigate the crash', severity: 'low' }],
+    });
+    const [created] = await ctx.sql`
+      SELECT entity_id FROM entity_identities
+      WHERE organization_id = ${ctx.workspace.org.id} AND namespace = 'automation_key'
+    `;
+    await ctx.workspace.owner.entities.update({
+      entity_id: Number(created.entity_id), affirm_fields: ['name'], field_note: 'Keep this action until reviewed',
+    });
+    const rule = await compileEntityRule(`export default (row) => {
+      if (row.op === "update" && row.next.$name !== row.next.name) {
+        row.deny("display name and extracted name must stay consistent");
+      }
+    };`);
+    await ctx.sql`UPDATE entity_types SET rules_compiled = ${rule}
+      WHERE organization_id = ${ctx.workspace.org.id} AND slug = 'topic'`;
+    const next = await nextCompletion(ctx);
+    await completeWithToken(ctx, next.token, next.runId, {
+      problems: [{ category: 'Stability', name: 'Deploy the crash fix', severity: 'high' }],
+    });
+    const [held] = await ctx.sql`SELECT name, slug, metadata FROM entities WHERE id = ${created.entity_id}`;
+    expect(held.name).toBe('Investigate the crash');
+    expect(held.metadata.name).toBe('Investigate the crash');
+    expect(held.metadata.severity).toBe('high');
+    const [card] = await ctx.sql`
+      SELECT id, action_input FROM runs WHERE organization_id = ${ctx.workspace.org.id}
+        AND action_key = 'entity_field_change' AND approval_status = 'pending'
+    `;
+    expect(card.action_input.fields).toEqual({ name: 'Deploy the crash fix', $name: 'Deploy the crash fix' });
+    await executeTool('manage_operations', { action: 'approve', run_id: Number(card.id) },
+      TEST_ENV, ownerAuthCtx(ctx.workspace.org.id, ctx.workspace.users.owner.id));
+    const [after] = await ctx.sql`SELECT name, slug, metadata FROM entities WHERE id = ${created.entity_id}`;
+    expect(after.name).toBe('Deploy the crash fix');
+    expect(after.metadata.name).toBe('Deploy the crash fix');
+    expect(after.slug).toBe(held.slug);
+  });
+
+  it.each(['approval', 'deny'] as const)('honors a $name %s policy for derived names', async (effect) => {
+    const ctx = await setupKeyedAutomation({
+      problems: { entity: 'topic', key: ['category'], name: ['name'] },
+    });
+    const first = await nextCompletion(ctx);
+    await completeWithToken(ctx, first.token, first.runId, {
+      problems: [{ category: 'Stability', name: 'Investigate the crash' }],
+    });
+    const [created] = await ctx.sql`
+      SELECT entity_id FROM entity_identities
+      WHERE organization_id = ${ctx.workspace.org.id} AND namespace = 'automation_key'
+    `;
+    const [policy] = await ctx.sql`
+      INSERT INTO write_approval_policies
+        (organization_id, resource_class, principal_kind, principal_id, entity_type_slug, field_path)
+      VALUES (${ctx.workspace.org.id}, 'entity', 'agent', ${ctx.agent.agentId}, 'topic', '$name')
+      RETURNING id
+    `;
+    await ctx.sql`INSERT INTO write_policy_action_effects (policy_id, action, effect)
+      VALUES (${policy.id}, 'update', ${effect})`;
+    const next = await nextCompletion(ctx);
+    await completeWithToken(ctx, next.token, next.runId, {
+      problems: [{ category: 'Stability', name: 'Deploy the crash fix' }],
+    });
+    const [after] = await ctx.sql`SELECT name, metadata FROM entities WHERE id = ${created.entity_id}`;
+    expect(after.name).toBe('Investigate the crash');
+    expect(after.metadata.name).toBe(effect === 'approval' ? 'Deploy the crash fix' : 'Investigate the crash');
+    const cards = await ctx.sql`
+      SELECT id, action_input FROM runs WHERE organization_id = ${ctx.workspace.org.id}
+        AND action_key = 'entity_field_change' AND approval_status = 'pending'
+    `;
+    expect(cards).toHaveLength(effect === 'approval' ? 1 : 0);
+    if (effect === 'approval') {
+      expect(cards[0].action_input.fields).toEqual({ $name: 'Deploy the crash fix' });
+      await executeTool('manage_operations', { action: 'approve', run_id: Number(cards[0].id) },
+        TEST_ENV, ownerAuthCtx(ctx.workspace.org.id, ctx.workspace.users.owner.id));
+      const [approved] = await ctx.sql`SELECT name FROM entities WHERE id = ${created.entity_id}`;
+      expect(approved.name).toBe('Deploy the crash fix');
+    }
   });
 
   it('syncs extracted fields into entities and respects a human-owned field on re-run, queuing an approval', async () => {

--- a/packages/server/src/__tests__/integration/entities/member-role-hooks.test.ts
+++ b/packages/server/src/__tests__/integration/entities/member-role-hooks.test.ts
@@ -86,6 +86,19 @@ describe('member roles through generic entity edits', () => {
       message: "You don't have permission to view this workspace. Ask a workspace owner or admin for access.", httpStatus: 403,
     });
   });
+  it.each([requireReadAccess, requireWriteAccess])('checks entity access inside the supplied transaction (%#)', async (guard) => {
+    const sql = getTestDb();
+    await sql.begin(async (tx) => {
+      const [created] = await tx`
+        INSERT INTO entities (organization_id, entity_type_id, name, slug, created_by)
+        SELECT organization_id, entity_type_id, 'Transactional record', 'transactional-record', created_by
+        FROM entities WHERE id = ${member.entityId}
+        RETURNING id
+      `;
+      await expect(guard(tx, Number(created.id), ownerToolContext(org.id, owner.userId)))
+        .resolves.toBeUndefined();
+    });
+  });
   it('applies the same existing write permission to ordinary entities', async () => {
     const client = await TestApiClient.for({ organizationId: org.id, userId: owner.userId, memberRole: 'owner' });
     await client.entity_schema.createType({ slug: 'contact', name: 'Contact' });

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -8,10 +8,7 @@
  */
 
 import { deriveToolActorSource } from '../../utils/apply-context';
-import {
-	RESERVED_COLUMN_NAMES,
-	validateEntityRowPatchGrantingApprovedFields,
-} from "../../authz/entity-row-validation";
+import { RESERVED_COLUMN_NAMES } from "../../authz/entity-row-validation";
 import { SCOPE_CHECK_NOT_APPLICABLE } from "../../auth/tool-access";
 import {
 	type EntityTransactionHookContext,
@@ -57,7 +54,6 @@ import {
 	deleteEntity,
 	type EntityData,
 	mergeEntityFields,
-	patchEntityRows,
 } from "../../utils/entity-management";
 import { applyMergeGroupInTransaction } from "../../utils/entity-merge";
 import { ToolUserError } from "../../utils/errors";
@@ -1194,111 +1190,29 @@ export async function applyEntityFieldChangeProposal(
 					`
 				)[0]
 			: undefined;
-		const merge =
-			Object.keys(metadataFields).length > 0
-				? await mergeEntityFields({
-						tx,
-						entityId: proposal.entity_id,
-						fields: metadataFields,
-						source: "human",
-						actorId: approverUserId,
-						note: proposal.reason ?? null,
-						// Don't overwrite a field the human re-edited after this proposal was queued.
-						expectedCurrent: proposal.current ?? null,
-						// This IS the approval — but only for what the card showed.
-						approvedFields: proposal.escalated_fields ?? [],
-					})
-				: ({
-						changed: false,
-						applied: {},
-						blocked: {},
-						stale: {},
-						affirmed: [],
-						nextMetadata: {},
-						nextControls: {},
-					} satisfies FieldMergeResult);
-		if (Object.keys(attributeFields).length > 0) {
-			const rows = await tx<{
-				name: string | null;
-				parent_id: number | null;
-				content: string | null;
-			}>`
-        SELECT name, parent_id, content FROM entities
-        WHERE id = ${proposal.entity_id} AND deleted_at IS NULL
-        FOR UPDATE
-      `;
-			if (rows.length === 0) {
-				throw new ToolUserError(`Entity ${proposal.entity_id} not found`, 404);
-			}
-			const live = {
-				$name: rows[0].name ?? null,
-				$parent_id:
-					rows[0].parent_id == null ? null : Number(rows[0].parent_id),
-				$content: rows[0].content ?? null,
-			} as Record<string, unknown>;
-			const apply: Record<string, unknown> = {};
-			for (const [key, proposed] of Object.entries(attributeFields)) {
-				const expected = proposal.current?.[key];
-				if (
-					proposal.current &&
-					Object.hasOwn(proposal.current, key) &&
-					JSON.stringify(live[key] ?? null) !== JSON.stringify(expected ?? null)
-				) {
-					merge.stale[key] = {
-						expected: expected ?? null,
-						live: live[key] ?? null,
-					};
-					continue;
+		// Plan metadata and attributes from the same locked pre-image and validate
+		// their combined result once. A valid metadata/name transition must not be
+		// judged against a temporary row containing only half of the approved edit.
+		const merge = await mergeEntityFields({
+			tx,
+			entityId: proposal.entity_id,
+			fields: metadataFields,
+			attributes: attributeFields,
+			source: "human",
+			actorId: approverUserId,
+			note: proposal.reason ?? null,
+			expectedCurrent: proposal.current ?? null,
+			approvedFields: proposal.escalated_fields ?? [],
+			beforePersist: (planned) => {
+				// An escalated card is one reviewed unit. Reject drift before rules
+				// see an unapproved fragment; ordinary ownership cards retain their
+				// existing per-field consent and may apply the fields still current.
+				if ((proposal.escalated_fields?.length ?? 0) > 0 &&
+					Object.keys(planned.stale).length > 0) {
+					throw new AtomicCardStaleError(planned.stale);
 				}
-				apply[key] = proposed;
-				merge.applied[key] = { old: live[key] ?? null, new: proposed };
-			}
-			if (Object.keys(apply).length > 0) {
-				const nextName =
-					"$name" in apply ? String(apply.$name ?? "") || null : null;
-				// Applying an approval is a WRITE, so it revalidates. A human blessing
-				// a field cannot bless an illegal state: without this, a rule could be
-				// satisfied by escalating, and the approval would then commit unchecked.
-				await patchEntityRows({
-					tx,
-					ids: [proposal.entity_id],
-					patch: await validateEntityRowPatchGrantingApprovedFields({
-						tx,
-						ids: [proposal.entity_id],
-						patch: {
-							...(nextName !== null ? { name: nextName } : {}),
-							...("$parent_id" in apply
-								? { parentId: apply.$parent_id as number | null }
-								: {}),
-							...("$content" in apply
-								? { content: apply.$content as string | null }
-								: {}),
-						},
-						// Same as the metadata half above, and it has to be set on BOTH: a
-						// card mixing `$name` with a metadata field runs through both
-						// writers inside one transaction, so an escalate re-thrown here
-						// rolls the approved metadata back out too.
-						approvedFields: proposal.escalated_fields ?? [],
-					}),
-				});
-			}
-		}
-		// An ESCALATED card is one unit: `updateEntity` deferred the whole
-		// proposal precisely because the fragment could not stand on its own, so
-		// applying a subset commits a state no rule validated and no human
-		// reviewed. Both halves have run by here, so `merge.stale` is the
-		// complete picture — throwing rolls the whole transaction back rather
-		// than re-deriving staleness with a second, divergent implementation.
-		//
-		// Scoped to escalated cards on purpose. A card minted from a field-
-		// ownership hold carries per-field consent (the human owns the VALUE,
-		// not the row), so its fields stay independently applicable.
-		if (
-			(proposal.escalated_fields?.length ?? 0) > 0 &&
-			Object.keys(merge.stale).length > 0
-		) {
-			throw new AtomicCardStaleError(merge.stale);
-		}
+			},
+		});
 		const appliedChanges = Object.entries(merge.applied).map(
 			([field, value]) => ({ field, old: value.old, new: value.new }),
 		);

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -220,6 +220,13 @@ interface EntityCreateOptions {
 interface EntityUpdateOptions {
 	/** Join an existing semantic mutation transaction when supplied. */
 	sql?: DbClient;
+	/** Keep an automatically derived label current until its name is customized. */
+	derivedName?: {
+		fields: readonly string[];
+		compute: (metadata: Readonly<Record<string, unknown>>) => string;
+	};
+	/** Keyed identities keep their existing URL when their display label changes. */
+	preserveSlug?: boolean;
 	/**
 	 * Semantic caller hook executed after the row write but before commit. Low-level
 	 * projection writers omit it; manage_entity uses it for canonical entity.updated.
@@ -680,6 +687,8 @@ export async function mergeEntityFields(params: {
 	tx: DbClient;
 	entityId: number;
 	fields: Record<string, unknown>;
+	/** Governed top-level attributes from an approved composite proposal. */
+	attributes?: Partial<Record<'$name' | '$parent_id' | '$content', unknown>>;
 	source: FieldWriteSource;
 	/** User id for a human edit; null/system otherwise. */
 	actorId: string | null;
@@ -697,10 +706,15 @@ export async function mergeEntityFields(params: {
 	 * for. See `validateEntityRowPatchGrantingApprovedFields`'s `approvedFields`.
 	 */
 	approvedFields?: readonly string[];
+	/** Assert caller-owned invariants on the full merge before validation or writes. */
+	beforePersist?: (merge: FieldMergeResult) => void;
 }): Promise<FieldMergeResult> {
 	const { tx, entityId, fields, source, actorId } = params;
-	const rows = await tx<{ metadata: unknown; field_controls: unknown }>`
-    SELECT metadata, field_controls FROM entities
+	const rows = await tx<{
+		metadata: unknown; field_controls: unknown;
+		name: string | null; parent_id: number | null; content: string | null;
+	}>`
+    SELECT metadata, field_controls, name, parent_id, content FROM entities
     WHERE id = ${entityId} AND deleted_at IS NULL
     FOR UPDATE
   `;
@@ -725,6 +739,31 @@ export async function mergeEntityFields(params: {
 		affirm: params.affirm,
 		requireApproval: params.requireApproval,
 	});
+	const attributePatch: EntityRowPatch = {};
+	const liveAttributes: Record<string, unknown> = {
+		$name: rows[0].name ?? null,
+		$parent_id: rows[0].parent_id == null ? null : Number(rows[0].parent_id),
+		$content: rows[0].content ?? null,
+	};
+	for (const [field, proposed] of Object.entries(params.attributes ?? {})) {
+		const live = liveAttributes[field];
+		if (params.expectedCurrent && Object.hasOwn(params.expectedCurrent, field) &&
+			JSON.stringify(live) !== JSON.stringify(params.expectedCurrent[field] ?? null)) {
+			merge.stale[field] = { expected: params.expectedCurrent[field] ?? null, live };
+			continue;
+		}
+		if (JSON.stringify(live) === JSON.stringify(proposed ?? null)) continue;
+		if (source !== 'human' && new Set(params.requireApproval ?? []).has(field)) {
+			merge.blocked[field] = { current: live, proposed };
+			continue;
+		}
+		if (field === '$name') attributePatch.name = String(proposed ?? '');
+		if (field === '$parent_id') attributePatch.parentId = proposed as number | null;
+		if (field === '$content') attributePatch.content = proposed as string | null;
+		merge.applied[field] = { old: live, new: proposed };
+		merge.changed = true;
+	}
+	params.beforePersist?.(merge);
 
 	if (merge.changed) {
 		await patchEntityRows({
@@ -734,6 +773,7 @@ export async function mergeEntityFields(params: {
 				tx,
 				ids: [entityId],
 				patch: {
+					...attributePatch,
 					metadata: merge.nextMetadata,
 					fieldControls: merge.nextControls,
 				},
@@ -744,12 +784,7 @@ export async function mergeEntityFields(params: {
 	return merge;
 }
 
-/**
- * Tolerant metadata/controls parse. Exported for `promote-keyed-entities`,
- * which reads live metadata inside a rule-containment catch — a throw there
- * would escape the catch and roll back the window completion it exists to save.
- */
-export function parseEntityJsonObject(value: unknown): Record<string, unknown> {
+function parseEntityJsonObject(value: unknown): Record<string, unknown> {
 	if (value == null) return {};
 	if (typeof value === "string") {
 		try {
@@ -784,11 +819,8 @@ export function parseEntityJsonObject(value: unknown): Record<string, unknown> {
  *
  * A rule that crashes or times out reads as a deny, so a broken rule surfaces as
  * an error rather than an unanswerable approval.
- *
- * Exported for automation promotion, whose merge strips human-owned and
- * policy-gated fields before validating and so faces the same split.
  */
-export async function fullProposalVerdict(params: {
+async function fullProposalVerdict(params: {
 	tx: DbClient;
 	entityId: number;
 	patch: EntityRowPatch;
@@ -1039,6 +1071,9 @@ export async function updateEntity(
 	CreatedEntity & { fieldMerge?: FieldMergeInfo; deferred?: DeferredMutation }
 > {
 	const sql = opts?.sql ?? getDb();
+	if (opts?.derivedName && data.name !== undefined) {
+		throw new Error("An explicit name cannot also be derived from metadata");
+	}
 
 	// Validate write access (uses PG for auth tables)
 	await requireWriteAccess(sql, entityId, ctx);
@@ -1140,6 +1175,18 @@ export async function updateEntity(
 				? JSON.parse(current[0].field_controls as string)
 				: (current[0].field_controls ?? {})
 		) as Record<string, FieldControl>;
+		// There is no ownership marker for top-level names. Only keep deriving a
+		// label that still matches its prior projection; a custom or already
+		// divergent label is preserved. This comparison stays under the row lock.
+		const derivedName = opts?.derivedName &&
+			current[0].name === opts.derivedName.compute(existing)
+			? opts.derivedName : undefined;
+		const proposedName = data.name ?? derivedName?.compute({ ...existing, ...metadataUpdates });
+		let effectiveName = proposedName;
+		const namingFieldsProposed = derivedName?.fields.some((field) =>
+			Object.hasOwn(metadataUpdates, field) &&
+			JSON.stringify(existing[field] ?? null) !== JSON.stringify(metadataUpdates[field] ?? null)
+		) ?? false;
 
 		// Non-human edits run ONE policy pass over metadata fields AND the
 		// top-level attributes (name/content/parent_id as reserved $-paths, so a
@@ -1152,7 +1199,7 @@ export async function updateEntity(
 			string,
 			{ current: unknown; proposed: unknown }
 		> = {};
-		let applyName = data.name !== undefined;
+		let applyName = proposedName !== undefined;
 		let applyParent = data.parent_id !== undefined;
 		let applyContent = hasContent;
 		// Computed for EVERY caller, not just the gated ones: when a write defers
@@ -1162,10 +1209,10 @@ export async function updateEntity(
 			string,
 			{ current: unknown; proposed: unknown }
 		> = {};
-		if (applyName && (data.name ?? null) !== (current[0].name ?? null)) {
+		if (applyName && (namingFieldsProposed || (proposedName ?? null) !== (current[0].name ?? null))) {
 			attributeProposals.$name = {
 				current: current[0].name ?? null,
-				proposed: data.name ?? null,
+				proposed: proposedName ?? null,
 			};
 		}
 		const currentParentId =
@@ -1259,7 +1306,7 @@ export async function updateEntity(
 			mergedMetadata = merge.nextMetadata;
 			// A human edit claims ownership of the fields it sets; an automation-source
 			// merge never claims ownership, so leave field_controls untouched.
-			mergedControls = isHumanEdit ? merge.nextControls : null;
+			mergedControls = isHumanEdit && merge.changed ? merge.nextControls : null;
 			fieldMerge = {
 				applied: Object.keys(merge.applied),
 				blocked: Object.fromEntries(
@@ -1270,6 +1317,17 @@ export async function updateEntity(
 				),
 			};
 		}
+		if (derivedName && mergedMetadata) {
+			// A held metadata value must never leak into the visible title. The
+			// full proposal still retains its corresponding name for approval.
+			effectiveName = derivedName.compute(mergedMetadata);
+			if (effectiveName !== proposedName) {
+				blockedAttributes.$name = {
+					current: applyName ? effectiveName : current[0].name ?? null,
+					proposed: proposedName ?? null,
+				};
+			}
+		}
 		if (Object.keys(blockedAttributes).length > 0) {
 			fieldMerge = {
 				applied: fieldMerge?.applied ?? [],
@@ -1278,11 +1336,13 @@ export async function updateEntity(
 		}
 
 		const rowPatch: EntityRowPatch = {};
-		if (applyName && data.name !== undefined) rowPatch.name = data.name;
-		const slugPatch = data.slug ?? (applyName ? newSlug : null);
+		if (applyName && effectiveName !== undefined && effectiveName !== current[0].name) {
+			rowPatch.name = effectiveName;
+		}
+		const slugPatch = opts?.preserveSlug ? null : data.slug ?? (applyName ? newSlug : null);
 		if (slugPatch !== null) rowPatch.slug = slugPatch;
 		if (applyParent) rowPatch.parentId = data.parent_id ?? null;
-		if (hasMetadataUpdates) rowPatch.metadata = mergedMetadata;
+		if (hasMetadataUpdates && fieldMerge?.applied.length) rowPatch.metadata = mergedMetadata;
 		if (mergedControls !== null) rowPatch.fieldControls = mergedControls;
 		if (data.enabled_classifiers !== undefined) {
 			rowPatch.enabledClassifiers = data.enabled_classifiers;
@@ -1309,11 +1369,15 @@ export async function updateEntity(
 		let deferEscalatedFields: string[] = [];
 		let validated: ValidatedEntityRowPatch | null = null;
 		try {
-			validated = await validateEntityRowPatch({
-				tx,
-				ids: [entityId],
-				patch: rowPatch,
-			});
+			// A replay with no inline changes must not become a new rule verdict
+			// or refresh updated_at. Ownership-held fields still queue below.
+			if (Object.keys(rowPatch).length > 0) {
+				validated = await validateEntityRowPatch({
+					tx,
+					ids: [entityId],
+					patch: rowPatch,
+				});
+			}
 		} catch (err) {
 			if (!(err instanceof EntityRowValidationError)) throw err;
 			const heldFields = Object.keys(fieldMerge?.blocked ?? {});
@@ -1370,7 +1434,7 @@ export async function updateEntity(
 			const escalation =
 				fullVerdict?.verdict.outcome === "escalate"
 					? fullVerdict.verdict
-					: err.verdict.outcome === "escalate"
+					: heldFields.length === 0 && err.verdict.outcome === "escalate"
 						? err.verdict
 						: null;
 
@@ -1410,7 +1474,13 @@ export async function updateEntity(
 
 		if (validated) {
 			await patchEntityRows({ tx, ids: [entityId], patch: validated });
-		} else {
+			if (rowPatch.name !== undefined && rowPatch.name !== current[0].name) {
+				fieldMerge = {
+					applied: [...(fieldMerge?.applied ?? []), "$name"],
+					blocked: fieldMerge?.blocked ?? {},
+				};
+			}
+		} else if (deferWholeWrite) {
 			// Nothing applied, so report every proposed field as blocked rather than
 			// letting `fieldMerge.applied` claim a write that did not happen.
 			fieldMerge = {

--- a/packages/server/src/utils/organization-access.ts
+++ b/packages/server/src/utils/organization-access.ts
@@ -11,7 +11,7 @@
  *   also needs `isAuthenticated` (system/internal calls like reaction scripts).
  */
 
-import { type DbClient, getDb } from '../db/client';
+import type { DbClient } from '../db/client';
 import type { ToolContext } from '../tools/registry';
 import { ToolUserError } from './errors';
 
@@ -44,7 +44,7 @@ export async function getWorkspaceRole(
  * Allowed if entity belongs to the user's organization and user is a member.
  */
 async function canReadEntity(sql: DbClient, entityId: number, ctx: ToolContext): Promise<boolean> {
-  const entityResult = await getDb()`
+  const entityResult = await sql`
     SELECT e.organization_id
     FROM entities e
     WHERE e.id = ${entityId}
@@ -82,7 +82,7 @@ export async function requireWriteAccess(
   entityId: number,
   ctx: ToolContext
 ): Promise<void> {
-  const rows = await getDb()`
+  const rows = await sql`
     SELECT 1 FROM entities
     WHERE id = ${entityId} AND organization_id = ${ctx.organizationId}
     LIMIT 1

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -36,7 +36,6 @@ import { ApprovalAttribution } from '@lobu/core/contracts/interaction-envelope';
 import {
   type CreateOrDeleteDecision,
   deferEntityCreate,
-  deferEntityFieldChange,
   type DeferredMutation,
   runMutationGate,
 } from '../authz/entity-mutation-gate';
@@ -45,15 +44,14 @@ import {
   resolveAutomationOwner,
 } from '../authz/entity-policy';
 import type { DbClient } from '../db/client';
+import type { Env } from '../index';
 import type { EntityOutput } from '../types/automations';
-import type { AppliedChange, BlockedChange } from './entity-field-merge';
-import { recordEntityWriteDenial } from './entity-write-denial-audit';
+import type { AppliedChange } from './entity-field-merge';
+import { EntityPolicyDenialError, recordEntityWriteDenial } from './entity-write-denial-audit';
 import {
-  fullProposalVerdict,
   hardDeleteEntityRows,
   insertEntityRow,
-  mergeEntityFields,
-  parseEntityJsonObject,
+  updateEntity,
 } from './entity-management';
 import { EntityRowValidationError, validateEntityRowInsert } from '../authz/entity-row-validation';
 import logger from './logger';
@@ -283,6 +281,9 @@ async function upsertKeyedEntity(params: {
   identifier: string;
   name: string;
   baseSlug: string;
+  output: EntityOutput;
+  stableKey: string;
+  runId: number;
   metadata: Record<string, unknown>;
   /** Extracted entity field values to sync into metadata (excludes the stable key). */
   fieldValues: Record<string, unknown>;
@@ -309,10 +310,11 @@ async function upsertKeyedEntity(params: {
 }): Promise<{
   entityId: number;
   created: boolean;
-  blocked: Record<string, BlockedChange>;
   /** Fields the automation actually wrote inline (auto-applied), old→new. */
   applied: Record<string, AppliedChange>;
   blockedCreate: boolean;
+  deferred?: DeferredMutation;
+  name?: string;
   /**
    * Set when the write was REFUSED here — every refusal, whichever decider made
    * it: a rule deny on either op, and a policy deny on an update or a create.
@@ -335,8 +337,7 @@ async function upsertKeyedEntity(params: {
   // 1. Existing identity → reuse its entity (the idempotent fast path), and SYNC the
   //    freshly-extracted field values into it honoring human ownership AND the org's
   //    update policy: un-gated fields are written; human-owned or policy-gated
-  //    fields are returned as `blocked` (the caller queues an approval) and never
-  //    overwritten inline.
+  //    fields are returned as a deferred approval and never overwritten inline.
   const existing = await tx<{ entity_id: number | string }>`
     SELECT ei.entity_id
     FROM entity_identities ei
@@ -351,146 +352,71 @@ async function upsertKeyedEntity(params: {
   `;
   if (existing.length > 0) {
     const entityId = Number(existing[0].entity_id);
-    // Owners are 'none' here on purpose: human ownership is enforced inside the
-    // merge itself; the gate only adds the org policy's field gates on top.
-    const decision = await runMutationGate({
-      action: 'update',
-      organizationId,
-      // The automation is the acting principal (its OWN rows bind); its owning agent
-      // is folded in as the ancestor via `ownerAgentId` so the agent's envelope
-      // ALSO binds — max-restrictive, so the agent can tighten but an automation-
-      // specific restriction is never loosened away.
-      principalKind: 'automation',
-      sql: tx,
-      attribution: ApprovalAttribution.Automation,
-      automationId: params.automationId,
-      principalId: mutationPrincipalId({ automationId: params.automationId }),
-      ownerAgentId: params.automationAgentId,
-      ownerResolved: params.automationOwnerResolved,
-      entityTypeSlug: params.entityTypeSlug,
-      entityId,
-      fields: Object.fromEntries(
-        Object.keys(params.fieldValues).map((field) => [field, 'none' as const])
-      ),
-    });
-    // Fail CLOSED on a deny: apply nothing and return a modeled policy outcome.
-    // Unexpected persistence errors still throw and roll back the completion.
-    if (decision.outcome === 'deny') {
-      return {
-        entityId,
-        created: false,
-        blocked: {},
-        applied: {},
-        blockedCreate: false,
-        denied: {
-          source: 'policy',
-          reason: decision.reason,
-          auditFields: Object.keys(params.fieldValues),
-        },
-      };
-    }
-    const requireApproval = [...decision.requireApproval];
+    const applied: Record<string, AppliedChange> = {};
     try {
-      const merge = await mergeEntityFields({
-        tx,
-        entityId,
-        fields: params.fieldValues,
-        source: 'automation',
-        actorId: null,
-        requireApproval,
+      // Promotion is an in-process Automation write, using the same principal
+      // and owning-agent envelope as its reaction. Reuse the shared update
+      // funnel so metadata, derived names, rules and approvals stay atomic.
+      const updated = await updateEntity(entityId, { metadata: params.fieldValues }, {} as Env, {
+        organizationId,
+        userId: null,
+        memberRole: null,
+        agentId: params.automationAgentId,
+        isAuthenticated: true,
+        tokenType: 'session',
+        scopedToOrg: true,
+        allowCrossOrg: false,
+        grantedOrganizationIds: null,
+        directSearchFederation: false,
+        actingAutomationId: params.automationId,
+        actingRunId: params.runId,
+      }, {
+        sql: tx,
+        policyPrincipalKind: 'automation',
+        attribution: ApprovalAttribution.Automation,
+        principalId: mutationPrincipalId({ automationId: params.automationId }),
+        ownerAgentId: params.automationAgentId,
+        ownerResolved: params.automationOwnerResolved,
+        parentRunId: params.runId,
+        preserveSlug: true,
+        derivedName: {
+          fields: params.output.name?.length ? params.output.name : params.output.key,
+          compute: (metadata) => buildEntityName(metadata, params.output, params.stableKey),
+        },
+        afterPersist: async (before, after) => {
+          for (const field of Object.keys(params.fieldValues)) {
+            const oldValue = before.metadata?.[field] ?? null;
+            const newValue = after.metadata?.[field] ?? null;
+            if (JSON.stringify(oldValue) !== JSON.stringify(newValue)) {
+              applied[field] = { old: oldValue, new: newValue };
+            }
+          }
+          if (before.name !== after.name) {
+            applied.$name = { old: before.name, new: after.name };
+          }
+        },
       });
       return {
         entityId,
+        name: updated.name,
         created: false,
-        blocked: merge.blocked,
-        applied: merge.applied,
+        applied,
         blockedCreate: false,
+        deferred: updated.deferred,
       };
     } catch (err) {
+      // The shared funnel rejects before persistence. Unexpected failures still
+      // escape to the enclosing savepoint and roll back the completion.
+      if (err instanceof EntityPolicyDenialError) {
+        return {
+          entityId, created: false, applied: {}, blockedCreate: false,
+          denied: { source: 'policy', reason: err.denial.reason, auditFields: err.denial.deniedFields },
+        };
+      }
       if (!(err instanceof EntityRowValidationError)) throw err;
-      // A write rule is a per-ROW verdict, so it must not escape this row.
-      // Letting it propagate rolls back the whole window completion — every
-      // promoted row and every declared output — and it recurs on every retry,
-      // so one escalating rule permanently poison-pills the automation.
-      //
-      // A deny is a refusal, not a request for review: fail the row closed,
-      // like the policy deny above.
-      if (err.verdict.outcome !== 'escalate') {
-        return {
-          entityId,
-          created: false,
-          blocked: {},
-          applied: {},
-          blockedCreate: false,
-          denied: {
-            source: 'rule',
-            reason: err.verdict.reason,
-            auditFields: err.verdict.fields,
-          },
-        };
-      }
-      // Hold the row WHOLE, and ask the rule about that same whole write.
-      //
-      // The caught verdict judged the RESIDUAL — `mergeEntityFields` strips
-      // human-owned and policy-gated fields before it validates, so the write
-      // the rule answered about can be a strict subset of the one the card
-      // replays. The replay demands `verdict.fields.every(f =>
-      // approvedFields.includes(f))`, so a grant copied off the residual mints
-      // a card no approval can ever clear: approving re-runs the rule against
-      // the full write, it names a field nobody granted, and the write throws.
-      // (`updateEntity` re-asks for the same reason — same helper.)
-      const [live] = await tx<{ metadata: unknown }>`
-        SELECT metadata FROM entities WHERE id = ${entityId}
-      `;
-      // Tolerant parse on purpose: this runs INSIDE the containment catch, so a
-      // throw here would escape it and roll back the very window completion the
-      // catch exists to save.
-      const current = parseEntityJsonObject(live?.metadata);
-      const held: Record<string, BlockedChange> = {};
-      for (const [field, proposed] of Object.entries(params.fieldValues)) {
-        held[field] = { current: current[field] ?? null, proposed };
-      }
-      // `fieldControls` is ungoverned, so a metadata-only patch asks the rule
-      // the whole question the card's replay will ask it.
-      const whole = await fullProposalVerdict({
-        tx,
-        entityId,
-        patch: { metadata: { ...current, ...params.fieldValues } },
-      });
-      // Stated in the terms the card proposes, not the residual's. A deny on
-      // the whole write is the same dead end as an uncovered escalate, so fail
-      // the row closed rather than card a proposal approval cannot rescue.
-      if (whole?.verdict.outcome === 'deny') {
-        return {
-          entityId,
-          created: false,
-          blocked: {},
-          applied: {},
-          blockedCreate: false,
-          denied: {
-            source: 'rule',
-            reason: whole.verdict.reason,
-            auditFields: whole.verdict.fields,
-          },
-        };
-      }
-      // A whole write the rule finds legal still needs the card — those fields
-      // are held by ownership or policy, not by the rule — but no grant, and
-      // no rule reason: neither describes why THIS card exists.
       return {
-        entityId,
-        created: false,
-        blocked: held,
-        applied: {},
-        blockedCreate: false,
-        ...(whole?.verdict.outcome === 'escalate'
-          ? {
-              escalated: {
-                fields: whole.verdict.fields,
-                reason: whole.verdict.reason,
-              },
-            }
-          : {}),
+        entityId, created: false, applied: {}, blockedCreate: false,
+        denied: { source: 'rule', reason: err.verdict.reason, auditFields: err.verdict.fields },
       };
     }
   }
@@ -504,7 +430,6 @@ async function upsertKeyedEntity(params: {
     return {
       entityId: 0,
       created: false,
-      blocked: {},
       applied: {},
       blockedCreate: true,
       ...(params.createGate.outcome === 'deny'
@@ -548,7 +473,6 @@ async function upsertKeyedEntity(params: {
       return {
         entityId: 0,
         created: false,
-        blocked: {},
         applied: {},
         blockedCreate: true,
         denied: {
@@ -565,7 +489,6 @@ async function upsertKeyedEntity(params: {
     return {
       entityId: 0,
       created: false,
-      blocked: {},
       applied: {},
       blockedCreate: true,
       escalated: { fields: err.verdict.fields, reason: err.verdict.reason },
@@ -586,7 +509,7 @@ async function upsertKeyedEntity(params: {
     RETURNING entity_id
   `;
   if (claimed.length > 0) {
-    return { entityId, created: true, blocked: {}, applied: {}, blockedCreate: false };
+    return { entityId, created: true, applied: {}, blockedCreate: false };
   }
 
   // Lost the race: another live transaction already claimed this key. Resolve
@@ -612,14 +535,13 @@ async function upsertKeyedEntity(params: {
     return {
       entityId: Number(winner[0].entity_id),
       created: false,
-      blocked: {},
       applied: {},
       blockedCreate: false,
     };
   }
   // Extremely unlikely: the conflicting claim was tombstoned between our INSERT
   // and this re-read. Keep our entity as the canonical one.
-  return { entityId, created: true, blocked: {}, applied: {}, blockedCreate: false };
+  return { entityId, created: true, applied: {}, blockedCreate: false };
 }
 
 /**
@@ -779,7 +701,8 @@ export async function promoteAutomationEntityOutput(
     try {
       const {
         created,
-        blocked,
+        deferred,
+        name: persistedName,
         applied,
         entityId,
         blockedCreate,
@@ -795,6 +718,9 @@ export async function promoteAutomationEntityOutput(
           identifier,
           name,
           baseSlug: slug,
+          output,
+          stableKey,
+          runId,
           metadata,
           fieldValues,
           createdBy,
@@ -895,25 +821,9 @@ export async function promoteAutomationEntityOutput(
       if (created) {
         result.changes.push({ entityId, name, kind: 'created', applied: {} });
       } else if (Object.keys(applied).length > 0) {
-        result.changes.push({ entityId, name, kind: 'updated', applied });
+        result.changes.push({ entityId, name: persistedName ?? name, kind: 'updated', applied });
       }
-      const blockedFields = Object.keys(blocked);
-      if (blockedFields.length > 0) {
-        result.deferred.push(
-          deferEntityFieldChange({
-            entityId,
-            fields: Object.fromEntries(blockedFields.map((f) => [f, blocked[f].proposed])),
-            current: Object.fromEntries(blockedFields.map((f) => [f, blocked[f].current])),
-            attribution: ApprovalAttribution.Automation,
-            // A rule-held row carries the rule's own grant and reason: the apply
-            // path replays the write, so an empty grant re-escalates, the write
-            // throws, and `applyFailure` resets the run to pending — forever.
-            ...(escalated ? { escalatedFields: escalated.fields, reason: escalated.reason } : {}),
-            automationId,
-            parentRunId: runId,
-          })
-        );
-      }
+      if (deferred) result.deferred.push(deferred);
     } catch (err) {
       // The savepoint gives us a clean error boundary, but the declared output
       // remains atomic: an unexpected failure must roll back the completion so


### PR DESCRIPTION
## Summary
When a later Automation window updates a keyed entity, its details change but its board/table title keeps the original wording. For example, an action can change from “Investigate the crash” to “Deploy the verified crash fix” while the visible title still says “Investigate the crash”.

Route existing keyed updates through the shared entity-write path. Derive names from accepted field values, preserve custom or already-diverged names and existing slugs, and include actual name changes in the run change set. Apply approved metadata/name changes as one validated patch, checking stale atomic approvals before validating a partial result. Keep access checks inside the supplied transaction and leave unchanged promotions untouched.

## Test plan
- [x] Reproduced the stale title through a real database-backed Automation completion: expected `Deploy the verified crash fix`, received `Investigate the crash`.
- [x] Added coverage for custom names, owned naming fields and their approval, name policy approval/denial, combined metadata/name rules, and stale approvals.
- [x] Focused integration suites: 78 passed across keyed promotion, atomic approval application, ownership/rule holds, and workspace access.
- [x] Codex pre-review fixes reread; eight intended paths staged explicitly; local `make pre-pr` and pre-commit checks pass.
- [ ] GitHub CI and exact-head semantic/UI gates pass.
- [ ] Squash revision deployed and live behavior verified.

Red → green evidence:
```text
Stale title regression: 1 failed, 25 skipped
Expected: Deploy the verified crash fix
Received: Investigate the crash

Composite approval regression: 1 failed, 51 passed
EntityRowValidationError: vendor and display name must change together

Transactional access regression: 2 failed, 22 skipped
ToolUserError: This record was not found in this workspace

After fixes: 4 test files passed, 78 tests passed
```

## Notes
Stable identities and URLs are preserved. Existing custom or already-diverged labels require targeted reconciliation; the change does not infer ownership of a historical top-level name. Public schemas, SDK operations and database structure remain unchanged.


## Review follow-up (merge pending)
The exact-head review found that a policy-held derived name must hold its changing naming inputs too, or the next promotion mistakes the resulting mismatch for a custom label. That correction passes the 78 focused integration tests locally but is not yet committed.

A subsequent review found the remaining approval-contract gap: ordinary per-field approvals can apply the title while skipping a stale naming input. A correct fix needs persisted dependency groups, including unchanged naming-input snapshots and group-aware proposal deduplication; this must remain separate from rule-consent `escalated_fields`. The requested grouped-approval design confirmation is pending. Do not merge this PR yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Approved entity changes now apply metadata and governed attributes atomically, preventing partial updates when stale data or approval rules are detected.
  - Keyed automation updates now consistently respect naming policies, approvals, write rules, and custom names.
  - Derived names update when appropriate while preserving human-customized names and keyed identities.
  - Access checks now reliably use the active transaction, including for newly created entities.
  - Deferred, denied, and escalated automation changes are recorded more consistently in change results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->