### PR TITLE
fix(mcp): hand off scoped file references to connector actions

### DIFF
--- a/docs/connector-authoring.md
+++ b/docs/connector-authoring.md
@@ -198,6 +198,28 @@ Declare `actions` with an `inputSchema`, `requiresApproval`, and annotations
 (`destructiveHint`, `openWorldHint`, `idempotentHint`); handle them in
 `execute(ctx)`. Omit it entirely if the connector has no actions.
 
+For binary inputs, use `fileInputSchema` from `@lobu/connector-sdk` on the
+file-valued field, for example `image: fileInputSchema({ maxBytes: 5 * 1024 *
+1024, contentTypes: ["image/png", "image/jpeg"] })`. Callers pass a reusable
+`{ $file: "lobu://file/<id>", ... }` reference; `execute(ctx)` receives
+`{ base64, filename, content_type }` at that field. Existing inline base64 inputs
+also work and obey the declared size and media-type limits.
+
+Clients can upload repeated multipart `files` fields to
+`POST /api/<workspace>/files` using their normal authenticated API session and
+write scope. The response contains a `files` array of references. ChatGPT can
+instead attach files directly to `run_sdk`; select `file_organization` on an
+account-scoped connection, then use `ctx.files` in the script. Upload references
+are also returned when the script fails, so retry with those references.
+
+Ingestion uses the shared artifact store and accepts up to 10 files, 50 MiB per
+file and 100 MiB per batch. Connector execution accepts at most 12 MiB of file
+data per operation, or the connector's smaller declared limit; the current
+isolate bridge caps each base64 string at 16 MiB. References are bound to the uploading user,
+workspace, and any agent or Automation identity. The existing operation queue
+records file authorization before approval and resolves the same stored bytes
+at execution; missing or substituted files fail before connector dispatch.
+
 ### Auth methods
 
 `none`, `env_keys` (scope `connection` or `organization`), `oauth` (built-in or

--- a/docs/connector-authoring.md
+++ b/docs/connector-authoring.md
@@ -214,11 +214,11 @@ are also returned when the script fails, so retry with those references.
 
 Ingestion uses the shared artifact store and accepts up to 10 files, 50 MiB per
 file and 100 MiB per batch. Connector execution accepts at most 12 MiB of file
-data per operation, or the connector's smaller declared limit; the current
-isolate bridge caps each base64 string at 16 MiB. References are bound to the uploading user,
-workspace, and any agent or Automation identity. The existing operation queue
-records file authorization before approval and resolves the same stored bytes
-at execution; missing or substituted files fail before connector dispatch.
+data per operation, or the connector's smaller declared limit. References are
+bound to the uploading user, workspace, and any agent or Automation identity.
+The existing operation queue records file authorization before approval and
+resolves the same stored bytes at execution; missing or substituted files fail
+before connector dispatch.
 
 ### Auth methods
 

--- a/docs/connector-authoring.md
+++ b/docs/connector-authoring.md
@@ -216,6 +216,8 @@ Ingestion uses the shared artifact store and accepts up to 10 files, 50 MiB per
 file and 100 MiB per batch. Connector execution accepts at most 12 MiB of file
 data per operation, or the connector's smaller declared limit. References are
 bound to the uploading user, workspace, and any agent or Automation identity.
+Within the same identity, human sessions and ordinary OAuth callers share a
+file binding; device-worker grants use a separate binding.
 The existing operation queue records file authorization before approval and
 resolves the same stored bytes at execution; missing or substituted files fail
 before connector dispatch.

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -522,13 +522,6 @@ export type QuerySdkResponses = {
    * Successful response
    */
   200: {
-    files?: Array<{
-      $file: string;
-      filename: string;
-      content_type: string;
-      size_bytes: number;
-      sha256: string;
-    }>;
     /**
      * The caller-supplied human-friendly heading for this result, echoed back for the UI.
      */
@@ -792,13 +785,6 @@ export type RunSdkResponses = {
    * Successful response
    */
   200: {
-    files?: Array<{
-      $file: string;
-      filename: string;
-      content_type: string;
-      size_bytes: number;
-      sha256: string;
-    }>;
     /**
      * The caller-supplied human-friendly heading for this result, echoed back for the UI.
      */
@@ -881,6 +867,13 @@ export type RunSdkResponses = {
       count: number;
     }>;
     dry_run: boolean;
+    files?: Array<{
+      $file: string;
+      filename: string;
+      content_type: string;
+      size_bytes: number;
+      sha256: string;
+    }>;
   };
 };
 

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -478,7 +478,7 @@ export type SearchSdkResponse = SearchSdkResponses[keyof SearchSdkResponses];
 export type QuerySdkData = {
   body: {
     /**
-     * TypeScript source. Must `export default async (ctx, client) => { ... }` — `ctx` is `{ organization_id, user_id, mode, sleep(ms) }`, where `await ctx.sleep(ms)` provides a bounded, abort-aware 0–30000ms polling delay; unrestricted timer globals are unavailable. `client` is the ClientSDK. Bare OAuth has organization_id=null: first select const workspace = await client.org(target) for workspace methods; account discovery and conversation titles work on the root client. The script's return value comes back as `return_value`; return it only for computed results and bounded samples. For bulk data prefer `client.query` / `query_sql` or paginated SDK reads — a return over the output cap is replaced by a `return_value_preview` head and a `return_truncated` report instead of shipping the full set to the model. Use `search_sdk` to discover SDK methods and `ctx.sleep`.
+     * TypeScript source. Must `export default async (ctx, client) => { ... }` — `ctx` is `{ organization_id, user_id, mode, files, sleep(ms) }`, where `await ctx.sleep(ms)` provides a bounded, abort-aware 0–30000ms polling delay; unrestricted timer globals are unavailable. `client` is the ClientSDK. Bare OAuth has organization_id=null: first select const workspace = await client.org(target) for workspace methods; account discovery and conversation titles work on the root client. The script's return value comes back as `return_value`; return it only for computed results and bounded samples. For bulk data prefer `client.query` / `query_sql` or paginated SDK reads — a return over the output cap is replaced by a `return_value_preview` head and a `return_truncated` report instead of shipping the full set to the model. Use `search_sdk` to discover SDK methods and `ctx.sleep`.
      */
     script: string;
     /**
@@ -522,6 +522,13 @@ export type QuerySdkResponses = {
    * Successful response
    */
   200: {
+    files?: Array<{
+      $file: string;
+      filename: string;
+      content_type: string;
+      size_bytes: number;
+      sha256: string;
+    }>;
     /**
      * The caller-supplied human-friendly heading for this result, echoed back for the UI.
      */
@@ -724,7 +731,7 @@ export type QuerySqlResponse = QuerySqlResponses[keyof QuerySqlResponses];
 export type RunSdkData = {
   body: {
     /**
-     * TypeScript source. Must `export default async (ctx, client) => { ... }` — `ctx` is `{ organization_id, user_id, mode, sleep(ms) }`, where `await ctx.sleep(ms)` provides a bounded, abort-aware 0–30000ms polling delay; unrestricted timer globals are unavailable. `client` is the ClientSDK. Bare OAuth has organization_id=null: first select const workspace = await client.org(target) for workspace methods; account discovery and conversation titles work on the root client. The script's return value comes back as `return_value`; return it only for computed results and bounded samples. For bulk data prefer `client.query` / `query_sql` or paginated SDK reads — a return over the output cap is replaced by a `return_value_preview` head and a `return_truncated` report instead of shipping the full set to the model. Use `search_sdk` to discover SDK methods and `ctx.sleep`.
+     * TypeScript source. Must `export default async (ctx, client) => { ... }` — `ctx` is `{ organization_id, user_id, mode, files, sleep(ms) }`, where `await ctx.sleep(ms)` provides a bounded, abort-aware 0–30000ms polling delay; unrestricted timer globals are unavailable. `client` is the ClientSDK. Bare OAuth has organization_id=null: first select const workspace = await client.org(target) for workspace methods; account discovery and conversation titles work on the root client. The script's return value comes back as `return_value`; return it only for computed results and bounded samples. For bulk data prefer `client.query` / `query_sql` or paginated SDK reads — a return over the output cap is replaced by a `return_value_preview` head and a `return_truncated` report instead of shipping the full set to the model. Use `search_sdk` to discover SDK methods and `ctx.sleep`.
      */
     script: string;
     /**
@@ -735,6 +742,19 @@ export type RunSdkData = {
      * Human-friendly heading for this result (e.g. "Companies missing a domain"). In run_sdk, it also labels browser tab groups opened by the script. The UI renders it above the execution status; without it the result card has no subject line. Set it whenever a person will read the result.
      */
     title?: string;
+    /**
+     * Files supplied by the chat host. The server imports bytes before running the script; ctx.files contains reusable Lobu file references. Do not invent download URLs, file IDs, or local paths.
+     */
+    files?: Array<{
+      download_url: string;
+      file_id: string;
+      mime_type?: string;
+      file_name?: string;
+    }>;
+    /**
+     * Workspace slug or ID that will own attached files. Required with files on an account-scoped MCP connection. Files become ctx.files; pass a file directly to a connector field declaring x-lobu-file. Existing references need no re-upload.
+     */
+    file_organization?: string;
     /**
      * Preview mode. Read SDK calls still execute, but write/admin/external SDK calls are canonicalized and validated, then skipped and returned in side_effect_preview without executing their handlers.
      */
@@ -772,6 +792,13 @@ export type RunSdkResponses = {
    * Successful response
    */
   200: {
+    files?: Array<{
+      $file: string;
+      filename: string;
+      content_type: string;
+      size_bytes: number;
+      sha256: string;
+    }>;
     /**
      * The caller-supplied human-friendly heading for this result, echoed back for the UI.
      */

--- a/packages/connector-sdk/src/file-input.ts
+++ b/packages/connector-sdk/src/file-input.ts
@@ -1,0 +1,64 @@
+/** Portable connector file input. The gateway resolves references after approval. */
+export interface FileReference {
+  $file: string;
+  filename?: string;
+  content_type?: string;
+  size_bytes?: number;
+  sha256?: string;
+}
+
+/** The bytes presented to connector code, outside the agent's script bridge. */
+export interface ConnectorFile {
+  base64: string;
+  filename: string;
+  content_type: string;
+}
+
+export interface FileInputOptions {
+  maxBytes: number;
+  contentTypes?: string[];
+}
+
+/** Base64 expands this to the isolate's existing 16 MiB string-message cap. */
+export const MAX_CONNECTOR_FILE_BYTES = 12 * 1024 * 1024;
+
+/**
+ * Declare a file-valued action field. Clients may pass a Lobu file reference
+ * or existing inline bytes. Connector code always receives ConnectorFile.
+ * This is a Lobu connector contract, not a declaration of draft MCP support.
+ */
+export function fileInputSchema(options: FileInputOptions): Record<string, unknown> {
+  if (!Number.isSafeInteger(options.maxBytes) || options.maxBytes <= 0 || options.maxBytes > MAX_CONNECTOR_FILE_BYTES) {
+    throw new Error(`fileInputSchema maxBytes must be between 1 and ${MAX_CONNECTOR_FILE_BYTES}`);
+  }
+  const metadata = {
+    filename: { type: 'string', minLength: 1, maxLength: 255 },
+    content_type: { type: 'string', minLength: 1, maxLength: 100 },
+  };
+  return {
+    'x-lobu-file': options,
+    description: 'Pass a file from run_sdk ctx.files or an authenticated Lobu file upload. Do not copy file bytes through the model or use a local pathname.',
+    anyOf: [
+      {
+        type: 'object',
+        properties: {
+          $file: { type: 'string', pattern: '^lobu://file/[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$' },
+          ...metadata,
+          size_bytes: { type: 'integer', minimum: 1 },
+          sha256: { type: 'string', pattern: '^[0-9a-f]{64}$' },
+        },
+        required: ['$file'],
+        additionalProperties: false,
+      },
+      {
+        type: 'object',
+        properties: {
+          base64: { type: 'string', minLength: 4, maxLength: 4 * Math.ceil(options.maxBytes / 3) },
+          ...metadata,
+        },
+        required: ['base64', 'filename', 'content_type'],
+        additionalProperties: false,
+      },
+    ],
+  };
+}

--- a/packages/connector-sdk/src/file-input.ts
+++ b/packages/connector-sdk/src/file-input.ts
@@ -19,7 +19,7 @@ export interface FileInputOptions {
   contentTypes?: string[];
 }
 
-/** Base64 expands this to the isolate's existing 16 MiB string-message cap. */
+/** Base64 encoding expands this raw-byte limit to 16 MiB. */
 export const MAX_CONNECTOR_FILE_BYTES = 12 * 1024 * 1024;
 
 /**

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -20,6 +20,8 @@ export {
   IntegrationConnector,
 } from './connector-runtime.js';
 export { defineConnector } from './define-connector.js';
+export { fileInputSchema, MAX_CONNECTOR_FILE_BYTES } from './file-input.js';
+export type { ConnectorFile, FileInputOptions, FileReference } from './file-input.js';
 export {
   canonicalDeviceManifestJson,
   defineDeviceConnector,

--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -493,6 +493,28 @@ describe('tool invocation audit coverage', () => {
     }
   );
 
+  it.each([true, false])('omits host file capabilities from persisted requests (valid: %s)', async (valid) => {
+    const downloadUrl = 'https://files.example.test/photo?signature=synthetic-private-file-capability';
+    const args = {
+      script: 'export default async (ctx) => ctx.files.length',
+      files: valid ? [{ download_url: downloadUrl, file_id: 'synthetic-private-file-id' }] : downloadUrl,
+    };
+    await recordToolInvocationAudit({
+      toolName: 'run_sdk', args,
+      result: { success: valid },
+      error: valid ? undefined : new Error('Invalid attachment input'),
+      durationMs: 1, ctx: authCtxFor('pat') as never,
+    });
+    const row = await latestAuditRow(orgId, 'run_sdk');
+    expect(row!.payload_data.request).toEqual({ script: args.script, files: REDACTED_SENTINEL });
+    expect(JSON.stringify(row)).not.toContain('synthetic-private-file');
+    expect(await readAuditEvent(row!.id, authCtxFor('pat'))).toMatchObject({
+      request: { script: args.script, files: REDACTED_SENTINEL },
+    });
+    // Audit redaction must not mutate the live tool's intake arguments.
+    expect(JSON.stringify(args.files)).toContain(downloadUrl);
+  });
+
   it('bounds large requests directly on their audit event', async () => {
     const script = 'x'.repeat(300 * 1024);
     await recordToolInvocationAudit({

--- a/packages/server/src/__tests__/integration/operation-file-handoff.test.ts
+++ b/packages/server/src/__tests__/integration/operation-file-handoff.test.ts
@@ -16,8 +16,15 @@ import { manageOperations } from '../../tools/admin/manage_operations';
 import type { ToolContext } from '../../tools/registry';
 import { initWorkspaceProvider } from '../../workspace';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
-import { createTestConnection, createTestConnectorDefinition, createTestSession, seedOwnerContext } from '../setup/test-fixtures';
-import { post } from '../setup/test-helpers';
+import {
+  createTestAccessToken,
+  createTestConnection,
+  createTestConnectorDefinition,
+  createTestOAuthClient,
+  createTestSession,
+  seedOwnerContext,
+} from '../setup/test-fixtures';
+import { mcpToolsCall, post } from '../setup/test-helpers';
 
 const CONNECTOR = 'demo.file.handoff';
 
@@ -26,6 +33,8 @@ describe('multipart file → operation approval → connector execution', () => 
   let orgSlug: string;
   let connectionId: number;
   let cookie: string;
+  let token: string;
+  let deviceToken: string;
   let directory: string;
   let store: ArtifactStore;
   let receiver: Server;
@@ -40,6 +49,11 @@ describe('multipart file → operation approval → connector execution', () => 
     ctx = seeded.ctx;
     orgSlug = seeded.org.slug;
     cookie = (await createTestSession(ctx.userId!)).cookieHeader;
+    const oauthClient = await createTestOAuthClient();
+    token = (await createTestAccessToken(ctx.userId!, ctx.organizationId, oauthClient.client_id)).token;
+    deviceToken = (await createTestAccessToken(ctx.userId!, ctx.organizationId, oauthClient.client_id, {
+      scope: 'device_worker:run mcp:read mcp:write mcp:admin',
+    })).token;
     directory = await mkdtemp(join(tmpdir(), 'lobu-file-handoff-test-'));
     store = new ArtifactStore(directory);
     vi.spyOn(gateway, 'getLobuCoreServices').mockReturnValue({ getArtifactStore: () => store });
@@ -104,6 +118,26 @@ describe('multipart file → operation approval → connector execution', () => 
     }), { ENVIRONMENT: 'test', BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only', RATE_LIMIT_ENABLED: 'false' } as Env);
   }
 
+  async function completeUpload(runId: number) {
+    const approval = await post(`/api/${orgSlug}/manage_operations`, { cookie, body: { action: 'approve', run_id: runId } });
+    expect(await approval.json()).toMatchObject({ approved: true });
+    const workerId = 'file-handoff-test-worker';
+    const job = await (await post('/api/workers/poll', { body: { worker_id: workerId, capabilities: {} } })).json();
+    expect(job.run_id).toBe(runId);
+    const executed = await executeCompiledConnector({
+      compiledCode: job.compiled_code,
+      job: { mode: 'action', actionKey: job.action_key, actionInput: job.action_input, config: job.config ?? {}, env: {}, credentials: {} },
+      allowedDomains: [],
+    });
+    expect(executed.mode).toBe('action');
+    if (executed.mode !== 'action') throw new Error('Expected connector action');
+    const completed = await post('/api/workers/complete-action', { body: {
+      run_id: runId, worker_id: workerId, status: 'success', action_output: executed.output,
+    } });
+    expect(await completed.json()).toMatchObject({ success: true });
+    return executed;
+  }
+
   it('uploads once, queues reusable metadata, and resolves bytes only when a human approves', async () => {
     const response = await upload();
     expect(response.status).toBe(201);
@@ -152,6 +186,41 @@ describe('multipart file → operation approval → connector execution', () => 
   it('refuses anonymous multipart uploads', async () => {
     const response = await upload('');
     expect([401, 403]).toContain(response.status);
+  });
+
+  it.each(['human', 'device'])('imports host attachments for %s callers through MCP run_sdk ctx.files and an actual connector', async (principal) => {
+    const download = vi.spyOn(egress, 'fetchPublicUrl').mockImplementation(async () => new Response('host-photo', { headers: { 'content-type': 'image/png' } }));
+    try {
+      const result = await mcpToolsCall('run_sdk', {
+        files: [{ download_url: 'https://files.example.test/photo.png', file_id: 'file-handoff-fixture', file_name: 'host.png' }],
+        file_organization: orgSlug,
+        script: `export default async (ctx, client) => ({ file: ctx.files[0], operation: await client.operations.execute({ connection_id: ${connectionId}, operation_key: 'upload', input: { image: ctx.files[0] } }) })`,
+      }, { token: principal === 'device' ? deviceToken : token, orgSlug });
+      expect(result.success).toBe(true);
+      expect(result.return_value.file).toEqual(result.files[0]);
+      const runId = result.return_value.operation.run_id;
+      const [run] = await getTestDb()`SELECT action_input, run_metadata FROM runs WHERE id = ${runId}`;
+      expect(run.action_input.image).toEqual(result.files[0]);
+      expect(run.run_metadata.input_files).toHaveLength(1);
+      expect(await completeUpload(runId)).toMatchObject({ mode: 'action', output: {
+        image: { base64: Buffer.from('host-photo').toString('base64'), filename: 'host.png', content_type: 'image/png' },
+      } });
+    } finally { download.mockRestore(); }
+  });
+
+  it('denies a device-worker token access to human uploads while preserving session-to-OAuth reuse', async () => {
+    const { files } = await (await upload()).json();
+    const args = { script: `export default async (ctx, client) => await client.operations.execute(${JSON.stringify({
+      connection_id: connectionId, operation_key: 'upload', input: { image: files[0] },
+    })})` };
+    const denied = await mcpToolsCall('run_sdk', args, { token: deviceToken, orgSlug });
+    expect(denied.success).toBe(false);
+    expect(denied.error.message).toContain('outside this caller');
+    const allowed = await mcpToolsCall('run_sdk', args, { token, orgSlug });
+    expect(allowed.success).toBe(true);
+    expect(await completeUpload(allowed.return_value.run_id)).toMatchObject({ mode: 'action', output: {
+      image: { base64: Buffer.from('photo-bytes').toString('base64') },
+    } });
   });
 
   it('accepts the current workspace slug and granted account targets without widening scoped access', async () => {

--- a/packages/server/src/__tests__/integration/operation-file-handoff.test.ts
+++ b/packages/server/src/__tests__/integration/operation-file-handoff.test.ts
@@ -1,0 +1,215 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { fileInputSchema } from '@lobu/connector-sdk';
+import { executeCompiledConnector } from '@lobu/connector-worker/executor/runtime';
+import * as egress from '@lobu/connector-worker/egress';
+import { app, type Env } from '../../index';
+import * as gateway from '../../lobu/gateway';
+import { ArtifactStore } from '../../gateway/files/artifact-store';
+import { inputArtifactId } from '../../gateway/files/input-files';
+import { ingestMcpFiles } from '../../mcp-file-inputs';
+import { manageOperations } from '../../tools/admin/manage_operations';
+import type { ToolContext } from '../../tools/registry';
+import { initWorkspaceProvider } from '../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { createTestConnection, createTestConnectorDefinition, createTestSession, seedOwnerContext } from '../setup/test-fixtures';
+import { post } from '../setup/test-helpers';
+
+const CONNECTOR = 'demo.file.handoff';
+
+describe('multipart file → operation approval → connector execution', () => {
+  let ctx: ToolContext;
+  let orgSlug: string;
+  let connectionId: number;
+  let cookie: string;
+  let directory: string;
+  let store: ArtifactStore;
+  let receiver: Server;
+  let uploadUrl: string;
+
+  beforeAll(async () => {
+    vi.stubEnv('LOBU_CLOUD_MODE', 'false');
+    vi.stubEnv('WORKER_API_TOKEN', '');
+    await cleanupTestDatabase();
+    await initWorkspaceProvider();
+    const seeded = await seedOwnerContext({ orgName: 'File handoff test' });
+    ctx = seeded.ctx;
+    orgSlug = seeded.org.slug;
+    cookie = (await createTestSession(ctx.userId!)).cookieHeader;
+    directory = await mkdtemp(join(tmpdir(), 'lobu-file-handoff-test-'));
+    store = new ArtifactStore(directory);
+    vi.spyOn(gateway, 'getLobuCoreServices').mockReturnValue({ getArtifactStore: () => store });
+    await createTestConnectorDefinition({ key: CONNECTOR, name: 'File handoff test', organization_id: ctx.organizationId });
+    const sql = getTestDb();
+    await sql`UPDATE connector_definitions SET actions_schema = ${sql.json({ upload: {
+      name: 'Upload test image', kind: 'write', requiresApproval: true,
+      input_schema: { type: 'object', properties: {
+        image: fileInputSchema({ maxBytes: 5 * 1024 * 1024, contentTypes: ['image/png'] }),
+        alt_text: { type: 'string' }, rank: { type: 'integer' },
+      }, required: ['image'] },
+    } })} WHERE organization_id = ${ctx.organizationId} AND key = ${CONNECTOR}`;
+    await sql`UPDATE connector_versions SET compiled_code = ${`
+      class ConnectorRuntime {
+        async sync() { return { items: [] }; }
+        async execute(ctx) {
+          if (!ctx.config.uploadUrl) return { success: true, output: ctx.input };
+          const { image, alt_text, rank } = ctx.input;
+          const form = new FormData();
+          form.append('image', new Blob([Buffer.from(image.base64, 'base64')], { type: image.content_type }), image.filename);
+          form.append('alt_text', alt_text);
+          form.append('rank', String(rank));
+          const response = await fetch(ctx.config.uploadUrl, { method: 'POST', body: form });
+          return { success: response.ok, output: await response.json() };
+        }
+      }
+      module.exports = { ConnectorRuntime };
+    `} WHERE connector_key = ${CONNECTOR}`;
+    connectionId = (await createTestConnection({ organization_id: ctx.organizationId, connector_key: CONNECTOR, created_by: ctx.userId!, visibility: 'private' })).id;
+    receiver = createServer(async (request, response) => {
+      try {
+        const chunks: Buffer[] = [];
+        for await (const chunk of request) chunks.push(Buffer.from(chunk));
+        const form = await new Response(Buffer.concat(chunks), { headers: { 'content-type': request.headers['content-type']! } }).formData();
+        const file = form.get('image') as File;
+        const bytes = Buffer.from(await file.arrayBuffer());
+        response.setHeader('content-type', 'application/json');
+        response.end(JSON.stringify({ filename: file.name, content_type: file.type, size_bytes: bytes.length,
+          sha256: createHash('sha256').update(bytes).digest('hex'), alt_text: form.get('alt_text'), rank: form.get('rank') }));
+      } catch {
+        response.writeHead(500).end('{}');
+      }
+    });
+    await new Promise<void>((resolve) => receiver.listen(0, '127.0.0.1', resolve));
+    const address = receiver.address();
+    if (!address || typeof address === 'string') throw new Error('Expected TCP test receiver');
+    uploadUrl = `http://127.0.0.1:${address.port}/image`;
+  });
+
+  afterAll(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    if (receiver) await new Promise<void>((resolve, reject) => receiver.close((error) => error ? reject(error) : resolve()));
+    if (directory) await rm(directory, { recursive: true, force: true });
+  });
+
+  async function upload(authCookie = cookie, bytes: Uint8Array = new TextEncoder().encode('photo-bytes')) {
+    const form = new FormData();
+    form.append('files', new File([new Uint8Array(bytes)], 'photo.png', { type: 'image/png' }));
+    return app.fetch(new Request(`http://localhost/api/${orgSlug}/files`, {
+      method: 'POST', headers: { Cookie: authCookie }, body: form,
+    }), { ENVIRONMENT: 'test', BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only', RATE_LIMIT_ENABLED: 'false' } as Env);
+  }
+
+  it('uploads once, queues reusable metadata, and resolves bytes only when a human approves', async () => {
+    const response = await upload();
+    expect(response.status).toBe(201);
+    const { files } = await response.json() as { files: Record<string, unknown>[] };
+    const args = { action: 'execute' as const, connection_id: connectionId, operation_key: 'upload', input: { image: files[0], alt_text: 'A test photograph', rank: 1 }, idempotency_key: 'file-handoff-test-once' };
+    const queued = await manageOperations(args, {} as Env, ctx) as { run_id: number; status: string };
+    expect(queued.status).toBe('pending_approval');
+    const [pending] = await getTestDb()`SELECT action_input, run_metadata, status FROM runs WHERE id = ${queued.run_id}`;
+    expect(pending.action_input.image).toEqual(files[0]);
+    expect(pending.run_metadata.input_files).toHaveLength(1);
+    expect(JSON.stringify(pending)).not.toContain('base64');
+    const approval = await post(`/api/${orgSlug}/manage_operations`, {
+      cookie, body: { action: 'approve', run_id: queued.run_id },
+    });
+    expect(approval.status).toBe(200);
+    expect(await approval.json()).toMatchObject({ approved: true });
+    const workerId = 'file-handoff-test-worker';
+    const claim = await post('/api/workers/poll', { body: { worker_id: workerId, capabilities: {} } });
+    expect(claim.status).toBe(200);
+    const job = await claim.json();
+    expect(job.run_id).toBe(queued.run_id);
+    expect(job.action_input.image.base64).toBe(Buffer.from('photo-bytes').toString('base64'));
+    const executed = await executeCompiledConnector({
+      compiledCode: job.compiled_code,
+      job: { mode: 'action', actionKey: job.action_key, actionInput: job.action_input, config: job.config ?? {}, env: {}, credentials: {} },
+      allowedDomains: [],
+    });
+    expect(executed.mode).toBe('action');
+    if (executed.mode !== 'action') throw new Error('Expected connector action');
+    const completion = await post('/api/workers/complete-action', { body: {
+      run_id: queued.run_id, worker_id: workerId, status: 'success', action_output: executed.output,
+    } });
+    expect(await completion.json()).toMatchObject({ success: true });
+    const [completed] = await getTestDb()`SELECT status, action_output FROM runs WHERE id = ${queued.run_id}`;
+    expect(completed.status).toBe('completed');
+    expect(completed.action_output).toMatchObject({
+      image: { base64: Buffer.from('photo-bytes').toString('base64'), filename: 'photo.png', content_type: 'image/png' },
+      alt_text: 'A test photograph', rank: 1,
+    });
+    const replay = await manageOperations(args, {} as Env, ctx);
+    expect(replay).toMatchObject({ run_id: queued.run_id, status: 'completed', output: completed.action_output });
+    const [{ count }] = await getTestDb()`SELECT COUNT(*)::integer AS count FROM runs WHERE organization_id = ${ctx.organizationId} AND action_key = 'upload'`;
+    expect(count).toBe(1);
+  });
+
+  it('refuses anonymous multipart uploads', async () => {
+    const response = await upload('');
+    expect([401, 403]).toContain(response.status);
+  });
+
+  it('accepts the current workspace slug and granted account targets without widening scoped access', async () => {
+    const download = vi.spyOn(egress, 'fetchPublicUrl').mockImplementation(async () => new Response('photo-bytes', { headers: { 'content-type': 'image/png' } }));
+    const attachments = [{ download_url: 'https://files.example.test/photo.png', file_id: 'file-handoff-fixture' }];
+    try {
+      for (const target of [orgSlug, ctx.organizationId]) {
+        expect(await ingestMcpFiles(attachments, target, { ...ctx, allowCrossOrg: false })).toHaveLength(1);
+      }
+      expect(await ingestMcpFiles(attachments, orgSlug, { ...ctx, organizationId: null, memberRole: undefined, allowCrossOrg: true, grantedOrganizationIds: [ctx.organizationId] })).toHaveLength(1);
+      const downloads = download.mock.calls.length;
+      await expect(ingestMcpFiles(attachments, 'other-workspace-test', { ...ctx, allowCrossOrg: false })).rejects.toThrow('unavailable');
+      await expect(ingestMcpFiles(attachments, orgSlug, { ...ctx, organizationId: null, allowCrossOrg: true, grantedOrganizationIds: [] })).rejects.toThrow('not available');
+      expect(download).toHaveBeenCalledTimes(downloads);
+    } finally { download.mockRestore(); }
+  });
+
+  it('delivers a 5 MiB photo and its metadata through the real isolate multipart transport', async () => {
+    const bytes = randomBytes(5 * 1024 * 1024);
+    const response = await upload(cookie, bytes);
+    expect(response.status).toBe(201);
+    const { files } = await response.json() as { files: Record<string, unknown>[] };
+    const queued = await manageOperations({ action: 'execute', connection_id: connectionId, operation_key: 'upload',
+      input: { image: files[0], alt_text: 'Full size test photograph', rank: 2 } }, {} as Env, ctx) as { run_id: number };
+    const approval = await post(`/api/${orgSlug}/manage_operations`, { cookie, body: { action: 'approve', run_id: queued.run_id } });
+    expect(await approval.json()).toMatchObject({ approved: true });
+    const workerId = 'file-handoff-test-worker';
+    const job = await (await post('/api/workers/poll', { body: { worker_id: workerId, capabilities: {} } })).json();
+    expect(job.run_id).toBe(queued.run_id);
+    const executed = await executeCompiledConnector({
+      compiledCode: job.compiled_code,
+      job: { mode: 'action', actionKey: job.action_key, actionInput: job.action_input, config: { uploadUrl }, env: {}, credentials: {} },
+      allowedDomains: ['127.0.0.1'],
+    });
+    expect(executed).toMatchObject({ mode: 'action', output: {
+      filename: 'photo.png', content_type: 'image/png', size_bytes: bytes.length,
+      sha256: createHash('sha256').update(bytes).digest('hex'), alt_text: 'Full size test photograph', rank: '2',
+    } });
+    const completed = await post('/api/workers/complete-action', { body: {
+      run_id: queued.run_id, worker_id: workerId, status: 'success', action_output: executed.mode === 'action' ? executed.output : {},
+    } });
+    expect(await completed.json()).toMatchObject({ success: true });
+  });
+
+  it.each(['missing', 'substituted'])('fails a %s file before handing the approved run to a worker', async (condition) => {
+    const { files } = await (await upload()).json() as { files: Record<string, unknown>[] };
+    const queued = await manageOperations({ action: 'execute', connection_id: connectionId, operation_key: 'upload', input: { image: files[0] } }, {} as Env, ctx) as { run_id: number };
+    let replacement: Record<string, unknown> | undefined;
+    if (condition === 'missing') await store.delete(inputArtifactId(files[0])!);
+    else replacement = ((await (await upload()).json()) as { files: Record<string, unknown>[] }).files[0];
+    const approval = await post(`/api/${orgSlug}/manage_operations`, {
+      cookie, body: { action: 'approve', run_id: queued.run_id, ...(replacement ? { input: { image: replacement } } : {}) },
+    });
+    expect(await approval.json()).toMatchObject({ approved: true });
+    const dispatch = await post('/api/workers/poll', { body: { worker_id: 'file-handoff-test-worker', capabilities: {} } });
+    expect(await dispatch.json()).toMatchObject({ skipped_run_id: queued.run_id });
+    const [run] = await getTestDb()`SELECT status, error_message FROM runs WHERE id = ${queued.run_id}`;
+    expect(run.status).toBe('failed');
+    expect(run.error_message).toContain(condition === 'missing' ? 'missing or changed' : 'changed after authorization');
+  });
+});

--- a/packages/server/src/__tests__/integration/operation-file-handoff.test.ts
+++ b/packages/server/src/__tests__/integration/operation-file-handoff.test.ts
@@ -196,11 +196,14 @@ describe('multipart file → operation approval → connector execution', () => 
     expect(await completed.json()).toMatchObject({ success: true });
   });
 
-  it.each(['missing', 'substituted'])('fails a %s file before handing the approved run to a worker', async (condition) => {
+  it.each(['missing', 'substituted', 'inline-replaced'])('fails a %s file before handing the approved run to a worker', async (condition) => {
     const { files } = await (await upload()).json() as { files: Record<string, unknown>[] };
     const queued = await manageOperations({ action: 'execute', connection_id: connectionId, operation_key: 'upload', input: { image: files[0] } }, {} as Env, ctx) as { run_id: number };
     let replacement: Record<string, unknown> | undefined;
     if (condition === 'missing') await store.delete(inputArtifactId(files[0])!);
+    else if (condition === 'inline-replaced') replacement = {
+      base64: Buffer.from('replacement').toString('base64'), filename: 'replacement.png', content_type: 'image/png',
+    };
     else replacement = ((await (await upload()).json()) as { files: Record<string, unknown>[] }).files[0];
     const approval = await post(`/api/${orgSlug}/manage_operations`, {
       cookie, body: { action: 'approve', run_id: queued.run_id, ...(replacement ? { input: { image: replacement } } : {}) },

--- a/packages/server/src/__tests__/unit/bounded-response.test.ts
+++ b/packages/server/src/__tests__/unit/bounded-response.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { readResponseBytesWithLimit, readResponseTextWithLimit } from "../../utils/bounded-response";
+
+describe("bounded response ingestion", () => {
+  test("preserves binary bytes and existing UTF-8 text decoding", async () => {
+    const bytes = Buffer.from([0, 255, 128, 65]);
+    expect(await readResponseBytesWithLimit(new Response(bytes), 4, "large")).toEqual(bytes);
+    expect(await readResponseTextWithLimit(new Response("héllo"), 6, "large")).toBe("héllo");
+  });
+
+  test.each([undefined, "2", "100"])("rejects oversized bodies with content-length %s", async (length) => {
+    let cancelled = false;
+    const body = new ReadableStream({
+      pull(controller) { controller.enqueue(new Uint8Array(3)); },
+      cancel() { cancelled = true; },
+    });
+    const response = new Response(body, { headers: length ? { "content-length": length } : {} });
+    await expect(readResponseBytesWithLimit(response, 4, "large")).rejects.toThrow("large (max 4 bytes).");
+    expect(cancelled).toBe(true);
+    expect(response.body?.locked).toBe(false);
+  });
+
+  test("releases the stream lock when reading fails", async () => {
+    const response = new Response(new ReadableStream({
+      pull(controller) { controller.error(new Error("transport failed")); },
+    }));
+    await expect(readResponseBytesWithLimit(response, 4, "large")).rejects.toThrow("transport failed");
+    expect(response.body?.locked).toBe(false);
+  });
+});

--- a/packages/server/src/__tests__/unit/mcp-file-input-contract.test.ts
+++ b/packages/server/src/__tests__/unit/mcp-file-input-contract.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { Value } from "@sinclair/typebox/value";
+import { getMcpTools } from "../../tools/registry";
+import { RunSchema, toMcpPublicSdkScriptResult } from "../../tools/sdk_run";
+
+describe("MCP attachment input", () => {
+  it("advertises native attachment transfer on run_sdk", () => {
+    const tool = getMcpTools().find((item) => item.name === "run_sdk");
+    expect(tool?._meta?.["openai/fileParams"]).toEqual(["files"]);
+    const schema = RunSchema.properties.files;
+    expect(schema).toBeDefined();
+    expect(schema.items.required).toEqual(["download_url", "file_id"]);
+    expect(Object.keys(schema.items.properties).sort()).toEqual([
+      "download_url", "file_id", "file_name", "mime_type",
+    ]);
+  });
+
+  it("accepts a host attachment without requiring optional metadata", () => {
+    expect(Value.Check(RunSchema, {
+      script: "export default async (ctx) => ctx.files",
+      files: [{ download_url: "https://files.example.test/photo", file_id: "file-example" }],
+    })).toBe(true);
+    expect(Value.Check(RunSchema, {
+      script: "export default async (ctx) => ctx.files",
+      files: [{ file_id: "file-example" }],
+    })).toBe(false);
+  });
+
+  it("keeps reusable uploads in the public result when the script fails", () => {
+    const files = [{ $file: 'lobu://file/00000000-0000-4000-8000-000000000001', filename: 'photo.png', content_type: 'image/png', size_bytes: 3, sha256: 'a'.repeat(64) }];
+    expect(toMcpPublicSdkScriptResult({ success: false, files, error: { message: 'Script failed after upload' } })).toMatchObject({ success: false, files });
+  });
+});

--- a/packages/server/src/__tests__/unit/mcp-file-input-contract.test.ts
+++ b/packages/server/src/__tests__/unit/mcp-file-input-contract.test.ts
@@ -7,6 +7,10 @@ describe("MCP attachment input", () => {
   it("advertises native attachment transfer on run_sdk", () => {
     const tool = getMcpTools().find((item) => item.name === "run_sdk");
     expect(tool?._meta?.["openai/fileParams"]).toEqual(["files"]);
+    expect(tool?.outputSchema.properties.files).toBeDefined();
+    expect(
+      getMcpTools().find((item) => item.name === "query_sdk")?.outputSchema.properties.files,
+    ).toBeUndefined();
     const schema = RunSchema.properties.files;
     expect(schema).toBeDefined();
     expect(schema.items.required).toEqual(["download_url", "file_id"]);

--- a/packages/server/src/gateway/__tests__/input-file-download.test.ts
+++ b/packages/server/src/gateway/__tests__/input-file-download.test.ts
@@ -1,0 +1,36 @@
+import { afterAll, afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import * as egress from '@lobu/connector-worker/egress';
+import { attachmentFromUrl, fetchInputFile, ingestInputFiles } from '../files/input-files';
+import { createArtifactTestEnv, TEST_GATEWAY_URL, type ArtifactTestEnv } from './setup';
+
+describe('host download adapter', () => {
+  let env: ArtifactTestEnv;
+  const fetch = spyOn(egress, 'fetchPublicUrl');
+  afterAll(() => fetch.mockRestore());
+  beforeEach(() => { env = createArtifactTestEnv(); });
+  afterEach(async () => { fetch.mockReset(); await env.cleanup(); });
+
+  test('imports an attachment when the host omits optional filename and MIME metadata', async () => {
+    fetch.mockResolvedValueOnce(new Response('png', { headers: { 'content-type': 'image/png' } }));
+    const files = await ingestInputFiles([
+      attachmentFromUrl('https://files.example.test/photo?token=secret-test', {}),
+    ], { isAuthenticated: true, organizationId: 'org-download-test', userId: 'user-download-test' }, env.artifactStore, TEST_GATEWAY_URL);
+    expect(files[0]).toMatchObject({ filename: 'attachment-1.png', content_type: 'image/png', size_bytes: 3 });
+    expect(JSON.stringify(files)).not.toContain('secret-test');
+  });
+
+  test('hides signed URLs on fetch and parsing errors', async () => {
+    fetch.mockRejectedValueOnce(new Error('Failed https://files.example.test/?token=secret-test'));
+    for (const url of ['https://files.example.test/?token=secret-test', 'invalid-secret-test']) {
+      try { await fetchInputFile(url); throw new Error('expected failure'); }
+      catch (error) { expect(String(error)).toContain('File download failed'); expect(String(error)).not.toContain('secret-test'); }
+    }
+  });
+
+  test('rejects local and insecure URLs before attempting network access', async () => {
+    for (const url of ['file:///tmp/photo.png', 'http://files.example.test/photo', 'https://user:password@files.example.test/photo']) {
+      await expect(fetchInputFile(url)).rejects.toThrow('HTTPS URL without embedded credentials');
+    }
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/gateway/__tests__/input-file-download.test.ts
+++ b/packages/server/src/gateway/__tests__/input-file-download.test.ts
@@ -19,6 +19,16 @@ describe('host download adapter', () => {
     expect(JSON.stringify(files)).not.toContain('secret-test');
   });
 
+  test('rejects response-derived MIME metadata outside the reusable file contract', async () => {
+    fetch.mockResolvedValueOnce(new Response('bytes', { headers: { 'content-type': `image/${'x'.repeat(100)}` } }));
+    await expect(ingestInputFiles(
+      [attachmentFromUrl('https://files.example.test/photo', {})],
+      { isAuthenticated: true, organizationId: 'org-download-test', userId: 'user-download-test' },
+      env.artifactStore,
+      TEST_GATEWAY_URL,
+    )).rejects.toThrow('invalid media type metadata');
+  });
+
   test('hides signed URLs on fetch and parsing errors', async () => {
     fetch.mockRejectedValueOnce(new Error('Failed https://files.example.test/?token=secret-test'));
     for (const url of ['https://files.example.test/?token=secret-test', 'invalid-secret-test']) {

--- a/packages/server/src/gateway/__tests__/input-files.test.ts
+++ b/packages/server/src/gateway/__tests__/input-files.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  ingestInputFiles,
+  inputArtifactId,
+  inputFileBinding,
+} from "../files/input-files.js";
+import { createArtifactTestEnv, TEST_GATEWAY_URL, type ArtifactTestEnv } from "./setup.js";
+
+const owner = { isAuthenticated: true, organizationId: "org-files-test", userId: "user-files-test" };
+
+describe("required input attachments", () => {
+  let env: ArtifactTestEnv;
+  beforeEach(() => { env = createArtifactTestEnv(); });
+  afterEach(() => env.cleanup());
+
+  test("accepts multipart Blob bytes and returns a reusable scoped reference", async () => {
+    const [file] = await ingestInputFiles([{
+      name: "photo.png", mimeType: "image/png", data: new Blob(["image-bytes"]),
+    }], owner, env.artifactStore, TEST_GATEWAY_URL);
+    const id = inputArtifactId(file)!;
+    const binding = inputFileBinding(owner);
+    expect(file?.sha256).toBe(createHash("sha256").update("image-bytes").digest("hex"));
+    expect(JSON.stringify(file)).not.toContain("token=");
+    expect((await env.artifactStore.read(id, { binding }))?.bytes.toString()).toBe("image-bytes");
+    for (const other of [
+      { ...owner, userId: "other-user-test" },
+      { ...owner, organizationId: "other-org-test" },
+      { ...owner, agentId: "agent-files-test" },
+    ]) {
+      expect(await env.artifactStore.read(id, { binding: inputFileBinding(other) })).toBeNull();
+    }
+  });
+
+  test("removes already stored files when a later required attachment fails", async () => {
+    const published = spyOn(env.artifactStore, "publish");
+    await expect(ingestInputFiles([
+      { name: "good.png", mimeType: "image/png", data: Buffer.from("good") },
+      { name: "missing.png", mimeType: "image/png", fetchData: async () => { throw new Error("source expired"); } },
+    ], owner, env.artifactStore, TEST_GATEWAY_URL)).rejects.toThrow("source expired");
+    const artifact = await published.mock.results[0]!.value;
+    expect(await env.artifactStore.inspect(artifact.artifactId)).toBeNull();
+  });
+});

--- a/packages/server/src/gateway/__tests__/input-files.test.ts
+++ b/packages/server/src/gateway/__tests__/input-files.test.ts
@@ -23,10 +23,12 @@ describe("required input attachments", () => {
     expect(file?.sha256).toBe(createHash("sha256").update("image-bytes").digest("hex"));
     expect(JSON.stringify(file)).not.toContain("token=");
     expect((await env.artifactStore.read(id, { binding }))?.bytes.toString()).toBe("image-bytes");
+    expect(inputFileBinding({ ...owner, scopes: ["mcp:read", "mcp:write"] })).toBe(binding);
     for (const other of [
       { ...owner, userId: "other-user-test" },
       { ...owner, organizationId: "other-org-test" },
       { ...owner, agentId: "agent-files-test" },
+      { ...owner, scopes: ["device_worker:run", "mcp:read", "mcp:write", "mcp:admin"] },
     ]) {
       expect(await env.artifactStore.read(id, { binding: inputFileBinding(other) })).toBeNull();
     }

--- a/packages/server/src/gateway/__tests__/operation-files.test.ts
+++ b/packages/server/src/gateway/__tests__/operation-files.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { fileInputSchema, MAX_CONNECTOR_FILE_BYTES } from '@lobu/connector-sdk';
+import { prepareOperationFiles, resolveOperationFiles } from '../../operations/file-inputs';
+import { ArtifactStore } from '../files/artifact-store';
+import { ingestInputFiles, inputArtifactId } from '../files/input-files';
+import type { ToolContext } from '../../tools/registry';
+import { createArtifactTestEnv, TEST_GATEWAY_URL, type ArtifactTestEnv } from './setup';
+
+const owner = { isAuthenticated: true, organizationId: 'org-operation-file-test', userId: 'user-file-test', memberRole: 'owner' } as ToolContext;
+const schema = { type: 'object', properties: { images: { type: 'array', items: fileInputSchema({ maxBytes: 20, contentTypes: ['image/png'] }) } } };
+
+describe('connector file authorization and resolution', () => {
+  let env: ArtifactTestEnv;
+  beforeEach(() => { env = createArtifactTestEnv(); });
+  afterEach(() => env.cleanup());
+  const upload = (data = 'photo') => ingestInputFiles([{ name: 'photo.png', mimeType: 'image/png', data: Buffer.from(data) }], owner, env.artifactStore, TEST_GATEWAY_URL);
+
+  test('stores references for approval, then resolves exact bytes on every execution attempt', async () => {
+    const [file] = await upload();
+    const prepared = await prepareOperationFiles({ images: [{ ...file, filename: 'invented.png' }] }, schema, owner, env.artifactStore);
+    expect(prepared.input).toEqual({ images: [file] });
+    expect(JSON.stringify(prepared)).not.toContain('base64');
+    const metadata = JSON.parse(JSON.stringify({ input_files: prepared.claims }));
+    const anotherReplica = new ArtifactStore(env.artifactsDir);
+    // A later execution needs only durable metadata and the shared artifact directory.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      expect(await resolveOperationFiles(prepared.input, metadata, anotherReplica)).toEqual({ images: [{ base64: Buffer.from('photo').toString('base64'), filename: 'photo.png', content_type: 'image/png' }] });
+    }
+  });
+
+  test('denies other users, workspaces, and bound agents before queuing', async () => {
+    const [file] = await upload();
+    for (const other of [{ ...owner, userId: 'other-user-test' }, { ...owner, organizationId: 'other-org-test' }, { ...owner, agentId: 'other-agent-test' }]) {
+      await expect(prepareOperationFiles({ images: [file] }, schema, other, env.artifactStore)).rejects.toThrow('outside this caller');
+    }
+  });
+
+  test('denies undeclared fields, missing authorization, and substitution after approval', async () => {
+    const [file] = await upload();
+    const [replacement] = await upload('replacement');
+    const prepared = await prepareOperationFiles({ images: [file] }, schema, owner, env.artifactStore);
+    await expect(prepareOperationFiles({ image: file }, {}, owner, env.artifactStore)).rejects.toThrow('must declare');
+    await expect(resolveOperationFiles(prepared.input, {}, env.artifactStore)).rejects.toThrow('changed after authorization');
+    await expect(resolveOperationFiles({ images: [replacement] }, { input_files: prepared.claims }, env.artifactStore)).rejects.toThrow('changed after authorization');
+    await env.artifactStore.delete(inputArtifactId(file)!);
+    await expect(resolveOperationFiles(prepared.input, { input_files: prepared.claims }, env.artifactStore)).rejects.toThrow('missing or changed');
+  });
+
+  test('enforces connector byte/type limits for stored and inline files', async () => {
+    const [large] = await upload('x'.repeat(21));
+    await expect(prepareOperationFiles({ images: [large] }, schema, owner, env.artifactStore)).rejects.toThrow('exceeds the connector limit');
+    for (const input of [
+      { base64: Buffer.from('x'.repeat(21)).toString('base64'), filename: 'large.png', content_type: 'image/png' },
+      { base64: Buffer.from('x').toString('base64'), filename: 'wrong.txt', content_type: 'text/plain' },
+    ]) await expect(prepareOperationFiles({ images: [input] }, schema, owner, env.artifactStore)).rejects.toThrow();
+  });
+
+  test('rejects file inputs that cannot fit the execution bridge before queuing', async () => {
+    expect(() => fileInputSchema({ maxBytes: MAX_CONNECTOR_FILE_BYTES + 1 })).toThrow('maxBytes must be between');
+    const [file] = await upload('x'.repeat(MAX_CONNECTOR_FILE_BYTES));
+    const [extra] = await upload('x');
+    const largeSchema = { properties: { images: { type: 'array', items: fileInputSchema({ maxBytes: MAX_CONNECTOR_FILE_BYTES }) } } };
+    await expect(prepareOperationFiles({ images: [file, extra] }, largeSchema, owner, env.artifactStore)).rejects.toThrow('12 MiB connector execution limit');
+  });
+});

--- a/packages/server/src/gateway/__tests__/operation-files.test.ts
+++ b/packages/server/src/gateway/__tests__/operation-files.test.ts
@@ -41,7 +41,19 @@ describe('connector file authorization and resolution', () => {
     const prepared = await prepareOperationFiles({ images: [file] }, schema, owner, env.artifactStore);
     await expect(prepareOperationFiles({ image: file }, {}, owner, env.artifactStore)).rejects.toThrow('must declare');
     await expect(resolveOperationFiles(prepared.input, {}, env.artifactStore)).rejects.toThrow('changed after authorization');
+    await expect(resolveOperationFiles({ images: [] }, { input_files: prepared.claims }, env.artifactStore)).rejects.toThrow('changed after authorization');
+    const pair = await prepareOperationFiles({ images: [file, replacement] }, schema, owner, env.artifactStore);
+    await expect(resolveOperationFiles({ images: [file] }, { input_files: pair.claims }, env.artifactStore)).rejects.toThrow('changed after authorization');
     await expect(resolveOperationFiles({ images: [replacement] }, { input_files: prepared.claims }, env.artifactStore)).rejects.toThrow('changed after authorization');
+    await expect(resolveOperationFiles(
+      { images: [{
+        base64: Buffer.from('replacement').toString('base64'),
+        filename: 'replacement.png',
+        content_type: 'image/png',
+      }] },
+      { input_files: prepared.claims },
+      env.artifactStore,
+    )).rejects.toThrow('changed after authorization');
     await env.artifactStore.delete(inputArtifactId(file)!);
     await expect(resolveOperationFiles(prepared.input, { input_files: prepared.claims }, env.artifactStore)).rejects.toThrow('missing or changed');
   });

--- a/packages/server/src/gateway/__tests__/operation-files.test.ts
+++ b/packages/server/src/gateway/__tests__/operation-files.test.ts
@@ -30,7 +30,12 @@ describe('connector file authorization and resolution', () => {
 
   test('denies other users, workspaces, and bound agents before queuing', async () => {
     const [file] = await upload();
-    for (const other of [{ ...owner, userId: 'other-user-test' }, { ...owner, organizationId: 'other-org-test' }, { ...owner, agentId: 'other-agent-test' }]) {
+    for (const other of [
+      { ...owner, userId: 'other-user-test' },
+      { ...owner, organizationId: 'other-org-test' },
+      { ...owner, agentId: 'other-agent-test' },
+      { ...owner, scopes: ['device_worker:run', 'mcp:write'] },
+    ]) {
       await expect(prepareOperationFiles({ images: [file] }, schema, other, env.artifactStore)).rejects.toThrow('outside this caller');
     }
   });

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -21,6 +21,7 @@ import type { CommandDispatcher } from "../commands/command-dispatcher.js";
 import { createChatReply } from "../commands/command-reply-adapters.js";
 import { normalizeStatefulChatCommand } from "../commands/command-spelling.js";
 import type { ArtifactStore } from "../files/artifact-store.js";
+import { ingestAttachments, type AttachmentSource } from "../files/attachment-ingestion.js";
 import type { ModelProviderModule } from "../modules/module-system.js";
 import type { CoreServices } from "../platform.js";
 import {
@@ -293,16 +294,6 @@ function isAudioAttachment(mime: string | undefined): boolean {
   return AUDIO_MIMES_PREFIX.some((p) => mime.startsWith(p));
 }
 
-function deriveFilename(
-  attachment: { name?: string; mimeType?: string; type?: string },
-  index: number
-): string {
-  if (attachment.name?.trim()) return attachment.name.trim();
-  const ext = attachment.mimeType?.split("/")[1]?.split(";")[0];
-  const stem = attachment.type || "attachment";
-  return ext ? `${stem}-${index + 1}.${ext}` : `${stem}-${index + 1}`;
-}
-
 /**
  * Detect a preview-link redemption in plain message text. Slack blocks slash
  * commands in an "Agents & AI Apps" DM, so `lobu run`'s `/lobu link <code>`
@@ -332,14 +323,7 @@ export function parsePreviewLinkCode(
  * Defined here so that this module — and its tests — don't have to take a
  * runtime dependency on the chat SDK.
  */
-export interface InboundAttachmentLike {
-  data?: Buffer | Blob;
-  fetchData?: () => Promise<Buffer>;
-  mimeType?: string;
-  name?: string;
-  size?: number;
-  type?: string;
-}
+export type InboundAttachmentLike = AttachmentSource;
 
 /**
  * Fetch every inbound attachment via the chat SDK's auth-aware
@@ -357,59 +341,25 @@ export async function ingestInboundAttachments(
   files: IngestedFile[];
   audioBytes: Array<{ buffer: Buffer; mimeType: string }>;
 }> {
-  if (!attachments?.length) return { files: [], audioBytes: [] };
-
-  const files: IngestedFile[] = [];
   const audioBytes: Array<{ buffer: Buffer; mimeType: string }> = [];
-
-  for (let i = 0; i < attachments.length; i++) {
-    const att = attachments[i]!;
-    try {
-      let buffer: Buffer | undefined;
-      if (att.data) {
-        buffer = Buffer.isBuffer(att.data)
-          ? att.data
-          : Buffer.from(await (att.data as Blob).arrayBuffer());
-      } else if (att.fetchData) {
-        buffer = await att.fetchData();
-      }
-      if (!buffer || buffer.length === 0) {
-        logger.warn(
-          { mimeType: att.mimeType, type: att.type, name: att.name },
-          "Skipping inbound attachment with no fetchable data"
-        );
-        continue;
-      }
-      const mimeType = att.mimeType || "application/octet-stream";
-      if (isAudioAttachment(mimeType)) {
-        audioBytes.push({ buffer, mimeType });
-      }
-      const filename = deriveFilename(att, i);
-      const published = await artifactStore.publish({
-        buffer,
-        filename,
-        contentType: mimeType,
-        publicGatewayUrl,
-      });
-      files.push({
-        id: published.artifactId,
-        name: published.filename,
-        mimetype: published.contentType,
-        size: published.size,
-        downloadUrl: published.downloadUrl,
-      });
-    } catch (error) {
+  const artifacts = await ingestAttachments(attachments ?? [], artifactStore, publicGatewayUrl, {
+    onBytes: (buffer, mimeType) => {
+      if (isAudioAttachment(mimeType)) audioBytes.push({ buffer, mimeType });
+    },
+    onError: (error, attachment) => {
       logger.error(
-        {
-          error: String(error),
-          mimeType: att.mimeType,
-          type: att.type,
-          name: att.name,
-        },
+        { error: String(error), mimeType: attachment.mimeType, type: attachment.type, name: attachment.name },
         "Failed to ingest inbound attachment"
       );
-    }
-  }
+    },
+  });
+  const files = artifacts.map((artifact) => ({
+    id: artifact.artifactId,
+    name: artifact.filename,
+    mimetype: artifact.contentType,
+    size: artifact.size,
+    downloadUrl: artifact.downloadUrl,
+  }));
 
   return { files, audioBytes };
 }

--- a/packages/server/src/gateway/files/attachment-ingestion.ts
+++ b/packages/server/src/gateway/files/attachment-ingestion.ts
@@ -1,0 +1,64 @@
+import { type ArtifactStore, MAX_ARTIFACT_BYTES } from "./artifact-store.js";
+import { ToolUserError } from "../../utils/errors.js";
+
+/** Transport adapters provide bytes or an authenticated fetch closure. */
+export interface AttachmentSource {
+  data?: Buffer | Blob;
+  fetchData?: () => Promise<Buffer>;
+  mimeType?: string;
+  name?: string;
+  size?: number;
+  type?: string;
+}
+
+/** Shared ingestion for chat, multipart uploads, and MCP attachments. */
+export async function ingestAttachments(
+  attachments: AttachmentSource[],
+  artifactStore: ArtifactStore,
+  publicGatewayUrl: string,
+  options: {
+    binding?: string;
+    signal?: AbortSignal;
+    maxTotalBytes?: number;
+    onBytes?: (buffer: Buffer, mimeType: string) => void;
+    /** Chat can report individual failures and continue; required files cannot. */
+    onError?: (error: unknown, attachment: AttachmentSource) => void;
+  } = {},
+): Promise<Awaited<ReturnType<ArtifactStore["publish"]>>[]> {
+  const artifacts: Awaited<ReturnType<ArtifactStore["publish"]>>[] = [];
+  let totalBytes = 0;
+  try {
+    for (const [index, attachment] of attachments.entries()) {
+      try {
+        options.signal?.throwIfAborted();
+        const buffer = attachment.data
+          ? Buffer.isBuffer(attachment.data)
+            ? attachment.data
+            : Buffer.from(await attachment.data.arrayBuffer())
+          : await attachment.fetchData?.();
+        options.signal?.throwIfAborted();
+        if (!buffer?.length) throw new ToolUserError(`File ${index + 1} has no readable bytes.`, 422);
+        totalBytes += buffer.length;
+        if (buffer.length > MAX_ARTIFACT_BYTES || totalBytes > (options.maxTotalBytes ?? Infinity)) {
+          throw new ToolUserError(`File ${index + 1} exceeds the file upload size limit.`, 413);
+        }
+        const mimeType = attachment.mimeType || "application/octet-stream";
+        const ext = attachment.mimeType?.split("/")[1]?.split(";")[0];
+        const stem = `${attachment.type || "attachment"}-${index + 1}`;
+        const filename = attachment.name?.trim() || (ext ? `${stem}.${ext}` : stem);
+        options.onBytes?.(buffer, mimeType);
+        artifacts.push(await artifactStore.publish({
+          buffer, filename, contentType: mimeType, publicGatewayUrl, binding: options.binding,
+        }));
+      } catch (error) {
+        if (!options.onError) throw error;
+        options.onError(error, attachment);
+      }
+    }
+    return artifacts;
+  } catch (error) {
+    // Strict batches never expose a partial set of required attachments.
+    await Promise.all(artifacts.map(({ artifactId }) => artifactStore.delete(artifactId)));
+    throw error;
+  }
+}

--- a/packages/server/src/gateway/files/input-files.ts
+++ b/packages/server/src/gateway/files/input-files.ts
@@ -89,9 +89,14 @@ export async function fetchInputFile(url: string, signal?: AbortSignal): Promise
       await cancelResponseBody(response);
       throw new ToolUserError(`File download returned HTTP ${response.status}. Upload the file again.`, 422);
     }
+    const contentType = response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase();
+    if (contentType && (contentType.length > 100 || /[\r\n\0]/.test(contentType))) {
+      await cancelResponseBody(response);
+      throw new ToolUserError('Downloaded file has invalid media type metadata.', 422);
+    }
     return {
       bytes: await readResponseBytesWithLimit(response, MAX_ARTIFACT_BYTES, 'File exceeds the upload size limit'),
-      contentType: response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase(),
+      contentType: contentType || undefined,
     };
   } catch (error) {
     if (error instanceof ToolUserError) throw error;

--- a/packages/server/src/gateway/files/input-files.ts
+++ b/packages/server/src/gateway/files/input-files.ts
@@ -10,9 +10,10 @@ import { cancelResponseBody, readResponseBytesWithLimit } from '../../utils/boun
 export const MAX_INPUT_FILES = 10;
 export const MAX_INPUT_TOTAL_BYTES = 100 * 1024 * 1024;
 
-export type InputFileOwner = Pick<AccountToolContext,
-  'organizationId' | 'userId' | 'agentId' | 'actingAutomationId' | 'isAuthenticated'>;
-
+export type InputFileOwner = Pick<
+  AccountToolContext,
+  'organizationId' | 'userId' | 'agentId' | 'actingAutomationId' | 'isAuthenticated' | 'scopes'
+>;
 
 export interface StoredInputFile extends FileReference {
   filename: string;
@@ -25,9 +26,11 @@ export function inputFileBinding(owner: InputFileOwner): string {
   if (!owner.isAuthenticated || !owner.organizationId || !owner.userId) {
     throw new ToolUserError('File input requires an authenticated user and a selected workspace.', 403);
   }
-  // A device/agent token must not inherit its human owner's private uploads.
+  // Human sessions and ordinary OAuth callers share files within an identity;
+  // agent, Automation, and device-worker callers use separate namespaces.
   const principal = JSON.stringify([
     owner.organizationId, owner.userId, owner.agentId ?? null, owner.actingAutomationId ?? null,
+    owner.scopes?.includes('device_worker:run') ? 'device-worker' : 'user',
   ]);
   return `input:${createHash('sha256').update(principal).digest('hex')}`;
 }

--- a/packages/server/src/gateway/files/input-files.ts
+++ b/packages/server/src/gateway/files/input-files.ts
@@ -1,0 +1,114 @@
+import { createHash } from 'node:crypto';
+import { fetchPublicUrl } from '@lobu/connector-worker/egress';
+import type { FileReference } from '@lobu/connector-sdk';
+import { type ArtifactStore, MAX_ARTIFACT_BYTES } from './artifact-store';
+import { ingestAttachments, type AttachmentSource } from './attachment-ingestion';
+import type { AccountToolContext } from '../../tools/registry';
+import { ToolUserError } from '../../utils/errors';
+import { cancelResponseBody, readResponseBytesWithLimit } from '../../utils/bounded-response';
+
+export const MAX_INPUT_FILES = 10;
+export const MAX_INPUT_TOTAL_BYTES = 100 * 1024 * 1024;
+
+export type InputFileOwner = Pick<AccountToolContext,
+  'organizationId' | 'userId' | 'agentId' | 'actingAutomationId' | 'isAuthenticated'>;
+
+
+export interface StoredInputFile extends FileReference {
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  sha256: string;
+}
+
+export function inputFileBinding(owner: InputFileOwner): string {
+  if (!owner.isAuthenticated || !owner.organizationId || !owner.userId) {
+    throw new ToolUserError('File input requires an authenticated user and a selected workspace.', 403);
+  }
+  // A device/agent token must not inherit its human owner's private uploads.
+  const principal = JSON.stringify([
+    owner.organizationId, owner.userId, owner.agentId ?? null, owner.actingAutomationId ?? null,
+  ]);
+  return `input:${createHash('sha256').update(principal).digest('hex')}`;
+}
+
+export function inputArtifactId(reference: unknown): string | null {
+  if (!reference || typeof reference !== 'object' || Array.isArray(reference)) return null;
+  const value = (reference as Record<string, unknown>).$file;
+  if (typeof value !== 'string') return null;
+  return /^lobu:\/\/file\/([0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})$/i.exec(value)?.[1] ?? null;
+}
+
+export function storedInputFile(metadata: {
+  artifactId: string; filename: string; contentType: string; size: number; sha256: string;
+}): StoredInputFile {
+  return {
+    $file: `lobu://file/${metadata.artifactId}`,
+    filename: metadata.filename,
+    content_type: metadata.contentType,
+    size_bytes: metadata.size,
+    sha256: metadata.sha256,
+  };
+}
+
+/** Strict counterpart to chat attachment ingestion: no silently omitted files. */
+export async function ingestInputFiles(
+  sources: AttachmentSource[],
+  owner: InputFileOwner,
+  store: ArtifactStore,
+  publicGatewayUrl: string,
+  signal?: AbortSignal,
+): Promise<StoredInputFile[]> {
+  const binding = inputFileBinding(owner);
+  if (sources.length === 0 || sources.length > MAX_INPUT_FILES) {
+    throw new ToolUserError(`Supply between 1 and ${MAX_INPUT_FILES} files.`, 400);
+  }
+  for (const [index, source] of sources.entries()) {
+    if ((source.name != null && (source.name.length > 255 || /[\r\n\0]/.test(source.name))) ||
+        (source.mimeType != null && (source.mimeType.length > 100 || /[\r\n\0]/.test(source.mimeType)))) {
+      throw new ToolUserError(`File ${index + 1} has invalid filename or media type metadata.`, 422);
+    }
+  }
+  const artifacts = await ingestAttachments(sources, store, publicGatewayUrl, { binding, signal, maxTotalBytes: MAX_INPUT_TOTAL_BYTES });
+  return artifacts.map(storedInputFile);
+}
+
+/** URL intake is common to all hosts; never forward provider credentials. */
+export async function fetchInputFile(url: string, signal?: AbortSignal): Promise<{ bytes: Buffer; contentType?: string }> {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:' || parsed.username || parsed.password) {
+      throw new ToolUserError('File download requires an HTTPS URL without embedded credentials.', 422);
+    }
+    const deadline = AbortSignal.timeout(30_000);
+    const response = await fetchPublicUrl(parsed, {
+      signal: signal ? AbortSignal.any([signal, deadline]) : deadline,
+      redirect: 'error',
+    });
+    if (!response.ok || !response.body) {
+      await cancelResponseBody(response);
+      throw new ToolUserError(`File download returned HTTP ${response.status}. Upload the file again.`, 422);
+    }
+    return {
+      bytes: await readResponseBytesWithLimit(response, MAX_ARTIFACT_BYTES, 'File exceeds the upload size limit'),
+      contentType: response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase(),
+    };
+  } catch (error) {
+    if (error instanceof ToolUserError) throw error;
+    if (error instanceof RangeError) throw new ToolUserError('File exceeds the file upload size limit.', 413);
+    // Download URLs can contain bearer tokens. Never expose fetch/parser errors.
+    throw new ToolUserError('File download failed. Supply a fresh direct download link or upload the file again.', 422);
+  }
+}
+
+export function attachmentFromUrl(url: string, metadata: Pick<AttachmentSource, 'name' | 'mimeType'>, signal?: AbortSignal): AttachmentSource {
+  const attachment: AttachmentSource = {
+    ...metadata,
+    fetchData: async () => {
+      const downloaded = await fetchInputFile(url, signal);
+      if (!attachment.mimeType) attachment.mimeType = downloaded.contentType;
+      return downloaded.bytes;
+    },
+  };
+  return attachment;
+}

--- a/packages/server/src/http/input-file-routes.ts
+++ b/packages/server/src/http/input-file-routes.ts
@@ -1,0 +1,43 @@
+import { Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
+import { mcpAuth } from '../auth/middleware';
+import { hasRequiredMcpScope } from '../auth/tool-access';
+import { ingestInputFiles, MAX_INPUT_FILES, MAX_INPUT_TOTAL_BYTES } from '../gateway/files/input-files';
+import type { Env } from '../index';
+import { getLobuCoreServices } from '../lobu/gateway';
+import { extractAuthContext, toToolContext } from '../tools/execute';
+import { ToolUserError } from '../utils/errors';
+import { resolvePublicGatewayUrl } from '../utils/public-origin';
+
+/** Ordinary authenticated multipart intake, usable by any client. */
+export const inputFileRoutes = new Hono<{ Bindings: Env }>();
+inputFileRoutes.post('/', mcpAuth, async (c, next) => {
+  const ctx = extractAuthContext(c);
+  if (!ctx.isAuthenticated || !ctx.userId || !ctx.organizationId || !ctx.memberRole || !hasRequiredMcpScope('write', ctx.scopes)) {
+    return c.json({ error: 'File upload requires workspace membership and write access.' }, 403);
+  }
+  if (ctx.executionMode === 'capture') return c.json({ error: 'File uploads cannot run in preview mode.' }, 400);
+  return next();
+}, bodyLimit({
+  maxSize: MAX_INPUT_TOTAL_BYTES + 1024 * 1024,
+  onError: (c) => c.json({ error: 'Files exceed the upload size limit.' }, 413),
+}), async (c) => {
+  const store = getLobuCoreServices()?.getArtifactStore();
+  if (!store) return c.json({ error: 'File storage is unavailable.' }, 503);
+  try {
+    const form = await c.req.formData();
+    const entries = form.getAll('files');
+    if (!entries.length || entries.length > MAX_INPUT_FILES || entries.some((entry) => !(entry instanceof File))) {
+      return c.json({ error: `Supply 1–${MAX_INPUT_FILES} files in the multipart files field.` }, 400);
+    }
+    const files = await ingestInputFiles((entries as File[]).map((file) => ({
+      name: file.name, mimeType: file.type || 'application/octet-stream', data: file,
+    })), toToolContext(extractAuthContext(c)), store, resolvePublicGatewayUrl(), c.req.raw.signal);
+    return c.json({ files }, 201);
+  } catch (error) {
+    if (error instanceof ToolUserError) return c.json({ error: error.message }, error.httpStatus as ContentfulStatusCode);
+    if (error instanceof TypeError) return c.json({ error: 'Supply a valid multipart file upload.' }, 400);
+    throw error;
+  }
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -61,6 +61,7 @@ import {
 	getMaxReservedLocks,
 	getReservedLockCount,
 } from "./gateway/orchestration/deployment-manager";
+import { inputFileRoutes } from "./http/input-file-routes";
 import { REST_TOOL_GET_ROUTES } from "./http/rest-tool-routes";
 import { isExcludedSpaPath } from "./http/spa-route-filter";
 import { isShuttingDown } from "./lifecycle-state";
@@ -1058,6 +1059,8 @@ app.get("/api/organizations", async (c) => {
 
 // Preview: mint a link code for an agent on a hosted preview bot (Slack,
 // Telegram, …). The code is redeemed by DMing that bot — no relay endpoint here.
+app.route("/api/:orgSlug/files", inputFileRoutes);
+
 app.post("/api/:orgSlug/preview/claims", mcpAuth, createPreviewClaim);
 
 // Notifications

--- a/packages/server/src/mcp-file-inputs.ts
+++ b/packages/server/src/mcp-file-inputs.ts
@@ -1,0 +1,56 @@
+import { type Static, Type } from '@sinclair/typebox';
+import type { AccountToolContext } from './tools/registry';
+import { resolveCrossOrgToolContext } from './sandbox/client-sdk';
+import { resolveGrantedWorkspaceTarget } from './auth/oauth/workspace-grants';
+import { getLobuCoreServices } from './lobu/gateway';
+import { attachmentFromUrl, ingestInputFiles, MAX_INPUT_FILES } from './gateway/files/input-files';
+import { ToolUserError } from './utils/errors';
+import { resolvePublicGatewayUrl } from './utils/public-origin';
+
+/** OpenAI's host file envelope is normalized only at this MCP boundary. */
+export const McpHostFilesSchema = Type.Array(Type.Object({
+  download_url: Type.String({ minLength: 1, maxLength: 16_384 }),
+  file_id: Type.String({ minLength: 1, maxLength: 1024 }),
+  mime_type: Type.Optional(Type.String({ minLength: 1, maxLength: 100 })),
+  file_name: Type.Optional(Type.String({ minLength: 1, maxLength: 255 })),
+}, { additionalProperties: false }), {
+  minItems: 1,
+  maxItems: MAX_INPUT_FILES,
+  description: 'Files supplied by the chat host. The server imports bytes before running the script; ctx.files contains reusable Lobu file references. Do not invent download URLs, file IDs, or local paths.',
+});
+
+export const StoredInputFileSchema = Type.Object({
+  $file: Type.String(),
+  filename: Type.String(),
+  content_type: Type.String(),
+  size_bytes: Type.Integer(),
+  sha256: Type.String(),
+});
+
+export async function ingestMcpFiles(
+  files: Static<typeof McpHostFilesSchema>,
+  organization: string | undefined,
+  ctx: AccountToolContext,
+) {
+  let owner = ctx;
+  if (organization && organization !== ctx.organizationId) {
+    if (ctx.allowCrossOrg) owner = await resolveCrossOrgToolContext(organization, ctx);
+    else {
+      // A scoped connection may name its current workspace by slug, but cannot switch.
+      const current = ctx.organizationId && ctx.userId
+        ? await resolveGrantedWorkspaceTarget({ userId: ctx.userId, grantedOrganizationIds: [ctx.organizationId], slugOrId: organization })
+        : null;
+      if (!current) throw new ToolUserError('File workspace is unavailable to this connection.', 403);
+      owner = { ...ctx, memberRole: current.role };
+    }
+  }
+  if (!owner.organizationId || !owner.memberRole) {
+    throw new ToolUserError('Set file_organization to a granted workspace before uploading attachments.', 403);
+  }
+  const store = getLobuCoreServices()?.getArtifactStore();
+  if (!store) throw new ToolUserError('File storage is unavailable. Try again when the gateway is ready.', 503);
+  return ingestInputFiles(files.map((file) => attachmentFromUrl(file.download_url, {
+    name: file.file_name,
+    mimeType: file.mime_type,
+  }, ctx.abortSignal)), owner, store, resolvePublicGatewayUrl(), ctx.abortSignal);
+}

--- a/packages/server/src/operations/file-inputs.ts
+++ b/packages/server/src/operations/file-inputs.ts
@@ -127,19 +127,25 @@ export async function resolveOperationFiles(
   metadata: Record<string, unknown> | null | undefined,
   store?: ArtifactStore,
 ): Promise<Record<string, unknown>> {
-  if (!hasFiles(input)) return input;
   const claims = Array.isArray(metadata?.input_files) ? metadata.input_files as FileClaim[] : [];
+  const changed = () => new ToolUserError('Operation file changed after authorization. Create a new operation with the intended file.', 422);
+  if (!hasFiles(input)) {
+    if (claims.length > 0) throw changed();
+    return input;
+  }
   const artifacts = storeOrThrow(store);
+  const unresolvedClaims = new Set(claims);
   let totalBytes = 0;
-  return rewriteFiles(input, {}, async (value, path) => {
+  const resolved = await rewriteFiles(input, {}, async (value, path) => {
     const artifactId = inputArtifactId(value);
     const claim = claims.find((item) => JSON.stringify(item.path) === JSON.stringify(path));
     if (!artifactId || !claim || claim.artifactId !== artifactId ||
         typeof claim.binding !== 'string' || !/^input:[0-9a-f]{64}$/.test(claim.binding) ||
         !Number.isSafeInteger(claim.maxBytes) || claim.maxBytes <= 0 || claim.maxBytes > MAX_CONNECTOR_FILE_BYTES ||
         typeof claim.sha256 !== 'string' || !/^[0-9a-f]{64}$/.test(claim.sha256)) {
-      throw new ToolUserError('Operation file changed after authorization. Create a new operation with the intended file.', 422);
+      throw changed();
     }
+    unresolvedClaims.delete(claim);
     const file = await artifacts.read(artifactId, { binding: claim.binding, maxBytes: claim.maxBytes });
     if (!file || file.metadata.sha256 !== claim.sha256) {
       throw new ToolUserError('An authorized operation file is missing or changed. Upload it again and create a new operation.', 422);
@@ -148,10 +154,13 @@ export async function resolveOperationFiles(
     if (totalBytes > MAX_CONNECTOR_FILE_BYTES) throw new ToolUserError('Operation files exceed the 12 MiB connector execution limit. Use smaller files or separate operations.', 413);
     return { base64: file.bytes.toString('base64'), filename: file.metadata.filename, content_type: file.metadata.contentType };
   });
+  if (unresolvedClaims.size > 0) throw changed();
+  return resolved;
 }
 
 export async function resolveRunFiles(runId: number, organizationId: string, input: Record<string, unknown>) {
-  if (!hasFiles(input)) return input;
+  // Approval can remove or inline a stored reference, so claims must be loaded
+  // before resolveOperationFiles decides that the input contains no references.
   const [run] = await getDb()<{ run_metadata: Record<string, unknown> | null }>`
     SELECT run_metadata FROM runs WHERE id = ${runId} AND organization_id = ${organizationId} AND run_type = 'action'
   `;

--- a/packages/server/src/operations/file-inputs.ts
+++ b/packages/server/src/operations/file-inputs.ts
@@ -1,0 +1,160 @@
+import { type FileInputOptions, MAX_CONNECTOR_FILE_BYTES } from '@lobu/connector-sdk';
+import { getDb } from '../db/client';
+import type { ArtifactStore } from '../gateway/files/artifact-store';
+import { inputArtifactId, inputFileBinding, MAX_INPUT_FILES, storedInputFile } from '../gateway/files/input-files';
+import { getLobuCoreServices } from '../lobu/gateway';
+import type { ToolContext } from '../tools/registry';
+import { ToolUserError } from '../utils/errors';
+
+interface FileClaim {
+  path: string[];
+  artifactId: string;
+  binding: string;
+  sha256: string;
+  maxBytes: number;
+}
+
+type Schema = Record<string, unknown>;
+const object = (value: unknown): value is Schema => !!value && typeof value === 'object' && !Array.isArray(value);
+const hasFiles = (input: unknown): boolean => JSON.stringify(input).includes('"$file":');
+
+function storeOrThrow(store?: ArtifactStore): ArtifactStore {
+  const resolved = store ?? getLobuCoreServices()?.getArtifactStore();
+  if (!resolved) throw new ToolUserError('File storage is unavailable.', 503);
+  return resolved;
+}
+
+function expandSchemas(schema: Schema, root: Schema, seen = new Set<Schema>()): Schema[] {
+  if (seen.has(schema)) return [];
+  if (seen.size >= 64) throw new ToolUserError('File input schema is too complex.', 422);
+  seen.add(schema);
+  const variants = [schema];
+  if (typeof schema.$ref === 'string' && schema.$ref.startsWith('#/')) {
+    let target: unknown = root;
+    for (const part of schema.$ref.slice(2).split('/')) {
+      target = object(target) ? target[part.replace(/~1/g, '/').replace(/~0/g, '~')] : undefined;
+    }
+    if (object(target)) variants.push(...expandSchemas(target, root, seen));
+  }
+  for (const key of ['allOf', 'anyOf', 'oneOf']) {
+    if (Array.isArray(schema[key])) {
+      for (const child of schema[key]) if (object(child)) variants.push(...expandSchemas(child, root, seen));
+    }
+  }
+  return variants;
+}
+
+/** Walk only caller input; no byte payload crosses the agent's SDK bridge. */
+async function rewriteFiles(
+  input: Record<string, unknown>,
+  schema: Schema,
+  resolve: (value: Schema, path: string[], schemas: Schema[]) => Promise<unknown>,
+): Promise<Record<string, unknown>> {
+  let visited = 0;
+  async function visit(value: unknown, path: string[], schemas: Schema[]): Promise<unknown> {
+    if (++visited > 10_000 || path.length > 64) throw new ToolUserError('File input is too complex.', 422);
+    const expanded = schemas.flatMap((item) => expandSchemas(item, schema));
+    if (object(value) && (Object.hasOwn(value, '$file') || expanded.some((item) => object(item['x-lobu-file'])))) return resolve(value, path, expanded);
+    if (!value || typeof value !== 'object') return value;
+    const entries: [string, unknown][] = [];
+    for (const [key, child] of Object.entries(value)) {
+      const childSchemas = expanded.flatMap((item) => {
+        const candidate = Array.isArray(value)
+          ? Array.isArray(item.items) ? item.items[Number(key)] : item.items
+          : object(item.properties) && Object.hasOwn(item.properties, key) ? item.properties[key] : item.additionalProperties;
+        return object(candidate) ? [candidate] : [];
+      });
+      entries.push([key, await visit(child, [...path, key], childSchemas)]);
+    }
+    return Array.isArray(value) ? entries.map(([, child]) => child) : Object.fromEntries(entries);
+  }
+  return await visit(input, [], [schema]) as Record<string, unknown>;
+}
+
+/** Authorize files before queuing; persist claims with the existing operation run. */
+export async function prepareOperationFiles(
+  input: Record<string, unknown>,
+  schema: Schema | undefined,
+  ctx: ToolContext,
+  store?: ArtifactStore,
+): Promise<{ input: Record<string, unknown>; claims: FileClaim[] }> {
+  const claims: FileClaim[] = [];
+  if (!hasFiles(input) && !JSON.stringify(schema ?? {}).includes('"x-lobu-file"')) return { input, claims };
+  let totalBytes = 0;
+  let fileCount = 0;
+  const prepared = await rewriteFiles(input, schema ?? {}, async (value, path, schemas) => {
+    const declarations = schemas.map((item) => item['x-lobu-file']).filter(object);
+    const artifactId = inputArtifactId(value);
+    if (declarations.length === 0 || (Object.hasOwn(value, '$file') && !artifactId)) {
+      throw new ToolUserError(`Field ${path.join('.')} must declare a valid connector file input.`, 422);
+    }
+    if (++fileCount > MAX_INPUT_FILES) throw new ToolUserError(`An operation supports at most ${MAX_INPUT_FILES} files.`, 422);
+    let maxBytes = MAX_CONNECTOR_FILE_BYTES;
+    for (const declaration of declarations) {
+      if (!Number.isSafeInteger(declaration.maxBytes) || Number(declaration.maxBytes) <= 0) {
+        throw new ToolUserError('Connector file input has an invalid size limit.', 422);
+      }
+      maxBytes = Math.min(maxBytes, Number(declaration.maxBytes));
+    }
+    const binding = artifactId ? inputFileBinding(ctx) : undefined;
+    const inlineBytes = !artifactId && typeof value.base64 === 'string' ? Buffer.from(value.base64, 'base64') : undefined;
+    const file = artifactId
+      ? await storeOrThrow(store).read(artifactId, { binding, maxBytes })
+      : inlineBytes?.length && inlineBytes.length <= maxBytes && inlineBytes.toString('base64') === value.base64 &&
+          typeof value.filename === 'string' && typeof value.content_type === 'string'
+        ? { bytes: inlineBytes, metadata: { artifactId: '', filename: value.filename, contentType: value.content_type, size: inlineBytes.length, sha256: '' } }
+        : null;
+    if (!file) throw new ToolUserError('File is unavailable, outside this caller’s scope, or exceeds the connector limit. Upload it again in this workspace.', 422);
+    for (const declaration of declarations) {
+      const contentTypes = (declaration as unknown as FileInputOptions).contentTypes;
+      if (contentTypes && (!Array.isArray(contentTypes) || !contentTypes.includes(file.metadata.contentType))) {
+        throw new ToolUserError(`File type ${file.metadata.contentType} is not accepted by this connector field.`, 422);
+      }
+    }
+    totalBytes += file.metadata.size;
+    if (totalBytes > MAX_CONNECTOR_FILE_BYTES) throw new ToolUserError('Operation files exceed the 12 MiB connector execution limit. Use smaller files or separate operations.', 413);
+    if (!artifactId) return value;
+    claims.push({ path, artifactId, binding: binding!, sha256: file.metadata.sha256, maxBytes });
+    // Approval cards show storage metadata, never caller-invented filenames/hashes.
+    return storedInputFile(file.metadata);
+  });
+  return { input: prepared, claims };
+}
+
+/** Called only with server-stamped metadata from an authorized action run. */
+export async function resolveOperationFiles(
+  input: Record<string, unknown>,
+  metadata: Record<string, unknown> | null | undefined,
+  store?: ArtifactStore,
+): Promise<Record<string, unknown>> {
+  if (!hasFiles(input)) return input;
+  const claims = Array.isArray(metadata?.input_files) ? metadata.input_files as FileClaim[] : [];
+  const artifacts = storeOrThrow(store);
+  let totalBytes = 0;
+  return rewriteFiles(input, {}, async (value, path) => {
+    const artifactId = inputArtifactId(value);
+    const claim = claims.find((item) => JSON.stringify(item.path) === JSON.stringify(path));
+    if (!artifactId || !claim || claim.artifactId !== artifactId ||
+        typeof claim.binding !== 'string' || !/^input:[0-9a-f]{64}$/.test(claim.binding) ||
+        !Number.isSafeInteger(claim.maxBytes) || claim.maxBytes <= 0 || claim.maxBytes > MAX_CONNECTOR_FILE_BYTES ||
+        typeof claim.sha256 !== 'string' || !/^[0-9a-f]{64}$/.test(claim.sha256)) {
+      throw new ToolUserError('Operation file changed after authorization. Create a new operation with the intended file.', 422);
+    }
+    const file = await artifacts.read(artifactId, { binding: claim.binding, maxBytes: claim.maxBytes });
+    if (!file || file.metadata.sha256 !== claim.sha256) {
+      throw new ToolUserError('An authorized operation file is missing or changed. Upload it again and create a new operation.', 422);
+    }
+    totalBytes += file.metadata.size;
+    if (totalBytes > MAX_CONNECTOR_FILE_BYTES) throw new ToolUserError('Operation files exceed the 12 MiB connector execution limit. Use smaller files or separate operations.', 413);
+    return { base64: file.bytes.toString('base64'), filename: file.metadata.filename, content_type: file.metadata.contentType };
+  });
+}
+
+export async function resolveRunFiles(runId: number, organizationId: string, input: Record<string, unknown>) {
+  if (!hasFiles(input)) return input;
+  const [run] = await getDb()<{ run_metadata: Record<string, unknown> | null }>`
+    SELECT run_metadata FROM runs WHERE id = ${runId} AND organization_id = ${organizationId} AND run_type = 'action'
+  `;
+  if (!run) throw new ToolUserError('Operation run is unavailable.', 404);
+  return resolveOperationFiles(input, run.run_metadata);
+}

--- a/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
@@ -27,6 +27,7 @@ import { resolveActionMode } from "../../../../operations/action-modes";
 import { getOperationForConnection } from "../../../../operations/connector-operations";
 import { LOST_LEASE_MESSAGE, runLeaseFence } from "../../../../runs/run-lease";
 import { executeHttpOperation } from "../../../../operations/execute-http-operation";
+import { prepareOperationFiles, resolveRunFiles } from "../../../../operations/file-inputs";
 import { validateOperationInput } from "../../../../operations/input-validation";
 import { getMissingKnownOAuthScopes } from "../../../../operations/oauth-scope-readiness";
 import type { OperationDescriptor } from "../../../../operations/types";
@@ -381,6 +382,11 @@ export async function executeOperationInline(
 	options: InlineExecutionOptions,
 ): Promise<InlineExecutionResult> {
 	const deferTerminalWrite = options.deferTerminalWrite ?? false;
+	try {
+		actionInput = await resolveRunFiles(runId, organizationId, actionInput);
+	} catch (error) {
+		return failRunInline(runId, organizationId, getErrorMessage(error), deferTerminalWrite, options.claimedBy);
+	}
 	if (operation.backend === "local_action") {
 		return executeLocalActionInline(
 			runId,
@@ -495,7 +501,7 @@ export async function handleExecute(
 	const sdkBrowserContext = browserContext
 		? undefined
 		: deriveSdkBrowserActionContext(ctx);
-	const runMetadata = browserContext
+	let runMetadata: Record<string, unknown> | undefined = browserContext
 		? { browser_context: browserContext }
 		: undefined;
 	if (
@@ -567,7 +573,7 @@ export async function handleExecute(
 		}
 	}
 
-	const input = args.input ?? {};
+	let input = args.input ?? {};
 	// A caller-provided automation_source is only an attribution hint. Durable
 	// feedback must follow the server-stamped Automation execution context.
 	const reactionAutomationId = ctx.actingAutomationId ?? null;
@@ -645,6 +651,13 @@ export async function handleExecute(
 		return {
 			error: `Policy denies '${operation.operation_key}' for this principal.`,
 		};
+	}
+	const preparedFiles = await prepareOperationFiles(input, operation.input_schema, ctx);
+	input = preparedFiles.input;
+	if (preparedFiles.claims.length > 0) {
+		const fileValidationError = validateOperationInput(operation, input);
+		if (fileValidationError) throw new ToolUserError(`Invalid stored file metadata: ${fileValidationError}`, 422);
+		runMetadata = { ...runMetadata, input_files: preparedFiles.claims };
 	}
 	const shouldQueue =
 		mode === "approval" || policyDecision === "require_approval";

--- a/packages/server/src/tools/audit.ts
+++ b/packages/server/src/tools/audit.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { REDACTED_SENTINEL } from '@lobu/core';
 import { currentMcpActivityEventMetadata } from '../lobu/stores/mcp-client-conversations';
 import { insertEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
@@ -8,8 +9,8 @@ import { getTool, type ToolContext } from './registry';
 
 const MAX_PREVIEW_CHARS = 500;
 const MAX_REQUEST_BYTES = 256 * 1024;
-// These tools retain their exact request on the audit event. Other tools
-// retain only the sanitized summary below.
+// These tools retain their request, except host file capabilities, on the
+// audit event. Other tools retain only the sanitized summary below.
 const REQUEST_EVENT_TOOLS = new Set(['run_sdk', 'query_sdk', 'query_sql']);
 const KNOWN_SECRET_SHAPE_RE =
   /\b(?:sk[-_][a-z0-9_-]{8,}|xox[baprs]-[a-z0-9-]{8,}|gh[pousr]_[a-z0-9_]{12,}|AKIA[A-Z0-9]{16}|eyJ[a-z0-9_-]{8,}\.[a-z0-9_-]{8,}\.[a-z0-9_-]{8,})\b/gi;
@@ -46,14 +47,23 @@ function captureRequest(params: ToolInvocationAuditParams): Record<string, unkno
   if (!REQUEST_EVENT_TOOLS.has(params.toolName)) return null;
 
   try {
-    const serialized = JSON.stringify(params.args);
+    const request = { ...params.args };
+    // Host attachment fields contain signed download URLs. Use the tool's
+    // declaration, including on validation failure, and never retain them.
+    const fileParams = getTool(params.toolName)?.mcpMeta?.['openai/fileParams'];
+    if (Array.isArray(fileParams)) {
+      for (const key of fileParams) {
+        if (typeof key === 'string' && Object.hasOwn(request, key)) request[key] = REDACTED_SENTINEL;
+      }
+    }
+    const serialized = JSON.stringify(request);
     const bytes = Buffer.byteLength(serialized, 'utf8');
     if (bytes > MAX_REQUEST_BYTES) {
       return { request_status: 'too_large', request_bytes: bytes };
     }
     return {
       request_status: 'complete',
-      request: params.args,
+      request,
     };
   } catch (error) {
     logger.warn({ error, toolName: params.toolName }, 'Failed to capture tool request');
@@ -194,7 +204,7 @@ function buildPayload(params: ToolInvocationAuditParams): Record<string, unknown
   // free-text values (and an unsalted credential-derived digest) whenever a
   // secret hides in a shape no pattern enumerates. These two fields record the
   // call shape and its declared discriminators; request-bearing tools
-  // additionally retain their exact args below.
+  // additionally retain their request below, excluding host file capabilities.
   const sanitizedArgsJson = JSON.stringify(
     sanitizeAuditArgs(params.args, getTool(params.toolName)?.inputSchema)
   );

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -365,6 +365,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
     description:
       'Execute a capability-scoped Lobu SDK script. On bare OAuth /mcp, select workspace operations with await client.org(target); account discovery and conversation titles require no target. The script can create, update, or delete Lobu data and invoke connector, agent, or device operations only through documented `client` methods; workspace permissions, operation policies, human approvals, and audit remain enforced. Use `query_sdk` for reads, `search_sdk` to discover methods, and `dry_run=true` to preview write, administrative, or external calls without executing them. For connector setup, do the authorized SDK work first using connections.connect or connections.reauthenticate. When human input is required, use only exact URLs returned by tools, explain which account/app and permissions the user is authorizing, and follow the returned resume_call/completion_check. Never invent setup URLs or ask for OAuth client secrets in chat; use the returned browser setup form. Resume the requested work after verifying authorization completed.',
     inputSchema: RunSchema,
+    mcpMeta: { 'openai/fileParams': ['files'] },
     outputSchema: SdkScriptResultSchema,
     annotations: {
       readOnlyHint: false,

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -50,6 +50,7 @@ import {
   QuerySchema,
   querySdkScript,
   RunSchema,
+  RunSdkScriptResultSchema,
   runSdkScript,
   SdkScriptResultSchema,
 } from './sdk_run';
@@ -366,7 +367,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
       'Execute a capability-scoped Lobu SDK script. On bare OAuth /mcp, select workspace operations with await client.org(target); account discovery and conversation titles require no target. The script can create, update, or delete Lobu data and invoke connector, agent, or device operations only through documented `client` methods; workspace permissions, operation policies, human approvals, and audit remain enforced. Use `query_sdk` for reads, `search_sdk` to discover methods, and `dry_run=true` to preview write, administrative, or external calls without executing them. For connector setup, do the authorized SDK work first using connections.connect or connections.reauthenticate. When human input is required, use only exact URLs returned by tools, explain which account/app and permissions the user is authorizing, and follow the returned resume_call/completion_check. Never invent setup URLs or ask for OAuth client secrets in chat; use the returned browser setup form. Resume the requested work after verifying authorization completed.',
     inputSchema: RunSchema,
     mcpMeta: { 'openai/fileParams': ['files'] },
-    outputSchema: SdkScriptResultSchema,
+    outputSchema: RunSdkScriptResultSchema,
     annotations: {
       readOnlyHint: false,
       destructiveHint: true,

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -24,11 +24,13 @@ import { withValidatedArgs } from "./validate-args";
 import { mcpResourceLinksForSdkReturnValue } from "../mcp-media-resources";
 import { attachMcpResultContent } from "./mcp-result-content";
 import { attachMcpResultMeta } from "./mcp-result-meta";
+import { ingestMcpFiles, McpHostFilesSchema, StoredInputFileSchema } from "../mcp-file-inputs";
+import { ToolUserError } from "../utils/errors";
 
 const SCRIPT_FIELDS = {
   script: Type.String({
     description:
-      "TypeScript source. Must `export default async (ctx, client) => { ... }` — `ctx` is `{ organization_id, user_id, mode, sleep(ms) }`, where `await ctx.sleep(ms)` provides a bounded, abort-aware 0–30000ms polling delay; unrestricted timer globals are unavailable. `client` is the ClientSDK. Bare OAuth has organization_id=null: first select const workspace = await client.org(target) for workspace methods; account discovery and conversation titles work on the root client. The script's return value comes back as `return_value`; return it only for computed results and bounded samples. For bulk data prefer `client.query` / `query_sql` or paginated SDK reads — a return over the output cap is replaced by a `return_value_preview` head and a `return_truncated` report instead of shipping the full set to the model. Use `search_sdk` to discover SDK methods and `ctx.sleep`.",
+      "TypeScript source. Must `export default async (ctx, client) => { ... }` — `ctx` is `{ organization_id, user_id, mode, files, sleep(ms) }`, where `await ctx.sleep(ms)` provides a bounded, abort-aware 0–30000ms polling delay; unrestricted timer globals are unavailable. `client` is the ClientSDK. Bare OAuth has organization_id=null: first select const workspace = await client.org(target) for workspace methods; account discovery and conversation titles work on the root client. The script's return value comes back as `return_value`; return it only for computed results and bounded samples. For bulk data prefer `client.query` / `query_sql` or paginated SDK reads — a return over the output cap is replaced by a `return_value_preview` head and a `return_truncated` report instead of shipping the full set to the model. Use `search_sdk` to discover SDK methods and `ctx.sleep`.",
     minLength: 1,
     maxLength: 100_000,
   }),
@@ -51,6 +53,12 @@ const SCRIPT_FIELDS = {
 
 export const RunSchema = Type.Object({
   ...SCRIPT_FIELDS,
+  files: Type.Optional(McpHostFilesSchema),
+  file_organization: Type.Optional(Type.String({
+    minLength: 1,
+    maxLength: 255,
+    description: "Workspace slug or ID that will own attached files. Required with files on an account-scoped MCP connection. Files become ctx.files; pass a file directly to a connector field declaring x-lobu-file. Existing references need no re-upload.",
+  })),
   dry_run: Type.Optional(
     Type.Boolean({
       description:
@@ -119,6 +127,7 @@ const StartedSideEffectSchema = Type.Object({
  * is being asked to review.
  */
 export const SdkScriptResultSchema = Type.Object({
+  files: Type.Optional(Type.Array(StoredInputFileSchema)),
   title: Type.Optional(
     Type.String({
       description: "The caller-supplied human-friendly heading for this result, echoed back for the UI.",
@@ -284,6 +293,8 @@ export function toMcpPublicSdkScriptResult(result: unknown): unknown {
     out.title = row.title.trim();
   }
 
+  if (Array.isArray(row.files)) out.files = row.files;
+
   if (Object.hasOwn(row, "return_value") && row.return_value !== undefined) {
     out.return_value = row.return_value;
   }
@@ -410,6 +421,20 @@ async function runSandbox(
     sdkMode: mode,
     agentDryRun,
   });
+  const startedAt = Date.now();
+  const timeoutMs = args.timeout_ms ?? 60_000;
+  const hostFiles = "files" in args ? args.files : undefined;
+  if (hostFiles?.length && dryRun) {
+    throw new ToolUserError('File uploads cannot run in preview mode. Upload once, then reuse the returned file references in dry-run scripts.', 400);
+  }
+  const files = hostFiles?.length
+    ? await ingestMcpFiles(hostFiles, "file_organization" in args ? args.file_organization : undefined, {
+        ...ctx,
+        abortSignal: ctx.abortSignal
+          ? AbortSignal.any([ctx.abortSignal, AbortSignal.timeout(timeoutMs)])
+          : AbortSignal.timeout(timeoutMs),
+      })
+    : [];
   const sdkContext = {
     ...ctx,
     sdkBrowserInvocation: { nonce: randomUUID(), title: args.title ?? "" },
@@ -434,8 +459,9 @@ async function runSandbox(
       organization_id: ctx.organizationId,
       user_id: ctx.userId,
       mode: mode === "read" ? "query_sdk" : "run_sdk",
+      files,
     },
-    limits: args.timeout_ms ? { timeoutMs: args.timeout_ms } : undefined,
+    limits: { timeoutMs: Math.max(1, timeoutMs - (Date.now() - startedAt)) },
   });
   if (ctx.executionMode === "capture" && result.skippedCalls > 0) {
     await captureEffect(ctx.captureIdentity, "sdk.run", {
@@ -455,6 +481,7 @@ async function runSandbox(
     : result.error;
   const title = args.title?.trim() || undefined;
   const output = {
+    ...(files.length > 0 ? { files } : {}),
     ...(title ? { title } : {}),
     success: result.success,
     return_value: result.returnValue,

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -127,7 +127,6 @@ const StartedSideEffectSchema = Type.Object({
  * is being asked to review.
  */
 export const SdkScriptResultSchema = Type.Object({
-  files: Type.Optional(Type.Array(StoredInputFileSchema)),
   title: Type.Optional(
     Type.String({
       description: "The caller-supplied human-friendly heading for this result, echoed back for the UI.",
@@ -186,6 +185,11 @@ export const SdkScriptResultSchema = Type.Object({
   ),
   dry_run: Type.Boolean(),
 });
+
+export const RunSdkScriptResultSchema = Type.Composite([
+  SdkScriptResultSchema,
+  Type.Object({ files: Type.Optional(Type.Array(StoredInputFileSchema)) }),
+]);
 
 type PublicSideEffectPreviewEntry = Static<typeof PublicSideEffectPreviewEntrySchema>;
 

--- a/packages/server/src/utils/bounded-response.ts
+++ b/packages/server/src/utils/bounded-response.ts
@@ -17,30 +17,39 @@ export async function readResponseTextWithLimit(
   maxBytes: number,
   tooLargeLabel: string
 ): Promise<string> {
+  return (await readResponseBytesWithLimit(response, maxBytes, tooLargeLabel)).toString('utf-8');
+}
+
+/** The same bounded body reader serves binary attachments and text responses. */
+export async function readResponseBytesWithLimit(
+  response: Response,
+  maxBytes: number,
+  tooLargeLabel: string
+): Promise<Buffer> {
   const declaredLength = Number(response.headers.get('content-length') ?? '0');
   if (!Number.isNaN(declaredLength) && declaredLength > maxBytes) {
     await cancelResponseBody(response);
-    throw new Error(`${tooLargeLabel} (max ${maxBytes} bytes).`);
+    throw new RangeError(`${tooLargeLabel} (max ${maxBytes} bytes).`);
   }
 
   const reader = response.body?.getReader();
-  if (!reader) return '';
+  if (!reader) return Buffer.alloc(0);
   const chunks: Uint8Array[] = [];
   let total = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    if (!value) continue;
-    total += value.byteLength;
-    if (total > maxBytes) {
-      try {
-        await reader.cancel();
-      } catch {
-        // Preserve the deterministic size error.
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        throw new RangeError(`${tooLargeLabel} (max ${maxBytes} bytes).`);
       }
-      throw new Error(`${tooLargeLabel} (max ${maxBytes} bytes).`);
+      chunks.push(value);
     }
-    chunks.push(value);
+    return Buffer.concat(chunks, total);
+  } finally {
+    try { await reader.cancel(); } catch { /* Preserve the primary read error. */ }
+    reader.releaseLock();
   }
-  return Buffer.concat(chunks).toString('utf-8');
 }

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -1,3 +1,4 @@
+import { resolveOperationFiles } from "../operations/file-inputs";
 /**
  * POST /api/workers/poll
  *
@@ -1915,7 +1916,16 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       ? resolvedPreviousCredentials
       : undefined;
 
-  const selectedActionInput = row.approved_input ?? row.action_input ?? undefined;
+  let selectedActionInput = row.approved_input ?? row.action_input ?? undefined;
+  if (row.run_type === 'action' && selectedActionInput) {
+    try {
+      selectedActionInput = await resolveOperationFiles(selectedActionInput, row.run_metadata);
+    } catch (error) {
+      const message = errorMessage(error);
+      await failClaimedWorkerRun({ runId: row.run_id, workerId: worker_id, errorMessage: message });
+      return c.json({ ...pollMetadata, next_poll_seconds: 1, skipped_run_id: row.run_id, error: message });
+    }
+  }
   const isChromeAction =
     row.run_type === 'action' &&
     (row.connector_key === 'chrome' || row.connector_key?.startsWith('chrome.'));


### PR DESCRIPTION
## Summary
Chat-host attachments could not reach connector file fields through MCP, which led agents to try local paths and browser upload workarounds.

- Reuse the artifact store and consolidate chat, multipart, and host attachment ingestion. Add ordinary authenticated multipart intake and a thin MCP host adapter.
- Declare file inputs with `fileInputSchema`; store caller-bound references with operation approvals, then resolve the authorized bytes at execution. Preserve references after script failures for retries. Exclude host file capabilities from retained audit requests using the existing tool declaration.
- Enforce connector media/size limits and a 12 MiB aggregate file limit per operation before approval. No connector-specific routing, additional storage backend, or database migration.

## Test plan
- [x] `make pre-pr`: workspace builds, strict typechecks, dead-code, naming, and shared runtime gates passed.
- [x] 132 focused unit tests and 98 integration tests, including owner/workspace/agent isolation, approval substitution, retry, and streamed download limits.
- [x] A 5 MiB random file passed the actual isolate multipart transport with byte-for-byte SHA-256 verification plus filename, MIME, alt text, and rank.
- [x] Booted an isolated local stack: authenticated HTTP upload → MCP operation → synthetic human-session approval → actual worker → persisted result. Real HTTPS host intake and reference reuse after script failure also passed.
- [x] Red→green evidence below.
- [x] Public client types regenerated from the running server OpenAPI document.
- [x] GitHub CI on final HEAD `697fe40b8eb163df0c0891b0c595c6d3f68315b4`, including packaged CLI and runtime smoke.
- [x] Codex `make review-fix`: tightened approval claim preservation, validated downloaded MIME metadata, and corrected the run/query output contracts. All edits were inspected; regenerated the client from the booted full API document and reran local gates.
- [x] Full Codex semantic review passed on `697fe40b8eb163df0c0891b0c595c6d3f68315b4`: zero bugs, zero blockers, tests adequate; `pi-review` passed. Device-worker grants have distinct file bindings, with actual MCP and session-to-OAuth regression coverage.

Red:
```text
Device-principal isolation regression: 5 pass, 2 fail; device credentials incorrectly resolved the human upload.
Original MCP contract: 0 pass, 2 fail (missing fileParams metadata and file input validation).
Explicit current workspace slug initially failed with CrossOrgAccessDenied; scoped and granted-account cases now pass.
Original execute/poll handlers: operation-file-handoff test failed because run_metadata.input_files was absent.
Audit file-capability regression: 24 pass, 2 fail; both valid and rejected attachment requests persisted the signed download URL.
Runtime size probe: 12,582,912 bytes decoded; 12,582,913 bytes failed with "a single bridge message exceeded 16777216 bytes".
```
Green:
```text
MCP attachment contract: 3 pass.
Device-principal isolation: 7 pass; actual MCP run_sdk tests cover human/device host intake and deny device access to human files while preserving session-to-OAuth reuse.
Operation file handoff: 10 pass, including full 5 MiB multipart delivery.
File size authorization rejects oversized operation inputs before queuing.
Approval regression coverage rejects reference replacement with inline bytes, removed references, and partially removed file sets.
Audit and operation file handoff co-run: 36 pass; persisted and author-readable requests exclude file capabilities without mutating live intake arguments.
make pre-pr: gates clean.
```

## Notes
Merged as `df342326e0318904dba8b8cf138bae3081b87efb`; production rollout verification is in progress. Actual ChatGPT UI attachment injection and the live Etsy file-reference path remain unverified. The current connected MCP authorization does not grant the test workspace; live continuation requires normal authorized workspace access and human operation approval. The smoke client stops at pending approvals.

With an explicitly authorized temporary session, live Etsy API smoke created an unpublished draft and verified image upload/readback, alt-text-only updates, complete-list reordering, image replacement, and title/description updates. Digital-file and video upload/readback/deletion also passed, as did deleting a nonfinal listing image. Final readback confirmed the listing is still a draft with one test image. Etsy rejects deleting the final image, and deleting the draft itself requires an ungranted listing-deletion scope. The temporary session was revoked and verified unauthenticated after testing. These live calls exercised the existing connector byte transport; they do not prove this PR's file-reference path is deployed.

Live testing found two connector-owned gaps: Etsy resets omitted image metadata, and the connector discarded provider validation details. The organization-local connector was updated separately through the existing validate/update source APIs. Retesting confirmed alt-text edits preserve rank, rank edits preserve alt text, and title validation errors identify the provider's rejected field. No Etsy-specific runtime branch was added to this PR. The follow-up connector source with this SDK helper compiles as version 0.5.4, retains all 93 actions and the three existing 5 MiB binary-field limits, and is not installed yet.

Diff: +1,237 / -95 lines (net +1,142: +548 runtime, +20 generated client types, +550 tests, +24 documentation). Shared ingestion and bounded-response reading are consolidated; file authorization and dispatch are new capability.

Daytona creation was blocked by the account disk quota; local verification used a disposable embedded database.

