### PR TITLE
fix(personal-agent): preserve task evidence and closed state

### DIFF
--- a/examples/personal-agent/evals/task-lifecycle.integration.ts
+++ b/examples/personal-agent/evals/task-lifecycle.integration.ts
@@ -341,6 +341,29 @@ describe("personal task lifecycle through persistent runtime", () => {
     expect((await h.entities())[0].metadata.status).toBe("done");
   });
 
+  it.each([
+    "done",
+    "dismissed",
+  ])("rejects closing a task as %s while retaining agent help", async (status) => {
+    const h = await setup();
+    await h.react(await h.complete([task]));
+    const [saved] = await h.entities();
+    await expect(
+      h.workspace.owner.entities.update({
+        entity_id: Number(saved.id),
+        metadata: { status },
+      })
+    ).rejects.toThrow("Clear agent_help when closing a task");
+    expect((await h.entities())[0].metadata).toMatchObject(task);
+    expect(await h.notices()).toHaveLength(1);
+    await h.workspace.owner.entities.update({
+      entity_id: Number(saved.id),
+      metadata: { status, agent_help: null },
+    });
+    expect((await h.entities())[0].metadata.status).toBe(status);
+    expect((await h.entities())[0].metadata.agent_help).toBeNull();
+  });
+
   it("recovers a provider failure without losing or duplicating the committed notice", async () => {
     const h = await setup();
     await h.react(await h.complete([task]));

--- a/examples/personal-agent/evals/task-lifecycle.integration.ts
+++ b/examples/personal-agent/evals/task-lifecycle.integration.ts
@@ -1,0 +1,415 @@
+import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runAutomationReactionTask } from "../../../packages/server/src/automations/reaction-task";
+import { compileEntityRule } from "../../../packages/server/src/authz/entity-rule-executor";
+import type { Env } from "../../../packages/server/src/index";
+import { __setChatInstanceManagerForTests } from "../../../packages/server/src/lobu/gateway";
+import { deliverNotificationTask } from "../../../packages/server/src/notifications/service";
+import { createAutomationRun } from "../../../packages/server/src/runs/queue-service";
+import { computePendingWindow } from "../../../packages/server/src/utils/window-utils";
+import { executeTool } from "../../../packages/server/src/tools/execute";
+import { createTestAutomationSubscription } from "../../../packages/server/src/__tests__/setup/automation-subscriptions";
+import {
+  cleanupTestDatabase,
+  getTestDb,
+} from "../../../packages/server/src/__tests__/setup/test-db";
+import {
+  createTestAgent,
+  createTestEntity,
+  createTestEvent,
+  insertChatConnectionRow,
+} from "../../../packages/server/src/__tests__/setup/test-fixtures";
+import {
+  TestApiClient,
+  TestWorkspace,
+} from "../../../packages/server/src/__tests__/setup/test-mcp-client";
+import config from "../lobu.config";
+
+// Exercise the real source-read, completion, promotion, isolated-reaction,
+// notification, and delivery persistence paths. Scheduling/claiming, extracted
+// model output, and the external chat transport are controlled test inputs.
+const definition = config.automations?.find(
+  (a) => a.slug === "hourly-task-collaborator"
+);
+if (!definition) {
+  throw new Error("Hourly task collaborator config is missing");
+}
+const taskOutput = definition.outputs?.tasks;
+if (!taskOutput || !("key" in taskOutput)) {
+  throw new Error("Hourly task collaborator task output is missing");
+}
+const taskType = config.entities?.find((e) => e.key === "task");
+if (!taskType) {
+  throw new Error("Task entity config is missing");
+}
+const taskRulesPath = taskType.rules?.path;
+if (!taskRulesPath) {
+  throw new Error("Task entity rules are missing");
+}
+const taskRulesUrl = new URL(taskRulesPath, new URL("../", import.meta.url));
+const automationPrompt = definition.prompt;
+const taskOutputKey = taskOutput.key;
+const taskProperties = taskType.properties;
+const taskRequired = taskType.required ?? [];
+const reaction = readFileSync(
+  new URL("../task-builder.reaction.ts", import.meta.url),
+  "utf8"
+);
+const task = {
+  source_scope: "connector:synthetic-task-fixture",
+  source_origin_id: "synthetic-verification-request",
+  task_key: "verify-calculation",
+  action: "Verify the synthetic calculation",
+  status: "backlog",
+  owner: "Synthetic Owner",
+  priority: "medium",
+  source: "https://example.invalid/request/verification",
+  rationale: "The owner explicitly requested a calculation check.",
+  agent_help: {
+    summary: "Check the calculation independently.",
+    prompt:
+      "Compute 17 times 19 and independently verify it; save the evidence.",
+  },
+};
+
+async function setup() {
+  const sql = getTestDb();
+  const workspace = await TestWorkspace.create({
+    name: "Synthetic Task Lifecycle",
+  });
+  const parent = await createTestEntity({
+    name: "Synthetic Task Board",
+    organization_id: workspace.org.id,
+    created_by: workspace.users.owner.id,
+  });
+  await sql`INSERT INTO entity_types (organization_id, slug, name, metadata_schema)
+    VALUES (${workspace.org.id}, 'task', 'Task', ${sql.json({ type: "object", properties: taskProperties, required: taskRequired } as never)})`;
+  const rules = readFileSync(taskRulesUrl, "utf8");
+  const compiledRules = await compileEntityRule(rules);
+  await sql`UPDATE entity_types SET rules_compiled = ${compiledRules} WHERE organization_id = ${workspace.org.id} AND slug = 'task'`;
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId: workspace.users.owner.id,
+    agentId: "personal-agent",
+  });
+  await insertChatConnectionRow({
+    id: "synthetic-task-chat",
+    organizationId: workspace.org.id,
+    agentId: agent.agentId,
+    platform: "slack",
+    status: "active",
+    settings: {},
+  });
+  await createTestAutomationSubscription({
+    organizationId: workspace.org.id,
+    agentId: agent.agentId,
+    connectionSlug: "agentconn-synthetic-task-chat",
+    channelId: "slack:C_SYNTHETIC_TASK",
+    teamId: "T_SYNTHETIC",
+    configuredBy: workspace.users.owner.id,
+  });
+  const post = vi.fn(async () => ({
+    messageId: "synthetic-receipt",
+    threadId: "slack:C_SYNTHETIC_TASK:synthetic-receipt",
+  }));
+  __setChatInstanceManagerForTests({ postMessageToChannel: post });
+  const created = (await workspace.owner.automations.create({
+    entity_id: parent.id,
+    slug: "synthetic-task-lifecycle",
+    name: "Synthetic Task Lifecycle",
+    prompt: automationPrompt,
+    outputs: {
+      tasks: {
+        entity: "task",
+        key: taskOutputKey,
+        name: ["action"],
+      },
+    },
+    triggers: [
+      {
+        kind: "schedule",
+        cron: "0 * * * *",
+        execution: "window",
+        active_run: "coalesce",
+        skip_if_unchanged: false,
+      },
+    ],
+    managed_agent_id: agent.agentId,
+  })) as { automation_id: string };
+  const automationId = Number(created.automation_id);
+  const api = await TestApiClient.for({
+    organizationId: workspace.org.id,
+    userId: workspace.users.owner.id,
+    memberRole: "owner",
+  });
+  await api.automations.setReactionScript({
+    automation_id: String(automationId),
+    reaction_script: reaction,
+  });
+  await sql`UPDATE automations SET next_run_at = NOW() - INTERVAL '10 minutes' WHERE id = ${automationId}`;
+  await createTestEvent({
+    entity_id: parent.id,
+    organization_id: workspace.org.id,
+    content: "Synthetic Owner asks for an independent check of 17 times 19.",
+    origin_id: task.source_origin_id,
+    occurred_at: new Date(Date.now() - 60_000),
+  });
+
+  async function complete(tasks: Record<string, unknown>[]) {
+    const { windowStart, windowEnd } = await computePendingWindow(
+      sql as never,
+      automationId
+    );
+    const queued = await createAutomationRun({
+      organizationId: workspace.org.id,
+      automationId,
+      agentId: agent.agentId,
+      windowStart: windowStart.toISOString(),
+      windowEnd: windowEnd.toISOString(),
+      dispatchSource: "scheduled",
+    });
+    await sql`UPDATE runs SET status = 'running', claimed_at = NOW(), claimed_by = 'synthetic-task-worker' WHERE id = ${queued.runId}`;
+    const read = (await api.knowledge.read({
+      automation_id: automationId,
+      run_id: queued.runId,
+    })) as { window_token: string };
+    expect(read.window_token).toBeTruthy();
+    const input = {
+      automation_id: String(automationId),
+      run_id: queued.runId,
+      window_token: read.window_token,
+      extracted_data: { tasks },
+    };
+    const result = (await api.automations.completeWindow(input)) as {
+      reaction_task_run_id: number;
+    };
+    expect(result.reaction_task_run_id).toBeGreaterThan(0);
+    return {
+      runId: queued.runId,
+      input,
+      taskRunId: result.reaction_task_run_id,
+    };
+  }
+  async function react(run: Awaited<ReturnType<typeof complete>>) {
+    const result = await runAutomationReactionTask(
+      {
+        organizationId: workspace.org.id,
+        automationId,
+        sourceRunId: run.runId,
+      },
+      {} as Env,
+      run.taskRunId
+    );
+    expect(result).toEqual({ status: "success" });
+  }
+  const entities = () =>
+    sql`SELECT e.id, e.metadata, e.field_controls FROM entities e JOIN entity_types t ON t.id = e.entity_type_id WHERE e.organization_id = ${workspace.org.id} AND t.slug = 'task' AND e.deleted_at IS NULL ORDER BY e.id`;
+  const notices = () =>
+    sql`SELECT id, metadata FROM events WHERE organization_id = ${workspace.org.id} AND metadata->>'_lobu_idempotency_key' LIKE 'task-builder:task:%' ORDER BY id`;
+  async function deliver() {
+    for (const notice of await notices())
+      await deliverNotificationTask({
+        organizationId: workspace.org.id,
+        eventId: Number(notice.id),
+      });
+  }
+  return {
+    sql,
+    workspace,
+    api,
+    automationId,
+    complete,
+    react,
+    entities,
+    notices,
+    deliver,
+    post,
+  };
+}
+
+describe("personal task lifecycle through persistent runtime", () => {
+  beforeEach(cleanupTestDatabase);
+  afterEach(() => __setChatInstanceManagerForTests(null));
+
+  it("commits one task, one inbox notification and one receipt across completion, reaction and delivery retries", async () => {
+    const h = await setup();
+    const run = await h.complete([task]);
+    await h.api.automations.completeWindow(run.input);
+    expect(await h.entities()).toHaveLength(1);
+    expect((await h.entities())[0].metadata.source).toBe(task.source);
+    expect(await h.notices()).toHaveLength(0);
+    await h.react(run);
+    await h.react(run);
+    const notices = await h.notices();
+    expect(notices).toHaveLength(1);
+    const [saved] = await h.entities();
+    expect(saved.metadata).toMatchObject(task);
+    const promoted = (await h.workspace.owner.automations.manage({
+      action: "list_promoted",
+      automation_id: String(h.automationId),
+    })) as { entities: Array<{ id: number }> };
+    expect(promoted.entities.map((e) => e.id)).toContain(Number(saved.id));
+    const url = new URL(
+      notices[0].metadata.resource_url,
+      "https://example.invalid"
+    );
+    expect(url.searchParams.get("prompt")).toContain(
+      `Review task #${saved.id}`
+    );
+    expect(url.searchParams.get("prompt")).toContain(
+      "Do not act on a closed task"
+    );
+    await h.deliver();
+    await h.deliver();
+    expect(h.post).toHaveBeenCalledTimes(1);
+    expect((await h.notices())[0].metadata.delivery).toHaveLength(1);
+  });
+
+  it("alerts on A to B to A, but not unchanged output or reaction replay", async () => {
+    const h = await setup();
+    for (const priority of ["medium", "high", "medium", "medium"]) {
+      const run = await h.complete([{ ...task, priority }]);
+      await h.react(run);
+      await h.react(run);
+    }
+    expect(await h.entities()).toHaveLength(1);
+    expect(await h.notices()).toHaveLength(3);
+    await h.deliver();
+    expect(h.post).toHaveBeenCalledTimes(3);
+  });
+
+  it("preserves a human-owned proposal and does not notify a held replacement", async () => {
+    const h = await setup();
+    await h.react(await h.complete([task]));
+    const [saved] = await h.entities();
+    const humanHelp = {
+      summary: "Only check the arithmetic.",
+      prompt: "Do not perform any other work.",
+    };
+    await h.workspace.owner.entities.update({
+      entity_id: Number(saved.id),
+      metadata: { agent_help: humanHelp },
+      field_note: "Synthetic owner instruction",
+    });
+    await h.react(await h.complete([task]));
+    const [current] = await h.entities();
+    expect(current.metadata.agent_help).toEqual(humanHelp);
+    expect(current.field_controls.agent_help.set_by).toBe(
+      h.workspace.users.owner.id
+    );
+    expect(Object.keys(current.field_controls)).toEqual(["agent_help"]);
+    expect(await h.notices()).toHaveLength(1);
+  });
+
+  it.each([
+    "done",
+    "dismissed",
+  ])("suppresses a queued reaction after the owner marks the task %s", async (status) => {
+    const h = await setup();
+    const run = await h.complete([task]);
+    const [saved] = await h.entities();
+    await h.workspace.owner.entities.update({
+      entity_id: Number(saved.id),
+      metadata: { status, agent_help: null },
+    });
+    await h.react(run);
+    expect(await h.notices()).toHaveLength(0);
+    await h.react(await h.complete([task]));
+    expect((await h.entities())[0].metadata.status).toBe(status);
+    expect(await h.notices()).toHaveLength(0);
+  });
+
+  it("persists later resolution without reopening or sending another offer", async () => {
+    const h = await setup();
+    await h.react(await h.complete([task]));
+    await h.react(
+      await h.complete([
+        {
+          ...task,
+          status: "done",
+          agent_help: null,
+          rationale:
+            "Verified 17 times 19 = 323; independently 380 minus 57 = 323.",
+        },
+      ])
+    );
+    expect((await h.entities())[0].metadata.status).toBe("done");
+    await h.react(await h.complete([task]));
+    expect((await h.entities())[0].metadata.status).toBe("done");
+    expect(await h.notices()).toHaveLength(1);
+    await h.react(await h.complete([]));
+    expect((await h.entities())[0].metadata.status).toBe("done");
+  });
+
+  it("recovers a provider failure without losing or duplicating the committed notice", async () => {
+    const h = await setup();
+    await h.react(await h.complete([task]));
+    h.post.mockRejectedValueOnce(new Error("synthetic provider outage"));
+    await expect(h.deliver()).rejects.toThrow("synthetic provider outage");
+    expect(await h.notices()).toHaveLength(1);
+    await h.deliver();
+    await h.deliver();
+    expect(h.post).toHaveBeenCalledTimes(2);
+    expect((await h.notices())[0].metadata.delivery).toHaveLength(1);
+  });
+
+  it("lets a human explicitly approve reopening a closed task", async () => {
+    const h = await setup();
+    await h.react(
+      await h.complete([{ ...task, status: "done", agent_help: null }])
+    );
+    await h.react(await h.complete([task]));
+    expect((await h.entities())[0].metadata.status).toBe("done");
+    const [pending] =
+      await h.sql`SELECT id FROM runs WHERE organization_id = ${h.workspace.org.id} AND action_key = 'entity_field_change' AND approval_status = 'pending'`;
+    expect(pending).toBeDefined();
+    const approved = (await executeTool(
+      "manage_operations",
+      { action: "approve", run_id: Number(pending.id) },
+      { ENVIRONMENT: "test", DATABASE_URL: process.env.DATABASE_URL } as Env,
+      {
+        organizationId: h.workspace.org.id,
+        tokenOrganizationId: h.workspace.org.id,
+        userId: h.workspace.users.owner.id,
+        memberRole: "owner",
+        agentId: null,
+        requestedAgentId: null,
+        isAuthenticated: true,
+        clientId: null,
+        scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+        tokenType: "oauth",
+        requestUrl: "http://localhost/api/synthetic",
+        baseUrl: "",
+        scopedToOrg: true,
+        allowCrossOrg: false,
+        grantedOrganizationIds: [h.workspace.org.id],
+        directSearchFederation: false,
+      }
+    )) as { approved: boolean };
+    expect(approved.approved).toBe(true);
+    expect((await h.entities())[0].metadata.status).toBe("backlog");
+  });
+
+  it("keeps a queued snapshot pointing at the task for a fresh-state check after closure", async () => {
+    const h = await setup();
+    await h.react(await h.complete([task]));
+    const [saved] = await h.entities();
+    await h.workspace.owner.entities.update({
+      entity_id: Number(saved.id),
+      metadata: { status: "done", agent_help: null },
+    });
+    await h.deliver();
+    // Notifications are durable snapshots, not permission to execute. A late
+    // delivery remains possible, so the handoff tells the agent to reread state.
+    expect(h.post).toHaveBeenCalledTimes(1);
+    const [notice] = await h.notices();
+    const prompt = new URL(
+      notice.metadata.resource_url,
+      "https://example.invalid"
+    ).searchParams.get("prompt");
+    expect(prompt).toContain(`Review task #${saved.id}`);
+    expect(prompt).toContain("Read its current status");
+    expect(prompt).toContain("Do not act on a closed task");
+    expect((await h.entities())[0].metadata.status).toBe("done");
+  });
+});

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -7,6 +7,7 @@ import {
   defineConfig,
   defineConnection,
   defineEntityType,
+  rulesFromFile,
   defineRelationshipType,
   defineSkill,
   every,
@@ -26,6 +27,7 @@ import type SpotifyConnector from "./spotify.connector.ts";
 import { takeoutConfig } from "./takeout-dirs.ts";
 import { taskBuilderPrompt } from "./task-builder.prompt.ts";
 import type TaskBuilderReaction from "./task-builder.reaction.ts";
+import type TaskRules from "./task.rules.ts";
 import type TwitterTakeoutConnector from "./twitter-takeout.connector.ts";
 
 const hourlyTaskCollaboratorSkill = defineSkill({
@@ -382,6 +384,7 @@ const task = defineEntityType({
   description:
     "An actionable item collaboratively managed by Burak and his personal agent.",
   metadata: { icon: "check-square", color: "#10B981" },
+  rules: rulesFromFile<typeof TaskRules>("./task.rules.ts"),
   properties: {
     action: field("Action", {
       minLength: 1,

--- a/examples/personal-agent/task.rules.ts
+++ b/examples/personal-agent/task.rules.ts
@@ -3,6 +3,12 @@ import type { EntityWriteRule } from "@lobu/cli/config";
 // A stale extraction or reply cannot silently undo a completed/dismissed task.
 // The existing review path still lets a human explicitly reopen it.
 const taskRules: EntityWriteRule = (row) => {
+  if (
+    ["done", "dismissed"].includes(String(row.next.status)) &&
+    row.next.agent_help != null
+  ) {
+    row.deny("Clear agent_help when closing a task.");
+  }
   if (!["done", "dismissed"].includes(String(row.committed.status))) return;
   const guardedFields: string[] = [];
   if (

--- a/examples/personal-agent/task.rules.ts
+++ b/examples/personal-agent/task.rules.ts
@@ -1,0 +1,23 @@
+import type { EntityWriteRule } from "@lobu/cli/config";
+
+// A stale extraction or reply cannot silently undo a completed/dismissed task.
+// The existing review path still lets a human explicitly reopen it.
+const taskRules: EntityWriteRule = (row) => {
+  if (!["done", "dismissed"].includes(String(row.committed.status))) return;
+  const guardedFields: string[] = [];
+  if (
+    row.changed("status") &&
+    !["done", "dismissed"].includes(String(row.next.status))
+  )
+    guardedFields.push("status");
+  if (row.changed("agent_help") && row.next.agent_help != null)
+    guardedFields.push("agent_help");
+  if (guardedFields.length > 0) {
+    row.escalate(
+      guardedFields,
+      "This task is closed. Reopening it or offering new agent work requires explicit review."
+    );
+  }
+};
+
+export default taskRules;

--- a/packages/server/src/__tests__/integration/automations/channel-feed-source.test.ts
+++ b/packages/server/src/__tests__/integration/automations/channel-feed-source.test.ts
@@ -59,17 +59,24 @@ describe("channel feed as an automation @feed source", () => {
     await withAclEdgeWrite(sql, async (tx) => {
       await tx`DELETE FROM entity_relationships WHERE organization_id = ${orgId}`;
     });
-    await sql`DELETE FROM entity_identities WHERE organization_id = ${orgId}`;
     await sql`DELETE FROM feeds WHERE organization_id = ${orgId}`;
     await sql`DELETE FROM connections WHERE organization_id = ${orgId}`;
-    // Keep the workspace's own $member/entities intact; only clear source state.
+    // `source` is a domain field, so identify promoted rows by their stable-key
+    // identity. Entity deletion cascades those claims; clear the remaining graph
+    // identities afterwards while keeping ordinary workspace entities intact.
     await sql`
-      DELETE FROM entities
-      WHERE organization_id = ${orgId}
-        AND (metadata->>'source' = 'automation_promotion' OR entity_type_id IN (
+      DELETE FROM entities e
+      WHERE e.organization_id = ${orgId}
+        AND (EXISTS (
+          SELECT 1 FROM entity_identities ei
+          WHERE ei.organization_id = e.organization_id
+            AND ei.entity_id = e.id
+            AND ei.namespace = 'automation_key'
+        ) OR e.entity_type_id IN (
           SELECT id FROM entity_types WHERE organization_id = ${orgId} AND slug IN ('$resource', '$member')
         ))
     `;
+    await sql`DELETE FROM entity_identities WHERE organization_id = ${orgId}`;
   });
 
   /** A chat (slack, managed) connection carrying the team id. Returns the id, the

--- a/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
@@ -1067,6 +1067,19 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     expect(appCrashes?.run_id).toBe((completion as { run_id: number }).run_id);
     // …while the untouched entity has no owned fields.
     expect(slowLoading?.field_controls).toEqual({});
+
+    await sql`
+      UPDATE entity_identities
+      SET deleted_at = NOW()
+      WHERE organization_id = ${workspace.org.id}
+        AND namespace = 'automation_key'
+        AND identifier = ${topicIdentity(automationId, SLOW_LOADING_KEY)}
+    `;
+    const afterRetraction = (await workspace.owner.automations.manage({
+      action: 'list_promoted',
+      automation_id: String(automationId),
+    })) as { entities: Array<{ id: number }> };
+    expect(afterRetraction.entities.map((entity) => entity.id)).toEqual([entityId]);
   });
 
   it('approve (affirm_fields) locks a value as-is so a later Automation change is blocked', async () => {

--- a/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/automations/promote-keyed-entities.test.ts
@@ -308,6 +308,7 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     `;
     expect(childTypes).toHaveLength(2);
     expect(childTypes.every((r) => String(r.slug) === 'topic')).toBe(true);
+    expect(childTypes.every((r) => r.source === null)).toBe(true);
 
     // Origin provenance lives on the entity itself — each promoted child carries
     // its run_id / stable_key in metadata (no separate observation event).

--- a/packages/server/src/__tests__/integration/entity-schema/metadata-provenance-keys.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/metadata-provenance-keys.test.ts
@@ -16,7 +16,7 @@ import {
   createTestOrganization,
   createTestUser,
 } from '../../setup/test-fixtures';
-import { cleanupTestDatabase } from '../../setup/test-db';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { TestApiClient } from '../../setup/test-mcp-client';
 
 describe('entity metadata validation > automation provenance keys', () => {
@@ -122,6 +122,161 @@ describe('entity metadata validation > automation provenance keys', () => {
         metadata: { status: 'not-a-state' },
       })
     ).rejects.toThrow();
+  });
+
+  it('initializes metadata when a stored row has null metadata', async () => {
+    const created = (await owner.entities.create({
+      type: 'strict-task',
+      name: 'Initialize null metadata',
+      metadata: { action: 'Initial content' },
+    })) as { entity: { id: number } };
+    await getTestDb()`UPDATE entities SET metadata = NULL WHERE id = ${created.entity.id}`;
+    await owner.entities.update({
+      entity_id: created.entity.id,
+      metadata: { action: 'Initialized content' },
+    });
+    const got = (await owner.entities.get({ entity_id: created.entity.id })) as {
+      entity: { metadata: Record<string, unknown> };
+    };
+    expect(got.entity.metadata.action).toBe('Initialized content');
+  });
+
+  it('edits a legacy promoted row when the strict schema has no source field', async () => {
+    await owner.entity_schema.createType({
+      slug: 'strict-no-source',
+      name: 'Strict without source',
+      metadata_schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { action: { type: 'string' }, status: { type: 'string' } },
+        required: ['action'],
+      },
+    } as never);
+    const created = (await owner.entities.create({
+      type: 'strict-no-source',
+      name: 'Legacy promotion',
+      metadata: { action: 'Keep required content', status: 'backlog' },
+    })) as { entity: { id: number } };
+    const sql = getTestDb();
+    // Reproduce the historical promotion shape, which bypassed schema validation.
+    await sql`
+      UPDATE entities
+      SET metadata = metadata || ${sql.json({
+        source: 'automation_promotion',
+        automation_id: 7,
+        automation_output: 'items',
+        run_id: 9,
+        stable_key: 'synthetic-legacy',
+      })}
+      WHERE id = ${created.entity.id}
+    `;
+    await expect(owner.entities.update({
+      entity_id: created.entity.id,
+      metadata: { status: 'done' },
+    })).rejects.toThrow("unknown property 'source'");
+    await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier)
+      SELECT organization_id, id, 'automation_key', 'synthetic-legacy'
+      FROM entities
+      WHERE id = ${created.entity.id}
+    `;
+    await owner.entities.update({
+      entity_id: created.entity.id,
+      metadata: { status: 'done' },
+    });
+    const got = (await owner.entities.get({ entity_id: created.entity.id })) as {
+      entity: { metadata: Record<string, unknown> };
+    };
+    expect(got.entity.metadata).toMatchObject({
+      action: 'Keep required content', status: 'done', source: 'automation_promotion',
+    });
+    await expect(owner.entities.update({
+      entity_id: created.entity.id,
+      metadata: { source: 'https://example.invalid/domain-value' },
+    })).rejects.toThrow("unknown property 'source'");
+    await expect(owner.entities.create({
+      type: 'strict-no-source',
+      name: 'Spoofed provenance metadata',
+      metadata: {
+        action: 'Stay strict',
+        source: 'automation_promotion',
+        automation_id: 7,
+        automation_output: 'items',
+        run_id: 9,
+        stable_key: 'not-an-identity',
+      },
+    })).rejects.toThrow("unknown property 'source'");
+  });
+
+  it.each([
+    ['property', {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        action: { type: 'string' },
+        source: { enum: ['verified'] },
+      },
+      required: ['action'],
+    }],
+    ['pattern', {
+      type: 'object',
+      additionalProperties: false,
+      properties: { action: { type: 'string' } },
+      patternProperties: { '^source$': { enum: ['verified'] } },
+      required: ['action'],
+    }],
+    ['composition', {
+      anyOf: [
+        {
+          type: 'object',
+          additionalProperties: false,
+          properties: { action: { type: 'string' } },
+          required: ['action'],
+        },
+        {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            action: { type: 'string' },
+            source: { enum: ['verified'] },
+          },
+          required: ['action', 'source'],
+        },
+      ],
+    }],
+  ])('validates a domain source declared by %s', async (kind, metadataSchema) => {
+    await owner.entity_schema.createType({
+      slug: `strict-domain-source-${kind}`,
+      name: 'Strict domain source',
+      metadata_schema: metadataSchema,
+    } as never);
+    const created = (await owner.entities.create({
+      type: `strict-domain-source-${kind}`,
+      name: `Declared source validation ${kind}`,
+      metadata: { action: 'Stay strict', source: 'verified' },
+    })) as { entity: { id: number } };
+    const sql = getTestDb();
+    await sql`
+      UPDATE entities
+      SET metadata = metadata || ${sql.json({
+        source: 'automation_promotion',
+        automation_id: 7,
+        automation_output: 'items',
+        run_id: 9,
+        stable_key: 'declared-source',
+      })}
+      WHERE id = ${created.entity.id}
+    `;
+    await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier)
+      SELECT organization_id, id, 'automation_key', ${`declared-source-${kind}`}
+      FROM entities
+      WHERE id = ${created.entity.id}
+    `;
+    await expect(owner.entities.update({
+      entity_id: created.entity.id,
+      metadata: { action: 'Still strict' },
+    })).rejects.toThrow();
   });
 
   /**

--- a/packages/server/src/__tests__/integration/entity-schema/metadata-provenance-keys.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/metadata-provenance-keys.test.ts
@@ -2,8 +2,8 @@
  * Automation-promotion provenance keys must survive metadata round-trips.
  *
  * `promote-keyed-entities.ts` stamps `automation_id` / `stable_key` / `run_id`
- * / `automation_output` (plus `source`) onto promoted entity metadata via raw SQL — outside
- * schema validation. Under an `additionalProperties: false` entity-type schema
+ * / `automation_output` onto promoted entity metadata outside schema validation.
+ * Under an `additionalProperties: false` entity-type schema
  * that meant a promoted entity's metadata could never be written back through
  * `entities.update`: reading the metadata, editing one domain field, and
  * saving rejected with an unknown platform property. Validation now exempts
@@ -98,9 +98,34 @@ describe('entity metadata validation > automation provenance keys', () => {
     expect(err?.message).toContain("unknown property 'bogus_field'");
   });
 
+  it('validates a partial patch against the merged entity metadata', async () => {
+    const created = (await owner.entities.create({
+      type: 'strict-task',
+      name: 'Partial edit',
+      metadata: { action: 'Preserve the required action', status: 'backlog' },
+    })) as { entity: { id: number } };
+
+    await owner.entities.update({
+      entity_id: created.entity.id,
+      metadata: { status: 'active' },
+    });
+    const got = (await owner.entities.get({ entity_id: created.entity.id })) as {
+      entity: { metadata: Record<string, unknown> };
+    };
+    expect(got.entity.metadata).toMatchObject({
+      action: 'Preserve the required action',
+      status: 'active',
+    });
+    await expect(
+      owner.entities.update({
+        entity_id: created.entity.id,
+        metadata: { status: 'not-a-state' },
+      })
+    ).rejects.toThrow();
+  });
+
   /**
-   * The entity form sends the whole object, because the server validates the
-   * patch as a document rather than the merge (owletto#845). So a cleared
+   * The entity form can send the whole object (owletto#845). A cleared
    * optional field arrives as `status: null` alongside its surviving siblings —
    * and the schema types `status` as a string enum, which the raw patch fails.
    */

--- a/packages/server/src/tools/admin/manage_automations/feedback.ts
+++ b/packages/server/src/tools/admin/manage_automations/feedback.ts
@@ -284,8 +284,8 @@ export async function handleGetFeedback(
  * field values) plus `field_controls` (which fields a human already owns).
  * The web activity view uses only the count + entity_type for its outputs
  * strip; field ownership/corrections live on the entity page. Promoted
- * children stamp `metadata.automation_id` / `source='automation_promotion'` at
- * promotion time.
+ * children stamp `metadata.automation_id` and hold an `automation_key` identity.
+ * `source` is a domain field and can contain the original evidence URL.
  *
  * Org-scoped so a member of org A can't enumerate org B's promoted entities by
  * passing an automation_id (auth also gates on requireAutomationAccess 'read').
@@ -306,8 +306,14 @@ export async function handleListPromoted(
     JOIN entity_types et ON et.id = e.entity_type_id
     WHERE e.organization_id = ${ctx.organizationId}
       AND e.deleted_at IS NULL
-      AND e.metadata->>'source' = 'automation_promotion'
       AND e.metadata->>'automation_id' = ${automationId}
+      AND EXISTS (
+        SELECT 1 FROM entity_identities ei
+        WHERE ei.organization_id = e.organization_id
+          AND ei.entity_id = e.id
+          AND ei.namespace = 'automation_key'
+          AND ei.deleted_at IS NULL
+      )
     ORDER BY e.name
     LIMIT ${limit}
   `;

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -653,6 +653,13 @@ async function handleUpdate(
 			before.entity_type as string,
 			metadataForValidation,
 			ctx,
+			{
+				legacyAutomationEntityId:
+					(before.metadata as Record<string, unknown> | null)?.source ===
+					'automation_promotion'
+						? entityId
+						: undefined,
+			},
 		);
 		if (!validation.valid) {
 			const errorMessages =

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -645,7 +645,9 @@ async function handleUpdate(
 		 * AJV mutates the copy; propagate its coercions without dropping sentinels.
 		 */
 		const metadataForValidation = Object.fromEntries(
-			Object.entries(args.metadata).filter(([, value]) => value !== null),
+			Object.entries({ ...before.metadata, ...args.metadata }).filter(
+				([, value]) => value !== null,
+			),
 		);
 		const validation = await validateEntityMetadata(
 			before.entity_type as string,
@@ -658,7 +660,12 @@ async function handleUpdate(
 				"Invalid metadata";
 			throw new ToolUserError(`Metadata validation failed: ${errorMessages}`, 400);
 		}
-		Object.assign(args.metadata, metadataForValidation);
+		// Coerce only the submitted patch. Copying the saved siblings back into
+		// the patch would claim human ownership of fields the caller never edited
+		// and could overwrite a concurrent update before the locked write.
+		for (const key of Object.keys(args.metadata)) {
+			if (args.metadata[key] !== null) args.metadata[key] = metadataForValidation[key];
+		}
 	}
 
 	// Build update data (only include fields that are present)
@@ -682,7 +689,7 @@ async function handleUpdate(
 	// Content body
 	if (args.content !== undefined) updateData.content = args.content;
 
-	// Metadata (replaces entire object)
+	// Metadata patch (merged with the locked current row in updateEntity)
 	if (args.metadata !== undefined) updateData.metadata = args.metadata;
 
 	// Human-correction note: annotates the field_controls marker for the fields

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -765,9 +765,7 @@ export async function promoteAutomationEntityOutput(
       }
     }
     const metadata: Record<string, unknown> = {
-      // `source` can be a declared domain field (for example an evidence URL).
-      // Origin attribution is already carried by automation_id/automation_output/run_id.
-      source: 'automation_promotion',
+      // Domain source evidence is preserved; provenance has its own keys below.
       ...fieldValues,
       automation_id: automationId,
       automation_output: outputName,

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -765,11 +765,13 @@ export async function promoteAutomationEntityOutput(
       }
     }
     const metadata: Record<string, unknown> = {
+      // `source` can be a declared domain field (for example an evidence URL).
+      // Origin attribution is already carried by automation_id/automation_output/run_id.
+      source: 'automation_promotion',
       ...fieldValues,
       automation_id: automationId,
       automation_output: outputName,
       stable_key: stableKey,
-      source: 'automation_promotion',
       // Origin provenance lives on the entity itself — the run that first
       // produced it. (No separate append-only observation event in phase 1;
       // the entity is upserted once, so this is its origin, not a time series.)

--- a/packages/server/src/utils/schema-validation.ts
+++ b/packages/server/src/utils/schema-validation.ts
@@ -24,6 +24,10 @@ interface ValidationResult {
   errors?: ValidationError[];
 }
 
+interface MetadataValidationOptions {
+  legacyAutomationEntityId?: number;
+}
+
 /**
  * Fetch the metadata schema for an entity type from the database.
  * Returns null if no schema is defined (allowing any metadata).
@@ -83,6 +87,25 @@ function withoutAutomationProvenanceKeys(
   );
 }
 
+function schemaMayDefineSource(schema: Record<string, unknown>): boolean {
+  const properties = schema.properties;
+  if (
+    properties &&
+    typeof properties === 'object' &&
+    !Array.isArray(properties) &&
+    Object.hasOwn(properties, 'source')
+  ) return true;
+  const patterns = schema.patternProperties;
+  if (
+    patterns &&
+    typeof patterns === 'object' &&
+    !Array.isArray(patterns) &&
+    Object.keys(patterns).some((pattern) => new RegExp(pattern).test('source'))
+  ) return true;
+  if (Array.isArray(schema.required) && schema.required.includes('source')) return true;
+  return schema.additionalProperties !== false;
+}
+
 /**
  * Validate entity metadata against the entity type's JSON schema.
  *
@@ -96,7 +119,8 @@ function withoutAutomationProvenanceKeys(
 export async function validateEntityMetadata(
   entityType: string,
   metadata: Record<string, unknown> | undefined | null,
-  ctx: ToolContext
+  ctx: ToolContext,
+  options: MetadataValidationOptions = {}
 ): Promise<ValidationResult> {
   // No metadata provided - valid (defaults to empty object). An explicit empty
   // object still needs schema validation because the schema may require fields.
@@ -129,8 +153,38 @@ export async function validateEntityMetadata(
   // otherwise fail every round-trip under additionalProperties: false.
   const ajv = getAjv();
   const validate = ajv.compile(schema);
-  const candidate = withoutAutomationProvenanceKeys(metadata);
-  const isValid = validate(candidate);
+  let candidate = withoutAutomationProvenanceKeys(metadata);
+  let isValid = validate(candidate);
+  // Old promotion stamped this exact marker even when source was not a domain
+  // field. Only an update of an existing promoted row may ignore it, and only
+  // when the schema does not define source as domain data.
+  if (
+    !isValid &&
+    options.legacyAutomationEntityId != null &&
+    candidate !== metadata &&
+    candidate.source === 'automation_promotion' &&
+    !schemaMayDefineSource(schema) &&
+    validate.errors?.some(
+      (error) => error.instancePath === '' &&
+        error.keyword === 'additionalProperties' &&
+        error.params.additionalProperty === 'source'
+    )
+  ) {
+    const identities = await getDb()`
+      SELECT 1
+      FROM entity_identities
+      WHERE entity_id = ${options.legacyAutomationEntityId}
+        AND organization_id = ${ctx.organizationId}
+        AND namespace = 'automation_key'
+        AND deleted_at IS NULL
+      LIMIT 1
+    `;
+    if (identities.length > 0) {
+      candidate = { ...candidate };
+      delete candidate.source;
+      isValid = validate(candidate);
+    }
+  }
   if (candidate !== metadata) {
     // The AJV singleton runs with coerceTypes, mutating the validated object
     // in place — callers persist those coercions. When we validated a stripped

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -9,6 +9,15 @@ export default defineConfig({
   // the repo root (with an explicit Node-backed invocation) or from inside the
   // package via the canonical `bun run test -- run ...` script.
   root: PACKAGE_ROOT,
+  resolve: {
+    alias: {
+      // Example fixtures load the real authoring config; server CI does not
+      // build the CLI distribution, so resolve its dependency-light source.
+      "@lobu/cli/config": fileURLToPath(
+        new URL("../cli/src/config/index.ts", import.meta.url),
+      ),
+    },
+  },
   test: {
     globalSetup: ["./src/__tests__/setup/global-setup.ts"],
     // Automation windows select rows by `events.created_at` and stop one

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -24,7 +24,12 @@ export default defineConfig({
     },
     // Integration tests need a DB ready before any test file starts. Unit tests
     // don't touch the DB, so they run fast regardless.
-    include: ["src/**/*.test.ts"],
+    include: [
+      "src/**/*.test.ts",
+      // Example-owned lifecycle fixtures share this isolated Postgres harness.
+      // The suffix keeps them out of examples' separate bun:test unit run.
+      "../../examples/*/evals/*.integration.ts",
+    ],
     // bun:test-style unit tests live alongside vitest integration tests — skip
     // those for vitest. They run via `bun test` (see the existing CI command).
     // Anything under `src/gateway/**/__tests__` is bun:test-style (carried over


### PR DESCRIPTION
## Summary
Task lifecycle tests exposed four persistence failures: promotion overwrote a declared source with its internal marker, partial metadata edits rejected saved required fields, stale output could reopen an automatically completed task, and a partial closure could leave an active help proposal.

Preserve declared source evidence without adding an internal source marker, and use existing promotion identity for output discovery; validate the merged metadata while writing only the submitted patch; use the personal-agent task type's existing write-rule/approval path to hold reopening of closed tasks and reject closure unless the proposal is cleared.

## Test plan

- [x] Real isolated Postgres lifecycle fixture: source read, completeWindow, keyed task persistence, compiled reaction, inbox, delivery receipts, retries, changed/reverted offers, owner fields, completion, and explicit reopening approval.
- [x] 120 integration tests passed across 9 suites, including Gmail source reads, window SQL consistency, channel sources, reaction crash recovery, and durable delivery.
- [x] 34 task configuration/reaction unit tests passed (89 assertions).
- [x] Root TypeScript check passed.
- [x] Clean CLI build-artifact reproduction: fixture failed to load before the test alias; all 113 then-current integration tests passed with the CLI artifact absent after the fix.
- [x] Explicit-path staging, final `make pre-pr`, and pre-commit checks passed.
- [x] Review-fix pass completed; all changes reread and 120 integration tests rerun green.
- [x] GitHub CI on final HEAD: all required checks green.
- [x] Exact-head Codex semantic review: zero bugs and zero blockers.
- [x] Production smoke: all 9 checks passed on squash commit `da81fd66ff0694e9874f2be05bd1a92c21b77342`; app, worker and embeddings all ready on the corresponding image release.
- [x] Live source-only repair through the personal agent: all 26 exact evidence matches updated; independent reread confirmed other metadata and field ownership unchanged.
- [x] Live lifecycle on the deployed commit: a new request became a task with preserved source evidence, an inbox notification, and one Slack delivery receipt. The agent executed two independent calculation methods, persisted completion with the proposal cleared, and a subsequent builder window kept both test tasks closed without another notice.
- [x] Live negative closure test rejected a status-only close while preserving the proposal and current state.
- [x] Historical data repair: restored 26 original labels and replaced 75 corrupted markers with explicit stored source references. Independent metadata, name and ownership comparisons passed; one completed legacy record received only missing identity fields.
- [x] Finished release fixture soft-deleted and its source tombstoned; test notifications marked read. One closed baseline fixture remains for the human Slack reply check.

Red before the fixes:
```
Tests  5 failed | 2 passed (7)
source: expected "https://example.invalid/request/verification", received "automation_promotion"
partial proposal/status edits: Metadata validation failed: missing required field: action
stale completed-task output: expected "done", received "backlog"
```

Green after the fixes:
```
Test Files  9 passed (9)
Tests       120 passed (120)
```

The review identified a legacy strict-schema edge case. A compatibility retry now requires an existing marker-bearing row and an active, tenant-scoped promotion identity; domain-source schemas remain enforced. Regression coverage includes spoofed metadata, ordinary properties, pattern properties, composed schemas, and nullable stored metadata.

The final review also reproduced incomplete closure (2 failing cases, 9 passing): setting only `status` retained the old `agent_help`. The task rule now rejects that write; clearing the proposal in the same update succeeds for both done and dismissed states.

## Notes
The example owns task semantics; shared runtime changes apply to entity metadata and promotion generally. No new database table or SDK method. Deadline reminder behavior is unchanged.

External transport is controlled in the deterministic suite. An already queued notification remains a snapshot and may arrive after closure; its activation prompt rereads current task state. Provider acceptance followed by receipt loss remains an at-least-once delivery boundary.


Live activation used the notification's actual prepared prompt through a private SDK agent conversation. A fresh human reply in the Slack notification thread remains unverified; it is not implied by the delivery or SDK execution proof. The 75 reference-only labels do not claim newly verified original message content.
