### PR TITLE
fix(automations): bound complete page responses by bytes

### DIFF
--- a/packages/server/src/__tests__/integration/automations/automation-response-budget.test.ts
+++ b/packages/server/src/__tests__/integration/automations/automation-response-budget.test.ts
@@ -1,0 +1,202 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization, createTestAccessToken, createTestAgent,
+  createTestConnection, createTestEntity, createTestOAuthClient,
+  createTestOrganization, createTestUser,
+} from '../../setup/test-fixtures';
+import { TestApiClient, TestMcpClient } from '../../setup/test-mcp-client';
+
+const ROW_COUNT = 150;
+
+describe('Automation response byte budget', () => {
+  let api: TestApiClient;
+  let wire: TestMcpClient;
+  let orgId: string;
+  let entityId: number;
+  let feedId: number;
+  let agentId: string;
+  let expectedIds: number[];
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Response Budget Org' });
+    const user = await createTestUser({ email: 'response-budget@test.example.com' });
+    orgId = org.id;
+    await addUserToOrganization(user.id, org.id, 'owner');
+    api = await TestApiClient.for({ organizationId: org.id, userId: user.id, memberRole: 'owner' });
+    const oauth = await createTestOAuthClient();
+    const { token } = await createTestAccessToken(user.id, org.id, oauth.client_id, {
+      scope: 'mcp:read mcp:write mcp:admin',
+    });
+    wire = new TestMcpClient({ token, orgSlug: org.slug });
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+    agentId = agent.agentId;
+    const entity = await createTestEntity({
+      organization_id: org.id, created_by: user.id, name: 'Budget context', entity_type: 'company',
+    });
+    entityId = Number(entity.id);
+    const connection = await createTestConnection({
+      organization_id: org.id, connector_key: 'test.connector', slug: 'response-budget-source',
+    });
+    const sql = getTestDb();
+    const [feed] = await sql`SELECT id FROM feeds WHERE connection_id = ${connection.id} AND feed_key = 'default'`;
+    feedId = Number(feed.id);
+    const inserted = await sql`
+      INSERT INTO events (organization_id, entity_ids, connection_id, feed_id, feed_key,
+        origin_id, title, payload_type, payload_text, semantic_type, connector_key, occurred_at, created_at)
+      SELECT ${org.id}, ARRAY[${entityId}]::bigint[], ${connection.id}, ${feedId}, 'default',
+        'response-budget-' || n, 'Large Unicode event ' || n, 'text', repeat('😀', 4100),
+        'content', 'test.connector', NOW() - (n + 120) * INTERVAL '1 second', NOW() - INTERVAL '2 minutes'
+      FROM generate_series(1, ${ROW_COUNT}) n
+      RETURNING id
+    `;
+    expectedIds = inserted.map(row => Number(row.id)).sort((a, b) => a - b);
+  });
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  async function automation(slug: string, contextBytes = 100_000, sourceQuery = `@feed:${feedId}`) {
+    return await api.automations.create({
+      entity_id: entityId, slug, name: slug, prompt: 'Review all source rows.',
+      managed_agent_id: agentId,
+      sources: [
+        { name: 'content', query: sourceQuery },
+        { name: 'context_rows', query: `SELECT id, name, repeat('c', ${contextBytes}) AS note FROM entities WHERE id = ${entityId}`, context: true },
+      ],
+      outputs: { signals: { event: 'observation' } },
+    }) as { automation_id: string };
+  }
+
+  it.each(['ref', 'sql'] as const)('reads every %s page through the real bridge and requires the full token chain', async (kind) => {
+    const created = await automation(`response-budget-wire-${kind}`, 100_000,
+      kind === 'ref' ? `@feed:${feedId}` : `SELECT * FROM events WHERE feed_id = ${feedId} ORDER BY occurred_at DESC`);
+    const result = await wire.runSdk<{
+      success: boolean;
+      error?: unknown;
+      return_value?: { ids: number[]; pages: number; firstCount: number; partialError: string; completed: { run_id: number; content_linked: number } };
+    }>(`export default async (_ctx, client) => {
+      const tokens = [], ids = [];
+      let runId, cursor = {}, pages = 0, firstCount, partialError = '';
+      while (pages < 100) {
+        const claim = await client.automations.claimNextWindow({
+          automation_id: '${created.automation_id}', limit: 500, lease_seconds: 900,
+          ...(runId ? { run_id: runId } : {}), ...cursor,
+        });
+        runId = claim.run_id;
+        const r = claim.context;
+        if (r.sources.context_rows.length !== 1 || r.sources.context_rows[0].note.length !== 100000 ||
+            r.sources_page.context_rows.has_more) throw new Error('context coverage changed');
+        if (r.sources.content.length !== r.content.length) throw new Error('source/content mismatch');
+        if (r.sources_page.content.returned !== r.content.length) throw new Error('wrong retained count');
+        tokens.push(r.window_token);
+        ids.push(...r.content.map(row => Number(row.id)));
+        pages++;
+        if (pages === 1) {
+          firstCount = r.content.length;
+          try {
+            await client.automations.completeWindow({ automation_id: '${created.automation_id}', run_id: runId,
+              window_tokens: tokens, extracted_data: { signals: [] } });
+          } catch (error) { partialError = error.message; }
+        }
+        if (!r.page.has_more) break;
+        if (!r.page.next_cursor || !r.content.length) throw new Error('page cannot advance');
+        const last = r.sources.content[r.sources.content.length - 1];
+        if (Number(last.id) !== r.page.next_cursor.id) throw new Error('cursor skipped a retained row');
+        cursor = { before_occurred_at: r.page.next_cursor.occurred_at, before_id: r.page.next_cursor.id };
+      }
+      const completed = await client.automations.completeWindow({
+        automation_id: '${created.automation_id}', run_id: runId, window_tokens: tokens, extracted_data: { signals: [] },
+      });
+      return { ids, pages, firstCount, partialError, completed };
+    }`);
+    expect(result.success, JSON.stringify(result.error)).toBe(true);
+    const value = result.return_value!;
+    expect(value.pages).toBeGreaterThan(1);
+    expect(value.firstCount).toBeGreaterThan(0);
+    expect(value.firstCount).toBeLessThan(ROW_COUNT);
+    expect(value.partialError).toMatch(/More Automation source pages remain/);
+    expect(value.ids.sort((a, b) => a - b)).toEqual(expectedIds);
+    expect(new Set(value.ids).size).toBe(ROW_COUNT);
+    expect(value.completed.content_linked).toBe(ROW_COUNT);
+    const [persisted] = await getTestDb()`
+      SELECT a.next_window_start, r.status, r.approved_input->>'window_end' AS window_end
+      FROM automations a JOIN runs r ON r.id = ${value.completed.run_id}
+      WHERE a.id = ${Number(created.automation_id)} AND a.organization_id = ${orgId}
+    `;
+    expect(persisted.status).toBe('completed');
+    expect(new Date(persisted.next_window_start).toISOString()).toBe(new Date(persisted.window_end).toISOString());
+  }, 60_000);
+
+  it('bounds the complete UTF-8 envelope and advances from its last retained row', async () => {
+    const created = await automation('response-budget-envelope');
+    const result = await api.knowledge.read({
+      automation_id: Number(created.automation_id), since: 'today', until: 'today', limit: 500,
+    }) as {
+      content: Array<{ id: number; payload_text: string; payload_truncated: boolean }>;
+      sources: Record<string, Array<{ id: number; note?: string }>>;
+      page: { has_more: boolean; next_cursor: { id: number } };
+    };
+    expect(Buffer.byteLength(JSON.stringify(result), 'utf8')).toBeLessThanOrEqual(1_048_576);
+    expect(result.content.length).toBeGreaterThan(0);
+    expect(result.content.length).toBeLessThan(ROW_COUNT);
+    expect(result.sources.context_rows[0].note).toHaveLength(100_000);
+    expect(result.content[0].payload_text).toBe('😀'.repeat(4000) + '… [truncated]');
+    expect(result.content[0].payload_truncated).toBe(true);
+    expect(result.page.has_more).toBe(true);
+    expect(result.page.next_cursor.id).toBe(Number(result.sources.content.at(-1)?.id));
+  });
+
+  it.each([true, false])('budgets duplicate events using source precedence (primary first: %s)', async (primaryFirst) => {
+    const primary = { name: 'content', query: `@feed:${feedId}` };
+    const duplicate = {
+      name: 'duplicate',
+      query: `SELECT * FROM events WHERE id = ${expectedIds[0]}`,
+    };
+    const created = await api.automations.create({
+      entity_id: entityId,
+      slug: `response-budget-duplicate-${primaryFirst}`,
+      name: 'Duplicate source response budget',
+      prompt: 'Review all source rows.',
+      managed_agent_id: agentId,
+      sources: [
+        ...(primaryFirst ? [primary, duplicate] : [duplicate, primary]),
+        { name: 'context_rows', query: `SELECT id, repeat('c', 960000) AS note FROM entities WHERE id = ${entityId}`, context: true },
+      ],
+      outputs: { signals: { event: 'observation' } },
+    }) as { automation_id: string };
+    const result = await api.knowledge.read({
+      automation_id: Number(created.automation_id), since: 'today', until: 'today', limit: 500,
+    }) as {
+      content: Array<{ id: number }>;
+      sources: Record<string, Array<{ id: number; note?: string }>>;
+      page: { has_more: boolean; next_cursor: { id: number } };
+    };
+    expect(Buffer.byteLength(JSON.stringify(result), 'utf8')).toBeLessThanOrEqual(1_048_576);
+    expect(result.sources.content).toHaveLength(1);
+    expect(result.content).toHaveLength(1);
+    expect(Number(result.content[0].id)).toBe(expectedIds[0]);
+    expect(result.sources.duplicate).toHaveLength(1);
+    expect(result.sources.context_rows[0].note).toHaveLength(960_000);
+    expect(result.page.has_more).toBe(true);
+    expect(result.page.next_cursor.id).toBe(expectedIds[0]);
+  });
+
+  it.each([5_000_000, 1_040_000])('fails explicitly when required context leaves no room for a content row (%i bytes)', async (contextBytes) => {
+    const created = await automation(`response-budget-context-${contextBytes}`, contextBytes);
+    const result = await wire.querySdk<{ success: boolean; error?: { message: string } }>(
+      `export default async (_ctx, client) => {
+        const r = await client.knowledge.read({ automation_id: ${created.automation_id}, since: 'today', until: 'today', limit: 500 });
+        return { count: r.content.length };
+      }`
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/Automation knowledge response cannot fit its byte budget/);
+    expect(result.error?.message).not.toMatch(/OutputSizeExceeded/);
+    const completed = await getTestDb()`SELECT id FROM runs
+      WHERE automation_id = ${Number(created.automation_id)} AND status = 'completed'`;
+    expect(completed).toEqual([]);
+  });
+});

--- a/packages/server/src/__tests__/integration/tools/content-read-bounds.test.ts
+++ b/packages/server/src/__tests__/integration/tools/content-read-bounds.test.ts
@@ -14,7 +14,6 @@ import {
   createTestAgent,
   createTestConnection,
   createTestEntity,
-  createTestEvent,
   createTestOrganization,
   createTestUser,
   ownerToolContext,
@@ -41,6 +40,8 @@ describe('agent-facing content read bounds', () => {
   let feedId: number;
   let hugeEventId: number;
   let hugeText: string;
+  let exactInputId: number;
+  const exactInputText = 'Complete exact input.'.repeat(6_000);
 
   beforeAll(async () => {
     await cleanupTestDatabase();
@@ -109,15 +110,21 @@ describe('agent-facing content read bounds', () => {
       RETURNING id
     `;
     hugeEventId = Number(inserted.id);
-    await createTestEvent({
-      organization_id: org.id,
-      entity_id: entityId,
-      connection_id: connection.id,
-      feed_id: feedId,
-      feed_key: 'default',
-      content: 'small companion',
-      occurred_at: new Date(),
-    });
+    const [exactInput] = await db<{ id: number | string }[]>`
+      INSERT INTO events (
+        organization_id, entity_ids, connection_id, feed_id, feed_key,
+        origin_id, payload_type, payload_text, payload_data, attachments,
+        occurred_at, semantic_type, connector_key, created_at
+      ) VALUES (
+        ${org.id}, ARRAY[${entityId}]::bigint[], ${connection.id}, ${feedId}, 'default',
+        'content-bounds-exact', 'text', ${exactInputText},
+        ${db.json({ body: 'p'.repeat(32 * 1024) })},
+        ${db.json([{ text: 't'.repeat(32 * 1024) }])},
+        NOW(), 'content', 'test.connector', NOW()
+      )
+      RETURNING id
+    `;
+    exactInputId = Number(exactInput.id);
   }, 120_000);
 
   afterAll(async () => {
@@ -289,17 +296,28 @@ describe('agent-facing content read bounds', () => {
     expect(customContentHuge?.payload_truncated).toBe(true);
     expect(customResult.total_count_chars).toBeGreaterThanOrEqual(LARGE_EVENT_CHARS);
 
-    const exact = (await owner.knowledge.read({
+    // Required exact inputs cannot be paged or silently shortened. Standalone
+    // exact-id reads remain full fidelity; an oversized Automation envelope
+    // must fail explicitly instead of overflowing the SDK transport.
+    await expect(owner.knowledge.read({
       automation_id: Number(created.automation_id),
       content_ids: [hugeEventId],
       since: 'today',
       until: 'today',
       limit: 50,
+    })).rejects.toThrow(/Automation knowledge response cannot fit its byte budget/);
+
+    const exact = (await owner.knowledge.read({
+      automation_id: Number(created.automation_id),
+      content_ids: [exactInputId],
+      since: 'today',
+      until: 'today',
+      limit: 50,
     })) as { sources: Record<string, Array<Record<string, unknown>>> };
     const exactTrigger = exact.sources.__event_inputs.find(
-      (row) => Number(row.id) === hugeEventId
+      (row) => Number(row.id) === exactInputId
     );
-    expect(exactTrigger?.payload_text).toBe(hugeText);
+    expect(exactTrigger?.payload_text).toBe(exactInputText);
     expect(exactTrigger?.payload_truncated).not.toBe(true);
     expect(exactTrigger?.payload_data).toEqual({ body: 'p'.repeat(32 * 1024) });
     expect(exactTrigger?.attachments).toEqual([{ text: 't'.repeat(32 * 1024) }]);

--- a/packages/server/src/tools/get_content/automation-mode.ts
+++ b/packages/server/src/tools/get_content/automation-mode.ts
@@ -18,7 +18,7 @@ import type { Env } from '../../index';
 import type { Outputs, UnprocessedRange, AutomationSource } from '../../types/automations';
 import { ToolUserError } from '../../utils/errors';
 import { type DataSourceContext, executeDataSources } from '../../utils/execute-data-sources';
-import { finalizeDynamicQueryRows } from '../../utils/content-read-bounds';
+import { AUTOMATION_READ_MAX_BYTES, finalizeDynamicQueryRows } from '../../utils/content-read-bounds';
 import logger from '../../utils/logger';
 import { runMetric } from '../../metrics/run-metric';
 import { getRecentFeedbackSummary } from '../../utils/automation-feedback';
@@ -91,11 +91,68 @@ function isMetricSource(
   return source.kind === 'metric' && source.ref?.type === 'metric';
 }
 
+// Budgeting and normal reads must normalize the same source rows, including
+// duplicate event identities that appear in more than one authored source.
+function normalizeEventSources(
+  results: Record<string, unknown[]>,
+  eventSourceNames: ReadonlySet<string>
+): unknown[] {
+  const seen = new Set<number>();
+  const allContent: unknown[] = [];
+
+  for (const [sourceName, rows] of Object.entries(results)) {
+    if (!eventSourceNames.has(sourceName)) continue;
+    for (const row of rows) {
+      const rec = row as Record<string, unknown>;
+      const id = typeof rec.id === 'number' ? rec.id : Number(rec.id);
+      if (Number.isFinite(id) && !seen.has(id)) {
+        seen.add(id);
+        allContent.push({
+          id,
+          entity_ids: rec.entity_ids,
+          platform: rec.platform ?? rec.connector_key,
+          origin_id: rec.origin_id as string,
+          semantic_type: rec.semantic_type ?? 'content',
+          origin_type: rec.origin_type ?? null,
+          payload_type: rec.payload_type ?? 'text',
+          payload_text: rec.payload_text ?? rec.text_content,
+          payload_truncated: rec.payload_truncated === true ? true : undefined,
+          content_length:
+            rec.content_length == null ? undefined : Number(rec.content_length),
+          payload_data: rec.payload_data ?? {},
+          payload_template: rec.payload_template ?? null,
+          attachments: parseRecordArray(rec.attachments),
+          attachments_truncated:
+            rec.attachments_truncated === true ? true : undefined,
+          attachments_bytes:
+            rec.attachments_bytes == null ? undefined : Number(rec.attachments_bytes),
+          author_name: rec.author_name ?? rec.author,
+          title: rec.title,
+          text_content: rec.payload_text ?? rec.text_content,
+          rating: (rec.metadata as Record<string, unknown>)?.rating || null,
+          source_url: rec.source_url ?? rec.url,
+          score: Number(rec.score) || 0,
+          metadata: rec.metadata || {},
+          classifications: {},
+          created_at: rec.created_at,
+          occurred_at: rec.occurred_at ?? rec.created_at,
+          origin_parent_id: rec.origin_parent_id ?? null,
+          root_origin_id: rec.origin_id as string,
+          depth: 0,
+        });
+      }
+    }
+  }
+
+  return allContent;
+}
+
 async function queryContentData(
   sql: DbClient,
   params: ContentQueryParams
 ): Promise<{
   sourcesContent: Record<string, unknown[]>;
+  eventSourceNames: ReadonlySet<string>;
   allContent: unknown[];
   page?: { has_more: boolean; next_cursor?: { occurred_at: string; id: number } };
   sourcesPage: Record<string, { returned: number; limit: number; has_more: boolean }>;
@@ -364,55 +421,11 @@ async function queryContentData(
     }
   }
 
-  const seen = new Set<number>();
-  const allContent: unknown[] = [];
-
-  for (const [sourceName, rows] of Object.entries(results)) {
-    if (!eventSourceNames.has(sourceName)) continue;
-    for (const row of rows) {
-      const rec = row as Record<string, unknown>;
-      const id = typeof rec.id === 'number' ? rec.id : Number(rec.id);
-      if (Number.isFinite(id) && !seen.has(id)) {
-        seen.add(id);
-        allContent.push({
-          id,
-          entity_ids: rec.entity_ids,
-          platform: rec.platform ?? rec.connector_key,
-          origin_id: rec.origin_id as string,
-          semantic_type: rec.semantic_type ?? 'content',
-          origin_type: rec.origin_type ?? null,
-          payload_type: rec.payload_type ?? 'text',
-          payload_text: rec.payload_text ?? rec.text_content,
-          payload_truncated: rec.payload_truncated === true ? true : undefined,
-          content_length:
-            rec.content_length == null ? undefined : Number(rec.content_length),
-          payload_data: rec.payload_data ?? {},
-          payload_template: rec.payload_template ?? null,
-          attachments: parseRecordArray(rec.attachments),
-          attachments_truncated:
-            rec.attachments_truncated === true ? true : undefined,
-          attachments_bytes:
-            rec.attachments_bytes == null ? undefined : Number(rec.attachments_bytes),
-          author_name: rec.author_name ?? rec.author,
-          title: rec.title,
-          text_content: rec.payload_text ?? rec.text_content,
-          rating: (rec.metadata as Record<string, unknown>)?.rating || null,
-          source_url: rec.source_url ?? rec.url,
-          score: Number(rec.score) || 0,
-          metadata: rec.metadata || {},
-          classifications: {},
-          created_at: rec.created_at,
-          occurred_at: rec.occurred_at ?? rec.created_at,
-          origin_parent_id: rec.origin_parent_id ?? null,
-          root_origin_id: rec.origin_id as string,
-          depth: 0,
-        });
-      }
-    }
-  }
+  const allContent = normalizeEventSources(results, eventSourceNames);
 
   return {
     sourcesContent: results as Record<string, unknown[]>,
+    eventSourceNames,
     sourcesPage,
     allContent,
     page: pageResult,
@@ -841,16 +854,15 @@ export async function handleAutomationMode(
       beforeId: args.before_id,
     },
   });
-  const {
+  const { eventSourceNames, totalCount, totalCountChars } = contentData;
+  let {
     sourcesContent,
     allContent,
     page: contentPage,
     sourcesPage,
-    totalCount,
-    totalCountChars,
   } = contentData;
 
-  const contentIds = allContent
+  let contentIds = allContent
     .map((item) => Number((item as Record<string, unknown>).id))
     .filter((id) => Number.isFinite(id) && id > 0)
     .map((id) => Math.trunc(id));
@@ -864,7 +876,7 @@ export async function handleAutomationMode(
   const tokenRunId =
     context.claimedWindow?.runId ??
     (boundRun && args.run_id != null ? Number(args.run_id) : null);
-  const windowToken = await generateWindowToken(
+  const signWindow = () => generateWindowToken(
     {
       automation_id: automationId,
       ...(tokenRunId != null ? { run_id: tokenRunId } : {}),
@@ -899,6 +911,7 @@ export async function handleAutomationMode(
     },
     env
   );
+  let windowToken = await signWindow();
 
   // Bound entities ride the payload as structured rows (id, name, type,
   // metadata, field_controls) — field_controls marks human-owned field values
@@ -981,7 +994,7 @@ export async function handleAutomationMode(
     logger.warn({ err }, '[get_content] Failed to fetch reaction data for automation mode');
   }
 
-  return {
+  const response = (): GetContentResult => ({
     content: allContent as ContentItem[],
     total: contentIds.length,
     page: {
@@ -1025,5 +1038,74 @@ export async function handleAutomationMode(
       totalCountChars > 400_000
         ? `Content is ~${Math.ceil(totalCountChars / 4000)}k tokens. Consider reducing limit or date range.`
         : undefined,
+  });
+
+  const serializedBytes = (value: unknown) => Buffer.byteLength(JSON.stringify(value), 'utf8');
+  const initial = response();
+  if (serializedBytes(initial) <= AUTOMATION_READ_MAX_BYTES) return initial;
+
+  // Reserve the entire fixed envelope before admitting primary event rows.
+  // Context sources have no cursor: never trim them to make a response fit.
+  // Include their normalized event representations as well as their raw rows.
+  const primaryRows = sourcesContent.content ?? [];
+  const auxiliarySources = { ...sourcesContent, content: [] };
+  const auxiliaryContent = normalizeEventSources(auxiliarySources, eventSourceNames);
+  const fixedEnvelope = { ...initial, sources: auxiliarySources, content: auxiliaryContent };
+  // The existing token contains the full ID set, so it already bounds the ID
+  // claim. Reserve room for a newly introduced next cursor, its signed claims,
+  // and changing page counters. The final serialized result is checked again.
+  let usedBytes = serializedBytes(fixedEnvelope) + 1024;
+  const cannotFit = () => new ToolUserError(
+    'Automation knowledge response cannot fit its byte budget with the required context and one content row. ' +
+      'Narrow non-pageable sources or bound entity payloads. Exact event inputs must fit in full. ' +
+      'No source rows were skipped and the window was not completed.',
+    422
+  );
+  if (!contentPage) throw cannotFit();
+
+  const normalizedBytes = new Map(initial.content.map((row) => {
+    const record = row as Record<string, unknown>;
+    return [Number(record.id), serializedBytes(record) + 1];
+  }));
+  const auxiliaryBytes = new Map(auxiliaryContent.map((row) => {
+    const record = row as Record<string, unknown>;
+    return [Number(record.id), serializedBytes(record) + 1];
+  }));
+  const seenPrimaryIds = new Set<number>();
+
+  let retained = 0;
+  for (const [index, row] of primaryRows.entries()) {
+    const id = Number((row as Record<string, unknown>).id);
+    usedBytes += serializedBytes(row) + 1;
+    if (!seenPrimaryIds.has(id)) {
+      seenPrimaryIds.add(id);
+      usedBytes += (normalizedBytes.get(id) ?? 0) - (auxiliaryBytes.get(id) ?? 0);
+    }
+    // A primary row can replace a larger auxiliary representation of the same
+    // event, so later prefixes may fit even if an earlier prefix did not.
+    if (usedBytes <= AUTOMATION_READ_MAX_BYTES) retained = index + 1;
+  }
+  if (retained === 0 || retained === primaryRows.length) throw cannotFit();
+
+  const keptRows = primaryRows.slice(0, retained);
+  const last = keptRows[keptRows.length - 1] as Record<string, unknown>;
+  const lastId = Number(last.id);
+  if (!last.occurred_at || !Number.isFinite(lastId)) throw cannotFit();
+  sourcesContent = { ...sourcesContent, content: keptRows };
+  allContent = normalizeEventSources(sourcesContent, eventSourceNames);
+  contentIds = allContent.map(item => Math.trunc(Number((item as Record<string, unknown>).id)))
+    .filter(id => Number.isFinite(id) && id > 0);
+  contentPage = {
+    has_more: true,
+    next_cursor: { occurred_at: new Date(last.occurred_at as string | Date).toISOString(), id: Math.trunc(lastId) },
   };
+  sourcesPage = {
+    ...sourcesPage,
+    content: { returned: retained, limit: contentLimit, has_more: true },
+  };
+  // Sign precisely the retained IDs and cursor, never the byte-omitted suffix.
+  windowToken = await signWindow();
+  const bounded = response();
+  if (serializedBytes(bounded) > AUTOMATION_READ_MAX_BYTES) throw cannotFit();
+  return bounded;
 }

--- a/packages/server/src/utils/content-read-bounds.ts
+++ b/packages/server/src/utils/content-read-bounds.ts
@@ -10,6 +10,8 @@
 export const CONTENT_TEXT_HEAD_CHARS = 4_000;
 export const CONTENT_JSON_MAX_BYTES = 16 * 1024;
 export const QUERY_SQL_RESULT_MAX_BYTES = 1_048_576;
+/** Whole Automation envelope, matching the script-output cap and below the SDK bridge cap. */
+export const AUTOMATION_READ_MAX_BYTES = 1_048_576;
 
 const TRUNCATION_SUFFIX = '… [truncated]';
 const SAFE_SQL_REF = /^[a-zA-Z_][a-zA-Z0-9_]*$/;


### PR DESCRIPTION
## Summary
Large Automation source pages can exceed the SDK bridge's 4 MiB response limit before a script can project them. Bound the complete knowledge response to 1 MiB and return a contiguous primary-source prefix through the existing cursor and signed page-chain contract.

Required auxiliary context and exact event inputs retain their full representation. If they leave no transportable page, fail explicitly without skipping source rows or completing the window. Count duplicate normalized event representations according to source precedence.

## Test plan
- [x] Focused integration tests: 30 passed across Automation response budgeting, source limits, claim recovery, and content-read bounds.
- [x] Real OAuth MCP → run_sdk → isolated-vm bridge: 150 large Unicode events traversed all eight pages exactly once; partial completion rejected; full completion linked all 150 and advanced the arrival mark.
- [x] Whole UTF-8 envelope, both source orders for duplicate events, exact-input fidelity, and oversized required-context failures covered.
- [x] Explicit staging and `make pre-pr`; pre-commit checks passed.
- [x] GitHub CI.
- [x] Codex semantic review on 2951fd9: confidence 88/100, simplicity 88/100, no bugs or blockers.
- [x] Deployed squash `83a99eb51f622e8b70ad1d0fd0ce21b5661c5a14`: production smoke 9 passed, 0 failed.
- [x] Live SDK traversed a real failed window: 1,846 distinct events across 26 contiguous pages, largest whole response 1,044,565 UTF-8 bytes; all auxiliary sources complete. Read-only transport verification: no analysis or window completion claimed.

Red, before the change:
```
Automation response byte budget
1 failed
OutputSizeExceeded: response exceeded 4194304 bytes
```
Green, after the change and pre-review fixes:
```
Test Files  4 passed (4)
Tests       30 passed (30)
Token valid: 150 content items across 8 page(s)
```

## Notes
No new API fields or storage. An oversized non-pageable Automation envelope now produces an actionable error; standalone exact-ID content reads retain their existing full-text behavior. This fixes transport bounds; it does not establish that an agent can analyze an arbitrarily large backlog in a single run.
