### PR TITLE
fix(notifications): retry delivery through the durable task queue

### DIFF
--- a/packages/server/src/__tests__/integration/authz/entity-approval-hold-vs-rule.test.ts
+++ b/packages/server/src/__tests__/integration/authz/entity-approval-hold-vs-rule.test.ts
@@ -169,7 +169,7 @@ async function readMetadata(id: number): Promise<Record<string, unknown>> {
 async function runCount(organizationId: string): Promise<number> {
 	const sql = getTestDb();
 	const rows = await sql<{ n: string }[]>`
-    SELECT count(*)::text AS n FROM runs WHERE organization_id = ${organizationId}
+    SELECT count(*)::text AS n FROM runs WHERE organization_id = ${organizationId} AND run_type = 'internal'
   `;
 	return Number(rows[0].n);
 }
@@ -322,7 +322,7 @@ describe("approval hold vs a frozen-state rule", () => {
 		const sql = getTestDb();
 		const [queued] = await sql<{ action_input: unknown }[]>`
       SELECT action_input FROM runs
-      WHERE organization_id = ${org.id}
+      WHERE organization_id = ${org.id} AND run_type = 'internal'
       ORDER BY id DESC LIMIT 1
     `;
 		const input = (
@@ -375,7 +375,7 @@ describe("approval hold vs a frozen-state rule", () => {
 		const sql = getTestDb();
 		const [queued] = await sql<{ action_input: unknown }[]>`
       SELECT action_input FROM runs
-      WHERE organization_id = ${org.id}
+      WHERE organization_id = ${org.id} AND run_type = 'internal'
       ORDER BY id DESC LIMIT 1
     `;
 		const input = (
@@ -591,7 +591,7 @@ describe("approval hold vs a frozen-state rule", () => {
 		// escalates a field the grant does not cover.
 		const [queued] = await sql<{ action_input: unknown }[]>`
       SELECT action_input FROM runs
-      WHERE organization_id = ${org.id}
+      WHERE organization_id = ${org.id} AND run_type = 'internal'
       ORDER BY id DESC LIMIT 1
     `;
 		const input = (

--- a/packages/server/src/__tests__/integration/notifications/durable-delivery.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/durable-delivery.test.ts
@@ -1,0 +1,440 @@
+import { Actions, Button, Card } from "chat";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { __setChatInstanceManagerForTests } from "../../../lobu/gateway";
+import {
+  createNotificationForUsers,
+  deliverNotificationTask,
+} from "../../../notifications/service";
+import {
+  NOTIFICATION_DELIVERY_TASK,
+  NOTIFICATION_DELIVERY_TASK_QUEUE,
+} from "../../../scheduled/task-definitions";
+import { createTestAutomationSubscription } from "../../setup/automation-subscriptions";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+  addUserToOrganization,
+  createTestAgent,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  insertChatConnectionRow,
+  linkSlackIdentityInGraph,
+} from "../../setup/test-fixtures";
+
+describe("durable notification delivery", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+  afterEach(() => {
+    __setChatInstanceManagerForTests(null);
+  });
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  async function setup() {
+    const org = await createTestOrganization();
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, org.id, "owner");
+    const agent = await createTestAgent({
+      organizationId: org.id,
+      agentId: "delivery-test",
+    });
+    await insertChatConnectionRow({
+      id: "delivery-test",
+      organizationId: org.id,
+      agentId: agent.agentId,
+      platform: "slack",
+      status: "active",
+      settings: {},
+    });
+    for (const channelId of ["slack:C_FIRST", "slack:C_SECOND"]) {
+      await createTestAutomationSubscription({
+        organizationId: org.id,
+        agentId: agent.agentId,
+        connectionSlug: "agentconn-delivery-test",
+        platform: "slack",
+        channelId,
+        teamId: "T_TEST",
+        configuredBy: user.id,
+      });
+    }
+    const post = vi.fn(
+      async (_connection: string, channel: string, _content: unknown) => ({
+        messageId: `message-${channel}`,
+        threadId: channel,
+      }),
+    );
+    __setChatInstanceManagerForTests({ postMessageToChannel: post });
+    const params = {
+      organizationId: org.id,
+      type: "agent_message" as const,
+      title: "Useful task",
+      idempotencyKey: "synthetic-notification",
+    };
+    return { org, user, post, params };
+  }
+
+  it("commits one queue handoff with the inbox, including racing producer retries", async () => {
+    const h = await setup();
+    const results = await Promise.all(
+      Array.from({ length: 6 }, () =>
+        createNotificationForUsers([h.user.id], h.params),
+      ),
+    );
+    expect(new Set(results.map((r) => r.eventId)).size).toBe(1);
+    expect(h.post).not.toHaveBeenCalled();
+    const sql = getTestDb();
+    const rows = await sql`
+      SELECT queue_name, action_input
+      FROM runs
+      WHERE organization_id = ${h.org.id}
+        AND action_key = ${NOTIFICATION_DELIVERY_TASK}
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].queue_name).toBe(NOTIFICATION_DELIVERY_TASK_QUEUE);
+    expect(rows[0].action_input.payload.eventId).toBe(results[0].eventId);
+  });
+
+  it("commits successful receipts and retries only the failed destination", async () => {
+    const h = await setup();
+    const event = await createNotificationForUsers([h.user.id], h.params);
+    let fail = true;
+    h.post.mockImplementation(async (_connection, channel) => {
+      if (channel === "slack:C_SECOND" && fail) {
+        throw new Error("provider unavailable");
+      }
+      return { messageId: `message-${channel}`, threadId: channel };
+    });
+    const input = { organizationId: h.org.id, eventId: Number(event.eventId) };
+    await expect(deliverNotificationTask(input)).rejects.toThrow();
+    const sql = getTestDb();
+    const [saved] = await sql`
+      SELECT metadata FROM events WHERE id = ${input.eventId}
+    `;
+    expect(saved.metadata.delivery).toHaveLength(1);
+    fail = false;
+    await deliverNotificationTask(input);
+    await deliverNotificationTask(input);
+    expect(
+      h.post.mock.calls.filter((c) => c[1] === "slack:C_FIRST"),
+    ).toHaveLength(1);
+    expect(
+      h.post.mock.calls.filter((c) => c[1] === "slack:C_SECOND"),
+    ).toHaveLength(2);
+  });
+
+  it("serializes concurrent delivery replays", async () => {
+    const h = await setup();
+    const event = await createNotificationForUsers([h.user.id], h.params);
+    const input = { organizationId: h.org.id, eventId: Number(event.eventId) };
+    await Promise.all([
+      deliverNotificationTask(input),
+      deliverNotificationTask(input),
+    ]);
+    expect(h.post).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries when a chat manager is unavailable", async () => {
+    const h = await setup();
+    const event = await createNotificationForUsers([h.user.id], h.params);
+    __setChatInstanceManagerForTests(null);
+    await expect(
+      deliverNotificationTask({
+        organizationId: h.org.id,
+        eventId: Number(event.eventId),
+      }),
+    ).rejects.toThrow("gateway");
+  });
+
+  it("retries a resolved owner DM without widening to channels", async () => {
+    const h = await setup();
+    await linkSlackIdentityInGraph({
+      organizationId: h.org.id,
+      userId: h.user.id,
+      teamId: "T_TEST",
+      slackUserId: "U_SYNTHETIC_OWNER",
+    });
+    let fail = true;
+    const postDirectMessage = vi.fn(async () => {
+      if (fail) {
+        throw new Error("provider unavailable");
+      }
+      return { messageId: "synthetic-dm-message", threadId: "synthetic-dm" };
+    });
+    __setChatInstanceManagerForTests({
+      postMessageToChannel: h.post,
+      postDirectMessage,
+    });
+    const event = await createNotificationForUsers([h.user.id], {
+      ...h.params,
+      type: "action_approval_needed",
+      deliveryScope: "targeted",
+      ownerUserId: h.user.id,
+    });
+    const input = {
+      organizationId: h.org.id,
+      eventId: Number(event.eventId),
+    };
+
+    await expect(deliverNotificationTask(input)).rejects.toThrow(
+      "provider unavailable",
+    );
+    fail = false;
+    await deliverNotificationTask(input);
+    await deliverNotificationTask(input);
+    expect(postDirectMessage).toHaveBeenCalledTimes(2);
+    expect(h.post).not.toHaveBeenCalled();
+  });
+
+  it("rejects another tenant's event", async () => {
+    const h = await setup();
+    const event = await createNotificationForUsers([h.user.id], h.params);
+    await expect(
+      deliverNotificationTask({
+        organizationId: "other-synthetic-org",
+        eventId: Number(event.eventId),
+      }),
+    ).rejects.toThrow();
+    expect(h.post).not.toHaveBeenCalled();
+  });
+
+  it("never sends an old notification into a newly bound channel", async () => {
+    const h = await setup();
+    const event = await createNotificationForUsers([h.user.id], h.params);
+    await createTestAutomationSubscription({
+      organizationId: h.org.id,
+      agentId: "delivery-test",
+      connectionSlug: "agentconn-delivery-test",
+      platform: "slack",
+      channelId: "slack:C_NEW",
+      teamId: "T_TEST",
+      configuredBy: h.user.id,
+    });
+    await deliverNotificationTask({
+      organizationId: h.org.id,
+      eventId: Number(event.eventId),
+    });
+    expect(h.post.mock.calls.map((c) => c[1])).toEqual([
+      "slack:C_FIRST",
+      "slack:C_SECOND",
+    ]);
+  });
+
+  it("rolls the inbox back when its queue handoff cannot commit", async () => {
+    const h = await setup();
+    const sql = getTestDb();
+    await sql.unsafe(`
+      CREATE FUNCTION test_reject_notification_task()
+      RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN
+        IF NEW.action_key = 'deliver-notification' THEN
+          RAISE EXCEPTION 'synthetic queue failure';
+        END IF;
+        RETURN NEW;
+      END
+      $$
+    `);
+    await sql.unsafe(`
+      CREATE TRIGGER test_reject_notification_task
+      BEFORE INSERT ON runs
+      FOR EACH ROW EXECUTE FUNCTION test_reject_notification_task()
+    `);
+    try {
+      await expect(
+        createNotificationForUsers([h.user.id], h.params),
+      ).rejects.toThrow("synthetic queue failure");
+      const [row] = await sql`
+        SELECT count(*)::int AS n
+        FROM events
+        WHERE organization_id = ${h.org.id}
+          AND metadata->>'_lobu_idempotency_key' = ${h.params.idempotencyKey}
+      `;
+      expect(row.n).toBe(0);
+      expect(h.post).not.toHaveBeenCalled();
+    } finally {
+      await sql.unsafe("DROP TRIGGER test_reject_notification_task ON runs");
+      await sql.unsafe("DROP FUNCTION test_reject_notification_task()");
+    }
+  });
+
+  it("does not fall back when the saved destination is unbound", async () => {
+    const h = await setup();
+    const event = await createNotificationForUsers([h.user.id], {
+      ...h.params,
+      channelId: "slack:C_FIRST",
+      deliveryScope: "targeted",
+    });
+    const sql = getTestDb();
+    await sql`
+      UPDATE automations
+      SET triggers = '[]'::jsonb
+      WHERE organization_id = ${h.org.id}
+        AND triggers::text LIKE '%C_FIRST%'
+    `;
+    await expect(
+      deliverNotificationTask({
+        organizationId: h.org.id,
+        eventId: Number(event.eventId),
+      }),
+    ).rejects.toThrow("no longer authorized");
+    expect(h.post).not.toHaveBeenCalled();
+  });
+
+  it("drops controls for an approval resolved before delivery", async () => {
+    const h = await setup();
+    const sql = getTestDb();
+    const [run] = await sql`
+      INSERT INTO runs (
+        organization_id, run_type, action_key, approval_status, status
+      ) VALUES (
+        ${h.org.id}, 'internal', 'synthetic-approval', 'pending', 'pending'
+      )
+      RETURNING id
+    `;
+    const event = await createNotificationForUsers([h.user.id], {
+      ...h.params,
+      type: "action_approval_needed",
+      decisionRunId: Number(run.id),
+    });
+    await sql`
+      UPDATE runs
+      SET approval_status = 'approved', status = 'completed'
+      WHERE id = ${run.id}
+    `;
+    await deliverNotificationTask({
+      organizationId: h.org.id,
+      eventId: Number(event.eventId),
+    });
+    expect(h.post).not.toHaveBeenCalled();
+  });
+
+  it("settles a resource-linked approval resolved during its first post", async () => {
+    const h = await setup();
+    const sql = getTestDb();
+    const [run] = await sql`
+      INSERT INTO runs (
+        organization_id, run_type, action_key, approval_status, status
+      ) VALUES (
+        ${h.org.id}, 'internal', 'synthetic-racing-approval', 'pending', 'pending'
+      )
+      RETURNING id
+    `;
+    const runId = Number(run.id);
+    const proposal = await createTestEvent({
+      organization_id: h.org.id,
+      title: "Synthetic approval",
+      content: "Approve this delivery",
+      semantic_type: "operation",
+    });
+    await sql`
+      UPDATE events
+      SET run_id = ${runId},
+          interaction_type = 'approval',
+          interaction_status = 'pending'
+      WHERE id = ${proposal.id}
+    `;
+    const card = Card({
+      title: "Approve this delivery",
+      children: [
+        Actions([
+          Button({
+            id: `run-approval:${runId}:approve`,
+            label: "Approve",
+          }),
+        ]),
+      ],
+    });
+    const event = await createNotificationForUsers([h.user.id], {
+      ...h.params,
+      type: "action_approval_needed",
+      resourceType: "event",
+      resourceId: String(proposal.id),
+      card,
+    });
+    const editMessageContent = vi.fn(async () => undefined);
+    h.post.mockImplementation(async (_connection, channel) => {
+      await sql`
+        UPDATE runs
+        SET approval_status = 'approved',
+            status = 'completed',
+            completed_at = NOW()
+        WHERE id = ${runId}
+      `;
+      return { messageId: `message-${channel}`, threadId: channel };
+    });
+    __setChatInstanceManagerForTests({
+      postMessageToChannel: h.post,
+      editMessageContent,
+    });
+
+    await deliverNotificationTask({
+      organizationId: h.org.id,
+      eventId: Number(event.eventId),
+    });
+    expect(h.post).toHaveBeenCalledTimes(1);
+    expect(editMessageContent).toHaveBeenCalledTimes(1);
+    const settledCard = JSON.stringify(editMessageContent.mock.calls[0]);
+    expect(settledCard).toContain("Approved");
+    expect(settledCard).not.toContain('"type":"button"');
+  });
+
+  it("includes the review link in a plain chat notification", async () => {
+    const h = await setup();
+    const event = await createNotificationForUsers([h.user.id], {
+      ...h.params,
+      resourceUrl: "https://example.test/review",
+    });
+    await deliverNotificationTask({
+      organizationId: h.org.id,
+      eventId: Number(event.eventId),
+    });
+    expect(h.post.mock.calls[0]?.[2]).toEqual({
+      markdown: "Useful task\n\nhttps://example.test/review",
+    });
+  });
+
+  it("does not treat a post without a message id as delivered", async () => {
+    const h = await setup();
+    const event = await createNotificationForUsers([h.user.id], h.params);
+    h.post.mockResolvedValue({ messageId: "", threadId: "synthetic-thread" });
+    await expect(
+      deliverNotificationTask({
+        organizationId: h.org.id,
+        eventId: Number(event.eventId),
+      }),
+    ).rejects.toThrow("message id");
+  });
+
+  it("does not replay a successful provider post without a thread id", async () => {
+    const h = await setup();
+    const event = await createNotificationForUsers([h.user.id], h.params);
+    h.post.mockImplementation(async (_connection, channel) => ({
+      messageId: `message-${channel}`,
+      threadId: "",
+    }));
+    const input = { organizationId: h.org.id, eventId: Number(event.eventId) };
+
+    await deliverNotificationTask(input);
+    await deliverNotificationTask(input);
+    expect(h.post).toHaveBeenCalledTimes(2);
+    const [saved] = await getTestDb()`
+      SELECT metadata FROM events WHERE id = ${input.eventId}
+    `;
+    expect(saved.metadata.delivery).toHaveLength(2);
+    expect(saved.metadata.delivery).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ channelKey: "slack:C_FIRST", threadId: "" }),
+        expect.objectContaining({ channelKey: "slack:C_SECOND", threadId: "" }),
+      ]),
+    );
+  });
+});

--- a/packages/server/src/__tests__/integration/notifications/durable-delivery.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/durable-delivery.test.ts
@@ -402,6 +402,59 @@ describe("durable notification delivery", () => {
     });
   });
 
+  it.each([
+    "ready", "activated", "running", "timeout", "expired",
+    "approval-required", "lost-identity", "not-page-activated",
+    "ready-with-approval", "resolved-separate-approval",
+  ])("checks current browser handoff readiness: %s", async (state) => {
+    const h = await setup();
+    const sql = getTestDb();
+    let activatedBy: string | null = null;
+    if (state === "activated") {
+      const [device] = await sql`
+        INSERT INTO device_workers (user_id, worker_id, platform, capabilities, organization_id, last_seen_at, app_version)
+        VALUES (${h.user.id}, 'synthetic-draft-device', 'chrome-extension', '[]'::jsonb, ${h.org.id}, NOW(), '0.6.1')
+        RETURNING id
+      `;
+      activatedBy = device.id;
+    }
+    const [run] = await sql`
+      INSERT INTO runs (
+        organization_id, run_type, action_key, approval_status, status,
+        activation_kind, activation_target_urls, run_metadata, expires_at,
+        activated_at, activated_by_device_worker_id, activation_tab_id
+      ) VALUES (
+        ${h.org.id}, 'action', 'synthetic-browser-draft',
+        ${state === "approval-required" ? "pending" : "auto"},
+        ${state === "running" || state === "timeout" ? state : "pending"},
+        ${state === "not-page-activated" ? null : "page_visit"},
+        CASE WHEN ${state === "not-page-activated"} THEN NULL ELSE ARRAY['https://example.test/draft']::text[] END,
+        ${sql.json(state === "lost-identity" ? {} : { page_activation_identity: "exact" })},
+        ${new Date(Date.now() + (state === "expired" ? -60000 : 60000))},
+        ${state === "activated" ? new Date() : null},
+        ${activatedBy}::uuid, ${state === "activated" ? 42 : null}
+      ) RETURNING id
+    `;
+    let decisionRunId: number | undefined;
+    if (state === "ready-with-approval" || state === "resolved-separate-approval") {
+      const [approval] = await sql`
+        INSERT INTO runs (organization_id, run_type, action_key, approval_status, status)
+        VALUES (${h.org.id}, 'internal', 'synthetic-separate-approval',
+          ${state === "resolved-separate-approval" ? "approved" : "pending"}, 'pending')
+        RETURNING id
+      `;
+      decisionRunId = Number(approval.id);
+    }
+    const event = await createNotificationForUsers([h.user.id], {
+      ...h.params,
+      browserRunId: Number(run.id),
+      browserUrl: "https://example.test/draft",
+      decisionRunId,
+    });
+    await deliverNotificationTask({ organizationId: h.org.id, eventId: Number(event.eventId) });
+    expect(h.post).toHaveBeenCalledTimes(state.startsWith("ready") ? 2 : 0);
+  });
+
   it("does not treat a post without a message id as delivered", async () => {
     const h = await setup();
     const event = await createNotificationForUsers([h.user.id], h.params);

--- a/packages/server/src/__tests__/integration/operations-approval-event-atomicity.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-event-atomicity.test.ts
@@ -137,7 +137,7 @@ describe("approval-event atomicity (item 16)", () => {
 
 	it("happy path: run + approval event committed atomically and event is readable by run id", async () => {
 		const sql = getTestDb();
-		const before = await sql`SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId}`;
+		const before = await sql`SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR}`;
 
 		const result = (await manageOperations(
 			{ action: "execute", connection_id: connectionId, operation_key: "needs_approval", input: {} },
@@ -178,13 +178,13 @@ describe("approval-event atomicity (item 16)", () => {
 			initiator: { kind: "user", user_id: userId },
 		});
 
-		const after = await sql`SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId}`;
+		const after = await sql`SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR}`;
 		expect(after[0].n).toBe(before[0].n + 1);
 	});
 
 	it("event write failure rolls back the run — no orphaned pending run, no event", async () => {
 		const sql = getTestDb();
-		const before = await sql`SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId}`;
+		const before = await sql`SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR}`;
 		const eventsBefore = await sql`
 			SELECT count(*)::int AS n FROM events
 			WHERE organization_id = ${orgId}
@@ -202,7 +202,7 @@ describe("approval-event atomicity (item 16)", () => {
 		).rejects.toThrow(/approval-event write failure/);
 
 		// The run INSERT shared the rolled-back transaction: no new run row.
-		const after = await sql`SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId}`;
+		const after = await sql`SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR}`;
 		expect(after[0].n).toBe(before[0].n);
 
 		// And NO new approval event was written (the failed insert rolled back with

--- a/packages/server/src/__tests__/integration/operations-approval-transition-atomicity.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-transition-atomicity.test.ts
@@ -861,7 +861,7 @@ describe("approval-run transition atomicity", () => {
 	it("queueAgentAsk run + pending card commit atomically (card failure leaves no run)", async () => {
 		const sql = getTestDb();
 		const runsBefore = await sql`
-			SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId}
+			SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId} AND run_type = 'internal'
 		`;
 		const eventsBefore = await sql`
 			SELECT count(*)::int AS n FROM events
@@ -881,7 +881,7 @@ describe("approval-run transition atomicity", () => {
 		// The run INSERT shared the rolled-back transaction: no stranded pending
 		// run and no orphaned card.
 		const runsAfter = await sql`
-			SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId}
+			SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId} AND run_type = 'internal'
 		`;
 		expect(runsAfter[0].n).toBe(runsBefore[0].n);
 		const eventsAfter = await sql`

--- a/packages/server/src/__tests__/unit/approval-dm-target.test.ts
+++ b/packages/server/src/__tests__/unit/approval-dm-target.test.ts
@@ -1,8 +1,8 @@
 /**
  * Approval delivery precedence: conversation → requester DM → inbox.
  *
- * `deliverToBotConnections` tries the DM tier BEFORE the channel tier and
- * returns on success, so feeding the requester into that tier unconditionally
+ * Notification delivery selects a resolved owner DM before channel targets,
+ * so feeding the requester into that tier unconditionally
  * would send an approval asked for in a channel to the asker's DM instead —
  * inverting the order. This pins the seam where that inversion lives.
  */

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -905,8 +905,8 @@ export class ChatInstanceManager {
   /**
    * Post a message to a channel as the bot — a one-shot outbound post, NOT an
    * inbound message that triggers an agent run (that's `routePlatformMessage`).
-   * Used by the notification fan-out (`deliverToBotConnections`) to surface an
-   * automation digest / approval in a bound channel.
+   * Used by the notification delivery task (`deliverNotificationTask`) to
+   * surface an automation digest / approval in a bound channel.
    *
    * `content` is any `chat` `AdapterPostableMessage` — `{ markdown }` (rendered
    * to each platform's native format rather than HTML-escaped), `{ card }` (a

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -1209,15 +1209,37 @@ export async function deliverNotificationTask(
 				const browserRunId = typeof row.metadata.browser_handoff_run_id === "number"
 					? row.metadata.browser_handoff_run_id : null;
 				if (decisionRunId != null || browserRunId != null) {
-					const [decision] = await tx<{ approval_status: string; status: string }>`
-						SELECT approval_status, status FROM runs
-						WHERE organization_id = ${input.organizationId} AND id = ${decisionRunId ?? browserRunId}
+					const runIds = [decisionRunId, browserRunId].filter(
+						(id): id is number => id != null,
+					);
+					// Match the inbox and page-activation endpoint's ready contract.
+					// A browser handoff and an approval can reference different runs.
+					const states = await tx<{
+						id: number;
+						approval_status: string;
+						browser_ready: boolean;
+					}>`
+						SELECT id, approval_status, COALESCE(
+							run_type = 'action' AND status = 'pending'
+							AND approval_status = 'auto'
+							AND activation_kind = 'page_visit'
+							AND run_metadata->>'page_activation_identity' = 'exact'
+							AND activated_at IS NULL
+							AND expires_at > current_timestamp,
+							false
+						) AS browser_ready
+						FROM runs
+						WHERE organization_id = ${input.organizationId}
+						  AND id = ANY(${pgBigintArray(runIds)}::bigint[])
 					`;
-					if (!decision) throw new Error("Notification decision run is unavailable");
+					const decision = states.find((state) => Number(state.id) === decisionRunId);
+					const browser = states.find((state) => Number(state.id) === browserRunId);
+					if ((decisionRunId != null && !decision) || (browserRunId != null && !browser)) {
+						throw new Error("Notification decision run is unavailable");
+					}
 					if (
-						(decisionRunId != null && decision.approval_status !== "pending") ||
-						(browserRunId != null &&
-							["completed", "failed", "cancelled"].includes(decision.status))
+						(decisionRunId != null && decision?.approval_status !== "pending") ||
+						(browserRunId != null && !browser?.browser_ready)
 					) {
 						return;
 					}

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -12,7 +12,9 @@ import {
 	pgTextArray,
 } from "../db/client";
 import { resolveBoundChannelRows } from "../gateway/channels/bound-channels";
-import { getChatInstanceManager, isLobuGatewayRunning } from "../lobu/gateway";
+import { getChatInstanceManager } from "../lobu/gateway";
+import { NOTIFICATION_DELIVERY_TASK } from "../scheduled/task-definitions";
+import { enqueueTasksInTransaction } from "../scheduled/task-scheduler";
 import type { McpActivityAttribution } from "../lobu/stores/mcp-client-conversations";
 import { resolveSlackUserIdForUser } from "../lobu/stores/chat-identity.js";
 import { resolveEventKindDefinition } from "../utils/event-kind-validation";
@@ -99,10 +101,11 @@ interface CreateNotificationParams {
 	 * Lobu user whose Slack DM is the first chat destination — the owner of the
 	 * change under review (field-change approvals), or the requester of an
 	 * approval that has no chat origin. When set, bot delivery tries their DM
-	 * FIRST — resolved via
-	 * the owner's workspace-scoped Slack identity — and only falls back
-	 * to the configured-target/org-wide channel chain when the owner has no
-	 * Slack identity or the DM fails. In-app inbox targeting is unaffected.
+	 * FIRST, resolved via the owner's workspace-scoped Slack identity. When no
+	 * identity resolves at creation, delivery falls back to the configured-target
+	 * or org-wide channel snapshot. Once a DM resolves, durable retries stay on
+	 * that private destination rather than widening to a channel after a transient
+	 * post failure. In-app inbox targeting is unaffected.
 	 */
 	ownerUserId?: string | null;
 	/**
@@ -144,15 +147,12 @@ interface CreateNotificationParams {
  * Forward a notification to the org's active chat-bot connections so it lands
  * in the bound channel — e.g. an automation digest posting to #leads.
  *
- * Resolves connections + their Automation subscriptions straight from Postgres and
- * posts in-process via the chat manager. Every app pod loads every active
- * connection at boot, so the locally-held instance can post regardless of
- * which pod fired the notification — correct under N>1 replicas, no cross-pod
- * routing needed.
+ * Resolves connections + their Automation subscriptions straight from Postgres.
+ * Durable delivery may run on any app pod; the chat manager lazily hydrates an
+ * active connection on the claiming pod before it posts.
  *
- * Best-effort: a connection with no live instance or no binding is skipped
- * without failing the others. A connection bound to several channels posts to
- * each.
+ * A connection bound to several channels produces one independently receipted
+ * destination per channel.
  */
 interface BotDeliveryTarget {
 	connectionId: string;
@@ -440,13 +440,11 @@ type PersistedNotificationDeliveryRecord = Omit<
  * Post-hoc metadata UPDATE, matching the routing stamp in
  * `gateway/routes/internal/interactions.ts`: `events` is append-only for
  * DELETE, and this touches delivery metadata only — never payload. It has to
- * run after the fan-out because the platform ids do not exist until the post
- * returns, and the durable notification write must not block on a best-effort
- * chat post.
+ * run after each post because the platform ids do not exist before it returns.
  *
  * Best-effort by default: losing the record costs a later in-place edit, not
- * the notification itself. `present_event` opts into required persistence
- * because the pointer drives in-place refresh and deduplicates later calls.
+ * the notification itself. `present_event` and durable delivery require
+ * persistence because receipts drive in-place refresh and deduplicate retries.
  */
 async function persistDeliveryMetadata(
 	eventId: number,
@@ -648,29 +646,6 @@ async function presentStoredEventToConversationLocked(
 	};
 }
 
-async function recordDeliveryError(
-	eventId: number,
-	code: "automation_target_unavailable" | "automation_target_post_failed",
-): Promise<void> {
-	try {
-		const sql = getDb();
-		await sql`
-      UPDATE events
-      SET metadata = coalesce(metadata, '{}'::jsonb)
-        || jsonb_build_object(
-          'delivery_error',
-          jsonb_build_object('code', ${code}, 'recorded_at', NOW())
-        )
-      WHERE id = ${eventId}
-    `;
-	} catch (err) {
-		logger.warn(
-			{ err, eventId, code },
-			"[Notifications] Failed to record delivery error",
-		);
-	}
-}
-
 function jsonRecord(value: unknown): Record<string, unknown> {
 	if (value && typeof value === "object" && !Array.isArray(value)) {
 		return value as Record<string, unknown>;
@@ -722,13 +697,17 @@ type StoredApprovalNotification = {
 export async function refreshApprovalNotificationCards(
 	organizationId: string,
 	runIds: number[],
+	options?: { required?: boolean },
 ): Promise<void> {
 	const ids = [
 		...new Set(runIds.filter((id) => Number.isSafeInteger(id) && id > 0)),
 	];
 	if (ids.length === 0) return;
 	const manager = getChatInstanceManager();
-	if (!manager) return;
+	if (!manager) {
+		if (options?.required) throw new Error("Notification chat gateway is unavailable");
+		return;
+	}
 	const rows = await getDb()<StoredApprovalNotification>`
 		SELECT
 			r.id AS run_id,
@@ -804,6 +783,7 @@ export async function refreshApprovalNotificationCards(
 						content,
 					})
 					.catch((err: unknown) => {
+						if (options?.required) throw err;
 						logger.warn(
 							{
 								err,
@@ -1044,140 +1024,323 @@ export async function resolveNotificationKindCard(
 	}
 }
 
-async function deliverToBotConnections(
-	params: Omit<CreateNotificationParams, "userId">,
-	eventId: number,
-): Promise<void> {
-	if (!isLobuGatewayRunning()) return;
-	const manager = getChatInstanceManager();
-	if (!manager) return;
+type NotificationDeliveryContext = Pick<
+	CreateNotificationParams,
+	| "connectionId"
+	| "channelId"
+	| "teamId"
+	| "deliveryScope"
+	| "ownerUserId"
+	| "decisionRunId"
+	| "actionOrigin"
+	| "automationId"
+>;
 
-	const text = params.body ? `${params.title}\n\n${params.body}` : params.title;
-	// Card precedence, richest first:
-	//   1. an explicit `card` — the caller built it, so it wins outright;
-	//   2. the notification's own event kind, whose render template gives chat
-	//      the same content the Memory view shows. This is what stops a caller
-	//      authoring its content twice (`payloadData` for web, a hand-built card
-	//      for chat) and drifting between them;
-	//   3. the markdown body.
-	const baseCard = params.card ?? (await resolveNotificationKindCard(params, eventId));
-	const card = baseCard ? addActionOrigin(baseCard, params.actionOrigin) : null;
-	const content = card ? { card } : { markdown: text };
-	const deliveryPlan = await resolveNotificationDeliveryPlan({
-		organizationId: params.organizationId,
-		automationId: params.automationId,
+interface NotificationDeliveryRequest {
+	context: NotificationDeliveryContext;
+	strictAutomationTarget: boolean;
+	targets: BotDeliveryTarget[];
+	ownerDm: { connectionId: string; slackUserId: string } | null;
+}
+
+export interface NotificationDeliveryTaskPayload {
+	organizationId: string;
+	eventId: number;
+}
+
+async function ownerIsMember(
+	organizationId: string,
+	userId: string,
+): Promise<boolean> {
+	const [member] = await getDb()`
+		SELECT 1 FROM member
+		WHERE "organizationId" = ${organizationId} AND "userId" = ${userId}
+		LIMIT 1
+	`;
+	return Boolean(member);
+}
+
+async function snapshotNotificationDelivery(
+	params: Omit<CreateNotificationParams, "userId">,
+): Promise<NotificationDeliveryRequest> {
+	const context: NotificationDeliveryContext = {
 		connectionId: params.connectionId,
 		channelId: params.channelId,
 		teamId: params.teamId,
 		deliveryScope: params.deliveryScope,
-	});
-	if (deliveryPlan.strictAutomationTarget && deliveryPlan.targets.length === 0) {
-		logger.error(
-			{
-				organizationId: params.organizationId,
-				automationId: params.automationId,
-			},
-			"[Notifications] Automation delivery target is unavailable — refusing org-wide fallback",
-		);
-		await recordDeliveryError(eventId, "automation_target_unavailable");
-		return;
-	}
+		ownerUserId: params.ownerUserId,
+		decisionRunId: params.decisionRunId,
+		actionOrigin: params.actionOrigin,
+		automationId: params.automationId,
+	};
+	const plan = await resolveNotificationDeliveryPlan(params);
+	const ownerDm =
+		params.ownerUserId &&
+		!plan.strictAutomationTarget &&
+		(await ownerIsMember(params.organizationId, params.ownerUserId))
+			? await resolveOwnerDmTarget(
+					params.organizationId,
+					params.ownerUserId,
+					params.connectionId,
+				)
+			: null;
+	return { context, ...plan, ownerDm };
+}
 
-	// Owner-routed tier: an approval whose gated fields have ONE human owner
-	// goes to that owner's Slack DM first (same card, same approve/reject
-	// buttons — the interaction bridge is connection-scoped, so clicks route
-	// identically). Any miss — no identity row, DM open/post failure — logs and
-	// falls through to the configured-target/org-wide chain unchanged.
-	if (params.ownerUserId && !deliveryPlan.strictAutomationTarget) {
+function sameDeliveryTarget(a: BotDeliveryTarget, b: BotDeliveryTarget): boolean {
+	return (
+		a.connectionId === b.connectionId &&
+		a.channelKey === b.channelKey &&
+		a.teamId === b.teamId
+	);
+}
+
+/**
+ * The inbox and this task commit together. A queue retry rehydrates the saved
+ * notification and posts only destinations without durable receipts. Selected
+ * destinations are frozen at creation and revalidated, so a later binding cannot
+ * turn a delayed private notification into new channel traffic.
+ *
+ * Providers do not accept a common idempotency key: acceptance followed by a
+ * lost receipt can still duplicate an external message. Never claim exactly-once.
+ */
+export async function deliverNotificationTask(
+	input: NotificationDeliveryTaskPayload,
+): Promise<void> {
+	const sql = getDb();
+	const [saved] = await sql<{ metadata: Record<string, unknown> }>`
+		SELECT metadata FROM events
+		WHERE id = ${input.eventId} AND organization_id = ${input.organizationId}
+	`;
+	if (!saved) {
+		throw new Error("Notification event is unavailable in this organization");
+	}
+	const request = saved.metadata.delivery_request as
+		| NotificationDeliveryRequest
+		| undefined;
+	if (!request || !Array.isArray(request.targets)) {
+		throw new Error("Notification delivery request is missing");
+	}
+	if (request.strictAutomationTarget && request.targets.length === 0) {
+		throw new Error("Automation notification target is unavailable");
+	}
+	const destinations = request.ownerDm
+		? [
+				{
+					connectionId: request.ownerDm.connectionId,
+					channelKey: "dm",
+					platform: "slack",
+					teamId: null,
+				},
+			]
+		: request.targets;
+	const failures: unknown[] = [];
+	let hasDelivery = false;
+	let approvalRunIdToRefresh = request.context.decisionRunId ?? null;
+	for (const target of destinations) {
 		try {
-			const dm = await resolveOwnerDmTarget(
-				params.organizationId,
-				params.ownerUserId,
-				params.connectionId,
-			);
-			if (dm) {
-				const sent = await manager.postDirectMessage(
-					dm.connectionId,
-					dm.slackUserId,
-					content,
-				);
+			// Reuse the event-row receipt boundary used by presentStoredEventToConversation.
+			// Each destination commits separately; a failure must not roll back a prior
+			// successful post's receipt and cause it to be sent again on retry.
+			await sql.begin(async (tx) => {
+				const [row] = await tx<{
+					title: string;
+					payload_text: string | null;
+					payload_data: Record<string, unknown>;
+					metadata: Record<string, unknown>;
+					semantic_type: string;
+					entity_ids: unknown;
+					superseded_by: number | null;
+				}>`
+					SELECT
+						title, payload_text, payload_data, metadata, semantic_type,
+						entity_ids, superseded_by
+					FROM events
+					WHERE id = ${input.eventId} AND organization_id = ${input.organizationId}
+					FOR UPDATE
+				`;
+				if (!row) throw new Error("Notification event disappeared");
+				if (row.superseded_by !== null) return;
+				const receipts = deliveryRecords(row.metadata);
+
+				const context = request.context;
+				// A delayed approval or browser handoff may already have been resolved.
+				// The event resource is also checked for approval families with no buttons.
+				const resourceId =
+					row.metadata.resource_type === "event" &&
+					typeof row.metadata.resource_id === "string" &&
+					/^\d+$/.test(row.metadata.resource_id)
+						? Number(row.metadata.resource_id)
+						: null;
+				const [resource] =
+					resourceId != null && Number.isSafeInteger(resourceId)
+						? await tx<{
+								run_id: number | null;
+								interaction_type: string | null;
+								interaction_status: string | null;
+								superseded_by: number | null;
+							}>`
+								SELECT run_id, interaction_type, interaction_status, superseded_by
+								FROM events
+								WHERE id = ${resourceId}
+								  AND organization_id = ${input.organizationId}
+							`
+						: [];
+				const decisionRunId = context.decisionRunId ??
+					(resource?.interaction_type === "approval" ? resource.run_id : null);
+				approvalRunIdToRefresh ??= decisionRunId;
+				if (
+					receipts.some(
+						(receipt) =>
+							receipt.connectionId === target.connectionId &&
+							receipt.channelKey === target.channelKey,
+					)
+				) {
+					hasDelivery = true;
+					return;
+				}
+				if (
+					resource?.interaction_type &&
+					(resource.superseded_by !== null ||
+						resource.interaction_status !== "pending")
+				) {
+					return;
+				}
+				const browserRunId = typeof row.metadata.browser_handoff_run_id === "number"
+					? row.metadata.browser_handoff_run_id : null;
+				if (decisionRunId != null || browserRunId != null) {
+					const [decision] = await tx<{ approval_status: string; status: string }>`
+						SELECT approval_status, status FROM runs
+						WHERE organization_id = ${input.organizationId} AND id = ${decisionRunId ?? browserRunId}
+					`;
+					if (!decision) throw new Error("Notification decision run is unavailable");
+					if (
+						(decisionRunId != null && decision.approval_status !== "pending") ||
+						(browserRunId != null &&
+							["completed", "failed", "cancelled"].includes(decision.status))
+					) {
+						return;
+					}
+				}
+
+				const current = await resolveNotificationDeliveryPlan({
+					...context,
+					organizationId: input.organizationId,
+				});
+				if (request.strictAutomationTarget && !current.strictAutomationTarget) {
+					throw new Error("Automation notification target changed");
+				}
+				if (request.ownerDm) {
+					if (
+						!context.ownerUserId ||
+						!(await ownerIsMember(input.organizationId, context.ownerUserId))
+					) {
+						throw new Error("Notification owner is no longer a workspace member");
+					}
+					const dm = await resolveOwnerDmTarget(
+						input.organizationId,
+						context.ownerUserId,
+						context.connectionId,
+					);
+					if (
+						!dm ||
+						dm.connectionId !== request.ownerDm.connectionId ||
+						dm.slackUserId !== request.ownerDm.slackUserId
+					) {
+						throw new Error("Notification owner destination changed");
+					}
+				} else if (
+					!current.targets.some((currentTarget) =>
+						sameDeliveryTarget(target, currentTarget),
+					)
+				) {
+					throw new Error("Notification destination is no longer authorized");
+				}
+				const manager = getChatInstanceManager();
+				if (!manager) throw new Error("Notification chat gateway is unavailable");
+				const params: Omit<CreateNotificationParams, "userId"> = {
+					...context,
+					organizationId: input.organizationId,
+					type: row.metadata.notification_type as CreateNotificationParams["type"],
+					title: row.title,
+					body: row.payload_text,
+					semanticType:
+						row.semantic_type === "notification" ? undefined : row.semantic_type,
+					payloadData: row.payload_data,
+					entityIds: parsePgNumberArray(row.entity_ids),
+					resourceUrl:
+						typeof row.metadata.resource_url === "string"
+							? row.metadata.resource_url
+							: null,
+				};
+				const baseCard = isCard(row.metadata.card)
+					? row.metadata.card
+					: await resolveNotificationKindCard(params, input.eventId);
+				const card = baseCard
+					? receipts.length
+						? baseCard
+						: addActionOrigin(baseCard, context.actionOrigin)
+					: undefined;
+				const body = row.payload_text
+					? `${row.title}\n\n${row.payload_text}`
+					: row.title;
+				const link = toAbsolutePermalink(params.resourceUrl);
+				const content = card
+					? { card }
+					: { markdown: link ? `${body}\n\n${link}` : body };
+				const sent = request.ownerDm
+					? await manager.postDirectMessage(
+							target.connectionId,
+							request.ownerDm.slackUserId,
+							content,
+						)
+					: await manager.postMessageToChannel(
+							target.connectionId,
+							target.channelKey,
+							content,
+						);
+				if (!sent.messageId) {
+					throw new Error("Delivery did not return an addressable message id");
+				}
 				await persistDeliveryMetadata(
-					eventId,
+					input.eventId,
 					[
+						...receipts,
 						{
-							connectionId: dm.connectionId,
-							channelKey: "dm",
+							connectionId: target.connectionId,
+							channelKey: target.channelKey,
 							messageId: sent.messageId,
 							threadId: sent.threadId,
 						},
 					],
-					card ?? undefined,
+					card,
+					{ db: tx, required: true },
 				);
-				return;
-			}
-			logger.warn(
-				{ organizationId: params.organizationId, ownerUserId: params.ownerUserId },
-				"[Notifications] Approval owner has no Slack identity in a connected workspace — falling back to channel delivery",
-			);
-		} catch (err) {
-			logger.warn(
-				{
-					err,
-					organizationId: params.organizationId,
-					ownerUserId: params.ownerUserId,
-				},
-				"[Notifications] Owner DM delivery failed — falling back to channel delivery",
-			);
+				hasDelivery = true;
+			});
+		} catch (error) {
+			failures.push(error);
 		}
 	}
-
-	try {
-		const targets = deliveryPlan.targets;
-		if (targets.length === 0) return;
-
-		const posted = await Promise.allSettled(
-			targets.map(
-				async ({
-					connectionId,
-					channelKey,
-				}): Promise<NotificationDeliveryRecord> => {
-					const sent = await manager.postMessageToChannel(
-						connectionId,
-						channelKey,
-						content,
-					);
-					return {
-						connectionId,
-						channelKey,
-						messageId: sent.messageId,
-						threadId: sent.threadId,
-					};
-				},
-			),
+	// Close the decision-during-post race: after receipt commit a concurrent
+	// terminalizer can see it; if it committed earlier, this refresh sees the
+	// terminal state. Refresh failure consumes this same task's retry budget.
+	if (hasDelivery && approvalRunIdToRefresh != null) {
+		await refreshApprovalNotificationCards(
+			input.organizationId,
+			[approvalRunIdToRefresh],
+			{ required: true },
 		);
-		const delivered: NotificationDeliveryRecord[] = [];
-		posted.forEach((result, index) => {
-			if (result.status === "fulfilled") {
-				delivered.push(result.value);
-				return;
-			}
-			logger.warn(
-				{
-					err: result.reason,
-					connectionId: targets[index]?.connectionId,
-					channelKey: targets[index]?.channelKey,
-				},
-				"[Notifications] Failed to post to bot connection channel",
-			);
-		});
-		await persistDeliveryMetadata(eventId, delivered, card ?? undefined);
-		if (deliveryPlan.strictAutomationTarget && delivered.length === 0) {
-			await recordDeliveryError(eventId, "automation_target_post_failed");
-		}
-	} catch (err) {
-		logger.warn(
-			{ err },
-			"[Notifications] Failed to deliver to bot connections",
+	}
+	if (failures.length) {
+		throw new AggregateError(
+			failures,
+			"Notification delivery failed: " +
+				failures
+					.map((error) =>
+						error instanceof Error ? error.message : String(error),
+					)
+					.join("; "),
 		);
 	}
 }
@@ -1235,6 +1398,8 @@ export async function createNotificationForUsers(
 		if (prior !== null) return { created: false, eventId: prior };
 	}
 
+	metadata.delivery_request = await snapshotNotificationDelivery(params);
+
 	let eventId: number;
 	try {
 		eventId = (await sql.begin(async (tx) => {
@@ -1267,6 +1432,16 @@ export async function createNotificationForUsers(
       FROM unnest(${pgTextArray(userIds)}::text[]) AS u(uid)
       ON CONFLICT DO NOTHING
     `;
+      await enqueueTasksInTransaction(tx, [{
+        name: NOTIFICATION_DELIVERY_TASK,
+        payload: { organizationId: params.organizationId, eventId: event.id },
+        opts: {
+          idempotencyKey: `${NOTIFICATION_DELIVERY_TASK}:${event.id}`,
+          organizationId: params.organizationId,
+          automationId: params.automationId ?? undefined,
+          parentRunId: params.runId ?? undefined,
+        },
+      }]);
 			return event.id;
 		})) as number;
 	} catch (error) {
@@ -1286,15 +1461,6 @@ export async function createNotificationForUsers(
 		throw error;
 	}
 
-	// Deliver to bot connections (fire-and-forget). The bot delivery targets
-	// the org's connection default channels and is identical for every user in
-	// this call, so fan it out once — not once per user.
-	deliverToBotConnections(params, eventId).catch((err) =>
-		logger.warn(
-			{ err },
-			"[Notifications] Failed to deliver to bot connections",
-		),
-	);
 	return { created: true, eventId };
 }
 

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -433,8 +433,8 @@ async function notifyOrgAdmins(
 /**
  * Which user, if any, should get the approval as a Slack DM.
  *
- * `deliverToBotConnections` tries the DM tier BEFORE the channel tier and
- * returns on success, so this is a real precedence decision and not a
+ * Notification delivery selects a resolved owner DM before channel targets,
+ * so this is a real precedence decision and not a
  * preference: hand it the requester while a chat origin is also set and an
  * approval asked for in a channel silently lands in the asker's DM instead,
  * inverting the documented conversation → DM → inbox order.

--- a/packages/server/src/scheduled/__tests__/task-scheduler.test.ts
+++ b/packages/server/src/scheduled/__tests__/task-scheduler.test.ts
@@ -28,6 +28,8 @@ import {
 import {
   AUTOMATION_REACTION_TASK,
   AUTOMATION_REACTION_TASK_QUEUE,
+  NOTIFICATION_DELIVERY_TASK,
+  NOTIFICATION_DELIVERY_TASK_QUEUE,
 } from "../task-definitions";
 
 interface SentRecord {
@@ -192,19 +194,22 @@ describe("TaskScheduler.start (cron seeding)", () => {
     expect(queue.sent).toHaveLength(1);
   });
 
-  test("registers the Automation reaction lane only when its handler exists", async () => {
+  test.each([
+    [AUTOMATION_REACTION_TASK, AUTOMATION_REACTION_TASK_QUEUE],
+    [NOTIFICATION_DELIVERY_TASK, NOTIFICATION_DELIVERY_TASK_QUEUE],
+  ])("registers the %s lane only when its handler exists", async (taskName, queueName) => {
     const withoutReactionQueue = new FakeQueue();
     await new TaskScheduler(withoutReactionQueue).start();
     expect(
-      withoutReactionQueue.workers.has(AUTOMATION_REACTION_TASK_QUEUE),
+      withoutReactionQueue.workers.has(queueName),
     ).toBe(false);
 
     const withReactionQueue = new FakeQueue();
     const scheduler = new TaskScheduler(withReactionQueue);
-    scheduler.register(AUTOMATION_REACTION_TASK, async () => {});
+    scheduler.register(taskName, async () => {});
     await scheduler.start();
 
-    expect(withReactionQueue.workers.has(AUTOMATION_REACTION_TASK_QUEUE)).toBe(
+    expect(withReactionQueue.workers.has(queueName)).toBe(
       true,
     );
   });

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -35,6 +35,7 @@ import {
 import { TaskScheduler } from './task-scheduler';
 import {
   AUTOMATION_REACTION_TASK,
+  NOTIFICATION_DELIVERY_TASK,
   INTERACTIVE_EVENT_CARD_REFRESH_TASK,
   WORKSPACE_EVENT_ACTIVATION_TASK,
 } from './task-definitions';
@@ -47,6 +48,8 @@ import { runScoreEvalRuns } from './score-eval-runs';
 import { getDb, pgTextArray } from '../db/client';
 import {
   createNotificationForUsers,
+  deliverNotificationTask,
+  type NotificationDeliveryTaskPayload,
   refreshInteractiveEventCardTask,
   type InteractiveEventCardRefreshTaskPayload,
 } from '../notifications/service';
@@ -492,6 +495,12 @@ function registerMaintenanceTasks(
         '[task] automation-reaction settled',
       );
     }
+  });
+
+  scheduler.register(NOTIFICATION_DELIVERY_TASK, async (ctx) => {
+    await deliverNotificationTask(
+      ctx.payload as NotificationDeliveryTaskPayload,
+    );
   });
 
   // scheduled_jobs ticker: scans the table every minute, spawns due rows

--- a/packages/server/src/scheduled/task-definitions.ts
+++ b/packages/server/src/scheduled/task-definitions.ts
@@ -9,6 +9,9 @@
 export const WORKSPACE_EVENT_ACTIVATION_TASK = 'activate-workspace-event';
 export const INTERACTIVE_EVENT_CARD_REFRESH_TASK =
   'refresh-interactive-event-card';
+export const NOTIFICATION_DELIVERY_TASK = 'deliver-notification';
+export const NOTIFICATION_DELIVERY_TASK_QUEUE =
+  `task:${NOTIFICATION_DELIVERY_TASK}`;
 export const AUTOMATION_REACTION_TASK = 'automation-reaction';
 export const AUTOMATION_REACTION_TASK_QUEUE =
   `task:${AUTOMATION_REACTION_TASK}`;
@@ -20,6 +23,9 @@ export const AUTOMATION_REACTION_TASK_QUEUE =
  * during a rolling deploy. Existing task names stay on the shared lane.
  */
 export function taskQueueName(name: string): string {
+  if (name === NOTIFICATION_DELIVERY_TASK) {
+    return NOTIFICATION_DELIVERY_TASK_QUEUE;
+  }
   return name === AUTOMATION_REACTION_TASK
     ? AUTOMATION_REACTION_TASK_QUEUE
     : 'task';
@@ -29,6 +35,7 @@ export function isTransactionalTaskName(name: string): boolean {
   return (
     name === WORKSPACE_EVENT_ACTIVATION_TASK ||
     name === INTERACTIVE_EVENT_CARD_REFRESH_TASK ||
-    name === AUTOMATION_REACTION_TASK
+    name === AUTOMATION_REACTION_TASK ||
+    name === NOTIFICATION_DELIVERY_TASK
   );
 }


### PR DESCRIPTION
## Summary

Notification creation currently commits the inbox event and then posts to chat in a detached promise. A crash or failed destination can lose delivery permanently because a producer retry returns the existing notification without retrying chat.

Commit the notification and its delivery job together through the existing task queue. Freeze and revalidate intended destinations, persist each successful post before continuing, and retry only destinations without receipts. Owner DM retries stay private. Delayed approvals check their current state, and a decision racing delivery settles the posted card through the same retry budget. Plain chat notifications retain their review link.

This adds no table or public API. Provider acceptance followed by a lost database receipt can still duplicate an external message; delivery is recoverable, not exactly once.

## Test plan

- [x] Focused database suites: 38 passed, including 14 durable-delivery regressions.
- [x] Existing notification and browser-activation callers: 41 passed.
- [x] Scheduler and owner-routing unit tests: 23 passed, including notification queue registration during a rolling deployment.
- [x] Booted the production scheduler against an isolated Postgres database: it consumed the notification handoff, completed the job, posted once through the synthetic provider, and persisted one receipt. The temporary probe and its test data were removed.
- [x] Full CI exposed an approval atomicity assertion counting background delivery tasks as operations (32 pass / 1 fail locally). Scope approval counts and latest-run reads to their operation kind/connector; all 33 related integration tests then passed.
- [x] Review found delayed browser-handoff notifications ignored activation and expiry. Valid persisted-state regressions reproduced 7 failures / 17 passes on the previous implementation. Delivery now uses the inbox/page-activation readiness contract; 57 notification, approval and page-activation tests pass, including 24 durable-delivery cases.
- [x] Bug reproduced before the fix: 7 durable-delivery regressions failed because creation had no transactional queue handoff and no delivery handler. The completed suite passes all 14 cases.
- [x] Intended files staged explicitly and `make pre-pr` passed; pre-commit formatting and typecheck passed.
- [x] GitHub CI and exact-commit semantic review passed at `3ef64c4391d6fbef25f5ff6cd719ddaf35935234`; Codex reported zero bugs/blockers, bug-free confidence 89 and simplicity 84. The reviewer sandbox could not start Vitest; the actual database suites and CI passed independently.
- [x] Production rollout verified at squash commit `7f6a61c9cea7cac6afaf58ffba439b6de48bc2ee`; all 9 production smoke checks passed. App and worker both use the promoted image, and the production task scheduler started.
- [x] Post-deployment managed Task Builder run exhausted all three sources, analyzed 142 stored events, advanced its checkpoint and completed its reaction. No task changes were warranted and no existing notices were duplicated.
- [ ] Fresh production delivery through the new queue remains unobserved: no new notification was generated between deployment and the final check. Queue consumption/post/receipt were verified with the booted production scheduler and synthetic provider in the isolated database test above; earlier real notifications have provider receipts. No external test messages were sent.

The regressions exercise racing producers and consumers, atomic enqueue failure, partial provider failure, missing gateways, owner-DM routing, tenant isolation, changed channel bindings, approval races, and provider receipts without a thread ID.
