### PR TITLE
fix: preserve Loki backlog and report digest coverage

### DIFF
--- a/examples/lobu-team/__tests__/loki-activity.connector.test.ts
+++ b/examples/lobu-team/__tests__/loki-activity.connector.test.ts
@@ -22,11 +22,14 @@ describe("Lobu Team Loki activity connector", () => {
         },
       } as never);
       expect(result.events).toHaveLength(1);
-      expect(result.events?.[0]?.metadata).toMatchObject({
+      const event = result.events[0]!;
+      expect(event.metadata).toMatchObject({
         errors: 0,
         warnings: 0,
       });
-      expect(result.events?.[0]?.origin_id).toBe(result.checkpoint?.window_end);
+      expect(result.checkpoint).toEqual({
+        window_end: event.origin_id,
+      });
     } finally {
       fetchSpy.mockRestore();
     }
@@ -38,13 +41,9 @@ describe("Lobu Team Loki activity connector", () => {
     expect(first).toHaveLength(72);
     expect(first[0]?.start.toISOString()).toBe(checkpoint.window_end);
     expect(first.at(-1)?.end.toISOString()).toBe("2026-08-11T12:00:00.000Z");
-    const second = windowsToCollect(
-      { window_end: first.at(-1)?.end.toISOString() },
-      now
-    );
-    expect(second[0]?.start.toISOString()).toBe(
-      first.at(-1)?.end.toISOString()
-    );
+    const firstBatchEnd = first.at(-1)!.end.toISOString();
+    const second = windowsToCollect({ window_end: firstBatchEnd }, now);
+    expect(second[0]?.start.toISOString()).toBe(firstBatchEnd);
     expect(second).toHaveLength(72);
   });
   it("collects aligned 20-minute windows and resumes from its checkpoint", () => {

--- a/examples/lobu-team/__tests__/loki-activity.connector.test.ts
+++ b/examples/lobu-team/__tests__/loki-activity.connector.test.ts
@@ -1,10 +1,52 @@
-import { describe, expect, it } from "bun:test";
-import {
+import { describe, expect, it, spyOn } from "bun:test";
+import LokiActivityConnector, {
   queryLokiActivity,
   windowsToCollect,
 } from "../loki-activity.connector.ts";
 
 describe("Lobu Team Loki activity connector", () => {
+  it("persists a successful empty window as coverage evidence", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        status: "success",
+        data: { resultType: "vector", result: [] },
+      })
+    );
+    try {
+      const result = await new LokiActivityConnector().sync({
+        feedKey: "activity",
+        checkpoint: null,
+        config: {
+          LOKI_URL: "https://loki.example.test",
+          namespace: "synthetic",
+        },
+      } as never);
+      expect(result.events).toHaveLength(1);
+      expect(result.events?.[0]?.metadata).toMatchObject({
+        errors: 0,
+        warnings: 0,
+      });
+      expect(result.events?.[0]?.origin_id).toBe(result.checkpoint?.window_end);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+  it("retains an old checkpoint and drains backlog in bounded oldest-first batches", () => {
+    const checkpoint = { window_end: "2026-08-10T12:00:00.000Z" };
+    const now = new Date("2026-08-13T12:23:00.000Z");
+    const first = windowsToCollect(checkpoint, now);
+    expect(first).toHaveLength(72);
+    expect(first[0]?.start.toISOString()).toBe(checkpoint.window_end);
+    expect(first.at(-1)?.end.toISOString()).toBe("2026-08-11T12:00:00.000Z");
+    const second = windowsToCollect(
+      { window_end: first.at(-1)?.end.toISOString() },
+      now
+    );
+    expect(second[0]?.start.toISOString()).toBe(
+      first.at(-1)?.end.toISOString()
+    );
+    expect(second).toHaveLength(72);
+  });
   it("collects aligned 20-minute windows and resumes from its checkpoint", () => {
     const windows = windowsToCollect(
       { window_end: "2026-08-13T11:40:00.000Z" },

--- a/examples/lobu-team/__tests__/product-activity-digest.reaction.test.ts
+++ b/examples/lobu-team/__tests__/product-activity-digest.reaction.test.ts
@@ -99,6 +99,29 @@ describe("Lobu Team product activity digest reaction", () => {
     );
   });
 
+  it("does not use a later feed recovery to complete an earlier arrival window", async () => {
+    for (const last_sync_at of [
+      context.window.window_end,
+      "2026-08-13T12:23:00.000Z",
+    ]) {
+      const send = mock();
+      const feeds = healthyFeeds.map((row) => ({ ...row, last_sync_at }));
+      expect(
+        digestCoverage(feeds, new Date(context.window.window_end))
+      ).toMatchObject({
+        product: false,
+        logs: false,
+      });
+      await productActivityDigest(context, {
+        query: mock().mockResolvedValue(feeds).mockResolvedValueOnce([]),
+        notifications: { send },
+        log: mock(),
+      } as unknown as ReactionClient);
+      expect(send).toHaveBeenCalledTimes(1);
+      expect(send.mock.calls[0]?.[0]?.body).toContain("Coverage incomplete");
+    }
+  });
+
   it("reports missing coverage even when no activity arrived", async () => {
     const send = mock();
     await productActivityDigest(context, {
@@ -366,6 +389,9 @@ describe("Lobu Team product activity digest reaction", () => {
     const coverageStatement = String(query.mock.calls[1]?.[0]);
     expect(coverageStatement).toContain(
       "e.origin_id = '2026-08-13T12:00:00.000Z'"
+    );
+    expect(coverageStatement).toContain(
+      "e.created_at < '2026-08-13T12:20:00.000Z'"
     );
   });
 

--- a/examples/lobu-team/__tests__/product-activity-digest.reaction.test.ts
+++ b/examples/lobu-team/__tests__/product-activity-digest.reaction.test.ts
@@ -3,10 +3,11 @@ import type { ReactionClient, ReactionContext } from "@lobu/connector-sdk";
 import productActivityDigest, {
   buildProductActivityCard,
   collectProductActivityDigest,
+  digestCoverage,
 } from "../product-activity-digest.reaction.ts";
 
 const context = {
-  extracted_data: { run: true, exclude_email: "emrekabakci@gmail.com" },
+  extracted_data: { run: true, exclude_email: "operator@example.test" },
   entities: [],
   window: {
     run_id: 1234,
@@ -26,11 +27,89 @@ const context = {
   organization_slug: "lobu-team",
 } satisfies ReactionContext;
 
+const healthyFeeds = ["lobu-product-activity-db", "lobu-production-logs"].map(
+  (connection_slug) => ({
+    connection_slug,
+    connection_status: "active",
+    status: "active",
+    last_sync_status: "success",
+    last_sync_at: "2026-08-13T12:03:00.000Z",
+    consecutive_failures: 0,
+    expected_log_window_collected: true,
+  })
+);
+const healthyCoverage = { product: true, logs: true, issues: [] };
+
 describe("Lobu Team product activity digest reaction", () => {
+  it("requires both feed health and a collected source window", () => {
+    const end = new Date(context.window.window_end);
+    expect(digestCoverage(healthyFeeds, end)).toEqual(healthyCoverage);
+    for (const patch of [
+      { connection_status: "revoked" },
+      { status: "paused" },
+      { last_sync_status: "failed" },
+      { last_sync_at: "2026-08-12T12:00:00.000Z" },
+      { expected_log_window_collected: false },
+    ]) {
+      const coverage = digestCoverage(
+        healthyFeeds.map((row) =>
+          row.connection_slug === "lobu-production-logs"
+            ? { ...row, ...patch }
+            : row
+        ),
+        end
+      );
+      expect(coverage.product).toBe(true);
+      expect(coverage.logs).toBe(false);
+      expect(coverage.issues).toHaveLength(1);
+    }
+  });
+
+  it("labels observed log counts as partial during catch-up", async () => {
+    const send = mock();
+    await productActivityDigest(context, {
+      query: mock()
+        .mockResolvedValue(
+          healthyFeeds.map((row) => ({
+            ...row,
+            expected_log_window_collected: false,
+          }))
+        )
+        .mockResolvedValueOnce([
+          {
+            connection_slug: "lobu-production-logs",
+            metadata: { errors: 3, warnings: 2 },
+          },
+        ]),
+      notifications: { send },
+      log: mock(),
+    } as unknown as ReactionClient);
+    expect(JSON.stringify(send.mock.calls[0]?.[0])).toContain(
+      "3 / 2 observed — coverage incomplete"
+    );
+  });
+
+  it("reports missing coverage even when no activity arrived", async () => {
+    const send = mock();
+    await productActivityDigest(context, {
+      query: mock().mockResolvedValue([]),
+      notifications: { send },
+      log: mock(),
+    } as unknown as ReactionClient);
+    expect(send).toHaveBeenCalledTimes(1);
+    const message = send.mock.calls[0]?.[0];
+    expect(JSON.stringify(message.card)).toContain(
+      "Unknown — coverage incomplete"
+    );
+    expect(message.body).toContain("Coverage incomplete");
+    expect(message.body).not.toContain("0 errors");
+  });
   it("stays silent when the window has no activity", async () => {
     const send = mock();
     const log = mock();
-    const query = mock().mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    const query = mock()
+      .mockResolvedValue(healthyFeeds)
+      .mockResolvedValueOnce([]);
     const client = {
       query,
       notifications: { send },
@@ -85,7 +164,9 @@ describe("Lobu Team product activity digest reaction", () => {
       },
     ];
     const send = mock().mockResolvedValue({ notified_count: 1 });
-    const query = mock().mockResolvedValueOnce(rows);
+    const query = mock()
+      .mockResolvedValue(healthyFeeds)
+      .mockResolvedValueOnce(rows);
     const client = {
       query,
       notifications: { send },
@@ -120,7 +201,7 @@ describe("Lobu Team product activity digest reaction", () => {
     // Excluded operator rows are handled in memory (no leading-wildcard LIKE
     // over events), and the window is read in bounded keyset pages so excluded
     // rows cannot consume a fixed LIMIT budget.
-    expect(queryText).not.toContain("LIKE '%emrekabakci@gmail.com%'");
+    expect(queryText).not.toContain("LIKE '%operator@example.test%'");
     expect(queryText).toContain("ORDER BY e.created_at ASC, e.id ASC");
     expect(queryText).toContain("LIMIT 1000");
   });
@@ -138,10 +219,14 @@ describe("Lobu Team product activity digest reaction", () => {
         payload_text: "codex · Ada · ada@example.com",
       },
     ]);
-    const card = buildProductActivityCard(digest, {
-      start: context.window.window_start,
-      end: context.window.window_end,
-    });
+    const card = buildProductActivityCard(
+      digest,
+      {
+        start: context.window.window_start,
+        end: context.window.window_end,
+      },
+      healthyCoverage
+    );
 
     expect(JSON.stringify(card)).toContain(
       '"label":"Online users","value":"1"'
@@ -155,12 +240,12 @@ describe("Lobu Team product activity digest reaction", () => {
         {
           connection_slug: "lobu-product-activity-db",
           title: "User login",
-          payload_text: "Burak · emrekabakci@gmail.com",
+          payload_text: "Operator · operator@example.test",
         },
         {
           connection_slug: "lobu-product-activity-db",
           title: "MCP activity",
-          payload_text: "lobu-cli · Burak · emrekabakci@gmail.com",
+          payload_text: "lobu-cli · Operator · operator@example.test",
         },
         {
           connection_slug: "lobu-product-activity-db",
@@ -168,12 +253,16 @@ describe("Lobu Team product activity digest reaction", () => {
           payload_text: "Ada · ada@example.com",
         },
       ],
-      "emrekabakci@gmail.com"
+      "operator@example.test"
     );
-    const card = buildProductActivityCard(digest, {
-      start: context.window.window_start,
-      end: context.window.window_end,
-    });
+    const card = buildProductActivityCard(
+      digest,
+      {
+        start: context.window.window_start,
+        end: context.window.window_end,
+      },
+      healthyCoverage
+    );
 
     expect(digest.logins).toEqual(["Ada · ada@example.com"]);
     expect(digest.mcp_conversations).toHaveLength(0);
@@ -181,7 +270,7 @@ describe("Lobu Team product activity digest reaction", () => {
       '"label":"Online users","value":"1"'
     );
     expect(JSON.stringify(card)).toContain("ada@example.com");
-    expect(JSON.stringify(card)).not.toContain("emrekabakci");
+    expect(JSON.stringify(card)).not.toContain("operator");
   });
 
   it("stays silent when the operator is the only online user", async () => {
@@ -189,16 +278,18 @@ describe("Lobu Team product activity digest reaction", () => {
       {
         connection_slug: "lobu-product-activity-db",
         title: "User login",
-        payload_text: "Burak · emrekabakci@gmail.com",
+        payload_text: "Operator · operator@example.test",
       },
       {
         connection_slug: "lobu-product-activity-db",
         title: "MCP activity",
-        payload_text: "lobu-cli · Burak · emrekabakci@gmail.com",
+        payload_text: "lobu-cli · Operator · operator@example.test",
       },
     ];
     const send = mock();
-    const query = mock().mockResolvedValueOnce(rows);
+    const query = mock()
+      .mockResolvedValue(healthyFeeds)
+      .mockResolvedValueOnce(rows);
     const client = {
       query,
       notifications: { send },
@@ -217,7 +308,7 @@ describe("Lobu Team product activity digest reaction", () => {
     const excludedPage = Array.from({ length: 1000 }, (_, i) => ({
       connection_slug: "lobu-product-activity-db",
       title: "User login",
-      payload_text: `Burak · emrekabakci@gmail.com · org ${i}`,
+      payload_text: `Operator · operator@example.test · org ${i}`,
       _created_at: "2026-08-13T12:01:00.000Z",
       _id: 1000 + i,
     }));
@@ -232,6 +323,7 @@ describe("Lobu Team product activity digest reaction", () => {
     ];
     const send = mock().mockResolvedValue({ notified_count: 1 });
     const query = mock()
+      .mockResolvedValue(healthyFeeds)
       .mockResolvedValueOnce(excludedPage)
       .mockResolvedValueOnce(validRows);
     const client = {
@@ -242,20 +334,22 @@ describe("Lobu Team product activity digest reaction", () => {
 
     await productActivityDigest(context, client);
 
-    expect(query.mock.calls).toHaveLength(2);
+    expect(query.mock.calls).toHaveLength(3);
     const serializedCard = JSON.stringify(send.mock.calls[0]?.[0]?.card);
     expect(serializedCard).toContain("ada@example.com");
-    expect(serializedCard).not.toContain("emrekabakci");
+    expect(serializedCard).not.toContain("operator");
   });
 
   it("reads only the claimed arrival window, including its lower boundary", async () => {
-    const query = mock().mockResolvedValue([]);
+    const query = mock()
+      .mockResolvedValue(healthyFeeds)
+      .mockResolvedValueOnce([]);
     await productActivityDigest(context, {
       query,
       notifications: { send: mock() },
       log: mock(),
     } as unknown as ReactionClient);
-    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledTimes(2);
     const statement = String(query.mock.calls[0]?.[0]);
     expect(statement).toContain("e.created_at >= '2026-08-13T12:00:00.000Z'");
     expect(statement).toContain("e.created_at < '2026-08-13T12:20:00.000Z'");

--- a/examples/lobu-team/__tests__/product-activity-digest.reaction.test.ts
+++ b/examples/lobu-team/__tests__/product-activity-digest.reaction.test.ts
@@ -14,7 +14,6 @@ const context = {
     automation_id: 42,
     window_start: "2026-08-13T12:00:00.000Z",
     window_end: "2026-08-13T12:20:00.000Z",
-    granularity: "20 minutes",
     content_analyzed: 0,
   },
   automation: {
@@ -33,7 +32,7 @@ const healthyFeeds = ["lobu-product-activity-db", "lobu-production-logs"].map(
     connection_status: "active",
     status: "active",
     last_sync_status: "success",
-    last_sync_at: "2026-08-13T12:03:00.000Z",
+    last_sync_at: "2026-08-13T12:18:00.000Z",
     consecutive_failures: 0,
     expected_log_window_collected: true,
   })
@@ -63,6 +62,17 @@ describe("Lobu Team product activity digest reaction", () => {
       expect(coverage.logs).toBe(false);
       expect(coverage.issues).toHaveLength(1);
     }
+
+    const missedProductCycle = digestCoverage(
+      healthyFeeds.map((row) =>
+        row.connection_slug === "lobu-product-activity-db"
+          ? { ...row, last_sync_at: "2026-08-13T12:03:00.000Z" }
+          : row
+      ),
+      end
+    );
+    expect(missedProductCycle.product).toBe(false);
+    expect(missedProductCycle.logs).toBe(true);
   });
 
   it("labels observed log counts as partial during catch-up", async () => {
@@ -353,6 +363,10 @@ describe("Lobu Team product activity digest reaction", () => {
     const statement = String(query.mock.calls[0]?.[0]);
     expect(statement).toContain("e.created_at >= '2026-08-13T12:00:00.000Z'");
     expect(statement).toContain("e.created_at < '2026-08-13T12:20:00.000Z'");
+    const coverageStatement = String(query.mock.calls[1]?.[0]);
+    expect(coverageStatement).toContain(
+      "e.origin_id = '2026-08-13T12:00:00.000Z'"
+    );
   });
 
   it("rejects invalid windows before reading or notifying", async () => {
@@ -410,7 +424,7 @@ describe("Lobu Team product activity digest reaction", () => {
       productActivityDigest(
         {
           ...context,
-          window: { ...context.window, run_id: undefined },
+          window: { ...context.window, run_id: undefined as never },
         },
         client
       )

--- a/examples/lobu-team/loki-activity.connector.ts
+++ b/examples/lobu-team/loki-activity.connector.ts
@@ -50,14 +50,18 @@ export function windowsToCollect(
   const checkpointMs = checkpoint?.window_end
     ? new Date(checkpoint.window_end).getTime()
     : Number.NaN;
-  const earliestMs = latestEndMs - MAX_CATCHUP_WINDOWS * WINDOW_MS;
   const startMs = Number.isFinite(checkpointMs)
-    ? Math.max(checkpointMs, earliestMs)
+    ? checkpointMs
     : latestEndMs - WINDOW_MS;
   if (startMs >= latestEndMs) return [];
 
+  // Bound each sync's work without moving the saved cursor past unread logs.
+  const batchEndMs = Math.min(
+    latestEndMs,
+    startMs + MAX_CATCHUP_WINDOWS * WINDOW_MS
+  );
   const windows: LokiActivityWindow[] = [];
-  for (let cursor = startMs; cursor < latestEndMs; cursor += WINDOW_MS) {
+  for (let cursor = startMs; cursor < batchEndMs; cursor += WINDOW_MS) {
     windows.push({
       start: new Date(cursor),
       end: new Date(cursor + WINDOW_MS),
@@ -248,7 +252,7 @@ export default class LokiActivityConnector extends ConnectorRuntime<
     name: "Kubernetes logs",
     description:
       "Collect error and warning counts plus recent samples from Lobu production Loki in aligned 20-minute windows.",
-    version: "1.0.0",
+    version: "1.0.1",
     authSchema: {
       methods: [
         {
@@ -305,7 +309,8 @@ export default class LokiActivityConnector extends ConnectorRuntime<
     const events: EventEnvelope[] = [];
     for (const window of windows) {
       const activity = await queryLokiActivity(ctx.config, window);
-      if (activity.errors === 0 && activity.warnings === 0) continue;
+      // Persist empty windows too: a durable zero distinguishes successful
+      // collection from a missing or failed log feed.
       events.push({
         origin_id: window.end.toISOString(),
         origin_type: "log_activity",

--- a/examples/lobu-team/product-activity-digest.reaction.ts
+++ b/examples/lobu-team/product-activity-digest.reaction.ts
@@ -57,6 +57,12 @@ export function digestCoverage(
       return false;
     }
     const syncedAt = new Date(feed.last_sync_at ?? "").getTime();
+    if (syncedAt >= windowEnd.getTime()) {
+      issues.push(
+        `${label}: latest successful sync completed at or after the window cutoff`
+      );
+      return false;
+    }
     if (
       !Number.isFinite(syncedAt) ||
       syncedAt < windowEnd.getTime() - FEED_FRESHNESS_MS
@@ -477,7 +483,8 @@ export default async (
     SELECT c.slug AS connection_slug, c.status AS connection_status, f.status, f.last_sync_status,
       f.last_sync_at, f.consecutive_failures,
       EXISTS (SELECT 1 FROM events e WHERE e.connection_id = c.id
-        AND e.origin_id = '${expectedLogEnd}' AND e.origin_type = 'log_activity')
+        AND e.origin_id = '${expectedLogEnd}' AND e.origin_type = 'log_activity'
+        AND e.created_at < '${end.toISOString()}')
         AS expected_log_window_collected
     FROM connections c JOIN feeds f ON f.connection_id = c.id
     WHERE c.deleted_at IS NULL AND f.deleted_at IS NULL AND (

--- a/examples/lobu-team/product-activity-digest.reaction.ts
+++ b/examples/lobu-team/product-activity-digest.reaction.ts
@@ -7,6 +7,88 @@ import type {
 const PRODUCT_ACTIVITY_CONNECTION = "lobu-product-activity-db";
 const LOG_ACTIVITY_CONNECTION = "lobu-production-logs";
 const CARD_TEXT_LIMIT = 2_800;
+const LOG_WINDOW_MS = 20 * 60 * 1000;
+const LOG_INGESTION_LAG_MS = 2 * 60 * 1000;
+const FEED_FRESHNESS_MS = 25 * 60 * 1000;
+
+interface FeedCoverageRow {
+  connection_slug: string;
+  connection_status: string;
+  status: string;
+  last_sync_status: string | null;
+  last_sync_at: string | null;
+  consecutive_failures: number;
+  expected_log_window_collected: boolean;
+}
+
+export interface DigestCoverage {
+  product: boolean;
+  logs: boolean;
+  issues: string[];
+}
+
+export function digestCoverage(
+  rows: FeedCoverageRow[],
+  windowEnd: Date
+): DigestCoverage {
+  const issues: string[] = [];
+  const healthy = (slug: string, label: string): boolean => {
+    const feed = rows.find((row) => row.connection_slug === slug);
+    if (!feed) {
+      issues.push(`${label}: feed unavailable`);
+      return false;
+    }
+    if (feed.connection_status !== "active") {
+      issues.push(
+        `${label}: connection ${feed.connection_status ?? "unavailable"}`
+      );
+      return false;
+    }
+    if (
+      feed.status !== "active" ||
+      feed.last_sync_status !== "success" ||
+      Number(feed.consecutive_failures) > 0
+    ) {
+      issues.push(
+        `${label}: feed ${feed.status}; last sync ${feed.last_sync_status ?? "unknown"}`
+      );
+      return false;
+    }
+    const syncedAt = new Date(feed.last_sync_at ?? "").getTime();
+    if (
+      !Number.isFinite(syncedAt) ||
+      syncedAt < windowEnd.getTime() - FEED_FRESHNESS_MS
+    ) {
+      issues.push(`${label}: last successful sync is stale or unknown`);
+      return false;
+    }
+    if (
+      slug === LOG_ACTIVITY_CONNECTION &&
+      feed.expected_log_window_collected !== true
+    ) {
+      issues.push(
+        `${label}: the expected log window has not been collected; catch-up may still be running`
+      );
+      return false;
+    }
+    return true;
+  };
+  return {
+    product: healthy(PRODUCT_ACTIVITY_CONNECTION, "Product activity"),
+    logs: healthy(LOG_ACTIVITY_CONNECTION, "Production logs"),
+    issues,
+  };
+}
+
+function logCounts(
+  digest: ProductActivityDigest,
+  coverage: DigestCoverage
+): string {
+  if (coverage.logs) return `${digest.errors} / ${digest.warnings}`;
+  return digest.errors || digest.warnings
+    ? `${digest.errors} / ${digest.warnings} observed — coverage incomplete`
+    : "Unknown — coverage incomplete";
+}
 
 export const input = {
   type: "object",
@@ -115,22 +197,34 @@ export function hasProductActivity(digest: ProductActivityDigest): boolean {
 
 export function buildProductActivityCard(
   digest: ProductActivityDigest,
-  window: { start: string; end: string }
+  window: { start: string; end: string },
+  coverage: DigestCoverage = {
+    product: false,
+    logs: false,
+    issues: ["Source coverage unverified"],
+  }
 ): CardElement {
   const online = uniqueUsers([...digest.logins, ...digest.mcp_conversations]);
+  const productCount = (count: number) =>
+    coverage.product ? count : `${count} observed`;
   const children: CardElement[] = [
     {
       type: "fields",
       children: [
-        field("Signups", digest.signups.length),
-        field("Login sessions", digest.logins.length),
-        field("Online users", online.length),
-        field("New connections", digest.connections.length),
-        field("Active MCP conversations", digest.mcp_conversations.length),
-        field("Errors / warnings", `${digest.errors} / ${digest.warnings}`),
+        field("Signups", productCount(digest.signups.length)),
+        field("Login sessions", productCount(digest.logins.length)),
+        field("Online users", productCount(online.length)),
+        field("New connections", productCount(digest.connections.length)),
+        field(
+          "Active MCP conversations",
+          productCount(digest.mcp_conversations.length)
+        ),
+        field("Errors / warnings", logCounts(digest, coverage)),
       ],
     },
   ];
+
+  appendSection(children, "Coverage incomplete", coverage.issues.map(safe));
 
   appendSection(children, "New signups", digest.signups.map(safe));
   appendSection(children, "Online users", online.map(safe));
@@ -158,7 +252,7 @@ export function buildProductActivityCard(
   return {
     type: "card",
     title: "Lobu production activity",
-    subtitle: formatWindow(window.start, window.end),
+    subtitle: `Activity received ${formatWindow(window.start, window.end)}`,
     children,
   };
 }
@@ -239,16 +333,20 @@ function formatWindow(start: string, end: string): string {
 
 function summaryBody(
   digest: ProductActivityDigest,
-  window: { start: string; end: string }
+  window: { start: string; end: string },
+  coverage: DigestCoverage
 ): string {
   return (
+    `${coverage.issues.length ? `Coverage incomplete: ${coverage.issues.join("; ")}. Observed activity: ` : ""}` +
     `${formatWindow(window.start, window.end)} · ` +
     `${digest.signups.length} signups · ` +
     `${digest.logins.length} login sessions · ` +
     `${uniqueUsers([...digest.logins, ...digest.mcp_conversations]).length} online users · ` +
     `${digest.connections.length} new connections · ` +
     `${digest.mcp_conversations.length} active MCP conversations · ` +
-    `${digest.errors} errors · ${digest.warnings} warnings`
+    (coverage.logs
+      ? `${digest.errors} errors · ${digest.warnings} warnings`
+      : `Errors / warnings: ${logCounts(digest, coverage)}`)
   );
 }
 
@@ -371,7 +469,25 @@ export default async (
     );
   }
   const digest = collectProductActivityDigest(rows, excludedEmail);
-  if (!hasProductActivity(digest)) {
+  const expectedLogEnd = new Date(
+    Math.floor((end.getTime() - LOG_INGESTION_LAG_MS) / LOG_WINDOW_MS) *
+      LOG_WINDOW_MS
+  ).toISOString();
+  // Bounded configuration rows and an exact source-identity index probe. A
+  // recent sync alone cannot prove catch-up has reached the expected window.
+  const coverageRows = (await client.query(`
+    SELECT c.slug AS connection_slug, c.status AS connection_status, f.status, f.last_sync_status,
+      f.last_sync_at, f.consecutive_failures,
+      EXISTS (SELECT 1 FROM events e WHERE e.connection_id = c.id
+        AND e.origin_id = '${expectedLogEnd}' AND e.origin_type = 'log_activity')
+        AS expected_log_window_collected
+    FROM connections c JOIN feeds f ON f.connection_id = c.id
+    WHERE c.deleted_at IS NULL AND f.deleted_at IS NULL AND (
+      (c.slug = '${PRODUCT_ACTIVITY_CONNECTION}' AND f.feed_key = 'query')
+      OR (c.slug = '${LOG_ACTIVITY_CONNECTION}' AND f.feed_key = 'activity'))
+  `)) as FeedCoverageRow[];
+  const coverage = digestCoverage(coverageRows, end);
+  if (!hasProductActivity(digest) && coverage.issues.length === 0) {
     client.log("No production activity; Slack digest skipped", {
       window_start: start.toISOString(),
       window_end: end.toISOString(),
@@ -381,14 +497,22 @@ export default async (
 
   await client.notifications.send({
     title: "Lobu production activity digest",
-    body: summaryBody(digest, {
-      start: start.toISOString(),
-      end: end.toISOString(),
-    }),
-    card: buildProductActivityCard(digest, {
-      start: start.toISOString(),
-      end: end.toISOString(),
-    }),
+    body: summaryBody(
+      digest,
+      {
+        start: start.toISOString(),
+        end: end.toISOString(),
+      },
+      coverage
+    ),
+    card: buildProductActivityCard(
+      digest,
+      {
+        start: start.toISOString(),
+        end: end.toISOString(),
+      },
+      coverage
+    ),
     recipients: "admins",
     idempotency_key: `product-activity-digest:run:${runId}`,
     automation_source: {

--- a/examples/lobu-team/product-activity-digest.reaction.ts
+++ b/examples/lobu-team/product-activity-digest.reaction.ts
@@ -9,7 +9,9 @@ const LOG_ACTIVITY_CONNECTION = "lobu-production-logs";
 const CARD_TEXT_LIMIT = 2_800;
 const LOG_WINDOW_MS = 20 * 60 * 1000;
 const LOG_INGESTION_LAG_MS = 2 * 60 * 1000;
-const FEED_FRESHNESS_MS = 25 * 60 * 1000;
+// Both feeds are scheduled 2–3 minutes before this digest. Ten minutes allows
+// normal run delay without treating a missed 20-minute cycle as current.
+const FEED_FRESHNESS_MS = 10 * 60 * 1000;
 
 interface FeedCoverageRow {
   connection_slug: string;
@@ -21,7 +23,7 @@ interface FeedCoverageRow {
   expected_log_window_collected: boolean;
 }
 
-export interface DigestCoverage {
+interface DigestCoverage {
   product: boolean;
   logs: boolean;
   issues: string[];
@@ -198,11 +200,7 @@ export function hasProductActivity(digest: ProductActivityDigest): boolean {
 export function buildProductActivityCard(
   digest: ProductActivityDigest,
   window: { start: string; end: string },
-  coverage: DigestCoverage = {
-    product: false,
-    logs: false,
-    issues: ["Source coverage unverified"],
-  }
+  coverage: DigestCoverage
 ): CardElement {
   const online = uniqueUsers([...digest.logins, ...digest.mcp_conversations]);
   const productCount = (count: number) =>


### PR DESCRIPTION
## Summary
Preserve the Loki feed checkpoint and collect its backlog oldest-first in bounded batches. Persist empty log windows as coverage evidence.

The digest reports incomplete coverage when a source is missing, paused, stale, catching up, or has only synced at or after the digest's fixed arrival cutoff. Log evidence must also have arrived before that cutoff. Missing coverage produces a notice even when no activity rows arrived; a healthy empty window stays silent.

## Test plan
- [x] Intended example paths staged explicitly; local build, typecheck, lint, naming and pre-commit gates passed.
- [x] Final example suite: `31 pass, 0 fail`.
- [x] Original red: `13 pass, 2 fail` for missing-coverage silence and skipped old checkpoints; both fixed.
- [x] Missed-cycle regression fails at the previous 25-minute freshness threshold and passes at 10 minutes.
- [x] Cutoff regression: `12 pass, 2 fail` before fixing post-cutoff feed state and log evidence; afterward `31 pass, 0 fail` across all example suites.
- [x] Codex reviewed the cutoff correction in a focused fixer pass; only status wording changed afterward.
- [x] Read-only production preview of the original backlog and real Slack card conversion passed; no notification was sent.
- Required GitHub CI and semantic-review results are recorded on the exact PR head.

## Notes
This change stays in the owning example. Restoring the paused live Loki feed still requires approval for private HTTP access, backlog recovery, and deployment of this connector version. The script-executor PR preserves these cases when renaming the digest files.


Final verification: Codex reviewed `ceb455d995dbce69ff418dd51bc70546093a265a` with confidence 93, zero bugs/blockers and adequate tests. All ten required checks passed before `make land N=3506` squash-merged this PR as `d3131ab5095e317f4222788273e39d761ae0474d`. The image workflow passed, and production smoke verified that exact squash revision live: **9 passed, 0 failed**. This proves the code rollout; tenant connector/configuration activation remains separate.
