### PR TITLE
fix(gmail): store readable HTML message bodies

### DIFF
--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -211,7 +211,7 @@ describe('Gmail replied signal (promote-on-interaction)', () => {
 
 describe('Gmail person attribution rule', () => {
   test('bumps the connector version for the changed sync contract', () => {
-    expect(new GmailConnector().definition.version).toBe('1.0.5');
+    expect(new GmailConnector().definition.version).toBe('1.0.6');
   });
 
   test('autoCreate is gated on person_relevant, with a legacy replied rule for pre-refresh payloads', () => {
@@ -725,7 +725,7 @@ describe('complete Gmail sync input', () => {
     connector.createClient = () => ({ raw: async () => ({
       ok: true, json: async () => ({ threads: [], nextPageToken: 'same' }),
     }) });
-    await expect(connector.sync(context({ schema_version: 2, scope: JSON.stringify(['label:INBOX', false]), pending: {
+    await expect(connector.sync(context({ schema_version: 3, scope: JSON.stringify(['label:INBOX', false]), pending: {
       query: 'after:1 before:2 (label:INBOX)',
       started_at: '2026-07-02T00:00:00Z', page_token: 'same',
     } }))).rejects.toThrow('repeated page token');
@@ -739,7 +739,7 @@ describe('complete Gmail sync input', () => {
     const first = await connector.sync(context(old, { lookback_days: 30 }));
     const after = Number(new URL(urls[0]).searchParams.get('q')?.match(/after:(\d+)/)?.[1]);
     expect(after).toBeLessThan(Date.parse(old.last_sync_at) / 1000 - 29 * 86400);
-    expect(first.checkpoint.schema_version).toBe(2);
+    expect(first.checkpoint.schema_version).toBe(3);
     await connector.sync(context(first.checkpoint, { query: '-in:spam -in:trash', lookback_days: 30 }));
     const widenedAfter = Number(new URL(urls[1]).searchParams.get('q')?.match(/after:(\d+)/)?.[1]);
     expect(widenedAfter).toBeLessThan(Date.parse(old.last_sync_at) / 1000 - 29 * 86400);
@@ -781,7 +781,7 @@ describe('complete Gmail sync input', () => {
     });
     const result = await connector.sync(
       context({
-        schema_version: 2,
+        schema_version: 3,
         scope: JSON.stringify(['label:INBOX', false]),
         pending: { query: 'after:1 before:2 (label:INBOX)', started_at: '2026-07-02T00:00:00Z', page_token: 'retired' },
       })
@@ -804,7 +804,7 @@ describe('complete Gmail sync input', () => {
     await expect(
       connector.sync(
         context({
-          schema_version: 2,
+          schema_version: 3,
           scope: JSON.stringify(['label:INBOX', false]),
           pending: { query: 'after:1 before:2 (label:INBOX)', started_at: '2026-07-02T00:00:00Z', page_token: 'live' },
         })
@@ -940,7 +940,7 @@ describe('Gmail empty MIME alternatives', () => {
       const text = mode === 'sync'
         ? (await connector.sync(context)).events[0].payload_text
         : (await connector.execute({ actionKey: 'get_thread', input: { thread_id: 'alternatives' }, credentials: context.credentials })).output.messages[0].body;
-      expect(text).toContain(html);
+      expect(text).toContain(mode === 'sync' ? 'Please confirm the delivery date.' : html);
     });
   }
 
@@ -998,7 +998,9 @@ describe('Gmail multipart body sections', () => {
     const body = mode === 'sync'
       ? (await connector.sync(context)).events[0].payload_text
       : (await connector.execute({ actionKey: 'get_thread', input: { thread_id: 'mixed-body' }, credentials: context.credentials })).output.messages[0].body;
-    expect(body).toContain('Opening section.\n\n<p>HTML-only middle section.</p>\n\nPlease sign the final section.');
+    expect(body).toContain(mode === 'sync'
+      ? 'Opening section.\n\nHTML-only middle section.\n\nPlease sign the final section.'
+      : 'Opening section.\n\n<p>HTML-only middle section.</p>\n\nPlease sign the final section.');
     expect(body).not.toContain('HTML duplicate');
     expect(urls.filter((url) => url.includes('/attachments/'))).toEqual([
       'https://www.googleapis.com/gmail/v1/users/me/messages/mixed-message/attachments/inline-tail',
@@ -1108,4 +1110,81 @@ describe('Gmail MIME body charset', () => {
       await expect(setup(bytes, contentType, external).sync(context)).rejects.toThrow();
     });
   }
+});
+
+describe('Gmail readable HTML sync bodies', () => {
+  const context = { feedKey: 'threads', config: {}, checkpoint: {}, credentials: { accessToken: 'synthetic-token' } };
+  const html = `<html><head><style>${'.layout { color: red; }'.repeat(5000)}</style><title>Layout title</title></head><body>
+    <script>trackingCode()</script><template>templateOnly</template>
+    <h2>Delivery &amp; payment</h2><p>Confirm café delivery by Friday.</p>
+    <table><tr><th>Item</th><th>Amount</th></tr><tr><td>Order 42</td><td>42 TL</td></tr></table>
+    <p><a href="https://example.com/confirm?order=42&amp;view=full">Confirm order</a></p>
+    <blockquote><p>Earlier reply: address approved.</p></blockquote>
+    <img src="https://tracking.example.com/pixel" alt="Invoice attached">
+    <img src="data:image/png;base64,unneeded">
+    <pre><code>line one\n  line two</code></pre>
+    <p>Please submit the signed agreement at the end.</p></body></html>`;
+
+  function setup(external = false) {
+    const connector = new GmailConnector();
+    const thread = toThreadResponse({ id: 'html-thread', messages: [
+      { id: 'later', body: 'I have confirmed the order.', date: '2026-07-02T10:00:00Z' },
+      { id: 'earlier', date: '2026-07-01T10:00:00Z' },
+    ] });
+    thread.messages[1].payload = {
+      ...thread.messages[1].payload, mimeType: 'text/html',
+      body: external ? { attachmentId: 'html-body' } : { data: Buffer.from(html).toString('base64url') },
+    };
+    const urls: string[] = [];
+    connector.createClient = () => ({ raw: async (url: string) => {
+      urls.push(url);
+      return { ok: true, status: 200, json: async () => url.includes('/attachments/')
+        ? { data: Buffer.from(html).toString('base64url') }
+        : url.includes('/threads/') ? thread : { threads: [{ id: thread.id }] } };
+    } });
+    return { connector, urls };
+  }
+
+  test.each([false, true])('stores readable complete HTML content (external body: %s)', async (external) => {
+    const { connector } = setup(external);
+    const result = await connector.sync(context);
+    const text = result.events[0].payload_text;
+    expect(text).not.toMatch(/<style>|\.layout|trackingCode|templateOnly|Layout title|tracking\.example|data:image/);
+    expect(text).toContain('Delivery & payment');
+    expect(text).toContain('Confirm café delivery by Friday.');
+    expect(text).toContain('Item | Amount');
+    expect(text).toContain('Order 42 | 42 TL');
+    expect(text).toContain('[Confirm order](https://example.com/confirm?order=42&view=full)');
+    expect(text).toContain('> Earlier reply: address approved.');
+    expect(text).toContain('Invoice attached');
+    expect(text).toContain('line one\n  line two');
+    expect(text).toContain('Please submit the signed agreement at the end.');
+    expect(text.indexOf('Message: earlier')).toBeLessThan(text.indexOf('Message: later'));
+    expect(text).toContain('\n\n---\n\nMessage: later');
+    expect(text).toContain('I have confirmed the order.');
+    expect(text.length).toBeLessThan(1000);
+    expect(result.events[0].origin_id).toBe('html-thread');
+  });
+
+  test('keeps the get_thread operation body in its original representation', async () => {
+    const { connector } = setup();
+    const result = await connector.execute({ actionKey: 'get_thread', input: { thread_id: 'html-thread' }, credentials: context.credentials });
+    expect(result.output.messages.find((message: { id: string }) => message.id === 'earlier').body).toBe(html);
+  });
+
+  test('does not checkpoint past a body conversion failure', async () => {
+    const { connector } = setup();
+    connector.emailBodyConverter.turndown = () => { throw new Error('synthetic conversion failure'); };
+    await expect(connector.sync(context)).rejects.toThrow('synthetic conversion failure');
+  });
+
+  test('revisits stored HTML on upgrade without changing thread identity', async () => {
+    const { connector, urls } = setup();
+    const previous = { schema_version: 2, scope: JSON.stringify(['label:INBOX', false]), last_sync_at: new Date(Date.now() - 60_000).toISOString() };
+    const result = await connector.sync({ ...context, config: { lookback_days: 30 }, checkpoint: previous });
+    const after = Number(new URL(urls[0]).searchParams.get('q')?.match(/after:(\d+)/)?.[1]);
+    expect(after).toBeLessThan(Date.parse(previous.last_sync_at) / 1000 - 29 * 86400);
+    expect(result.checkpoint.schema_version).toBe(3);
+    expect(result.events[0].origin_id).toBe('html-thread');
+  });
 });

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -19,6 +19,33 @@ import {
   type SyncContext,
   type SyncResult,
 } from '@lobu/connector-sdk';
+import TurndownService from 'turndown';
+
+function createEmailBodyConverter(): TurndownService {
+  const converter = new TurndownService({
+    headingStyle: 'atx',
+    codeBlockStyle: 'fenced',
+    preformattedCode: true,
+    blankReplacement: (_content, node) =>
+      node.nodeName === 'TD' || node.nodeName === 'TH' ? ' | ' : node.isBlock ? '\n\n' : '',
+  });
+  converter.remove(['head', 'title', 'script', 'style', 'template']);
+  // Email layout tables also carry invoices and schedules. Keep every cell
+  // boundary instead of joining adjacent amounts or losing empty columns.
+  converter.addRule('emailTableCell', {
+    filter: ['td', 'th'],
+    replacement: (content) => `${content.trim()} | `,
+  });
+  converter.addRule('emailTableRow', {
+    filter: 'tr',
+    replacement: (content) => `\n${content.replace(/\s*\|\s*$/, '')}\n`,
+  });
+  converter.addRule('emailImageDescription', {
+    filter: 'img',
+    replacement: (_content, node) => node.getAttribute('alt') ?? '',
+  });
+  return converter;
+}
 
 // ---------------------------------------------------------------------------
 // Gmail API types
@@ -120,7 +147,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     name: 'Gmail',
     description:
       'Syncs Gmail threads, live-reads matching messages, and supports sending, drafts, and replies.',
-    version: '1.0.5',
+    version: '1.0.6',
     faviconDomain: 'mail.google.com',
     authSchema: {
       methods: [
@@ -405,11 +432,11 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     const scope = ctx.config.query?.trim() || (labels.length > 0
       ? `{${labels.map((l) => `label:${l}`).join(' ')}}`
       : `label:${label}`);
-    // Old checkpoints describe snippet-only input. Revisit the configured
-    // lookback once when upgrading or changing the source filter, preserving
-    // thread origin IDs so ingestion supersedes rather than duplicates rows.
     const scopeKey = JSON.stringify([scope, humanSendersOnly]);
-    const resumable = checkpoint.schema_version === 2 && checkpoint.scope === scopeKey;
+    // Older checkpoints predate full-body or readable-HTML ingestion. Revisit
+    // the configured lookback when upgrading or changing the source filter;
+    // stable thread origin IDs let ingestion supersede the previous content.
+    const resumable = checkpoint.schema_version === 3 && checkpoint.scope === scopeKey;
     const pending = resumable ? checkpoint.pending : undefined;
     const windowStart = pending?.started_at ?? syncStartedAt.toISOString();
     const afterDate = resumable && checkpoint.last_sync_at
@@ -478,7 +505,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
           if (humanSendersOnly && !attribution.personRelevant) continue;
           const messageTexts: string[] = [];
           for (const message of messages) {
-            const body = await this.extractBody(message.payload, http, message.id) || message.snippet || '';
+            const body = await this.extractBody(message.payload, http, message.id, true) || message.snippet || '';
             messageTexts.push([
               `Message: ${message.id}`,
               `From: ${this.getHeader(message, 'From') || 'Unknown'}`,
@@ -524,12 +551,12 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     // until the whole window has been walked, or the unread tail is skipped.
     const newCheckpoint: GmailCheckpoint = pageToken
       ? {
-          schema_version: 2,
+          schema_version: 3,
           scope: scopeKey,
           ...(resumable && checkpoint.last_sync_at ? { last_sync_at: checkpoint.last_sync_at } : {}),
           pending: { query, started_at: windowStart, page_token: pageToken },
         }
-      : { schema_version: 2, scope: scopeKey, last_sync_at: windowStart };
+      : { schema_version: 3, scope: scopeKey, last_sync_at: windowStart };
 
     return {
       events,
@@ -1108,10 +1135,13 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     return { name: trimmed, email: null };
   }
 
+  private readonly emailBodyConverter = createEmailBodyConverter();
+
   private async extractBody(
     payload: GmailMessagePayload,
     http: HttpClient,
-    messageId: string
+    messageId: string,
+    readableHtml = false
   ): Promise<string> {
     const disposition = payload.headers?.find((h) => h.name.toLowerCase() === 'content-disposition')
       ?.value.split(';', 1)[0].trim().toLowerCase();
@@ -1131,7 +1161,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
         : payload.parts;
       const sections: string[] = [];
       for (const part of parts) {
-        const text = await this.extractBody(part, http, messageId);
+        const text = await this.extractBody(part, http, messageId, readableHtml);
         if (!text) continue;
         if (isAlternative) return text;
         sections.push(text);
@@ -1152,6 +1182,9 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       text = this.base64UrlDecode(body.data, payload);
     }
     if (!text && payload.body?.size) throw new Error('Gmail returned a nonempty message body without data');
+    // Convert each HTML leaf after charset decoding, preserving plain parts,
+    // multipart ordering and the get_thread operation's original body format.
+    if (readableHtml && mimeType === 'text/html') text = this.emailBodyConverter.turndown(text);
     // An empty plain-text alternative must not hide a readable HTML body.
     return text.trim() ? text : '';
   }


### PR DESCRIPTION
## Summary
HTML-only Gmail messages currently store page styling and markup as searchable thread text. Convert each decoded HTML MIME body to readable Markdown during sync using the existing Turndown dependency, retaining links, table boundaries, quotes, image descriptions, and preformatted content.

Plain-text alternatives, multipart section order, chronological message boundaries, and the raw `get_thread` operation remain intact. Bump the connector to 1.0.6 and the checkpoint representation to version 3 so the configured lookback refreshes existing HTML rows under stable thread identities.

## Test plan
- [x] 89 Gmail tests passed, including HTML-only and external bodies, empty alternatives, mixed parts, charset errors, original raw reads, conversion failure, and checkpoint upgrade.
- [x] Real isolated-vm worker execution of the bundled connector with synthetic provider responses: 115,276 HTML characters became 237 stored characters; amount, deadline, URL, quote, final instruction and checkpoint verified.
- [x] Connector package typecheck and pre-review fixer.
- [x] Explicit staging and `make pre-pr`; pre-commit checks passed.
- [x] GitHub CI.
- [x] Codex semantic review on 32ea3df: confidence 90/100, simplicity 92/100, no bugs or blockers.
- [x] Deployed squash `363961986ac43e69916608f3568b1e1dece4cea4`: production smoke 9 passed, 0 failed.
- [x] Live post-deployment sync: 500 threads completed on connector 1.0.6 with checkpoint schema 3; subsequent normal scheduled syncs also completed with schema 3.
- [x] Same 100-thread sample: 1,062,578 to 623,815 stored characters (41.3% reduction); 13 threads superseded. Representative HTML messages fell from 96,729 to 13,011, 17,199 to 4,443 and 26,266 to 4,285 characters. Readable questions, dates, payment terms and links verified.
- [x] Expected squash remains an ancestor of the later deployed revision `d5390e765ae9a172ecd086c1b54c7c08e1f22802`.

Red:
```
Gmail readable HTML sync bodies
1 pass / 3 fail
HTML styling retained; old checkpoint did not revisit the lookback.
```
Green:
```
89 pass / 0 fail
worker=isolated-vm htmlCharacters=115276 storedCharacters=237 passed=true
```

## Notes
No additional dependency or raw-body copy in event metadata. Conversion and charset errors propagate before checkpoint advancement. Cloud executes bundled source for built-in connector keys; a stored definition update alone does not activate this change before the image rollout. The upgrade intentionally revisits the configured lookback; an incomplete historical import remains incomplete until its cursor is exhausted.

Live limitation: two unchanged bodies in the sample still contain style markup. Their provider MIME structure was not verified; this change intentionally converts declared HTML MIME leaves and preserves plain-text alternatives. The historical backfill still has a pending cursor. The task builder has separate execution-completion failures; successful ingestion is not proof of current tasks.
