### PR TITLE
feat: cache-bust brand assets with content-hash query tokens

### DIFF
--- a/packages/server/src/__tests__/integration/pages/public-pages-contract.test.ts
+++ b/packages/server/src/__tests__/integration/pages/public-pages-contract.test.ts
@@ -188,6 +188,12 @@ describe.skipIf(!WEB_AVAILABLE)('public page contract', () => {
     expect(response.headers.get('cache-control')).toContain('public, max-age=300');
     expect(body).toContain('Public Contract Org | Lobu');
     expect(body).toContain('window.__LOBU_PUBLIC_BOOTSTRAP__');
+    expect(body).toContain(
+      '<meta property="og:image" content="http://localhost/lobu-og.png?v=c4cf0dfc" />'
+    );
+    expect(body).toContain(
+      '<meta name="twitter:image" content="http://localhost/lobu-og.png?v=c4cf0dfc" />'
+    );
     expect(body).toContain('Tracked public brands');
     expect(body).toContain('Brand launch feedback');
   });

--- a/packages/server/src/public-pages.ts
+++ b/packages/server/src/public-pages.ts
@@ -931,7 +931,7 @@ function stripOverriddenHead(templateHtml: string): string {
 }
 
 function injectIntoTemplate(templateHtml: string, model: PublicPageModel): string {
-  const ogImage = model.openGraphImage || `${new URL(model.canonicalUrl).origin}/lobu-og.png`;
+  const ogImage = model.openGraphImage || `${new URL(model.canonicalUrl).origin}/lobu-og.png?v=c4cf0dfc`;
   const headTags = [
     `<meta name="description" content="${escapeAttribute(model.description)}" />`,
     `<meta name="robots" content="${escapeAttribute(model.robots)}" />`,

--- a/scripts/__tests__/check-mac-bundle-ids.test.ts
+++ b/scripts/__tests__/check-mac-bundle-ids.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
@@ -254,4 +255,61 @@ describe("check-mac-bundle-ids", () => {
       }
     }
   });
+
+  // Brand assets are served immutable, so every referencing URL carries a
+  // content-hash token. Regenerating an asset without updating its refs
+  // leaves browsers and edge caches on the stale copy.
+  it.skipIf(owlettoSubmoduleStubbed)(
+    "cache-busts brand assets with content hashes",
+    () => {
+      const pub = join(REPO_ROOT, "packages/owletto/public");
+      const files = [
+        "favicon.ico",
+        "favicon.svg",
+        "apple-touch-icon.png",
+        "site.webmanifest",
+        "icon-192.png",
+        "icon-512.png",
+        "icon-maskable-512.png",
+        "lobu-og.png",
+      ];
+      const token: Record<string, string> = {};
+      for (const file of files) {
+        token[file] = createHash("sha256")
+          .update(readFileSync(join(pub, file)))
+          .digest("hex")
+          .slice(0, 8);
+      }
+      const index = readFileSync(
+        join(REPO_ROOT, "packages/owletto/index.html"),
+        "utf8"
+      );
+      for (const file of [
+        "favicon.ico",
+        "favicon.svg",
+        "apple-touch-icon.png",
+        "site.webmanifest",
+      ]) {
+        expect(index).toContain(`/${file}?v=${token[file]}`);
+      }
+      expect(index).toContain(
+        `https://app.lobu.ai/lobu-og.png?v=${token["lobu-og.png"]}`
+      );
+      const manifest = JSON.parse(
+        readFileSync(join(pub, "site.webmanifest"), "utf8")
+      ) as { icons: Array<{ src: string }> };
+      for (const icon of manifest.icons) {
+        const match = icon.src.match(/^\/([^?]+)\?v=([0-9a-f]{8})$/);
+        if (!match) {
+          throw new Error(`manifest icon src is not versioned: ${icon.src}`);
+        }
+        expect(match[2]).toBe(token[match[1]]);
+      }
+      const serverPages = readFileSync(
+        join(REPO_ROOT, "packages/server/src/public-pages.ts"),
+        "utf8"
+      );
+      expect(serverPages).toContain(`/lobu-og.png?v=${token["lobu-og.png"]}`);
+    }
+  );
 });


### PR DESCRIPTION
## Summary
- Bump `packages/owletto` to the cache-bust pointer (lobu-ai/owletto#1087): brand URLs carry ?v=<sha256[:8]> so immutable-served icons actually refresh in browsers and edge caches
- Server OG fallback URL versioned the same way
- Release gate extended: asserts every brand ref matches its file content hash (red on regen-without-update, green here)

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr` clean
- [x] Tests run: `bun test scripts/__tests__/check-mac-bundle-ids.test.ts` 15/15 (incl. new cache-bust test)
- [ ] Bug fix: stale favicon/OG in prod edge cache (verified live before/after on deploy)
- [ ] If bot runtime changed: n/a

## Notes
- No asset bytes touched — URL-only change. After deploy, verify the versioned URLs serve new bytes; the unversioned URLs stay stale until edge eviction (harmless — nothing references them anymore).
- Paired with lobu-ai/owletto#1087; merge the submodule first, then bump the pointer to its squash commit before landing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default Open Graph image reference to ensure browsers and social platforms retrieve the latest asset.

* **Tests**
  * Added validation to confirm brand assets, favicon references, manifest icons, and Open Graph images use matching content-based cache-busting versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->