### PR TITLE
feat: reuse durable Automation windows for direct source reads

### DIFF
--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -112,6 +112,22 @@ while (page.has_more) {
   page = continuation.context.page;
 }
 
+for (const [source_name, firstPage] of Object.entries(claim.context.sources_page ?? {})) {
+  let source_cursor = firstPage.next_cursor;
+  while (source_cursor) {
+    const continuation = await client.automations.claimNextWindow({
+      automation_id: "42",
+      run_id: claim.run_id,
+      source_name,
+      source_cursor,
+      limit: 100,
+    });
+    // Process/reduce continuation.context.sources[source_name] in code.
+    tokens.push(continuation.context.window_token);
+    source_cursor = continuation.context.sources_page[source_name].next_cursor;
+  }
+}
+
 await client.automations.completeWindow({
   automation_id: "42",
   run_id: claim.run_id,
@@ -128,6 +144,24 @@ the next claim — indefinitely. Submit the completion with whatever the extract
 contract allows for an empty result rather than dropping the lease; nothing is
 lost by completing an empty window, because the mark only ever moves forward over
 arrivals the run was actually shown.
+
+A feed with `readWindowAxis` uses its live reader for `@feed` sources. Other
+sync-capable feeds retain their stored-arrival read. Read-only feeds must support
+the window contract or fail explicitly. Live rows are not copied into `events`
+and their provider IDs are never treated as stored event IDs. The connector
+receives the fixed `[start, end)` bounds and acknowledges its source timestamp
+axis in `sources_page[name].window_axis`. This describes source time, not Lobu
+arrival time: for example, Gmail uses message receipt time and Drive uses file
+modification time. It does not promise deletion history or delayed-import
+coverage. Readers needing those guarantees must use provider change tracking.
+
+Each live source has an independent cursor chain. All required chains must be
+complete before checkpoint advancement, even when a page is empty. The chain
+also binds the feed configuration and connector version; changes mid-read fail
+instead of combining different queries. SQL summaries remain ordinary context
+sources. A processor can reduce pages in code and return only a summary to the
+model. Automatic unchanged-source skipping is disabled for live sources because
+an unqueried or partial source cannot prove an unchanged window.
 
 The database serializes claims per Automation. The signed tokens bind the exact
 window, run attempt, lease, source IDs, and page chain. A stale attempt cannot

--- a/docs/connector-authoring.md
+++ b/docs/connector-authoring.md
@@ -224,3 +224,17 @@ browser-auth or live `cdp`). Full schemas are in the SDK reference.
 - Seeds: `examples/lobu-crm/npm-downloads.connector.ts` (minimal, no auth),
   `examples/brand-intelligence/*.connector.ts` (richer: auth, actions, per-feed
   `eventKinds`).
+
+### Windowed source reads
+
+Feeds that can apply fixed source-time bounds declare `readWindowAxis` alongside
+`read`. An Automation `@feed` source then uses the existing live reader without
+persisting rows. `FeedReadContext.window` carries `{ start, end }`, a half-open
+range fixed for the run. Compose it with configured filters on every page; do
+not substitute a moving lookback or guess a timestamp column. Return
+`window: { ...ctx.window, axis: 'updated_at' }` using the declared timestamp,
+`hasMore`, and the native `nextCursor` when more pages remain. Empty pages may
+still have a cursor. Propagate missing metadata, provider failures and capacity
+limits; they must never certify an exhausted window. A reader that cannot honor
+these bounds must reject the request. Time-based reads cover the declared source
+timestamp, not all possible edits, deletions or late imports.

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4767,6 +4767,14 @@ export type ManageAutomationsData = {
      */
     lease_seconds?: number;
     /**
+     * Automation source name to continue; pair with source_cursor and the same run_id.
+     */
+    source_name?: string;
+    /**
+     * Signed window_token from the preceding page of this source. Retain every returned window_token for completeWindow.
+     */
+    source_cursor?: string;
+    /**
      * [claim_next_window continuation] Cursor timestamp from context.page.next_cursor.
      */
     before_occurred_at?: string;
@@ -5242,6 +5250,9 @@ export type ManageAutomationsResponses = {
                   returned: number;
                   limit: number;
                   has_more: boolean;
+                  next_cursor?: string;
+                  window_axis?: string;
+                  feed_id?: number;
                 };
           };
           extraction_schema?: {
@@ -5845,6 +5856,14 @@ export type ReadKnowledgeData = {
      */
     offset?: number;
     /**
+     * Automation source name to continue; pair with source_cursor and the same run_id.
+     */
+    source_name?: string;
+    /**
+     * Signed window_token from the preceding page of this source. Retain every returned window_token for completeWindow.
+     */
+    source_cursor?: string;
+    /**
      * Chronological cursor anchor for older results. Pair with before_id. Only used when sort_by=date and sort_order=desc.
      */
     before_occurred_at?: string;
@@ -5991,6 +6010,9 @@ export type ReadKnowledgeResponses = {
             returned: number;
             limit: number;
             has_more: boolean;
+            next_cursor?: string;
+            window_axis?: string;
+            feed_id?: number;
           };
     };
     entities?: Array<unknown>;

--- a/packages/connector-sdk/src/__tests__/feed-read-window.test.ts
+++ b/packages/connector-sdk/src/__tests__/feed-read-window.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { assertFeedReadWindow, validateFeedReadWindow } from '../feed-read-window';
+
+const window = { start: '2026-01-01T00:00:00.000Z', end: '2026-01-02T00:00:00.000Z' };
+describe('source window contract', () => {
+  test('rejects unsupported readers and missing exhaustion', () => {
+    expect(() => assertFeedReadWindow({ rows: [], hasMore: false }, window, 'updated_at')).toThrow(/acknowledge/);
+    expect(() => assertFeedReadWindow({ rows: [], window: { ...window, axis: 'updated_at' } }, window, 'updated_at')).toThrow(/exhaustion/);
+  });
+  test('rejects changed bounds, missing axes and contradictory continuation', () => {
+    for (const coverage of [{ ...window, start: window.end, axis: 'updated_at' }, { ...window, axis: '' }]) {
+      expect(() => assertFeedReadWindow({ rows: [], hasMore: false, window: coverage }, window, 'updated_at')).toThrow();
+    }
+    expect(() => assertFeedReadWindow({ rows: [], hasMore: false, nextCursor: 'next', window: { ...window, axis: 'updated_at' } }, window, 'updated_at')).toThrow();
+    expect(() => assertFeedReadWindow({ rows: [], hasMore: false, window: { ...window, axis: 'created_at' } }, window, 'updated_at')).toThrow(/axis/);
+    expect(() => assertFeedReadWindow({ rows: [], hasMore: false, window: { ...window, axis: 'updated_at' } }, window)).toThrow(/declare/);
+  });
+  test('allows empty pages with authoritative continuation and ordinary unwindowed reads', () => {
+    expect(() => assertFeedReadWindow({ rows: [], hasMore: true, nextCursor: 'next', window: { ...window, axis: 'updated_at' } }, window, 'updated_at')).not.toThrow();
+    expect(() => assertFeedReadWindow({ rows: [] })).not.toThrow();
+  });
+  test('rejects invalid and reversed windows', () => {
+    expect(() => validateFeedReadWindow({ ...window, end: window.start })).toThrow();
+    expect(() => validateFeedReadWindow({ ...window, start: 'invalid' })).toThrow();
+  });
+});

--- a/packages/connector-sdk/src/connector-runtime.ts
+++ b/packages/connector-sdk/src/connector-runtime.ts
@@ -22,6 +22,7 @@ import type {
   WebhookRegistration,
   WebhookRegistrationContext,
 } from './connector-types.js';
+import { assertFeedReadWindow, validateFeedReadWindow } from './feed-read-window.js';
 
 /**
  * ConnectorRuntime is the base class for all connectors.
@@ -81,13 +82,17 @@ export abstract class ConnectorRuntime<C = Record<string, unknown>, F = Record<s
    * kind or persistence flag.
    */
   async read(ctx: FeedReadContext<F>): Promise<FeedReadResult> {
-    const handler = this.definition.feeds?.[ctx.feedKey]?.read;
+    if (ctx.window) validateFeedReadWindow(ctx.window);
+    const feed = this.definition.feeds?.[ctx.feedKey];
+    const handler = feed?.read;
     if (!handler) {
       throw new Error(
         `${this.definition.key} feed '${ctx.feedKey}' does not support source reads`
       );
     }
-    return handler(ctx);
+    const result = await handler(ctx);
+    assertFeedReadWindow(result, ctx.window, feed.readWindowAxis);
+    return result;
   }
 
   /**

--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -518,6 +518,8 @@ export interface FeedDefinition {
    * it because their implementation is remote. Users never select a feed mode.
    */
   operations?: FeedOperation[];
+  /** Declares that live reads can honor fixed windows on this source timestamp. */
+  readWindowAxis?: string;
   /**
    * Routes inbound app-webhook deliveries to this feed. Lives on the feed (not
    * the connector's webhook schema) because feeds_schema is the persisted,
@@ -994,6 +996,17 @@ export interface WebhookRegistration {
 
 export type FeedOperation = 'sync' | 'read';
 
+/** Fixed half-open source-time bounds, preserved across every page of a read. */
+export interface FeedReadWindow {
+  start: string;
+  end: string;
+}
+
+/** The connector explicitly acknowledges the bounds and names its time axis. */
+export interface FeedReadWindowCoverage extends FeedReadWindow {
+  axis: string;
+}
+
 /**
  * A source read for one configured feed. The connector interprets `query` in
  * its native vocabulary and pushes pagination/sort into the source. Results are
@@ -1005,6 +1018,7 @@ export interface FeedReadContext<F = Record<string, unknown>> {
   query?: string;
   /** Source-native continuation token from the previous page, when supported. */
   cursor?: string;
+  window?: FeedReadWindow;
   config: F;
   credentials: SyncCredentials | null;
   sessionState?: Record<string, unknown> | null;
@@ -1022,6 +1036,8 @@ export interface FeedReadResult {
   nextCursor?: string;
   /** Explicit page exhaustion signal for sources without a continuation token. */
   hasMore?: boolean;
+  /** Required for a windowed read; absence means the reader cannot honor it. */
+  window?: FeedReadWindowCoverage;
 }
 
 export type FeedSyncHandler<C = Record<string, unknown>, F = Record<string, unknown>> = (

--- a/packages/connector-sdk/src/define-connector.ts
+++ b/packages/connector-sdk/src/define-connector.ts
@@ -148,6 +148,7 @@ function buildDefinition(spec: ConnectorSpec): RuntimeConnectorDefinition {
           eventKinds: feed.eventKinds,
           sync: feed.sync,
           read: feed.read,
+          readWindowAxis: feed.readWindowAxis,
         },
       ]),
     );

--- a/packages/connector-sdk/src/feed-read-window.ts
+++ b/packages/connector-sdk/src/feed-read-window.ts
@@ -1,0 +1,29 @@
+import type { FeedReadResult, FeedReadWindow } from './connector-types.js';
+
+export function validateFeedReadWindow(window: FeedReadWindow): void {
+  if (!Number.isFinite(Date.parse(window.start)) || !Number.isFinite(Date.parse(window.end)) ||
+      Date.parse(window.start) >= Date.parse(window.end)) {
+    throw new Error('Source read window must have valid start < end bounds.');
+  }
+}
+
+/** Verify the reader honored the feed's declared window contract. */
+export function assertFeedReadWindow(
+  result: FeedReadResult,
+  window?: FeedReadWindow,
+  declaredAxis?: string,
+): void {
+  if (!window) return;
+  validateFeedReadWindow(window);
+  if (!declaredAxis?.trim()) {
+    throw new Error('Source feed does not declare a window time axis.');
+  }
+  if (result.window?.start !== window.start || result.window?.end !== window.end ||
+      result.window.axis !== declaredAxis) {
+    throw new Error('Source reader did not acknowledge the requested window and time axis.');
+  }
+  if (typeof result.hasMore !== 'boolean' ||
+      (result.nextCursor !== undefined && (!result.nextCursor || !result.hasMore))) {
+    throw new Error('Windowed source reads must explicitly report page exhaustion.');
+  }
+}

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -93,6 +93,8 @@ export type {
   FeedReadContext,
   FeedReadHandler,
   FeedReadResult,
+  FeedReadWindow,
+  FeedReadWindowCoverage,
   FeedSyncHandler,
   EntityTypeContribution,
   QueryContext,
@@ -280,3 +282,4 @@ export type {
   SocketAddress,
   SocketOptions,
 } from './net.js';
+export { assertFeedReadWindow, validateFeedReadWindow } from './feed-read-window.js';

--- a/packages/connector-worker/src/executor/interface.ts
+++ b/packages/connector-worker/src/executor/interface.ts
@@ -65,6 +65,7 @@ export type ExecutorJob =
       feedId?: number | null;
       query?: string;
       cursor?: string;
+      window?: { start: string; end: string };
       config: Record<string, unknown>;
       credentials: SyncCredentials | null;
       sessionState: Record<string, unknown> | null;
@@ -144,6 +145,7 @@ export type ExecutorResult =
       total?: number;
       nextCursor?: string;
       hasMore?: boolean;
+      window?: { start: string; end: string; axis: string };
     }
   | {
       mode: 'webhook_register';

--- a/packages/connector-worker/src/executor/isolate.ts
+++ b/packages/connector-worker/src/executor/isolate.ts
@@ -297,12 +297,14 @@ const GUEST_RUNNER = String.raw`
     if (job.mode === 'read') {
       var readResult = await instance.read({
         feedId: job.feedId === null ? undefined : job.feedId, feedKey: job.feedKey, query: job.query, cursor: job.cursor,
+        window: job.window,
         config: mergedConfig, credentials: job.credentials, sessionState: job.sessionState,
         limit: job.limit, offset: job.offset, sort: job.sort
       });
       return {
         mode: 'read', rows: (readResult && readResult.rows) || [], columns: readResult && readResult.columns,
-        total: readResult && readResult.total, nextCursor: readResult && readResult.nextCursor, hasMore: readResult && readResult.hasMore
+        total: readResult && readResult.total, nextCursor: readResult && readResult.nextCursor, hasMore: readResult && readResult.hasMore,
+        window: readResult && readResult.window
       };
     }
 

--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -211,7 +211,7 @@ describe('Gmail replied signal (promote-on-interaction)', () => {
 
 describe('Gmail person attribution rule', () => {
   test('bumps the connector version for the changed sync contract', () => {
-    expect(new GmailConnector().definition.version).toBe('1.0.6');
+    expect(new GmailConnector().definition.version).toBe('1.0.7');
   });
 
   test('autoCreate is gated on person_relevant, with a legacy replied rule for pre-refresh payloads', () => {

--- a/packages/connectors/src/__tests__/jira-source-read.test.ts
+++ b/packages/connectors/src/__tests__/jira-source-read.test.ts
@@ -466,7 +466,7 @@ describe('Jira feed source read', () => {
     const c = new JiraConnector();
     expect(typeof c.definition.feeds?.issues?.sync).toBe('function');
     expect(typeof c.definition.feeds?.issues?.read).toBe('function');
-    expect(c.definition.version).toBe('1.1.3');
+    expect(c.definition.version).toBe('1.1.4');
   });
 
   test('offers every scope Jira requires to deliver issue and comment webhooks', () => {

--- a/packages/connectors/src/__tests__/linear-source-read.test.ts
+++ b/packages/connectors/src/__tests__/linear-source-read.test.ts
@@ -185,6 +185,6 @@ describe('Linear feed source read', () => {
     const c = new LinearConnector();
     expect(typeof c.definition.feeds?.issues?.sync).toBe('function');
     expect(typeof c.definition.feeds?.issues?.read).toBe('function');
-    expect(c.definition.version).toBe('1.1.0');
+    expect(c.definition.version).toBe('1.1.1');
   });
 });

--- a/packages/connectors/src/__tests__/source-windows.test.ts
+++ b/packages/connectors/src/__tests__/source-windows.test.ts
@@ -1,0 +1,144 @@
+import { beforeAll, describe, expect, mock, test } from 'bun:test';
+import { connectorSdkMock } from './connector-sdk.mock';
+
+mock.module('@lobu/connector-sdk', () => connectorSdkMock());
+let Gmail: typeof import('../google_gmail').default;
+let Drive: typeof import('../google_drive').default;
+let Linear: typeof import('../linear').default;
+let Jira: typeof import('../jira').default;
+beforeAll(async () => {
+  Gmail = (await import('../google_gmail')).default;
+  Drive = (await import('../google_drive')).default;
+  Linear = (await import('../linear')).default;
+  Jira = (await import('../jira')).default;
+});
+const window = { start: '2026-01-01T00:00:00.250Z', end: '2026-01-02T00:00:00.250Z' };
+const credentials = { accessToken: 'synthetic-token' };
+
+describe('live source windows', () => {
+  test.each([
+    [{}, 'label:INBOX'],
+    [{ label: 'STARRED' }, 'label:STARRED'],
+    [{ labels: ['work', 'personal'] }, '{label:work label:personal}'],
+    [{ query: 'from:one@example.test OR from:two@example.test' }, 'from:one@example.test OR from:two@example.test'],
+  ])('Gmail preserves configured window scope %j', async (config, scope) => {
+    let query = '';
+    const c = new Gmail();
+    Object.assign(c, { createClient: () => ({ raw: async (url: string) => {
+      query = new URL(url).searchParams.get('q') ?? '';
+      return Response.json({ messages: [] });
+    } }) });
+    await c.read({ feedKey: 'threads', config, credentials, window, query: 'has:attachment' });
+    expect(query).toStartWith(`(${scope}) (has:attachment) after:`);
+  });
+
+  test('Gmail person filtering inspects thread metadata and preserves an empty page cursor', async () => {
+    const threadRequests: string[] = [];
+    const c = new Gmail();
+    Object.assign(c, { createClient: () => ({ raw: async (url: string) => {
+      const u = new URL(url);
+      if (u.pathname.endsWith('/messages')) return Response.json({ messages: [{ id: 'm1', threadId: 't1' }], nextPageToken: 'more' });
+      const message = { id: 'm1', threadId: 't1', internalDate: String(Date.parse(window.start)), payload: { headers: [{ name: 'From', value: 'Alice <alice@example.test>' }] } };
+      if (u.pathname.includes('/threads/')) {
+        threadRequests.push(url);
+        return Response.json({ messages: [message] });
+      }
+      return Response.json(message);
+    } }) });
+    const result = await c.read({ feedKey: 'threads', config: { human_senders_only: true }, credentials, window });
+    expect(threadRequests).toHaveLength(1);
+    expect(new URL(threadRequests[0]).searchParams.get('format')).toBe('metadata');
+    expect(result.rows).toEqual([]);
+    expect(result.nextCursor).toBe('more');
+    expect(result.hasMore).toBe(true);
+  });
+
+  test('Drive rejects a file without its window timestamp', async () => {
+    const c = new Drive();
+    Object.assign(c, { client: () => ({ raw: async () => Response.json({ files: [{ id: 'file-1' }] }) }) });
+    await expect(c.read({ feedKey: 'files', config: {}, credentials, window })).rejects.toThrow(/modified|malformed/i);
+  });
+
+  test('Linear rejects ambiguous exhaustion', async () => {
+    const c = new Linear();
+    Object.assign(c, { graphql: async () => ({ issues: { nodes: [], pageInfo: {} } }) });
+    await expect(c.read({ feedKey: 'issues', config: {}, credentials, window })).rejects.toThrow(/cursor|exhaustion/i);
+  });
+
+  test('Jira rejects an unfinished page without a cursor', async () => {
+    const c = new Jira();
+    Object.assign(c, { restBase: async () => 'https://jira.example.test/rest/api/3', client: () => ({ json: async () => ({ issues: [], isLast: false }) }) });
+    await expect(c.read({ feedKey: 'issues', config: {}, credentials, window })).rejects.toThrow(/cursor|exhaustion/i);
+  });
+  test('Jira rejects a window page without explicit exhaustion metadata', async () => {
+    const c = new Jira();
+    Object.assign(c, { restBase: async () => 'https://jira.example.test/rest/api/3', client: () => ({ json: async () => ({ issues: [] }) }) });
+    await expect(c.read({ feedKey: 'issues', config: {}, credentials, window })).rejects.toThrow(/cursor|exhaustion/i);
+  });
+  test('Jira acknowledges an explicitly exhausted window page', async () => {
+    const c = new Jira();
+    Object.assign(c, { restBase: async () => 'https://jira.example.test/rest/api/3', client: () => ({ json: async () => ({ issues: [], isLast: true }) }) });
+    const result = await c.read({ feedKey: 'issues', config: {}, credentials, window });
+    expect(result).toMatchObject({ rows: [], hasMore: false, window: { ...window, axis: 'updated_at' } });
+  });
+  test('Gmail uses internal arrival time, exact half-open bounds, and retains empty-page continuation', async () => {
+    const requests: URL[] = [];
+    const c = new Gmail();
+    Object.assign(c, { createClient: () => ({ raw: async (url: string) => {
+      const u = new URL(url); requests.push(u);
+      if (u.pathname.endsWith('/messages')) return Response.json({ messages: [{ id: 'start' }, { id: 'end' }], nextPageToken: 'next-page' });
+      const id = u.pathname.split('/').pop();
+      return Response.json({ id, threadId: id, internalDate: String(Date.parse(id === 'start' ? window.start : window.end)), payload: { headers: [{ name: 'Date', value: '2000-01-01' }] } });
+    } }) });
+    const result = await c.read({ feedKey: 'threads', config: { query: '-in:spam' }, credentials, window, limit: 2 });
+    expect(result.rows.map((row) => row.id)).toEqual(['start']);
+    expect(result.window).toEqual({ ...window, axis: 'received_at' });
+    expect(requests[0].searchParams.get('q')).toContain('-in:spam');
+    expect(requests[0].searchParams.get('q')).toContain(`after:${Math.floor(Date.parse(window.start) / 1000) - 1}`);
+    expect(result.nextCursor).toBe('next-page');
+    expect(result.hasMore).toBe(true);
+  });
+
+  test('Gmail fails the page when one message cannot be fetched', async () => {
+    const c = new Gmail();
+    Object.assign(c, { createClient: () => ({ raw: async (url: string) =>
+      new URL(url).pathname.endsWith('/messages')
+        ? Response.json({ messages: [{ id: 'unavailable' }] })
+        : new Response('provider unavailable', { status: 503 }),
+    }) });
+    await expect(c.read({ feedKey: 'threads', config: {}, credentials, window })).rejects.toThrow(/503/);
+  });
+
+  test('Drive combines configured scope, requested limit and fixed modified-time bounds', async () => {
+    let request: URL | undefined;
+    const c = new Drive();
+    Object.assign(c, { client: () => ({ raw: async (url: string) => {
+      request = new URL(url); return Response.json({ files: [], nextPageToken: 'next' });
+    } }) });
+    const result = await c.read({ feedKey: 'files', config: { query: "name contains 'report'" }, credentials, window, limit: 2 });
+    expect(request?.searchParams.get('pageSize')).toBe('2');
+    expect(request?.searchParams.get('q')).toContain(`modifiedTime >= '${window.start}'`);
+    expect(request?.searchParams.get('q')).toContain(`modifiedTime < '${window.end}'`);
+    expect(request?.searchParams.get('q')).toContain("name contains 'report'");
+    expect(result.window).toEqual({ ...window, axis: 'modified_at' });
+    expect(result.nextCursor).toBe('next');
+  });
+
+  test('Drive rejects incomplete provider search results', async () => {
+    const c = new Drive();
+    Object.assign(c, { client: () => ({ raw: async () => Response.json({ files: [], incompleteSearch: true }) }) });
+    await expect(c.read({ feedKey: 'files', config: {}, credentials, window })).rejects.toThrow(/incomplete/i);
+  });
+
+  test('Linear replaces the moving lookback and rejects a missing continuation', async () => {
+    let query = '';
+    const c = new Linear();
+    Object.assign(c, { graphql: async (_credentials: unknown, text: string) => {
+      query = text; return { issues: { nodes: [], pageInfo: { hasNextPage: true, endCursor: null } } };
+    } });
+    await expect(c.read({ feedKey: 'issues', config: { lookback_days: 1 }, credentials, window })).rejects.toThrow(/cursor/i);
+    expect(query).toContain(JSON.stringify(window.start));
+    expect(query).toContain(JSON.stringify(window.end));
+    expect(query).toContain('lt:');
+  });
+});

--- a/packages/connectors/src/google_drive.ts
+++ b/packages/connectors/src/google_drive.ts
@@ -336,7 +336,7 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
     name: 'Google Drive',
     description:
       'Syncs Google Drive file metadata and text content, and reads a file on demand.',
-    version: '1.0.0',
+    version: '1.0.1',
     faviconDomain: 'drive.google.com',
     authSchema: {
       methods: [
@@ -364,6 +364,7 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
           'Google Drive files can sync into memory and be read directly from Drive.',
         sync: (ctx) => this.syncFeed(ctx),
         read: (ctx) => this.readFeed(ctx),
+        readWindowAxis: 'modified_at',
         configSchema: {
           type: 'object',
           properties: {
@@ -476,16 +477,22 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
     const http = this.client(token);
     const config = (ctx.config ?? {}) as DriveConfig;
 
+    if ((ctx.offset ?? 0) > 0) throw new Error('Drive source reads paginate with a cursor, not an offset.');
+    if (ctx.sort && !(ctx.sort.column === 'modified_at' && ctx.sort.order === 'desc')) {
+      throw new Error('Drive source reads support modified_at descending sort only.');
+    }
+    const query = [buildListQuery(config), ctx.query].filter(Boolean).map((q) => `(${q})`);
+    if (ctx.window) query.push(`modifiedTime >= '${new Date(ctx.window.start).toISOString()}' AND modifiedTime < '${new Date(ctx.window.end).toISOString()}'`);
     const params = new URLSearchParams({
       // Nothing materialises configSchema defaults, so the fallback here is
       // what `max_results` actually defaults to and must match what the schema
       // advertises. 1000 is Drive's own pageSize ceiling.
-      pageSize: String(Math.max(1, Math.min(config.max_results ?? 500, 1000))),
+      pageSize: String(Math.max(1, Math.min(ctx.limit ?? config.max_results ?? 500, 1000))),
       fields: `files(${FILE_FIELDS}),nextPageToken,incompleteSearch`,
       orderBy: 'modifiedTime desc',
       supportsAllDrives: 'true',
       includeItemsFromAllDrives: 'true',
-      q: buildListQuery(config),
+      q: query.join(' AND '),
     });
     if (ctx.cursor) params.set('pageToken', ctx.cursor);
 
@@ -497,11 +504,16 @@ export default class GoogleDriveConnector extends ConnectorRuntime<
     }
 
     const data = (await response.json()) as DriveFileListResponse;
+    if (data.incompleteSearch) throw new Error('Drive returned an incomplete search; the window was not processed.');
+    if (ctx.window && (data.files ?? []).some((file) => !file.id || !Number.isFinite(Date.parse(file.modifiedTime ?? '')))) {
+      throw new Error('Drive returned malformed file identity or modified timestamp.');
+    }
     const rows = (data.files ?? []).map((file) => this.driveFileToRow(file));
 
     return {
       rows,
       columns: [...DRIVE_FILE_COLUMNS],
+      ...(ctx.window ? { window: { ...ctx.window, axis: 'modified_at' } } : {}),
       nextCursor: data.nextPageToken,
       hasMore: Boolean(data.nextPageToken),
     };

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -133,6 +133,7 @@ const GMAIL_SEARCH_COLUMNS = [
   { name: 'from_name', type: 'string' },
   { name: 'from_email', type: 'string' },
   { name: 'date', type: 'string' },
+  { name: 'received_at', type: 'string' },
   { name: 'snippet', type: 'string' },
   { name: 'url', type: 'string' },
 ];
@@ -147,7 +148,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     name: 'Gmail',
     description:
       'Syncs Gmail threads, live-reads matching messages, and supports sending, drafts, and replies.',
-    version: '1.0.6',
+    version: '1.0.7',
     faviconDomain: 'mail.google.com',
     authSchema: {
       methods: [
@@ -183,6 +184,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
           'Gmail threads can sync into memory for attribution and Automations, and be read directly from Gmail.',
         sync: (ctx) => this.syncFeed(ctx),
         read: (ctx) => this.readFeed(ctx),
+        readWindowAxis: 'received_at',
         configSchema: {
           type: 'object',
           properties: {
@@ -418,20 +420,12 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       throw new Error('Gmail requires Google OAuth credentials.');
     }
 
-    const label = ctx.config.label || 'INBOX';
-    const labels = Array.isArray(ctx.config.labels)
-      ? ctx.config.labels
-          .filter((l) => typeof l === 'string' && l.trim().length > 0)
-          .map((l) => l.trim())
-      : [];
     const maxResults = Math.min(ctx.config.max_results ?? 50, 500);
     const lookbackDays = ctx.config.lookback_days ?? 30;
     const humanSendersOnly = ctx.config.human_senders_only === true;
 
     const checkpoint = ctx.checkpoint ?? {};
-    const scope = ctx.config.query?.trim() || (labels.length > 0
-      ? `{${labels.map((l) => `label:${l}`).join(' ')}}`
-      : `label:${label}`);
+    const scope = this.feedScope(ctx.config);
     const scopeKey = JSON.stringify([scope, humanSendersOnly]);
     // Older checkpoints predate full-body or readable-HTML ingestion. Revisit
     // the configured lookback when upgrading or changing the source filter;
@@ -621,7 +615,13 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     // (config.query) with the caller's terms as raw Gmail search syntax — each
     // feed read owns its query semantics; we do not escape Gmail operators here.
     // An empty string means no `q` filter — list the authenticated mailbox.
-    const parts = [ctx.config.query, ctx.query].map((part) => part?.trim()).filter(Boolean);
+    const parts = [ctx.window ? this.feedScope(ctx.config) : ctx.config.query, ctx.query]
+      .map((part) => part?.trim()).filter(Boolean)
+      .map((part) => ctx.window ? `(${part})` : part);
+    if (ctx.window) {
+      // Gmail search uses whole seconds. Widen, then enforce exact internalDate bounds below.
+      parts.push(`after:${Math.floor(Date.parse(ctx.window.start) / 1000) - 1} before:${Math.ceil(Date.parse(ctx.window.end) / 1000)}`);
+    }
     const q = parts.join(' ');
 
     // Gmail search has no arbitrary sort — results are always reverse-chronological
@@ -640,14 +640,38 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
 
     const http = this.createClient(token);
     const page = await this.listMessagePage(http, q, limit, ctx.cursor);
-    const rows = await this.fetchMessageRows(http, page.messages);
+    const fetched = await this.fetchMessageRows(http, page.messages);
+    let rows = ctx.window ? fetched.filter((row) => {
+      const timestamp = Date.parse(String(row.received_at ?? ''));
+      if (!Number.isFinite(timestamp)) throw new Error('Gmail message has no valid internalDate for window processing.');
+      return timestamp >= Date.parse(ctx.window!.start) && timestamp < Date.parse(ctx.window!.end);
+    }) : fetched;
+
+    if (ctx.window && ctx.config.human_senders_only) {
+      // Person relevance depends on the conversation (sent/draft/list headers),
+      // so reuse sync's attribution with metadata only, never message bodies.
+      const relevant = new Set<string>();
+      const threadIds = [...new Set(rows.map((row) => String(row.thread_id)))];
+      for (const threadId of threadIds) {
+        const params = new URLSearchParams({ format: 'metadata' });
+        for (const header of ['From', 'To', 'Cc', 'List-Id', 'Precedence']) params.append('metadataHeaders', header);
+        const response = await http.raw(`${this.BASE_URL}/threads/${threadId}?${params}`);
+        if (!response.ok) throw new Error(`Gmail threads.get error (${response.status}): ${await response.text()}`);
+        const thread = await response.json() as GmailThreadGetResponse;
+        if (!thread.messages?.length) throw new Error('Gmail returned a thread without messages');
+        const messages = [...thread.messages].sort((a, b) => Number(a.internalDate) - Number(b.internalDate));
+        if (this.resolvePersonAttribution(messages, true).personRelevant) relevant.add(threadId);
+      }
+      rows = rows.filter((row) => relevant.has(String(row.thread_id)));
+    }
 
     // No `total`: Gmail's list endpoint returns no reliable match count, and
     // `resultSizeEstimate` is a coarse estimate — reporting the page length as a
-    // total would be wrong. Callers page until a short page.
+    // total would be wrong. Callers follow the cursor, including empty filtered pages.
     return {
       rows,
       columns: GMAIL_SEARCH_COLUMNS,
+      ...(ctx.window ? { window: { ...ctx.window, axis: 'received_at' } } : {}),
       nextCursor: page.nextPageToken,
       hasMore: Boolean(page.nextPageToken),
     };
@@ -684,8 +708,9 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     for (const m of ids) {
       const url = `${this.BASE_URL}/messages/${m.id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=Date`;
       const res = await http.raw(url);
-      if (!res.ok) continue; // skip a single unreachable message, keep the batch reliable
+      if (!res.ok) throw new Error(`Gmail messages.get error (${res.status}): ${await res.text()}`);
       const msg = (await res.json()) as GmailMessage;
+      if (!msg.id || !msg.threadId) throw new Error('Gmail returned malformed message identity.');
       const rawFrom = this.getHeader(msg, 'From') || 'Unknown';
       const { name, email } = this.parseFromHeader(rawFrom);
       rows.push({
@@ -696,6 +721,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
         from_name: name,
         from_email: email,
         date: this.getHeader(msg, 'Date') || '',
+        received_at: Number.isFinite(Number(msg.internalDate)) ? new Date(Number(msg.internalDate)).toISOString() : null,
         snippet: msg.snippet || '',
         url: `https://mail.google.com/mail/u/0/#inbox/${msg.threadId}`,
       });
@@ -952,6 +978,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
         id: msg.id,
         from: this.getHeader(msg, 'From') || 'Unknown',
         date: this.getHeader(msg, 'Date') || '',
+        received_at: Number.isFinite(Number(msg.internalDate)) ? new Date(Number(msg.internalDate)).toISOString() : null,
         snippet: msg.snippet,
         body: await this.extractBody(msg.payload, http, msg.id),
       });
@@ -971,6 +998,15 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
+
+  private feedScope(config: GmailConfig): string {
+    const labels = Array.isArray(config.labels)
+      ? config.labels.filter((label) => typeof label === 'string' && label.trim()).map((label) => label.trim())
+      : [];
+    return config.query?.trim() || (labels.length
+      ? `{${labels.map((label) => `label:${label}`).join(' ')}}`
+      : `label:${config.label || 'INBOX'}`);
+  }
 
   private resolvePersonAttribution(
     messages: GmailMessage[],

--- a/packages/connectors/src/jira.ts
+++ b/packages/connectors/src/jira.ts
@@ -231,6 +231,7 @@ function buildJiraJql(args: {
   query?: string;
   sort?: { column: string; order: 'asc' | 'desc' };
   defaultWhenEmpty?: string;
+  window?: { start: string; end: string };
 }): string {
   const trimmed = args.baseQuery.trim();
   // Keep an omitted scope bounded instead of scanning the whole site.
@@ -255,8 +256,13 @@ function buildJiraJql(args: {
     }
   }
 
+  if (args.window) {
+    const bounds = `updated >= ${Date.parse(args.window.start)} AND updated < ${Date.parse(args.window.end)}`;
+    body = body ? `(${body}) AND (${bounds})` : bounds;
+  }
+
   // `body` is non-empty from here on: an empty base fell back to
-  // `defaultWhenEmpty`, and the caller query can only widen it.
+  // `defaultWhenEmpty`, and the caller query can further restrict it.
   if (orderBy) {
     if (args.sort) {
       throw new Error(
@@ -291,7 +297,7 @@ export default class JiraConnector extends ConnectorRuntime<JiraCheckpoint, Jira
     name: 'Jira',
     description:
       'Syncs and live-reads Jira Cloud issues via JQL, and receives real-time issue/comment webhooks.',
-    version: '1.1.3',
+    version: '1.1.4',
     faviconDomain: 'atlassian.com',
     webhook: {
       // Jira Connect app webhooks HMAC-sign the raw body with the installation
@@ -369,6 +375,7 @@ export default class JiraConnector extends ConnectorRuntime<JiraCheckpoint, Jira
           'Jira issues can sync into memory and be read directly from Jira via JQL.',
         sync: (ctx) => this.syncFeed(ctx),
         read: (ctx) => this.readFeed(ctx),
+        readWindowAxis: 'updated_at',
         configSchema: {
           type: 'object',
           properties: {
@@ -453,6 +460,8 @@ export default class JiraConnector extends ConnectorRuntime<JiraCheckpoint, Jira
     const jql = buildJiraJql({
       baseQuery,
       query: asString(ctx.query),
+      window: ctx.window,
+      ...(ctx.window ? { defaultWhenEmpty: '' } : {}),
       sort: ctx.sort,
     });
 
@@ -482,14 +491,25 @@ export default class JiraConnector extends ConnectorRuntime<JiraCheckpoint, Jira
       `${base}/search/jql?${params.toString()}`,
       { method: 'GET', headers: { Accept: 'application/json' } },
     );
-    const rows = (data.issues ?? [])
+    if (!Array.isArray(data.issues) ||
+        (ctx.window && typeof data.isLast !== 'boolean') ||
+        (data.isLast === false && !data.nextPageToken) ||
+        (ctx.window && data.isLast === true && Boolean(data.nextPageToken))) {
+      throw new Error('Jira did not return a valid page cursor/exhaustion state.');
+    }
+    const rows = data.issues
       .map((issue) => this.issueRow(issue, ctx.config))
       .filter((row) => row !== null);
+
+    if (ctx.window && (rows.length !== data.issues.length || rows.some((row) => !Number.isFinite(Date.parse(String(row.updated_at ?? '')))))) {
+      throw new Error('Jira returned malformed issue identity or updated timestamp.');
+    }
 
     // No reliable total from /search/jql — omit rather than lie with page length.
     return {
       rows,
       columns: [...JIRA_ISSUE_COLUMNS],
+      ...(ctx.window ? { window: { ...ctx.window, axis: 'updated_at' } } : {}),
       nextCursor: data.nextPageToken,
       hasMore: Boolean(data.nextPageToken),
     };

--- a/packages/connectors/src/linear.ts
+++ b/packages/connectors/src/linear.ts
@@ -110,6 +110,7 @@ function buildLinearIssueFilter(args: {
   teamKey?: string;
   textTerms?: string[];
   updatedAfterIso?: string;
+  updatedBeforeIso?: string;
 }): string {
   const parts: string[] = [];
   if (args.teamKey) {
@@ -117,6 +118,9 @@ function buildLinearIssueFilter(args: {
   }
   if (args.updatedAfterIso) {
     parts.push(`{ updatedAt: { gte: ${JSON.stringify(args.updatedAfterIso)} } }`);
+  }
+  if (args.updatedBeforeIso) {
+    parts.push(`{ updatedAt: { lt: ${JSON.stringify(args.updatedBeforeIso)} } }`);
   }
   const terms = (args.textTerms ?? []).map((t) => t.trim()).filter(Boolean);
   for (const term of terms) {
@@ -140,7 +144,7 @@ export default class LinearConnector extends ConnectorRuntime<LinearCheckpoint, 
     name: 'Linear',
     description:
       'Syncs and live-reads Linear issues via GraphQL, and receives real-time issue/comment webhooks.',
-    version: '1.1.0',
+    version: '1.1.1',
     faviconDomain: 'linear.app',
     webhook: {
       signatureHeader: 'linear-signature',
@@ -180,6 +184,7 @@ export default class LinearConnector extends ConnectorRuntime<LinearCheckpoint, 
           'Linear issues can sync into memory and be read directly from Linear.',
         sync: (ctx) => this.syncFeed(ctx),
         read: (ctx) => this.readFeed(ctx),
+        readWindowAxis: 'updated_at',
         configSchema: {
           type: 'object',
           properties: {
@@ -261,7 +266,8 @@ export default class LinearConnector extends ConnectorRuntime<LinearCheckpoint, 
     const filter = buildLinearIssueFilter({
       teamKey: asString(ctx.config.team_key),
       textTerms,
-      updatedAfterIso: updatedAfter,
+      updatedAfterIso: ctx.window?.start ?? updatedAfter,
+      updatedBeforeIso: ctx.window?.end,
     });
 
     const requestedLimit = Math.min(Math.max(Math.trunc(ctx.limit ?? 50), 1), 500);
@@ -297,10 +303,17 @@ export default class LinearConnector extends ConnectorRuntime<LinearCheckpoint, 
       .map((node) => this.issueRow(node))
       .filter((row) => row !== null);
     const pageInfo = response.issues?.pageInfo;
-    const nextCursor = pageInfo?.hasNextPage ? pageInfo.endCursor ?? undefined : undefined;
+    if (!Array.isArray(response.issues?.nodes) || typeof pageInfo?.hasNextPage !== 'boolean' || (pageInfo.hasNextPage && !pageInfo.endCursor)) {
+      throw new Error('Linear did not return a valid page cursor/exhaustion state.');
+    }
+    if (ctx.window && (rows.length !== response.issues!.nodes!.length || rows.some((row) => !Number.isFinite(Date.parse(String(row.updated_at ?? '')))))) {
+      throw new Error('Linear returned malformed issue identity or updated timestamp.');
+    }
+    const nextCursor = pageInfo.hasNextPage ? pageInfo.endCursor ?? undefined : undefined;
     return {
       rows,
       columns: [...LINEAR_ISSUE_COLUMNS],
+      ...(ctx.window ? { window: { ...ctx.window, axis: 'updated_at' } } : {}),
       nextCursor,
       hasMore: Boolean(nextCursor),
     };

--- a/packages/core/src/contracts/tools/manage-automations.ts
+++ b/packages/core/src/contracts/tools/manage-automations.ts
@@ -551,6 +551,18 @@ export const ManageAutomationsSchema = Type.Object(
           "[claim_next_window] Lease duration in seconds (default 900).",
       })
     ),
+    source_name: Type.Optional(
+      Type.String({
+        description:
+          "Automation source name to continue; pair with source_cursor and the same run_id.",
+      })
+    ),
+    source_cursor: Type.Optional(
+      Type.String({
+        description:
+          "Signed window_token from the preceding page of this source. Retain every returned window_token for completeWindow.",
+      })
+    ),
     before_occurred_at: Type.Optional(
       Type.String({
         description:
@@ -1050,6 +1062,9 @@ export const AutomationClaimNextWindowContextSchema = Type.Object({
         returned: Type.Integer(),
         limit: Type.Integer(),
         has_more: Type.Boolean(),
+        next_cursor: Type.Optional(Type.String()),
+        window_axis: Type.Optional(Type.String()),
+        feed_id: Type.Optional(Type.Integer()),
       })
     )
   ),

--- a/packages/core/src/contracts/tools/read-knowledge.ts
+++ b/packages/core/src/contracts/tools/read-knowledge.ts
@@ -143,6 +143,18 @@ export const GetContentSchema = Type.Object({
       default: 0,
     })
   ),
+  source_name: Type.Optional(
+    Type.String({
+      description:
+        "Automation source name to continue; pair with source_cursor and the same run_id.",
+    })
+  ),
+  source_cursor: Type.Optional(
+    Type.String({
+      description:
+        "Signed window_token from the preceding page of this source. Retain every returned window_token for completeWindow.",
+    })
+  ),
   before_occurred_at: Type.Optional(
     Type.String({
       description:

--- a/packages/server/src/__tests__/integration/automations/channel-feed-source.test.ts
+++ b/packages/server/src/__tests__/integration/automations/channel-feed-source.test.ts
@@ -367,30 +367,45 @@ describe("channel feed as an automation @feed source", () => {
     expect(rows[0].text).toBe("inside window");
   });
 
-  it("rejects a source-read-only @feed instead of compiling it to an empty events read", async () => {
+  it.each([
+    { operations: ["read"], axis: undefined, kind: "feed" },
+    { operations: ["read", "sync"], axis: "source_at", kind: "feed" },
+    { operations: ["read", "sync"], axis: undefined, kind: "event" },
+  ])("routes $operations with window axis $axis through $kind", async ({ operations, axis, kind }) => {
     const sql = getTestDb();
+    const key = `source_${operations.join("_")}_${axis ?? "unbounded"}`;
     await createTestConnectorDefinition({
-      key: "readonly_src",
+      key,
       name: "Read Only Source",
       organization_id: orgId,
-      feeds_schema: { items: { name: "Items", operations: ["read"] } },
+      feeds_schema: { items: { name: "Items", operations, ...(axis ? { readWindowAxis: axis } : {}) } },
     });
     const conn = await createTestConnection({
       organization_id: orgId,
-      connector_key: "readonly_src",
+      connector_key: key,
       createDefaultFeed: false,
     });
-    await sql`
+    const [feed] = await sql`
       INSERT INTO feeds (organization_id, connection_id, feed_key, status, created_at, updated_at)
       VALUES (${orgId}, ${conn.id}, 'items', 'active', NOW(), NOW())
+      RETURNING id
     `;
 
-    // A read-only feed never persists events, so an events SELECT over it would
-    // silently return nothing forever. The reference must fail loudly instead.
+    const sources = await normalizeAutomationSources(sql as unknown as DbClient, orgId, [
+      { name: "items", query: `@feed:${feed.id}` },
+    ]);
+    expect(sources[0].kind).toBe(kind);
+    if (kind === "feed") expect(sources[0].query).toBe(`@feed:${feed.id}`);
+    else expect(sources[0].query).toContain("feed_id IN");
+  });
+
+  it("rejects duplicate source names before one source can overwrite another", async () => {
+    const sql = getTestDb();
     await expect(
       normalizeAutomationSources(sql as unknown as DbClient, orgId, [
-        { name: "items", query: "@feed:items" },
-      ])
-    ).rejects.toThrow(/source-read-only/i);
+        { name: "items", query: "SELECT id FROM events" },
+        { name: "items", query: "SELECT id FROM events" },
+      ]),
+    ).rejects.toThrow(/source names must be unique/);
   });
 });

--- a/packages/server/src/__tests__/integration/automations/schedule-skip-unchanged.test.ts
+++ b/packages/server/src/__tests__/integration/automations/schedule-skip-unchanged.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { DbClient } from "../../../db/client";
 import type { Env } from "../../../index";
 import { manageAutomations } from "../../../tools/admin/manage_automations";
 import { materializeDueAutomationRuns } from "../../../automations/automation";
@@ -59,7 +60,27 @@ describe("scheduled Automation unchanged gate", () => {
 			WHERE id = ${automationId}
 		`;
 
-		const result = await materializeDueAutomationRuns({} as Env, sql);
+		// A skip must book the exact database horizon inspected before source execution.
+		let inspectedHorizon: string | undefined;
+		const observe = (client: DbClient): DbClient => new Proxy(client, {
+			apply(target, self, args) {
+				const query = Reflect.apply(target, self, args);
+				const text = Array.isArray(args[0]) ? args[0].join('') : '';
+				if (!inspectedHorizon && /AS\s+db_now/.test(text) && text.includes('FROM automations')) {
+					return query.then(async (rows: Array<{ db_now: string | Date }>) => {
+						inspectedHorizon = new Date(rows[0].db_now).toISOString();
+						await sql`SELECT pg_sleep(0.02)`;
+						return rows;
+					});
+				}
+				return query;
+			},
+			get(target, key) {
+				if (key === 'begin') return (callback: (tx: DbClient) => Promise<unknown>) => target.begin((tx) => callback(observe(tx)));
+				return Reflect.get(target, key);
+			},
+		});
+		const result = await materializeDueAutomationRuns({} as Env, observe(sql));
 
 		expect(result).toMatchObject({
 			dueAutomations: 1,
@@ -74,6 +95,8 @@ describe("scheduled Automation unchanged gate", () => {
 			WHERE automation_id = ${automationId} AND run_type = 'automation'
 		`;
 		expect(runs).toHaveLength(1);
+		expect(inspectedHorizon).toBeDefined();
+		expect(new Date(runs[0].window_end as string).toISOString()).toBe(inspectedHorizon);
 		expect(runs[0]).toMatchObject({
 			status: "completed",
 			outcome: "scoreable",

--- a/packages/server/src/__tests__/integration/automations/window-claim-recovery.test.ts
+++ b/packages/server/src/__tests__/integration/automations/window-claim-recovery.test.ts
@@ -1,3 +1,7 @@
+import { COMPILE_CONFIG_HASH } from '@lobu/connector-worker/compile';
+import { compileConnectorSource } from '../../../utils/connector-compiler';
+import { generateWindowToken, verifyWindowToken } from '../../../utils/jwt';
+import { fingerprintAutomationSources } from '../../../tools/get_content/automation-mode';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { clearAuthCacheForTests } from '../../../auth';
 import { closeDbSingleton, type DbClient } from '../../../db/client';
@@ -11,6 +15,8 @@ import { initWorkspaceProvider } from '../../../workspace';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import {
   createTestAgent,
+  createTestConnectorDefinition,
+  createTestConnection,
   createTestEntity,
   createTestEvent,
   seedOwnerContext,
@@ -31,7 +37,8 @@ type ClaimContext = {
   extraction_schema?: {
     properties?: Record<string, unknown>;
   };
-  sources_page?: Record<string, { returned: number; limit: number; has_more: boolean }>;
+  sources?: Record<string, Array<Record<string, unknown>>>;
+  sources_page?: Record<string, { returned: number; limit: number; has_more: boolean; next_cursor?: string; window_axis?: string }>;
   window_start: string;
   window_end: string;
   window_token: string;
@@ -138,6 +145,208 @@ describe('Automation window claim and recovery', () => {
     `;
     return run.runId;
   }
+
+  async function addLiveSources(failAt?: number) {
+    const key = 'window.read.fixture';
+    const sourceCode = `
+      import { defineConnector } from '@lobu/connector-sdk';
+      export default defineConnector({
+        key: '${key}', name: 'Window reader fixture', version: '1.0.0',
+        authSchema: { methods: [{ type: 'none' }] },
+        feeds: { items: { name: 'Items', readWindowAxis: 'source_at', read: async (ctx) => {
+          const offset = Number(ctx.cursor ?? 0);
+          if (ctx.config.fail_at === offset) throw new Error('Synthetic page failure');
+          const count = Math.min(ctx.limit, ctx.config.count - offset);
+          const rows = Array.from({length: count}, (_, i) => ({id: String(offset + i + 1), source_at: ctx.window.start}));
+          const next = offset + count;
+          return { rows, hasMore: next < ctx.config.count,
+            nextCursor: next < ctx.config.count ? String(next) : undefined,
+            window: {...ctx.window, axis: 'source_at'} };
+        } } }
+      });
+    `;
+    const compiled = await compileConnectorSource(sourceCode);
+    await createTestConnectorDefinition({ key, name: 'Window fixture', organization_id: orgId,
+      feeds_schema: { items: { operations: ['read'], readWindowAxis: 'source_at' } } });
+    await sql`UPDATE connector_versions SET compiled_code = ${compiled.compiledCode},
+      compiled_code_hash = ${compiled.compiledCodeHash}, compile_config_hash = ${COMPILE_CONFIG_HASH},
+      source_code = ${sourceCode} WHERE connector_key = ${key} AND version = '1.0.0'`;
+    const connection = await createTestConnection({ organization_id: orgId, connector_key: key,
+      createDefaultFeed: false, created_by: userId, visibility: 'private' });
+    const feeds: number[] = [];
+    for (const count of [3, 5]) {
+      const config = { count, ...(count === 5 && failAt !== undefined ? { fail_at: failAt } : {}) };
+      const [feed] = await sql`INSERT INTO feeds (organization_id, connection_id, feed_key, config, status)
+        VALUES (${orgId}, ${connection.id}, 'items', ${sql.json(config)}, 'active') RETURNING id`;
+      feeds.push(Number(feed.id));
+    }
+    await api.automations.createVersion({
+      automation_id: String(automationId), prompt: 'Extract signals using complete source windows.',
+      sources: [
+        { name: 'content', query: "SELECT id, occurred_at, payload_text FROM events WHERE semantic_type = 'content' ORDER BY occurred_at DESC, id DESC" },
+        { name: 'alpha', query: `@feed:${feeds[0]}` },
+        { name: 'İşler 🌍', query: `@feed:${feeds[1]}` },
+        { name: 'summary', context: true, query: 'SELECT COUNT(*)::int AS count FROM events' },
+      ],
+    });
+    return feeds;
+  }
+
+  it('completes mixed live sources, stored events and SQL aggregates with interleaved cursors', async () => {
+    const feeds = await addLiveSources();
+    for (let index = 0; index < 3; index++) {
+      await createTestEvent({ entity_id: entityId, organization_id: orgId,
+        content: `Mixed source ${index}`, occurred_at: dayStart(1) });
+    }
+    const first = await claim({ limit: 2 });
+    expect(first.context.sources?.alpha).toHaveLength(2);
+    expect(first.context.sources?.summary).toHaveLength(1);
+    expect(first.context.sources_page?.alpha.window_axis).toBe('source_at');
+    expect((await verifyWindowToken(first.context.window_token, ENV)).content_ids).toHaveLength(2);
+    const complete = (tokens: string[]) => api.automations.completeWindow({
+      automation_id: String(automationId), run_id: first.run_id,
+      window_tokens: tokens, extracted_data: { signals: [] },
+    });
+    const local = await claim({ run_id: first.run_id, limit: 2,
+      before_occurred_at: first.context.page.next_cursor?.occurred_at,
+      before_id: first.context.page.next_cursor?.id });
+    await expect(complete([first.context.window_token, local.context.window_token])).rejects.toThrow(/missing|Incomplete/);
+    const alpha = await claim({ run_id: first.run_id, limit: 2, source_name: 'alpha', source_cursor: first.context.window_token });
+    const beta = await claim({ run_id: first.run_id, limit: 2, source_name: 'İşler 🌍', source_cursor: first.context.window_token });
+    const betaEnd = await claim({ run_id: first.run_id, limit: 2, source_name: 'İşler 🌍', source_cursor: beta.context.window_token });
+    expect(alpha.context.content).toEqual([]);
+    expect(alpha.context.sources?.alpha).toHaveLength(1);
+    expect(betaEnd.context.sources?.['İşler 🌍']).toHaveLength(1);
+    expect((await verifyWindowToken(betaEnd.context.window_token, ENV)).content_ids).toEqual([]);
+    const tokens = [betaEnd.context.window_token, first.context.window_token, alpha.context.window_token, local.context.window_token, beta.context.window_token];
+    await expect(complete(tokens)).resolves.toMatchObject({ completed_now: true, content_linked: 3 });
+    await sql`UPDATE feeds SET deleted_at = NOW() WHERE id IN (${feeds[0]}, ${feeds[1]})`;
+    await expect(complete(tokens)).resolves.toMatchObject({ completed_now: false, content_linked: 0 });
+    const [row] = await sql`SELECT a.next_window_start, r.run_metadata FROM automations a JOIN runs r ON r.id = ${first.run_id} WHERE a.id = ${automationId}`;
+    expect(new Date(row.next_window_start).toISOString()).toBe(first.context.window_end);
+    expect(row.run_metadata.source_coverage).toEqual([
+      { name: 'alpha', feed_id: feeds[0], axis: 'source_at', rows: 3 },
+      { name: 'İşler 🌍', feed_id: feeds[1], axis: 'source_at', rows: 5 },
+    ]);
+    const [persisted] = await sql`SELECT count(*)::int AS n FROM events WHERE feed_id IN (${feeds[0]}, ${feeds[1]})`;
+    expect(persisted.n).toBe(0);
+  }, 30_000);
+
+  async function queuedLiveRun() {
+    await addLiveSources();
+    const pending = await computePendingWindow(sql, automationId);
+    const run = await createAutomationRun({ organizationId: orgId, automationId, agentId,
+      windowStart: pending.windowStart.toISOString(), windowEnd: pending.windowEnd.toISOString(), dispatchSource: 'scheduled' });
+    await sql`UPDATE runs SET status = 'running' WHERE id = ${run.runId}`;
+    return { runId: run.runId, windowStart: pending.windowStart.toISOString(), windowEnd: pending.windowEnd.toISOString() };
+  }
+
+  it('pages a queued agent run through knowledge.read and completes all live sources', async () => {
+    const run = await queuedLiveRun();
+    const first = await api.knowledge.read({ automation_id: automationId, run_id: run.runId, limit: 2 }) as ClaimContext;
+    const tokens = [first.window_token];
+    for (const name of ['alpha', 'İşler 🌍']) {
+      let cursor = first.sources_page?.[name].next_cursor;
+      while (cursor) {
+        const page = await api.knowledge.read({ automation_id: automationId, run_id: run.runId,
+          source_name: name, source_cursor: cursor, limit: 2 }) as ClaimContext;
+        tokens.push(page.window_token);
+        cursor = page.sources_page?.[name].next_cursor;
+      }
+    }
+    await expect(api.automations.completeWindow({ automation_id: String(automationId), run_id: run.runId,
+      window_tokens: tokens, extracted_data: { signals: [] } })).resolves.toMatchObject({ completed_now: true });
+  }, 30_000);
+
+  it('rejects a legacy unbound receipt that omits a queued run live sources', async () => {
+    const run = await queuedLiveRun();
+    // A valid receipt from an earlier, event-only read of the same range must
+    // not substitute for the current run's required live source traversal.
+    const token = await generateWindowToken({ automation_id: automationId, window_start: run.windowStart,
+      window_end: run.windowEnd, content_count: 0, content_ids: [], page_has_more: false }, ENV);
+    await expect(api.automations.completeWindow({ automation_id: String(automationId), run_id: run.runId,
+      window_token: token, extracted_data: { signals: [] } })).rejects.toThrow(/run-bound|source/i);
+    const [after] = await sql`SELECT next_window_start FROM automations WHERE id = ${automationId}`;
+    expect(new Date(after.next_window_start).toISOString()).toBe(run.windowStart);
+  }, 30_000);
+
+  it('does not materialize a scheduler window after its arrival mark advanced', async () => {
+    const [before] = await sql`
+      SELECT next_window_start FROM automations WHERE id = ${automationId}
+    `;
+    const observedStart = new Date(before.next_window_start).toISOString();
+    await sql`
+      UPDATE automations
+      SET next_window_start = next_window_start + interval '1 hour'
+      WHERE id = ${automationId}
+    `;
+
+    const result = await createAutomationRun({
+      organizationId: orgId,
+      automationId,
+      agentId,
+      windowStart: observedStart,
+      windowEnd: new Date(new Date(observedStart).getTime() + DAY_MS).toISOString(),
+      dispatchSource: 'scheduled',
+      expectedWindowStart: observedStart,
+    });
+
+    expect(result).toEqual({ runId: 0, status: 'superseded', created: false });
+    const [runs] = await sql`
+      SELECT count(*)::int AS count FROM runs WHERE automation_id = ${automationId}
+    `;
+    expect(runs.count).toBe(0);
+  });
+
+  it('leaves the checkpoint unchanged after page failure and succeeds on a fresh retry', async () => {
+    const feeds = await addLiveSources(2);
+    const first = await claim({ limit: 2 });
+    await expect(claim({ run_id: first.run_id, limit: 2, source_name: 'İşler 🌍', source_cursor: first.context.window_token })).rejects.toThrow(/Synthetic page failure/);
+    const [failed] = await sql`SELECT a.next_window_start, r.status FROM automations a JOIN runs r ON r.id = ${first.run_id} WHERE a.id = ${automationId}`;
+    expect(new Date(failed.next_window_start).toISOString()).toBe(first.context.window_start);
+    expect(failed.status).toBe('failed');
+    await sql`UPDATE feeds SET config = config - 'fail_at' WHERE id = ${feeds[1]}`;
+    const retry = await claim({ limit: 10 });
+    expect(retry.run_id).not.toBe(first.run_id);
+    expect(retry.context.window_start).toBe(first.context.window_start);
+    await expect(api.automations.completeWindow({ automation_id: String(automationId), run_id: retry.run_id,
+      window_token: retry.context.window_token, extracted_data: { signals: [] } })).resolves.toMatchObject({ completed_now: true, content_linked: 0 });
+    const fingerprint = await fingerprintAutomationSources({ sql, automationId,
+      windowStart: retry.context.window_start, windowEnd: retry.context.window_end });
+    expect(fingerprint).toEqual({ fingerprint: undefined, empty: false });
+  }, 30_000);
+
+  it('rejects changed feed configuration and malformed source cursors without booking data', async () => {
+    const feeds = await addLiveSources();
+    const first = await claim({ limit: 2 });
+    await expect(claim({ run_id: first.run_id, source_name: 'other', source_cursor: first.context.window_token })).rejects.toThrow(/Source cursor/);
+    const [healthy] = await sql`SELECT status FROM runs WHERE id = ${first.run_id}`;
+    expect(healthy.status).toBe('running');
+    await sql`UPDATE feeds SET config = config || '{"count":8}'::jsonb WHERE id = ${feeds[0]}`;
+    await expect(claim({ run_id: first.run_id, source_name: 'alpha', source_cursor: first.context.window_token })).rejects.toThrow(/configuration changed/);
+    const [after] = await sql`SELECT next_window_start FROM automations WHERE id = ${automationId}`;
+    expect(new Date(after.next_window_start).toISOString()).toBe(first.context.window_start);
+  }, 30_000);
+
+  it('rejects a source cursor from an expired run before touching the new claim', async () => {
+    await addLiveSources();
+    const stale = await claim({ limit: 2 });
+    await sql`UPDATE runs SET expires_at = NOW() - INTERVAL '1 second' WHERE id = ${stale.run_id}`;
+    const current = await claim({ limit: 2 });
+    expect(current.run_id).not.toBe(stale.run_id);
+    await expect(claim({ run_id: current.run_id, source_name: 'alpha', source_cursor: stale.context.window_token })).rejects.toThrow(/cursor|run/i);
+    const [run] = await sql`SELECT status FROM runs WHERE id = ${current.run_id}`;
+    expect(run.status).toBe('running');
+  }, 30_000);
+
+  it('rechecks private-source ownership on continuation and books no progress after revocation', async () => {
+    const feeds = await addLiveSources();
+    const first = await claim({ limit: 2 });
+    await sql`UPDATE connections SET created_by = NULL WHERE id = (SELECT connection_id FROM feeds WHERE id = ${feeds[0]})`;
+    await expect(claim({ run_id: first.run_id, source_name: 'alpha', source_cursor: first.context.window_token })).rejects.toThrow(/accessible|access|permission|found/i);
+    const [after] = await sql`SELECT next_window_start FROM automations WHERE id = ${automationId}`;
+    expect(new Date(after.next_window_start).toISOString()).toBe(first.context.window_start);
+  }, 30_000);
 
   it('recovers a first-ever failed assigned-agent window before any external claim', async () => {
     const failedStart = dayStart(4);
@@ -407,11 +616,15 @@ describe('Automation window claim and recovery', () => {
     `;
     expect(Number(edited.current_version_id)).not.toBe(Number(snapshot.version_id));
 
+
     const claimed = await claim();
     expect(claimed.run_id).toBe(pending.runId);
     expect(claimed.context.window_axis).toBe('created_at');
     expect(claimed.context.extraction_schema?.properties).toHaveProperty('signals');
     expect(claimed.context.extraction_schema?.properties).not.toHaveProperty('findings');
+    await expect(api.automations.completeWindow({ automation_id: String(automationId), run_id: claimed.run_id,
+      template_version_id: Number(edited.current_version_id), window_token: claimed.context.window_token, extracted_data: { signals: [] }
+    })).rejects.toThrow(/version pinned/);
     await expect(
       api.automations.completeWindow({
         automation_id: String(automationId),

--- a/packages/server/src/__tests__/integration/connectors/gmail-source-read.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/gmail-source-read.test.ts
@@ -144,7 +144,7 @@ describe('Gmail feed source read', () => {
 
     expect(cap.listQueries).toEqual(['in:inbox newer_than:30d']);
     expect(res.columns.map((col) => col.name)).toEqual([
-      'id', 'thread_id', 'subject', 'from', 'from_name', 'from_email', 'date', 'snippet', 'url',
+      'id', 'thread_id', 'subject', 'from', 'from_name', 'from_email', 'date', 'received_at', 'snippet', 'url',
     ]);
     expect(res.rows).toHaveLength(3);
     expect(res.rows[0]).toMatchObject({
@@ -234,11 +234,10 @@ describe('Gmail feed source read', () => {
     expect(ok.rows.length).toBeGreaterThan(0);
   });
 
-  it('skips a single unreadable message instead of failing the batch', async () => {
+  it('rejects an unreadable message so a partial page cannot be certified', async () => {
     const cap: Capture = { listQueries: [], listMaxResults: [] };
     const c = connectorWith(cap, { unreadable: new Set(['m2']) });
-    const res = await readThreads(c, { ...CREDS, query: 'in:inbox', config: {}, limit: 10 });
-    expect(res.rows.map((r) => r.id)).toEqual(['m1', 'm3']); // m2 skipped
+    await expect(readThreads(c, { ...CREDS, query: 'in:inbox', config: {}, limit: 10 })).rejects.toThrow(/404/);
   });
 
   it('throws without credentials', async () => {

--- a/packages/server/src/__tests__/unit/atlassian-mcp-feed-read.test.ts
+++ b/packages/server/src/__tests__/unit/atlassian-mcp-feed-read.test.ts
@@ -5,7 +5,7 @@ const calls: Array<{
 	args: Record<string, unknown>;
 }> = [];
 
-let responseMode: "normal" | "ambiguous-sites" = "normal";
+let responseMode: "normal" | "ambiguous-sites" | "malformed" | "missing-cursor" | "missing-exhaustion" = "normal";
 
 mock.module("../../mcp-proxy/client", () => ({
 	discoverTools: async () => [],
@@ -44,6 +44,12 @@ mock.module("../../mcp-proxy/client", () => ({
 				],
 			};
 		}
+		if (responseMode === "malformed" || responseMode === "missing-cursor" || responseMode === "missing-exhaustion") {
+			const text = responseMode === "malformed"
+				? "Try again later"
+				: JSON.stringify(responseMode === "missing-cursor" ? { issues: [], isLast: false } : { issues: [] });
+			return { content: [{ type: "text", text }] };
+		}
 		const token = typeof toolArgs.nextPageToken === "string" ? toolArgs.nextPageToken : undefined;
 		if (!token) {
 			return {
@@ -53,10 +59,11 @@ mock.module("../../mcp-proxy/client", () => ({
 						type: "text",
 						text: JSON.stringify({
 							issues: [
-								{ id: "1", key: "KAN-1", summary: "one" },
-								{ id: "2", key: "KAN-2", summary: "two" },
+								{ id: "1", key: "KAN-1", summary: "one", updated: "2026-01-01T12:00:00Z" },
+								{ id: "2", key: "KAN-2", summary: "two", updated: "2026-01-01T12:00:00Z" },
 							],
 							nextPageToken: "page-2",
+							isLast: false,
 						}),
 					},
 				],
@@ -72,6 +79,7 @@ mock.module("../../mcp-proxy/client", () => ({
 							{ id: "3", key: "KAN-3", summary: "three" },
 							{ id: "4", key: "KAN-4", summary: "four" },
 						],
+						isLast: true,
 					}),
 				},
 			],
@@ -86,6 +94,25 @@ beforeAll(async () => {
 });
 
 describe("readAtlassianMcpFeed", () => {
+  const windowParams = {
+    organizationId: "org-window", connectionId: 1, connectorKey: "mcp.atlassian",
+    mcpConfig: { upstream_url: "https://mcp.atlassian.com/v1/mcp", tool_prefix: "atlassian" },
+    feedConfig: { cloud_id: "cloud-window" }, connectionConfig: {}, baseQuery: "project = KAN",
+    window: { start: "2026-01-01T00:00:00Z", end: "2026-01-02T00:00:00Z" },
+  };
+  it.each(["malformed", "missing-cursor", "missing-exhaustion"] as const)("rejects %s window results", async (mode) => {
+    responseMode = mode;
+    await expect(readAtlassianMcpFeed(windowParams)).rejects.toThrow(/page|cursor|malformed/i);
+  });
+  it("binds fixed Jira bounds and returns source coverage", async () => {
+    responseMode = "normal";
+    calls.length = 0;
+    const result = await readAtlassianMcpFeed(windowParams);
+    expect(result.window).toEqual({ ...windowParams.window, axis: "updated_at" });
+    expect(calls[0].args.jql).toContain(`updated >= ${Date.parse(windowParams.window.start)}`);
+    expect(calls[0].args.jql).toContain(`updated < ${Date.parse(windowParams.window.end)}`);
+    expect(result.hasMore).toBe(true);
+  });
 	it("returns nextPageToken and passes it to the next source request", async () => {
 		calls.length = 0;
 		responseMode = "normal";

--- a/packages/server/src/__tests__/unit/automations/automation-dispatch-message.test.ts
+++ b/packages/server/src/__tests__/unit/automations/automation-dispatch-message.test.ts
@@ -93,10 +93,15 @@ describe("automation dispatch message", () => {
 			'client.knowledge.read({ automation_id: 13, run_id: 647146, limit: 25 })',
 		);
 		expect(message).toContain(
-			"If page.has_more is true and you need more evidence, call knowledge.read again with the same automation_id and run_id plus page.next_cursor as before_occurred_at/before_id.",
+			"While page.has_more is true, call knowledge.read again with the same automation_id and run_id plus page.next_cursor as before_occurred_at/before_id.",
 		);
 		expect(message).toContain(
 			"Keep the returned window_token from every page you actually analyze.",
+		);
+		expect(message).toContain("source_name and source_cursor");
+		expect(message).toContain("empty pages with a continuation");
+		expect(message).toContain(
+			"Reduce pages in code",
 		);
 		expect(message).toContain(
 			"window_tokens: [all window_token values from pages you actually analyzed]",

--- a/packages/server/src/__tests__/unit/source-window-pages.test.ts
+++ b/packages/server/src/__tests__/unit/source-window-pages.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { assertCompleteSourceWindowPages } from '../../automations/source-window-pages';
+import type { SourceWindowPage } from '../../utils/jwt';
+
+const required = [{ name: 'alpha', feed_id: 1 }, { name: 'beta', feed_id: 2 }];
+const a: SourceWindowPage = { name: 'alpha', feed_id: 1, axis: 'updated_at', revision: 'config-a', returned: 0, next_cursor: 'a-next' };
+const aEnd: SourceWindowPage = { ...a, before_cursor: 'a-next', next_cursor: undefined, returned: 2 };
+const b: SourceWindowPage = { name: 'beta', feed_id: 2, axis: 'received_at', revision: 'config-b', returned: 1 };
+const proof = (pages: SourceWindowPage[]) => [{ required_sources: required, source_pages: pages }];
+
+describe('source window completion proof', () => {
+  test('allows shuffled pages and an empty intermediate provider page', () => {
+    expect(assertCompleteSourceWindowPages(proof([aEnd, b, a]), required)).toEqual([
+      { name: 'alpha', feed_id: 1, axis: 'updated_at', rows: 2 },
+      { name: 'beta', feed_id: 2, axis: 'received_at', rows: 1 },
+    ]);
+  });
+  test.each([
+    ['missing source', [a, aEnd]],
+    ['missing page', [a, b]],
+    ['missing root', [aEnd, b]],
+    ['duplicate root', [a, a, aEnd, b]],
+    ['duplicate continuation', [a, aEnd, aEnd, b]],
+    ['disconnected page', [a, aEnd, b, { ...aEnd, before_cursor: 'unseen' }]],
+    ['changed configuration', [a, { ...aEnd, revision: 'changed' }, b]],
+    ['changed time axis', [a, { ...aEnd, axis: 'created_at' }, b]],
+    ['wrong feed', [a, { ...aEnd, feed_id: 3 }, b]],
+    ['cycle', [a, { ...aEnd, next_cursor: 'a-next' }, b]],
+  ] as const)('rejects %s', (_name, pages) => {
+    expect(() => assertCompleteSourceWindowPages(proof([...pages]), required)).toThrow(/Incomplete/);
+  });
+  test('cannot replace the required source roster with a caller-selected subset', () => {
+    expect(() => assertCompleteSourceWindowPages([{ required_sources: [required[0]], source_pages: [a, aEnd] }], required)).toThrow(/pinned/);
+    expect(() => assertCompleteSourceWindowPages([{}], required)).toThrow(/pinned/);
+  });
+});

--- a/packages/server/src/automations/automation.ts
+++ b/packages/server/src/automations/automation.ts
@@ -255,6 +255,7 @@ async function enqueueAutomationRunForRecord(
 	dispatchSource: AutomationRunPayload["dispatch_source"],
 	sourceFingerprint?: string,
 	tx?: DbClient,
+	inspectedWindow?: { windowStart: Date; windowEnd: Date },
 ): Promise<QueueAutomationRunResult> {
 	if ((automation.status ?? "active") !== "active") {
 		throw new Error(`Automation ${automation.id} is not active.`);
@@ -280,7 +281,7 @@ async function enqueueAutomationRunForRecord(
 	// mark was seeded at cutover. The scheduled path checks for that before it
 	// gets here and waits a tick; a manual trigger gets a clear answer instead
 	// of a run that reads nothing.
-	const { windowStart, windowEnd } = await computePendingWindow(sql, automation.id);
+	const { windowStart, windowEnd } = inspectedWindow ?? await computePendingWindow(sql, automation.id);
 	if (windowEnd <= windowStart) {
 		throw new ToolUserError(
 			`Automation ${automation.id} has nothing new to run yet: rows stored after ` +
@@ -301,6 +302,7 @@ async function enqueueAutomationRunForRecord(
 			agentKind:
 				executor?.kind === "device" ? executor.agentKind : null,
 			sourceFingerprint,
+			expectedWindowStart: inspectedWindow?.windowStart.toISOString(),
 		};
 	const queued = tx
 		? await createAutomationRunInTransaction(runParams, tx)
@@ -912,13 +914,14 @@ export async function materializeDueAutomationRuns(
 						automation,
 						"scheduled",
 						sourceFingerprint,
+						undefined,
+						pending,
 					);
 					// `created: false` means this reused an already-active run that a
 					// concurrent replica materialized for real work. Completing that
 					// row as "skipped" would silently kill a live dispatch.
 					if (skippedRun.created) {
-						// Book the range the RUN recorded, not the one fingerprinted a
-						// moment earlier: the horizon moved in between.
+						// The run and fingerprint share exactly the same inspected range.
 						await completeSkippedAutomationRun(
 							sql,
 							automation.id,
@@ -927,7 +930,11 @@ export async function materializeDueAutomationRuns(
 							skippedRun.runId,
 						);
 					}
-					await advanceAutomationScheduleAfterSuccessfulWindow(sql, automation.id);
+					// A superseded observation means another completion already moved the
+					// arrival mark and owns schedule advancement for that window.
+					if (skippedRun.status !== "superseded") {
+						await advanceAutomationScheduleAfterSuccessfulWindow(sql, automation.id);
+					}
 					logger.info(
 						{ automationId: automation.id, empty: sourceState.empty },
 						"[automation] Skipped unchanged Automation sources before agent dispatch"
@@ -939,7 +946,9 @@ export async function materializeDueAutomationRuns(
 				sql,
 				automation,
 				"scheduled",
-				sourceFingerprint
+				sourceFingerprint,
+				undefined,
+				pending,
 			);
 			return result.created ? "created" : "skipped";
 		},
@@ -1137,7 +1146,7 @@ export function buildDispatchMessage(params: {
 		"",
 		"Required steps:",
 		`1. Call query_sdk with a script that runs client.knowledge.read({ automation_id: ${params.automationId}, run_id: ${params.runId}, limit: 25 }). The run ID binds the queued version, window, and trigger inputs. Keep the returned window_token from every page you actually analyze.`,
-		`2. Follow the Automation instructions above against the returned payload — content, sources, entities, extraction_schema, reactions_guidance, past_reactions, and past_feedback. If page.has_more is true and you need more evidence, call knowledge.read again with the same automation_id and run_id plus page.next_cursor as before_occurred_at/before_id. Collect that page's window_token too; do this for every additional page you actually analyze.`,
+		`2. Follow the Automation instructions above against the returned payload — content, sources, entities, extraction_schema, reactions_guidance, past_reactions, and past_feedback. While page.has_more is true, call knowledge.read again with the same automation_id and run_id plus page.next_cursor as before_occurred_at/before_id. Collect that page's window_token too. For each live sources_page entry with has_more and next_cursor, call knowledge.read with the same automation_id and run_id plus source_name and source_cursor from that entry's next_cursor. Follow each source to exhaustion, including empty pages with a continuation. Reduce pages in code and return compact evidence to the model; keep exactly one window_token for every analyzed page. Completion requires all source chains, not only the primary event page. A context source with has_more but no next_cursor is truncated: retry the initial read with a larger limit and replace its first-page token, or report the source limit if it still cannot fit. Live rows may be metadata/snippets; use connector reads for needed detail.`,
 		`3. Call run_sdk with a script that runs client.automations.completeWindow({ window_tokens: [all window_token values from pages you actually analyzed], extracted_data, run_id: ${params.runId} }). Pass exactly one token per page you actually analyzed, including the first page.`,
 		"4. Include this run_metadata object in complete_window exactly, and add any extra provider/job fields you know:",
 		JSON.stringify(
@@ -1157,7 +1166,7 @@ export function buildDispatchMessage(params: {
 					`This run was activated by durable workspace event id${workspaceContentIds.length === 1 ? "" : "s"} ${workspaceContentIds.join(", ")}. Lobu includes ${workspaceContentIds.length === 1 ? "it" : "them"} in the top-level content and signs ${workspaceContentIds.length === 1 ? "its" : "their"} exact id${workspaceContentIds.length === 1 ? "" : "s"} into the window_token. Analyze each trigger input exactly once.`,
 				]
 			: []),
-		"Treat the Automation as having no data only when `content` and every array in `sources` are empty. In that case, do not fabricate results.",
+		"Treat the Automation as having no data only when `content` and every array in `sources` are empty. Check that every page and source is exhausted before declaring the window empty. In that case, do not fabricate results.",
 	].join("\n");
 }
 

--- a/packages/server/src/automations/source-refs.ts
+++ b/packages/server/src/automations/source-refs.ts
@@ -52,7 +52,7 @@ async function validateCustomSqlSource(
 // is prompt CONTEXT, not events: its rows must never be signed as event
 // content_ids (channel_messages.id is not an events.id — complete_window links
 // content_ids into automation_run_events.event_id, an FK to events).
-export type AutomationSourceKind = 'event' | 'entity' | 'metric' | 'channel';
+export type AutomationSourceKind = 'event' | 'entity' | 'metric' | 'channel' | 'feed';
 
 export type AutomationSourceRef =
   | { type: 'feed'; value: string }
@@ -65,6 +65,7 @@ export type AutomationSourceRef =
 export interface NormalizedAutomationSource extends AutomationSource {
   kind: AutomationSourceKind;
   ref?: AutomationSourceRef;
+  feedId?: number;
   /**
    * This ref-backed source has the canonical event projection and can be
    * bounded in SQL after paging.
@@ -228,6 +229,7 @@ interface ResolvedFeed {
   feedKey: string;
   /** Declared feed capabilities; empty when no definition resolved. */
   operations: string[];
+  readWindowAxis?: string;
 }
 
 async function resolveFeeds(
@@ -242,14 +244,16 @@ async function resolveFeeds(
     feed_key: string;
     connection_slug: string;
     operations: unknown;
+    read_window_axis: string | null;
   }>`
     SELECT f.id, f.config ->> 'store' AS store, f.feed_key, c.slug AS connection_slug,
-           COALESCE(cd.feed_operations, '[]'::jsonb) AS operations
+           COALESCE(cd.feed_operations, '[]'::jsonb) AS operations, cd.read_window_axis
     FROM feeds f
     JOIN connections c ON c.id = f.connection_id
     LEFT JOIN LATERAL (
       SELECT connector_definitions.feeds_schema -> f.feed_key -> 'operations'
-        AS feed_operations
+        AS feed_operations,
+        connector_definitions.feeds_schema -> f.feed_key ->> 'readWindowAxis' AS read_window_axis
       FROM connector_definitions
       WHERE connector_definitions.key = c.connector_key
         AND connector_definitions.organization_id = f.organization_id
@@ -287,6 +291,7 @@ async function resolveFeeds(
       connectionSlug: String(r.connection_slug),
       feedKey: String(r.feed_key),
       operations: Array.isArray(r.operations) ? r.operations.map(String) : [],
+      readWindowAxis: r.read_window_axis ?? undefined,
     }))
     .filter((r) => Number.isSafeInteger(r.id) && r.id > 0);
 }
@@ -350,6 +355,7 @@ async function compileRefToQuery(
 ): Promise<{
   query: string | null;
   kind: AutomationSourceKind;
+  feedId?: number;
   controlledEventProjection?: boolean;
 }> {
   switch (ref.type) {
@@ -358,18 +364,11 @@ async function compileRefToQuery(
       if (feeds.length === 0) throw new Error(`@feed:${ref.value} did not match any feed`);
       const eventFeeds = feeds.filter((f) => f.store === 'events');
       const channelFeeds = feeds.filter((f) => f.store === 'channel_messages');
-      // A source-only feed never persists events, so compiling it to an
-      // `events` SELECT would silently yield zero rows forever. Reject it loudly
-      // instead. A feed whose definition did not resolve keeps the events read:
-      // that is the uninstalled-connector case, not a declared capability gap.
-      const sourceOnly = eventFeeds.find(
-        (f) => f.operations.length > 0 && !f.operations.includes('sync')
-      );
-      if (sourceOnly) {
-        throw new Error(
-          `@feed:${ref.value} is a source-read-only feed and stores no events; ` +
-            'read it with feeds.readMany instead of an @feed source'
-        );
+      if (eventFeeds.some((f) => f.operations.includes('read') && (f.readWindowAxis || !f.operations.includes('sync')))) {
+        if (feeds.length !== 1) {
+          throw new Error(`@feed:${ref.value} matches multiple feeds; reference one feed for a live source.`);
+        }
+        return { query: null, kind: 'feed', feedId: feeds[0].id };
       }
       // Don't mix storage planes in one source: a single SELECT cannot span
       // both `events` and `channel_messages`.
@@ -535,6 +534,14 @@ export async function normalizeAutomationSources(
   organizationId: string,
   sources: AutomationSource[]
 ): Promise<NormalizedAutomationSource[]> {
+  const seenNames = new Set<string>();
+  for (const source of sources) {
+    if (seenNames.has(source.name)) {
+      throw new Error(`Automation source name "${source.name}" is duplicated; source names must be unique`);
+    }
+    seenNames.add(source.name);
+  }
+
   const normalized: NormalizedAutomationSource[] = [];
   for (const source of sources) {
     const ref = parseAutomationSourceRef(source.query);
@@ -553,7 +560,7 @@ export async function normalizeAutomationSources(
       });
       continue;
     }
-    const { query, kind, controlledEventProjection } = await compileRefToQuery(
+    const { query, kind, controlledEventProjection, feedId } = await compileRefToQuery(
       sql,
       organizationId,
       ref
@@ -564,6 +571,7 @@ export async function normalizeAutomationSources(
       kind,
       ref,
       controlledEventProjection,
+      feedId,
     });
   }
   return normalized;

--- a/packages/server/src/automations/source-window-pages.ts
+++ b/packages/server/src/automations/source-window-pages.ts
@@ -1,0 +1,51 @@
+import { ToolUserError } from '../utils/errors';
+import type { SourceWindowPage } from '../utils/jwt';
+
+interface SourceProof {
+  required_sources?: Array<{ name: string; feed_id: number }>;
+  source_pages?: SourceWindowPage[];
+}
+
+/** Same completion proof as event pages, independently for every declared live source. */
+export function assertCompleteSourceWindowPages(
+  tokens: SourceProof[],
+  required: Array<{ name: string; feed_id: number }>,
+): Array<{ name: string; feed_id: number; axis: string; rows: number }> {
+  const roster = (sources: typeof required) => JSON.stringify(
+    [...sources].sort((a, b) => a.name.localeCompare(b.name)),
+  );
+  const expected = roster(required);
+  const pages = tokens.flatMap((token) => token.source_pages ?? []);
+  const fail = (message: string): never => {
+    throw new ToolUserError(`Incomplete Automation source window: ${message}`, 409);
+  };
+  if (tokens.some((token) => roster(token.required_sources ?? []) !== expected)) {
+    fail('source receipts do not match the pinned Automation sources.');
+  }
+  if (pages.some((page) => !required.some((source) => source.name === page.name && source.feed_id === page.feed_id))) {
+    fail('unexpected source receipt.');
+  }
+  return required.map((source) => {
+    const chain = pages.filter((page) => page.name === source.name);
+    const roots = chain.filter((page) => page.before_cursor == null);
+    if (roots.length !== 1) fail(`${source.name} requires exactly one first page.`);
+    const root = roots[0];
+    if (chain.some((page) => page.feed_id !== root.feed_id || page.axis !== root.axis || page.revision !== root.revision)) {
+      fail(`${source.name} changed its source request during pagination.`);
+    }
+    const visited = new Set<SourceWindowPage>();
+    let current = root;
+    let rows = 0;
+    while (true) {
+      if (visited.has(current)) fail(`${source.name} has a cyclic page chain.`);
+      visited.add(current);
+      rows += current.returned;
+      if (current.next_cursor == null) break;
+      const next = chain.filter((page) => page.before_cursor === current.next_cursor);
+      if (next.length !== 1) fail(`${source.name} has missing or duplicate pages. Continue its sources_page cursor and retain every window_token.`);
+      current = next[0];
+    }
+    if (visited.size !== chain.length) fail(`${source.name} has disconnected or duplicate pages.`);
+    return { ...source, axis: root.axis, rows };
+  });
+}

--- a/packages/server/src/lib/connector-pushdown.ts
+++ b/packages/server/src/lib/connector-pushdown.ts
@@ -9,6 +9,9 @@
  */
 
 import { executeCompiledConnector } from '@lobu/connector-worker/executor/runtime';
+import { assertFeedReadWindow, validateFeedReadWindow, type FeedReadWindow, type FeedReadWindowCoverage } from '@lobu/connector-sdk';
+import { createHash } from 'node:crypto';
+import { stableJson } from '../utils/insert-event';
 import {
   classifyToolError,
   getErrorMessage,
@@ -184,6 +187,9 @@ export interface ReadSourceFeedParams {
   query?: string;
   /** Source-native continuation token recovered from the public cursor envelope. */
   cursor?: string;
+  window?: FeedReadWindow;
+  /** A continuation may not silently read a changed feed configuration/version. */
+  sourceRevision?: string;
   /** Row cap pushed down to the source (connector clamps it). */
   limit?: number;
   offset?: number;
@@ -201,6 +207,8 @@ export interface ReadSourceFeedResult {
   total?: number;
   nextCursor?: string;
   hasMore?: boolean;
+  window?: FeedReadWindowCoverage;
+  sourceRevision?: string;
 }
 
 function deadlineError(feedId: number): Error & { exitReason: 'timeout' } {
@@ -243,6 +251,7 @@ export function classifyPushdownFailure(err: unknown): ToolErrorCode {
  * per-request read with all state in Postgres, runnable on any replica.
  */
 export async function readSourceFeed(p: ReadSourceFeedParams): Promise<ReadSourceFeedResult> {
+  if (p.window) validateFeedReadWindow(p.window);
   remainingReadMs(p);
   const sql = getDb();
 
@@ -256,7 +265,7 @@ export async function readSourceFeed(p: ReadSourceFeedParams): Promise<ReadSourc
             c.device_worker_id,
             COALESCE(pinned_dw.user_id, (o.metadata::jsonb)->>'personal_org_for_user_id') AS device_owner_user_id,
             COALESCE(c.config, '{}'::jsonb) AS connection_config,
-            cd.version AS definition_version, cd.feed_operations,
+            cd.version AS definition_version, cd.feed_operations, cd.read_window_axis,
             cd.mcp_config, cd.runtime, cd.required_capability,
             cd.has_compiled_code, cd.selected_artifact_hash
      FROM feeds f
@@ -267,6 +276,7 @@ export async function readSourceFeed(p: ReadSourceFeedParams): Promise<ReadSourc
        SELECT cd0.version, cd0.mcp_config, cd0.runtime, cd0.required_capability,
               COALESCE(cd0.feeds_schema -> f.feed_key -> 'operations', '[]'::jsonb)
                 AS feed_operations,
+              cd0.feeds_schema -> f.feed_key ->> 'readWindowAxis' AS read_window_axis,
               (
                 SELECT cv.compiled_code_hash
                 FROM connector_versions cv
@@ -343,6 +353,7 @@ export async function readSourceFeed(p: ReadSourceFeedParams): Promise<ReadSourc
     feed_status: string;
     definition_version: string | null;
     feed_operations: unknown;
+    read_window_axis: string | null;
     connection_id: number;
     connector_key: string;
     auth_profile_id: number | null;
@@ -365,10 +376,32 @@ export async function readSourceFeed(p: ReadSourceFeedParams): Promise<ReadSourc
   }
   const feed = feedRows[0];
   const feedOperations = Array.isArray(feed.feed_operations) ? feed.feed_operations : [];
+  const readWindowAxis = feed.read_window_axis?.trim() || undefined;
+  const sourceRevision = createHash('sha256').update(stableJson({
+    feedId: feed.id, feedKey: feed.feed_key, connectionId: feed.connection_id,
+    connectorKey: feed.connector_key, config: feed.config,
+    connectionConfig: feed.connection_config, version: feed.pinned_version ?? feed.definition_version,
+    artifact: feed.selected_artifact_hash, mcpConfig: feed.mcp_config, device: feed.device_worker_id,
+    authProfile: feed.auth_profile_id, appAuthProfile: feed.app_auth_profile_id,
+    operations: feedOperations, readWindowAxis,
+  })).digest('hex');
+  if (p.sourceRevision && p.sourceRevision !== sourceRevision) {
+    throw new ToolError('VALIDATION', 'Source configuration changed during the window read; restart the window.');
+  }
+  const finish = (result: ReadSourceFeedResult): ReadSourceFeedResult => {
+    assertFeedReadWindow(result, p.window, readWindowAxis);
+    return { ...result, sourceRevision };
+  };
   if (!feedOperations.includes('read')) {
     throw new ToolError(
       'VALIDATION',
       `feed '${p.feedId}' does not support source reads`,
+    );
+  }
+  if (p.window && !readWindowAxis) {
+    throw new ToolError(
+      'VALIDATION',
+      `feed '${p.feedId}' does not declare a source-time window axis`,
     );
   }
 
@@ -396,6 +429,9 @@ export async function readSourceFeed(p: ReadSourceFeedParams): Promise<ReadSourc
   }
 
   if (metadataOnlyDeviceConnector) {
+    if (p.window) {
+      throw new ToolError('VALIDATION', 'This device reader does not support source-time windows.');
+    }
     remainingReadMs(p);
     return readDeviceFeed({
       organizationId: p.scope.organizationId,
@@ -433,6 +469,7 @@ export async function readSourceFeed(p: ReadSourceFeedParams): Promise<ReadSourc
     connectionConfig: feed.connection_config,
     query: p.query,
     cursor: p.cursor,
+    window: p.window,
     limit: p.limit,
     offset: p.offset,
     sort: p.sort,
@@ -440,7 +477,7 @@ export async function readSourceFeed(p: ReadSourceFeedParams): Promise<ReadSourc
     deadlineAt: p.deadlineAt,
   });
   if (adapterResult) {
-    return { ...adapterResult, columns: adapterResult.columns ?? [] };
+    return finish({ ...adapterResult, columns: adapterResult.columns ?? [] });
   }
 
   const compiledCode = await resolveConnectorCodeForKey(
@@ -476,6 +513,7 @@ export async function readSourceFeed(p: ReadSourceFeedParams): Promise<ReadSourc
       feedKey: feed.feed_key,
       query: p.query,
       cursor: p.cursor,
+      window: p.window,
       config,
       env: dbEgressConfig(),
       sessionState,
@@ -490,11 +528,12 @@ export async function readSourceFeed(p: ReadSourceFeedParams): Promise<ReadSourc
   if (result.mode !== 'read') {
     throw new Error(`Expected read result, got mode=${result.mode}`);
   }
-  return {
+  return finish({
     rows: result.rows,
     columns: result.columns ?? [],
     total: result.total,
     nextCursor: result.nextCursor,
     hasMore: result.hasMore,
-  };
+    window: result.window,
+  });
 }

--- a/packages/server/src/lib/source-feed-adapters.ts
+++ b/packages/server/src/lib/source-feed-adapters.ts
@@ -1,4 +1,4 @@
-import type { FeedReadResult } from '@lobu/connector-sdk';
+import type { FeedReadResult, FeedReadWindow } from '@lobu/connector-sdk';
 import {
   ATLASSIAN_JIRA_ISSUES_FEED_KEY,
   isAtlassianMcpConfig,
@@ -16,6 +16,7 @@ export interface SourceFeedAdapterParams {
   connectionConfig: Record<string, unknown>;
   query?: string;
   cursor?: string;
+  window?: FeedReadWindow;
   limit?: number;
   offset?: number;
   sort?: { column: string; order: 'asc' | 'desc' };
@@ -53,6 +54,7 @@ const atlassianMcpAdapter: SourceFeedAdapter = {
       baseQuery: storedQuery,
       query: params.query,
       cursor: params.cursor,
+      window: params.window,
       limit: params.limit,
       offset: params.offset,
       sort: params.sort,

--- a/packages/server/src/lib/source-feed-page.ts
+++ b/packages/server/src/lib/source-feed-page.ts
@@ -1,0 +1,204 @@
+import { createHash } from 'node:crypto';
+import type { FeedReadWindow } from '@lobu/connector-sdk';
+import type { AuthzScope } from '../authz/scope';
+import { readSourceFeed } from './connector-pushdown';
+
+export interface SourceFeedPageRequest {
+  feed_id: number;
+  query?: string;
+  cursor?: string;
+  limit?: number;
+  sort?: { column: string; order: 'asc' | 'desc' };
+  window?: FeedReadWindow;
+  sourceRevision?: string;
+}
+
+interface SourceCursor {
+  v: 1;
+  feed_id: number;
+  position: number;
+  source_cursor?: string;
+  request_hash: string;
+}
+
+function sourceRequestHash(
+  query: string | undefined,
+  sort: { column: string; order: 'asc' | 'desc' } | undefined,
+  window?: FeedReadWindow,
+): string {
+  return createHash('sha256')
+    .update(JSON.stringify({ query: query?.trim() ?? '', sort: sort ?? null, ...(window ? { window } : {}) }))
+    .digest('base64url')
+    .slice(0, 16);
+}
+
+/**
+ * A caller-supplied cursor that does not decode, or does not belong to this
+ * (feed, query, sort) request. Marked structurally rather than by message text so the
+ * classifier never confuses it with a connector error that merely mentions a
+ * cursor.
+ */
+export class SourceCursorError extends Error {}
+
+function decodeSourceCursor(
+  cursor: string | undefined,
+  feedId: number,
+  query: string | undefined,
+  sort: { column: string; order: 'asc' | 'desc' } | undefined,
+  window?: FeedReadWindow,
+): { position: number; sourceCursor?: string } {
+  if (!cursor) return { position: 0 };
+  let parsed: SourceCursor;
+  try {
+    parsed = JSON.parse(
+      Buffer.from(cursor, 'base64url').toString('utf8'),
+    ) as SourceCursor;
+  } catch {
+    throw new SourceCursorError('Invalid source cursor');
+  }
+  if (
+    parsed.v !== 1 ||
+    parsed.feed_id !== feedId ||
+    !Number.isSafeInteger(parsed.position) ||
+    parsed.position < 0 ||
+    (parsed.source_cursor !== undefined &&
+      (typeof parsed.source_cursor !== 'string' ||
+        parsed.source_cursor.length === 0)) ||
+    parsed.request_hash !== sourceRequestHash(query, sort, window)
+  ) {
+    throw new SourceCursorError(
+      'Source cursor does not match this feed read request',
+    );
+  }
+  return {
+    position: parsed.position,
+    ...(parsed.source_cursor ? { sourceCursor: parsed.source_cursor } : {}),
+  };
+}
+
+function encodeSourceCursor(
+  feedId: number,
+  position: number,
+  query: string | undefined,
+  sort: { column: string; order: 'asc' | 'desc' } | undefined,
+  sourceCursor?: string,
+  window?: FeedReadWindow,
+): string {
+  const payload: SourceCursor = {
+    v: 1,
+    feed_id: feedId,
+    position,
+    request_hash: sourceRequestHash(query, sort, window),
+    ...(sourceCursor ? { source_cursor: sourceCursor } : {}),
+  };
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+}
+
+function sourceReadError(message: string): Error & { exitReason: 'timeout' } {
+  return Object.assign(new Error(message), { exitReason: 'timeout' as const });
+}
+
+/** Shared bounded pager for direct feed reads and Automation source windows. */
+export async function readSourceFeedPage(
+  read: SourceFeedPageRequest,
+  timeoutMs: number,
+  scope: AuthzScope,
+  signal?: AbortSignal,
+) {
+  const page = decodeSourceCursor(
+    read.cursor,
+    read.feed_id,
+    read.query,
+    read.sort,
+    read.window,
+  );
+  const controller = new AbortController();
+  const deadlineAt = Date.now() + timeoutMs;
+  const onCallerAbort = () => controller.abort(signal?.reason);
+  signal?.addEventListener('abort', onCallerAbort, { once: true });
+  if (signal?.aborted) onCallerAbort();
+  const offset = page.sourceCursor ? 0 : page.position;
+  const limit = Math.max(1, Math.min(500, Math.trunc(read.limit ?? 50)));
+  const pending = readSourceFeed({
+    scope: scope,
+    feedId: read.feed_id,
+    query: read.query,
+    cursor: page.sourceCursor,
+    limit,
+    offset,
+    sort: read.sort,
+    window: read.window,
+    sourceRevision: read.sourceRevision,
+    signal: controller.signal,
+    deadlineAt,
+  });
+  pending.catch(() => {});
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(
+        sourceReadError(
+          `source read ${read.feed_id} timed out after ${timeoutMs}ms`,
+        ),
+      );
+    }, timeoutMs);
+  });
+  try {
+    const result = await Promise.race([pending, deadline]);
+    if (!Array.isArray(result.rows) || result.rows.some((row) => !row || typeof row !== 'object' || Array.isArray(row))) {
+      throw new Error('Source reader returned malformed rows.');
+    }
+    if (result.rows.length > limit) throw new Error('Source reader exceeded the requested page limit.');
+    if (result.nextCursor !== undefined &&
+        (typeof result.nextCursor !== 'string' || !result.nextCursor.trim())) {
+      throw new Error('Source reader returned a malformed continuation cursor.');
+    }
+    if (read.window && result.hasMore && !result.nextCursor) {
+      throw new Error('Windowed source reader reported more results without a continuation cursor.');
+    }
+    if (result.nextCursor && result.nextCursor === page.sourceCursor) {
+      throw new Error('Source reader returned a non-advancing cursor.');
+    }
+    const nextPosition = page.position + result.rows.length;
+    // Once a source has selected token pagination, absence of a replacement
+    // token means exhaustion. Never downgrade that traversal to an offset
+    // cursor: token-only providers reject offsets and cannot resume that page.
+    let hasMore: boolean;
+    if (result.nextCursor !== undefined) {
+      hasMore = true;
+    } else if (page.sourceCursor !== undefined) {
+      hasMore = false;
+    } else if (result.hasMore !== undefined) {
+      hasMore = result.hasMore;
+    } else if (result.total !== undefined) {
+      hasMore = nextPosition < result.total;
+    } else {
+      hasMore = result.rows.length >= limit;
+    }
+    return {
+      feed_id: read.feed_id,
+      ok: true as const,
+      rows: result.rows,
+      columns: result.columns,
+      window: result.window,
+      sourceRevision: result.sourceRevision,
+      ...(result.total === undefined ? {} : { total: result.total }),
+      ...(hasMore
+        ? {
+            next_cursor: encodeSourceCursor(
+              read.feed_id,
+              nextPosition,
+              read.query,
+              read.sort,
+              result.nextCursor,
+              read.window,
+            ),
+          }
+        : {}),
+    };
+  } finally {
+    if (timer) clearTimeout(timer);
+    signal?.removeEventListener('abort', onCallerAbort);
+  }
+}

--- a/packages/server/src/operations/atlassian-mcp-feed.ts
+++ b/packages/server/src/operations/atlassian-mcp-feed.ts
@@ -1,3 +1,4 @@
+import type { FeedReadResult, FeedReadWindow } from '@lobu/connector-sdk';
 /**
  * Atlassian Rovo MCP feed-read adapter.
  *
@@ -58,6 +59,7 @@ export const ATLASSIAN_MCP_FEEDS = {
 		description:
 			"Live Jira issues via JQL. Reads call Rovo searchJiraIssuesUsingJql; signed Jira issue/comment webhooks are copied into events.",
 		operations: ["read"],
+		readWindowAxis: "updated_at",
 		configSchema: {
 			type: "object",
 			properties: {
@@ -242,15 +244,20 @@ function splitTrailingOrderBy(jql: string): { body: string; orderBy: string | nu
 
 export function buildAtlassianMcpJql(args: {
 	baseQuery: string;
+	window?: FeedReadWindow;
 	query?: string;
 	sort?: { column: string; order: "asc" | "desc" };
 }): string {
 	const trimmed = args.baseQuery.trim();
-	const jql = trimmed.length > 0 ? trimmed : "updated >= -90d";
+	const jql = trimmed.length > 0 ? trimmed : (args.window ? "" : "updated >= -90d");
 	let { body, orderBy } = splitTrailingOrderBy(jql);
-	if (!body && orderBy) body = "updated >= -90d";
+	if (!body && orderBy) body = args.window ? "" : "updated >= -90d";
 
 	const callerQuery = args.query?.trim() ?? "";
+	if (args.window) {
+		const bounds = `updated >= ${Date.parse(args.window.start)} AND updated < ${Date.parse(args.window.end)}`;
+		body = body ? `(${body}) AND (${bounds})` : bounds;
+	}
 	if (callerQuery) {
 		const caller = splitTrailingOrderBy(callerQuery);
 		if (caller.body) {
@@ -363,48 +370,66 @@ function tryParseJson(text: string): unknown {
 	}
 }
 
-function collectIssues(value: unknown, into: unknown[]): void {
-	if (!value) return;
-	if (Array.isArray(value)) {
-		for (const item of value) collectIssues(item, into);
-		return;
-	}
+function collectIssues(value: unknown, into: unknown[], requirePage = false): number {
 	if (typeof value === "string") {
-		collectIssues(tryParseJson(value), into);
-		return;
+		return collectIssues(tryParseJson(value), into, requirePage);
 	}
-	if (typeof value !== "object") return;
+	if (Array.isArray(value)) {
+		return value.reduce(
+			(count, item) => count + collectIssues(item, into, requirePage),
+			0,
+		);
+	}
+	if (!value || typeof value !== "object") return 0;
 	const record = value as Record<string, unknown>;
 	if (record.type === "text" && typeof record.text === "string") {
-		collectIssues(tryParseJson(record.text), into);
-		return;
+		return collectIssues(tryParseJson(record.text), into, requirePage);
 	}
-	if (Array.isArray(record.issues)) {
-		into.push(...record.issues);
-		return;
-	}
-	if (Array.isArray(record.values)) {
-		into.push(...record.values);
-		return;
+	const issues = Array.isArray(record.issues)
+		? record.issues
+		: Array.isArray(record.values)
+			? record.values
+			: null;
+	if (issues) {
+		const cursor = parseAtlassianMcpNextPageToken(record);
+		if (
+			requirePage &&
+			((record.isLast !== true && !cursor) ||
+				(record.isLast === true && Boolean(cursor)))
+		) {
+			throw new Error("Jira MCP returned an ambiguous page cursor/exhaustion state.");
+		}
+		into.push(...issues);
+		return 1;
 	}
 	if (Array.isArray(record.content)) {
-		collectIssues(record.content, into);
-		return;
+		return collectIssues(record.content, into, requirePage);
 	}
-	if (asString(record.id) || asString(record.key)) {
+	if (!requirePage && (asString(record.id) || asString(record.key))) {
 		into.push(record);
 	}
+	return 0;
 }
 
 export function parseAtlassianMcpIssues(
 	payload: unknown,
 	config: Record<string, unknown> = {},
+	requirePage = false,
 ): Record<string, unknown>[] {
 	const collected: unknown[] = [];
-	collectIssues(payload, collected);
+	const pages = collectIssues(payload, collected, requirePage);
+	if (requirePage && pages !== 1) {
+		throw new Error("Jira MCP did not return one recognizable result page.");
+	}
 	const rows: Record<string, unknown>[] = [];
 	for (const item of collected) {
 		const row = mapAtlassianIssueToRow(item, config);
+		if (
+			requirePage &&
+			(!row || !Number.isFinite(Date.parse(String(row.updated_at ?? ""))))
+		) {
+			throw new Error("Jira MCP returned a malformed issue or updated timestamp.");
+		}
 		if (row) rows.push(row);
 	}
 	return rows;
@@ -569,18 +594,13 @@ export async function readAtlassianMcpFeed(params: {
 	baseQuery: string;
 	query?: string;
 	cursor?: string;
+	window?: FeedReadWindow;
 	limit?: number;
 	offset?: number;
 	sort?: { column: string; order: "asc" | "desc" };
 	signal?: AbortSignal;
 	deadlineAt?: number;
-}): Promise<{
-	rows: Record<string, unknown>[];
-	columns: { name: string; type: string }[];
-	total?: number;
-	nextCursor?: string;
-	hasMore?: boolean;
-}> {
+}): Promise<FeedReadResult> {
 	const config = { ...params.connectionConfig, ...params.feedConfig };
 	let cloudId = asString(config.cloud_id) ?? asString(config.cloudId);
 	if (!cloudId) {
@@ -603,6 +623,7 @@ export async function readAtlassianMcpFeed(params: {
 
 	const jql = buildAtlassianMcpJql({
 		baseQuery: params.baseQuery,
+		window: params.window,
 		query: params.query,
 		sort: params.sort,
 	});
@@ -632,12 +653,13 @@ export async function readAtlassianMcpFeed(params: {
 	if (result.isError) {
 		throw new Error(mcpTextError(result.content, "searchJiraIssuesUsingJql failed"));
 	}
-	const rows = parseAtlassianMcpIssues(result.content, config);
+	const rows = parseAtlassianMcpIssues(result.content, config, Boolean(params.window));
 	const nextCursor = parseAtlassianMcpNextPageToken(result.content);
 
 	return {
 		rows,
 		columns: [...ATLASSIAN_JIRA_ISSUE_COLUMNS],
+		...(params.window ? { window: { ...params.window, axis: "updated_at" } } : {}),
 		nextCursor,
 		hasMore: Boolean(nextCursor),
 	};

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -653,6 +653,8 @@ async function createAutomationRunWithClient(
     deviceWorkerId?: string | null;
     agentKind?: string | null;
     sourceFingerprint?: string;
+    /** Scheduler-only fence against materializing an arrival window whose mark already advanced. */
+    expectedWindowStart?: string;
   }
 ): Promise<{ runId: number; status: string; created: boolean }> {
   const existing = await findActiveAutomationRun(sql, params.automationId);
@@ -663,14 +665,33 @@ async function createAutomationRunWithClient(
     return { runId: existing.id, status: existing.status, created: false };
   }
 
-  // Snapshot the automation's current_version_id at run-creation time so the
-  // entire run uses a fixed version even if the group is edited mid-run.
-  const versionRows = await sql`
-    SELECT current_version_id
-    FROM automations
-    WHERE id = ${params.automationId}
-    LIMIT 1
-  `;
+  // Snapshot the version and, for a scheduler observation made before this
+  // transaction, lock and verify the arrival mark. Without the fence another
+  // replica can complete that window after fingerprinting but before this
+  // INSERT, allowing the old range to be materialized again.
+  const versionRows = params.expectedWindowStart
+    ? await sql<{ current_version_id: unknown; next_window_start: string | Date | null }>`
+        SELECT current_version_id, next_window_start
+        FROM automations
+        WHERE id = ${params.automationId}
+        FOR UPDATE
+      `
+    : await sql<{ current_version_id: unknown; next_window_start: string | Date | null }>`
+        SELECT current_version_id, next_window_start
+        FROM automations
+        WHERE id = ${params.automationId}
+        LIMIT 1
+      `;
+  const currentWindowStart = versionRows[0]?.next_window_start == null
+    ? null
+    : new Date(versionRows[0].next_window_start).toISOString();
+  if (params.expectedWindowStart && currentWindowStart !== params.expectedWindowStart) {
+    logger.info(
+      { automationId: params.automationId },
+      '[queue] Skipping stale automation window after its arrival mark advanced'
+    );
+    return { runId: 0, status: 'superseded', created: false };
+  }
   const snapshotVersionId =
     versionRows.length > 0 && versionRows[0].current_version_id != null
       ? Number(versionRows[0].current_version_id)
@@ -754,6 +775,8 @@ interface CreateAutomationRunParams {
   deviceWorkerId?: string | null;
   agentKind?: string | null;
   sourceFingerprint?: string;
+  /** Scheduler-only fence against materializing an arrival window whose mark already advanced. */
+  expectedWindowStart?: string;
 }
 
 async function createAutomationRunInternal(

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -584,7 +584,7 @@ export default async (_ctx, client) => {
 	},
 	"automations.create": {
 		summary:
-			"Create an Automation. Successful creates return the canonical `{ action: 'create', automation_id, version, status }` receipt; policy-gated creates return a pending approval receipt with `run_id`. Requires slug and managed_agent_id; window/manual Automations also need prompt, skills, or a reaction script. Use device_worker_id to pin execution to a registered device and agent_kind to select its interchangeable local CLI. Declare named outputs as `{ entity, key, name? }` or `{ event }`, or omit outputs for a run-result/reaction-only Automation. Event output rows are standard drafts with required content and optional title, metadata, author, source_url, occurred_at, parent_event_id, payload_type, and idempotency_key. Outputs require window execution. Each sources[] entry requires `name` and a read-only SELECT/WITH `query` projecting an `id` column; optional `context: true` marks the source as context-only. entity_id is optional for an org-scoped Automation.",
+			"Create an Automation. Successful creates return the canonical `{ action: 'create', automation_id, version, status }` receipt; policy-gated creates return a pending approval receipt with `run_id`. Requires slug and managed_agent_id; window/manual Automations also need prompt, skills, or a reaction script. Use device_worker_id to pin execution to a registered device and agent_kind to select its interchangeable local CLI. Declare named outputs as `{ entity, key, name? }` or `{ event }`, or omit outputs for a run-result/reaction-only Automation. Event output rows are standard drafts with required content and optional title, metadata, author, source_url, occurred_at, parent_event_id, payload_type, and idempotency_key. Outputs require window execution. Each sources[] entry requires `name` and `query`: an @feed reference for a configured feed, or read-only SELECT/WITH SQL. Event SQL projects an `id` column; `context: true` permits aggregate context without event IDs. Window-capable live feeds use their existing reader and report per-source pagination. entity_id is optional for an org-scoped Automation.",
 		access: "admin",
 		throws: ["EntityNotFound"],
 		signature:
@@ -666,10 +666,10 @@ export default async (_ctx, client) => {
 	},
 	"automations.claimNextWindow": {
 		summary:
-			"Atomically claim the Automation unclaimed arrival window and return bounded source context plus a fenced window_token. The window is [arrival mark, now - settle) over events.created_at, not a calendar period. The caller MUST finish the claim with completeWindow, even for an empty or non-actionable window. Pass run_id and context.page.next_cursor to continue a multi-page claim.",
+			"Atomically claim the Automation unclaimed arrival window and return bounded source context plus a fenced window_token. The window is [arrival mark, now - settle) over events.created_at, not a calendar period. The caller MUST finish the claim with completeWindow, even for an empty or non-actionable window. Continue event pages with run_id and context.page.next_cursor. Continue each live source with run_id, source_name and sources_page[name].next_cursor as source_cursor. Keep every window_token for completeWindow; code may aggregate rows before returning results to the model. Each live source reports its own window_axis.",
 		access: "write",
 		signature:
-			"automations.claimNextWindow(input: { automation_id: string; lease_seconds?: number; limit?: number; run_id?: number; before_occurred_at?: string; before_id?: number }): Promise<AutomationClaimNextWindowResult>",
+			"automations.claimNextWindow(input: { automation_id: string; lease_seconds?: number; limit?: number; run_id?: number; before_occurred_at?: string; before_id?: number; source_name?: string; source_cursor?: string }): Promise<AutomationClaimNextWindowResult>",
 		example:
 			"const claim = await client.automations.claimNextWindow({ automation_id: '42' });",
 	},

--- a/packages/server/src/sandbox/namespaces/automations.ts
+++ b/packages/server/src/sandbox/namespaces/automations.ts
@@ -114,7 +114,9 @@ export type AutomationClaimNextWindowInput = Input<
 	| "limit"
 	| "run_id"
 	| "before_occurred_at"
-	| "before_id",
+	| "before_id"
+	| "source_name"
+	| "source_cursor",
 	"automation_id"
 >;
 

--- a/packages/server/src/tools/admin/manage_automations/claim-next-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/claim-next-window.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../runs/queue-service';
 import { classifyRunOutcome, SUPERSEDED_BY_ARRIVAL_MARK } from '../../../runs/run-outcome';
 import { ToolUserError } from '../../../utils/errors';
+import { verifyWindowToken } from '../../../utils/jwt';
 import {
   automationArrivalSettleMs,
   computePendingWindow,
@@ -105,6 +106,10 @@ export async function handleClaimNextWindow(
       400
     );
   }
+  if (Boolean(args.source_name) !== Boolean(args.source_cursor) ||
+      (args.source_cursor && (args.run_id == null || args.before_occurred_at != null || args.before_id != null))) {
+    throw new ToolUserError('Source continuations require source_name, source_cursor and run_id; do not mix event cursors.', 400);
+  }
   const hasBeforeOccurredAt = args.before_occurred_at != null;
   const hasBeforeId = args.before_id != null;
   if (hasBeforeOccurredAt !== hasBeforeId) {
@@ -118,6 +123,14 @@ export async function handleClaimNextWindow(
       'Automation source-page cursors require run_id from the active window claim.',
       400
     );
+  }
+
+  if (args.source_cursor) {
+    const cursor = await verifyWindowToken(args.source_cursor, env);
+    if (cursor.automation_id !== automationId || cursor.run_id !== args.run_id ||
+        !cursor.source_pages?.some((page) => page.name === args.source_name && page.next_cursor)) {
+      throw new ToolUserError('Source cursor does not continue this Automation run/source.', 409);
+    }
   }
 
   const sql = getDb();
@@ -293,6 +306,8 @@ export async function handleClaimNextWindow(
         limit: args.limit,
         before_occurred_at: args.before_occurred_at,
         before_id: args.before_id,
+        source_name: args.source_name,
+        source_cursor: args.source_cursor,
       },
       env,
       sql,

--- a/packages/server/src/tools/admin/manage_automations/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_automations/complete-window.ts
@@ -7,6 +7,8 @@
  */
 
 import Ajv from 'ajv';
+import { assertCompleteSourceWindowPages } from '../../../automations/source-window-pages';
+import { normalizeAutomationSources } from '../../../automations/source-refs';
 import addFormats from 'ajv-formats';
 import {
   enqueueWorkspaceEventActivations,
@@ -267,13 +269,7 @@ export async function handleCompleteWindow(
       throw new ToolUserError('All window_tokens must belong to the same Automation run/window.', 400);
     }
   }
-  const terminalPageToken = assertCompleteWindowPageChain(tokenPayloads);
-  const leaseFenceToken =
-    terminalPageToken?.run_id != null
-      ? terminalPageToken
-      : tokenRunId !== null
-        ? firstToken
-        : undefined;
+  assertCompleteWindowPageChain(tokenPayloads);
 
   const pgSql = createDbClientFromEnv(env);
   await requireAutomationAccess(pgSql, [String(automationId)], ctx, 'write');
@@ -304,7 +300,7 @@ export async function handleCompleteWindow(
   let runTriggerSignals: unknown[] = [];
   const runRows = await sql`
     SELECT (r.approved_input->>'version_id')::bigint AS version_id,
-           r.approved_input
+           r.status, r.approved_input
     FROM runs r
     JOIN automations a
       ON a.id = r.automation_id
@@ -338,6 +334,9 @@ export async function handleCompleteWindow(
       : '';
   const manualOpenRun = !assignedAgentId && !assignedDeviceWorkerId;
 
+  if (snapshotVersionId != null && runRows[0].version_id != null && snapshotVersionId !== Number(runRows[0].version_id)) {
+    throw new ToolUserError('Completion must use the version pinned to the Automation run.', 409);
+  }
   if (snapshotVersionId == null && runRows[0].version_id != null) {
     snapshotVersionId = Number(runRows[0].version_id);
   }
@@ -359,7 +358,9 @@ export async function handleCompleteWindow(
       i.organization_id,
       i.created_by,
       wv.id as version_id,
-      wv.outputs
+      wv.outputs,
+      i.sources,
+      wv.version_sources
     FROM automations i
     LEFT JOIN automation_versions wv
       ON wv.id = COALESCE(${snapshotVersionId}::bigint, i.current_version_id)
@@ -375,6 +376,23 @@ export async function handleCompleteWindow(
       404
     );
   }
+
+  // New completions must cover the pinned version's live sources, even if a
+  // caller submits a legacy token without a roster. A completed run already
+  // holds its durable coverage; replay must not depend on a feed still existing.
+  const versionSources = parseJson(automationRows[0].version_sources) || [];
+  const sources = versionSources.length > 0 ? versionSources : parseJson(automationRows[0].sources) || [];
+  const requiredSources = runRows[0].status === 'completed'
+    ? firstToken.required_sources ?? []
+    : (await normalizeAutomationSources(sql, String(automationRows[0].organization_id), sources))
+      .filter((source) => source.kind === 'feed')
+      .map((source) => ({ name: source.name, feed_id: source.feedId! }));
+  if (requiredSources.length && tokenRunId !== runId) {
+    throw new ToolUserError('Live source completion requires run-bound window tokens.', 409);
+  }
+  const sourceCoverage = assertCompleteSourceWindowPages(tokenPayloads, requiredSources);
+  delete provenanceMetadata.source_coverage;
+  if (sourceCoverage.length) provenanceMetadata.source_coverage = sourceCoverage;
 
   // Fetch classifiers separately
   const classifierRows = await sql`
@@ -687,7 +705,7 @@ export async function handleCompleteWindow(
     }
     if (lockedRun.expires_at != null) {
       const leaseExpiresAt = new Date(lockedRun.expires_at).toISOString();
-      if (!leaseFenceToken?.lease_expires_at || leaseFenceToken.lease_expires_at !== leaseExpiresAt) {
+      if (!tokenPayloads.some((token) => token.run_id === runId && token.lease_expires_at === leaseExpiresAt)) {
         throw new ToolUserError('window_token does not own the current Automation lease.', 409);
       }
       if (new Date(lockedRun.expires_at).getTime() <= Date.now()) {

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -13,7 +13,6 @@
  * - trigger_feed: Trigger an immediate sync for a feed
  */
 
-import { createHash } from 'node:crypto';
 import {
   getErrorMessage,
   isRetryable,
@@ -38,6 +37,7 @@ import {
   feedLinkedToBusinessEntitySql,
 } from '../../authz/channel-about';
 import { compileConnectionRowVisibility } from '../../authz/connection-visibility';
+import { readSourceFeedPage, SourceCursorError } from '../../lib/source-feed-page';
 import { authzScopeFromToolContext } from '../../authz/scope';
 import { reconcileAtlassianMcpJiraSite } from '../../connect/atlassian-mcp-site';
 import { deriveFeedHealthSemantics, feedWebhookDrivenSql } from '../../connectors/feed-health-semantics';
@@ -45,7 +45,6 @@ import { getDb, pgBigintArray } from '../../db/client';
 import type { Env } from '../../index';
 import {
   classifyPushdownFailure,
-  readSourceFeed,
 } from '../../lib/connector-pushdown';
 import {
   ATLASSIAN_JIRA_ISSUES_FEED_KEY,
@@ -602,179 +601,9 @@ async function handleReadFeed(
   return { action: 'read_feed', feed, recent_runs: runs };
 }
 
-interface SourceCursor {
-  v: 1;
-  feed_id: number;
-  position: number;
-  source_cursor?: string;
-  request_hash: string;
-}
-
-function sourceRequestHash(
-  query: string | undefined,
-  sort: { column: string; order: 'asc' | 'desc' } | undefined,
-): string {
-  return createHash('sha256')
-    .update(JSON.stringify({ query: query?.trim() ?? '', sort: sort ?? null }))
-    .digest('base64url')
-    .slice(0, 16);
-}
-
-/**
- * A caller-supplied cursor that does not decode, or does not belong to this
- * (feed, query, sort) request. Marked structurally rather than by message text so the
- * classifier never confuses it with a connector error that merely mentions a
- * cursor.
- */
-class SourceCursorError extends Error {}
-
-function decodeSourceCursor(
-  cursor: string | undefined,
-  feedId: number,
-  query: string | undefined,
-  sort: { column: string; order: 'asc' | 'desc' } | undefined,
-): { position: number; sourceCursor?: string } {
-  if (!cursor) return { position: 0 };
-  let parsed: SourceCursor;
-  try {
-    parsed = JSON.parse(
-      Buffer.from(cursor, 'base64url').toString('utf8'),
-    ) as SourceCursor;
-  } catch {
-    throw new SourceCursorError('Invalid source cursor');
-  }
-  if (
-    parsed.v !== 1 ||
-    parsed.feed_id !== feedId ||
-    !Number.isSafeInteger(parsed.position) ||
-    parsed.position < 0 ||
-    (parsed.source_cursor !== undefined &&
-      (typeof parsed.source_cursor !== 'string' ||
-        parsed.source_cursor.length === 0)) ||
-    parsed.request_hash !== sourceRequestHash(query, sort)
-  ) {
-    throw new SourceCursorError(
-      'Source cursor does not match this feed read request',
-    );
-  }
-  return {
-    position: parsed.position,
-    ...(parsed.source_cursor ? { sourceCursor: parsed.source_cursor } : {}),
-  };
-}
-
-function encodeSourceCursor(
-  feedId: number,
-  position: number,
-  query: string | undefined,
-  sort: { column: string; order: 'asc' | 'desc' } | undefined,
-  sourceCursor?: string,
-): string {
-  const payload: SourceCursor = {
-    v: 1,
-    feed_id: feedId,
-    position,
-    request_hash: sourceRequestHash(query, sort),
-    ...(sourceCursor ? { source_cursor: sourceCursor } : {}),
-  };
-  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
-}
-
-function sourceReadError(message: string): Error & { exitReason: 'timeout' } {
-  return Object.assign(new Error(message), { exitReason: 'timeout' as const });
-}
-
-/**
- * Faults this handler owns are recognised structurally; everything else is a
- * connector/source failure, including typed resolution failures owned by
- * readSourceFeed, goes to the shared pushdown classifier.
- */
 function sourceErrorCode(err: unknown): ToolErrorCode {
   if (err instanceof SourceCursorError) return 'VALIDATION';
   return classifyPushdownFailure(err);
-}
-
-async function readSourceWithinDeadline(
-  read: Static<typeof ReadFeedsAction>['reads'][number],
-  timeoutMs: number,
-  ctx: ToolContext,
-) {
-  const controller = new AbortController();
-  const deadlineAt = Date.now() + timeoutMs;
-  const onCallerAbort = () => controller.abort(ctx.abortSignal?.reason);
-  ctx.abortSignal?.addEventListener('abort', onCallerAbort, { once: true });
-  if (ctx.abortSignal?.aborted) onCallerAbort();
-  const page = decodeSourceCursor(
-    read.cursor,
-    read.feed_id,
-    read.query,
-    read.sort,
-  );
-  const offset = page.sourceCursor ? 0 : page.position;
-  const limit = Math.max(1, Math.min(500, Math.trunc(read.limit ?? 50)));
-  const pending = readSourceFeed({
-    scope: authzScopeFromToolContext(ctx),
-    feedId: read.feed_id,
-    query: read.query,
-    cursor: page.sourceCursor,
-    limit,
-    offset,
-    sort: read.sort,
-    signal: controller.signal,
-    deadlineAt,
-  });
-  pending.catch(() => {});
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const deadline = new Promise<never>((_resolve, reject) => {
-    timer = setTimeout(() => {
-      controller.abort();
-      reject(
-        sourceReadError(
-          `source read ${read.feed_id} timed out after ${timeoutMs}ms`,
-        ),
-      );
-    }, timeoutMs);
-  });
-  try {
-    const result = await Promise.race([pending, deadline]);
-    const nextPosition = page.position + result.rows.length;
-    // Once a source has selected token pagination, absence of a replacement
-    // token means exhaustion. Never downgrade that traversal to an offset
-    // cursor: token-only providers reject offsets and cannot resume that page.
-    let hasMore: boolean;
-    if (result.nextCursor !== undefined) {
-      hasMore = true;
-    } else if (page.sourceCursor !== undefined) {
-      hasMore = false;
-    } else if (result.hasMore !== undefined) {
-      hasMore = result.hasMore;
-    } else if (result.total !== undefined) {
-      hasMore = nextPosition < result.total;
-    } else {
-      hasMore = result.rows.length >= limit;
-    }
-    return {
-      feed_id: read.feed_id,
-      ok: true as const,
-      rows: result.rows,
-      columns: result.columns,
-      ...(result.total === undefined ? {} : { total: result.total }),
-      ...(hasMore
-        ? {
-            next_cursor: encodeSourceCursor(
-              read.feed_id,
-              nextPosition,
-              read.query,
-              read.sort,
-              result.nextCursor,
-            ),
-          }
-        : {}),
-    };
-  } finally {
-    if (timer) clearTimeout(timer);
-    ctx.abortSignal?.removeEventListener('abort', onCallerAbort);
-  }
 }
 
 async function handleReadFeeds(
@@ -791,7 +620,9 @@ async function handleReadFeeds(
   const results = await Promise.all(
     args.reads.slice(0, 10).map(async (read) => {
       try {
-        return await readSourceWithinDeadline(read, timeoutMs, ctx);
+        const { window: _window, sourceRevision: _revision, ...result } =
+          await readSourceFeedPage(read, timeoutMs, authzScopeFromToolContext(ctx), ctx.abortSignal);
+        return result;
       } catch (err) {
         const error_code = sourceErrorCode(err);
         return {

--- a/packages/server/src/tools/get_content/automation-mode.ts
+++ b/packages/server/src/tools/get_content/automation-mode.ts
@@ -7,6 +7,8 @@
  */
 
 import { createHash } from 'node:crypto';
+import { readSourceFeedPage } from '../../lib/source-feed-page';
+import { generateWindowToken, verifyWindowToken, type SourceWindowPage } from '../../utils/jwt';
 import type { ContentItem } from '@lobu/connector-sdk';
 import {
   automationTriggerSignals,
@@ -52,6 +54,8 @@ import { stableJson } from '../../utils/insert-event';
 
 interface ContentQueryParams {
   sources: AutomationSource[];
+  /** Already-resolved source set when the caller must make one atomic routing decision. */
+  normalizedSources?: NormalizedAutomationSource[];
   window_start: string;
   window_end: string;
   organizationId: string;
@@ -73,6 +77,7 @@ interface ContentQueryParams {
   throwOnSourceError?: boolean;
   /** Preserve the pre-bounds source row shape used by skip_if_unchanged. */
   fingerprintMode?: boolean;
+  sourcePage?: SourceWindowPage;
   /** Exclude workspace-identity audit rows for ordinary-member reads. */
   excludeWorkspaceAudit?: boolean;
   page?: {
@@ -155,7 +160,9 @@ async function queryContentData(
   eventSourceNames: ReadonlySet<string>;
   allContent: unknown[];
   page?: { has_more: boolean; next_cursor?: { occurred_at: string; id: number } };
-  sourcesPage: Record<string, { returned: number; limit: number; has_more: boolean }>;
+  sourcesPage: Record<string, { returned: number; limit: number; has_more: boolean; next_cursor?: string; window_axis?: string; feed_id?: number }>;
+  sourcePages: SourceWindowPage[];
+  requiredSources: Array<{ name: string; feed_id: number }>;
   totalCount: number;
   totalCountChars: number;
   exceedsRowLimit: boolean;
@@ -170,7 +177,7 @@ async function queryContentData(
     windowEnd: params.window_end,
     excludeProducedByAutomationId: params.automationId,
   };
-  const normalizedSources = await normalizeAutomationSources(
+  const normalizedSources = params.normalizedSources ?? await normalizeAutomationSources(
     sql,
     params.organizationId,
     params.sources
@@ -193,10 +200,16 @@ async function queryContentData(
       .map((source) => source.name)
   );
   const sqlSources = normalizedSources
-    .filter((source) => source.kind !== 'metric')
+    .filter((source) => source.kind !== 'metric' && source.kind !== 'feed' && !params.sourcePage)
     .map(({ name, query }) => ({ name, query }));
   const pagedSourceNames = new Set(sqlSources.map((source) => source.name));
-  const metricSources = normalizedSources.filter(isMetricSource);
+  const metricSources = params.sourcePage ? [] : normalizedSources.filter(isMetricSource);
+  const feedSources = normalizedSources.filter((source) => source.kind === 'feed');
+  const requiredSources = feedSources.map((source) => ({ name: source.name, feed_id: source.feedId! }));
+  const sourcePages: SourceWindowPage[] = [];
+  if (params.sourcePage && !requiredSources.some((source) => source.name === params.sourcePage!.name && source.feed_id === params.sourcePage!.feed_id)) {
+    throw new ToolUserError('Source continuation no longer matches this Automation source.', 409);
+  }
 
   const results = await executeDataSources(sqlSources, queryContext, sql, {
     throwOnError: params.throwOnSourceError,
@@ -345,7 +358,7 @@ async function queryContentData(
   // read that column directly instead of serializing every row (a 5MB
   // payload_text included) through to_jsonb. Custom SQL keeps the to_jsonb
   // shape, which safely counts 0 when the source projects no payload_text.
-  const statsEventSources = normalizedSources.filter((source) => source.kind === 'event');
+  const statsEventSources = normalizedSources.filter((source) => source.kind === 'event' && !params.sourcePage);
   let totalCount = 0;
   let totalCountChars = 0;
   if (statsEventSources.length > 0) {
@@ -382,7 +395,35 @@ async function queryContentData(
   // to detect overflow. Context sources have no event cursor, but sources_page
   // still reports that they were capped instead of silently injecting the full
   // result set into the model turn.
-  const sourcesPage: Record<string, { returned: number; limit: number; has_more: boolean }> = {};
+  const sourcesPage: Record<string, { returned: number; limit: number; has_more: boolean; next_cursor?: string; window_axis?: string; feed_id?: number }> = {};
+  if (!params.fingerprintMode && !page?.beforeOccurredAt) {
+    const livePages = await Promise.all(feedSources
+      .filter((source) => !params.sourcePage || params.sourcePage.name === source.name)
+      .map(async (source) => ({
+        source,
+        result: await readSourceFeedPage({
+          feed_id: source.feedId!,
+          limit: Math.min(page?.limit ?? 100, 500),
+          window: { start: params.window_start, end: params.window_end },
+          cursor: params.sourcePage?.next_cursor,
+          sourceRevision: params.sourcePage?.revision,
+        }, 30_000, { organizationId: params.organizationId, principal: params.userId }),
+      })));
+    for (const { source, result } of livePages) {
+      results[source.name] = result.rows;
+      const receipt: SourceWindowPage = {
+        name: source.name, feed_id: source.feedId!, revision: result.sourceRevision!,
+        axis: result.window!.axis, returned: result.rows.length,
+        ...(params.sourcePage?.next_cursor ? { before_cursor: params.sourcePage.next_cursor } : {}),
+        ...(result.next_cursor ? { next_cursor: result.next_cursor } : {}),
+      };
+      sourcePages.push(receipt);
+      sourcesPage[source.name] = {
+        returned: result.rows.length, limit: Math.min(page?.limit ?? 100, 500),
+        has_more: Boolean(result.next_cursor), window_axis: receipt.axis, feed_id: receipt.feed_id,
+      };
+    }
+  }
   if (page) {
     for (const sourceName of pagedSourceNames) {
       if (sourceName === page.sourceName && eventSourceNames.has(sourceName)) continue;
@@ -404,7 +445,7 @@ async function queryContentData(
     // Automations deliberately name their primary event source something other
     // than "content"; those sources are still bounded above and report
     // sources_page.has_more, but no fake cursor row is synthesized.
-    if (eventSourceNames.has(page.sourceName)) {
+    if (!params.sourcePage && eventSourceNames.has(page.sourceName)) {
       const rows = results[page.sourceName] ?? [];
       const trimmed = rows.slice(0, page.limit);
       const hasMore = rows.length > page.limit;
@@ -437,6 +478,8 @@ async function queryContentData(
     sourcesContent: results as Record<string, unknown[]>,
     eventSourceNames,
     sourcesPage,
+    sourcePages,
+    requiredSources,
     allContent,
     page: pageResult,
     totalCount,
@@ -470,8 +513,12 @@ export async function fingerprintAutomationSources(args: {
   const sources = (
     versionSources.length > 0 ? versionSources : parseJson(row.sources) || []
   ) as AutomationSource[];
+  const normalized = await normalizeAutomationSources(args.sql, String(row.organization_id), sources);
+  // An unqueried or partial live source never proves an unchanged window.
+  if (normalized.some((source) => source.kind === 'feed')) return { fingerprint: undefined, empty: false };
   const result = await queryContentData(args.sql, {
     sources,
+    normalizedSources: normalized,
     window_start: args.windowStart,
     window_end: args.windowEnd,
     organizationId: String(row.organization_id),
@@ -606,7 +653,6 @@ export async function handleAutomationMode(
     throwOnSourceError?: boolean;
   }
 ): Promise<GetContentResult> {
-  const { generateWindowToken } = await import('../../utils/jwt');
 
   const automationId = args.automation_id!;
   if (
@@ -839,9 +885,25 @@ export async function handleAutomationMode(
   // reads keep the verified caller's own connection visibility.
   const visibilityUserId = context.userId ?? (automation.created_by as string);
 
+  let sourceContinuation: SourceWindowPage | undefined;
+  if (args.source_cursor || args.source_name) {
+    if (!args.source_cursor || !args.source_name || args.before_occurred_at || args.before_id) {
+      throw new ToolUserError('Pair source_name with source_cursor; do not mix source and event cursors.', 400);
+    }
+    const cursor = await verifyWindowToken(args.source_cursor, env);
+    const expectedRunId = context.claimedWindow?.runId ?? (boundRun ? Number(args.run_id) : undefined);
+    if (!expectedRunId || cursor.run_id !== expectedRunId || cursor.automation_id !== automationId ||
+        cursor.window_start !== windowStartIso || cursor.window_end !== windowEndIso) {
+      throw new ToolUserError('Source cursor does not belong to this Automation run/window.', 409);
+    }
+    sourceContinuation = cursor.source_pages?.find((page) => page.name === args.source_name);
+    if (!sourceContinuation?.next_cursor) throw new ToolUserError('Source cursor has no next page for this source.', 409);
+  }
+
   // Run content query and total stats in parallel
   const contentData = await queryContentData(sql, {
     sources,
+    sourcePage: sourceContinuation,
     window_start: windowStartIso,
     window_end: windowEndIso,
     organizationId: automation.organization_id as string,
@@ -914,17 +976,25 @@ export async function handleAutomationMode(
             page_next_id: contentPage.next_cursor.id,
           }
         : {}),
-      page_has_more: contentPage?.has_more ?? false,
+      ...(!sourceContinuation ? { page_has_more: contentPage?.has_more ?? false } : {}),
+      required_sources: contentData.requiredSources,
+      source_pages: contentData.sourcePages,
       truncated_source_names: Object.entries(sourcesPage)
         .filter(
           ([sourceName, page]) =>
-            page.has_more && (sourceName !== 'content' || !contentPage)
+            page.has_more && !contentData.requiredSources.some((source) => source.name === sourceName) && (sourceName !== 'content' || !contentPage)
         )
         .map(([sourceName]) => sourceName),
     },
     env
   );
   let windowToken = await signWindow();
+  const setSourceCursors = () => {
+    for (const receipt of contentData.sourcePages) {
+      if (receipt.next_cursor) sourcesPage[receipt.name].next_cursor = windowToken;
+    }
+  };
+  setSourceCursors();
 
   // Bound entities ride the payload as structured rows (id, name, type,
   // metadata, field_controls) — field_controls marks human-owned field values
@@ -1060,7 +1130,7 @@ export async function handleAutomationMode(
   // Reserve the entire fixed envelope before admitting primary event rows.
   // Context sources have no cursor: never trim them to make a response fit.
   // Include their normalized event representations as well as their raw rows.
-  const primaryRows = sourcesContent.content ?? [];
+  const primaryRows = eventSourceNames.has('content') ? sourcesContent.content ?? [] : [];
   const auxiliarySources = { ...sourcesContent, content: [] };
   const auxiliaryContent = normalizeEventSources(auxiliarySources, eventSourceNames);
   const fixedEnvelope = { ...initial, sources: auxiliarySources, content: auxiliaryContent };
@@ -1118,6 +1188,7 @@ export async function handleAutomationMode(
   };
   // Sign precisely the retained IDs and cursor, never the byte-omitted suffix.
   windowToken = await signWindow();
+  setSourceCursors();
   const bounded = response();
   if (serializedBytes(bounded) > AUTOMATION_READ_MAX_BYTES) throw cannotFit();
   return bounded;

--- a/packages/server/src/tools/get_content/types.ts
+++ b/packages/server/src/tools/get_content/types.ts
@@ -115,7 +115,7 @@ export const GetContentResultSchema = Type.Object({
    * Per-source page state, keyed by source name. Every SQL-backed source is
    * capped at the request's `limit`; this is how a caller distinguishes a
    * fully-read source from a truncated one. Only the primary event source
-   * carries a cursor (see `page.next_cursor`); the rest report `has_more` alone.
+   * carries an event cursor (see `page.next_cursor`); live sources carry their own next_cursor.
    */
   sources_page: Type.Optional(
     Type.Record(
@@ -124,6 +124,9 @@ export const GetContentResultSchema = Type.Object({
         returned: Type.Integer(),
         limit: Type.Integer(),
         has_more: Type.Boolean(),
+        next_cursor: Type.Optional(Type.String()),
+        window_axis: Type.Optional(Type.String()),
+        feed_id: Type.Optional(Type.Integer()),
       })
     )
   ),

--- a/packages/server/src/utils/jwt.ts
+++ b/packages/server/src/utils/jwt.ts
@@ -22,6 +22,16 @@ export function deriveJwtSecret(encryptionKey: string): string {
     .digest('base64');
 }
 
+export interface SourceWindowPage {
+  name: string;
+  feed_id: number;
+  revision: string;
+  axis: string;
+  before_cursor?: string;
+  next_cursor?: string;
+  returned: number;
+}
+
 interface WindowTokenPayload {
   automation_id: number;
   /** Durable Automation run this read was bound to. Omitted on legacy/preview reads. */
@@ -38,6 +48,8 @@ interface WindowTokenPayload {
   page_next_id?: number;
   page_has_more?: boolean;
   truncated_source_names?: string[];
+  required_sources?: Array<{ name: string; feed_id: number }>;
+  source_pages?: SourceWindowPage[];
   iat: number; // issued at - returned to caller for staleness detection
   exp: number; // expiration
 }
@@ -48,16 +60,6 @@ interface WindowTokenPayload {
 function base64urlEncode(str: string): string {
   const base64 = btoa(str);
   return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
-/**
- * Base64url decode a string
- */
-function base64urlDecode(str: string): string {
-  const base64 = str.replace(/-/g, '+').replace(/_/g, '/');
-  const padding = str.length % 4;
-  const padded = padding ? base64 + '='.repeat(4 - padding) : base64;
-  return atob(padded);
 }
 
 /**
@@ -125,8 +127,8 @@ export async function generateWindowToken(
   };
 
   const header = { alg: 'HS256', typ: 'JWT' };
-  const headerEncoded = base64urlEncode(JSON.stringify(header));
-  const payloadEncoded = base64urlEncode(JSON.stringify(fullPayload));
+  const headerEncoded = Buffer.from(JSON.stringify(header), 'utf8').toString('base64url');
+  const payloadEncoded = Buffer.from(JSON.stringify(fullPayload), 'utf8').toString('base64url');
   const dataToSign = `${headerEncoded}.${payloadEncoded}`;
   const signature = await createSignature(dataToSign, secret);
 
@@ -164,7 +166,7 @@ export async function verifyWindowToken(
   // Decode payload
   let payload: WindowTokenPayload;
   try {
-    payload = JSON.parse(base64urlDecode(payloadEncoded));
+    payload = JSON.parse(Buffer.from(payloadEncoded, 'base64url').toString('utf8'));
   } catch {
     throw new Error('Invalid token payload');
   }


### PR DESCRIPTION
## Summary

- Allow Automation `@feed` sources to read providers directly inside the existing claimed window. Reuse the direct-feed pager, run lease, signed window tokens, and atomic completion; do not mirror provider rows into events.
- Require an exhausted, consistent cursor chain for every live source before advancing the checkpoint. SQL context frames remain supported without event IDs. Live sources cannot be classified as unchanged without reading them.
- Declare fixed source-time windows for Gmail, Drive, Linear, and Jira (including the Atlassian MCP adapter), preserve source scope, and fail incomplete provider responses. Scheduled fingerprints and queued runs now share exactly the same bounds and reject stale checkpoint observations.

## Test plan

- [x] Intended 44 files staged explicitly; `make pre-pr` (build, strict package typecheck, knip, lint, naming).
- [x] 53 focused integration tests: external claims, run-bound reads, mixed/interleaved sources, missing pages, source failures, source changes, owner access revocation, replay, scheduler bounds, and direct feed reads. The latest affected subset passed 50/50; the unchanged external-claim suite passed 3/3.
- [x] 233 focused unit/connector tests passed across separate harness invocations. Dispatch tests run separately from connector SDK mocks.
- [x] Real compiled synthetic connector exercised through the server read/claim/complete path with isolated embedded Postgres; no provider rows inserted into events.

Red → green evidence:

```text
Before: source-only @feed rejected instead of participating in durable reads.
Before: scheduled fingerprint end and booked run end differed (.628 vs .683).
Before: configured Gmail scope/human filtering and malformed provider exhaustion: 5 pass, 8 fail.
Before: malformed MCP source result handling: 4 pass, 2 fail.
Before: legacy unbound receipt could omit a queued run's required live sources: 21 pass, 1 fail.
After: final affected integration run: 50 passed, 0 failed (5 files).
After: external-claim integration: 3 passed, 0 failed.
After: focused connector/SDK/proof units: 229 passed; separate dispatch suite: 4 passed.
```

## Notes

The generated TypeScript client was refreshed from a booted isolated server; its 22 added lines match the new source cursor fields and page metadata.

Source-time windows use each provider's declared received/modified/updated timestamp. This is not a provider change log and does not promise detection of deletions or late imports outside that axis. Existing sync-only sources retain arrival-time SQL semantics. Provider version/configuration changes invalidate a continuation.

Independent exact-head Codex review passed with zero bugs or blockers; required CI and UI gates passed. Deployment and a real scheduled Task Builder run will be verified after merge.
