### PR TITLE
fix(cli): verify installed device runtime entrypoints before activation

### DIFF
--- a/scripts/__tests__/runtime-entrypoints.test.ts
+++ b/scripts/__tests__/runtime-entrypoints.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { ensureComponent } from "../../packages/cli/src/internal/runtime-components.js";
+import {
+  COMPONENTS,
+  runtimeVerificationSource,
+} from "../runtime-components.mjs";
+
+const directories: string[] = [];
+afterEach(async () => {
+  await Promise.all(
+    directories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true }))
+  );
+});
+
+async function temporary() {
+  const directory = await mkdtemp(join(tmpdir(), "lobu-entrypoints-"));
+  directories.push(directory);
+  return directory;
+}
+
+async function file(path: string, contents: string) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents);
+}
+
+test("device entries load dependencies from installed packages, not staging copies", async () => {
+  const directory = await temporary();
+  await file(join(directory, "package.json"), '{"type":"module"}');
+  for (const [owner, paths] of [
+    [
+      "cli",
+      [
+        "dist/commands/daemon.js",
+        "dist/commands/automation.js",
+        "dist/commands/connector.js",
+      ],
+    ],
+    ["connector-worker", ["dist/bin.js"]],
+  ] as const) {
+    const installed = join(directory, "node_modules/@lobu", owner);
+    const dependency = join(
+      installed,
+      "node_modules/@fixture/runtime-dependency"
+    );
+    await file(
+      join(dependency, "package.json"),
+      '{"type":"module","exports":"./index.js"}'
+    );
+    await file(
+      join(dependency, "index.js"),
+      'export default "installed dependency";'
+    );
+    for (const path of paths) {
+      const source =
+        'import value from "@fixture/runtime-dependency"; export default value;';
+      await file(join(installed, path), source);
+      await file(join(directory, "vendor", owner, path), source);
+    }
+  }
+  const result = spawnSync(
+    "node",
+    [
+      "--input-type=module",
+      "-e",
+      'import { pathToFileURL } from "node:url"; for (const path of process.argv.slice(1)) { const entry = await import(pathToFileURL(path)); if (entry.default !== "installed dependency") throw new Error("Wrong dependency"); }',
+      ...Object.values(COMPONENTS.device.entries).map((entry) =>
+        join(directory, entry)
+      ),
+    ],
+    { encoding: "utf8", cwd: directory }
+  );
+  expect(result.stderr).toBe("");
+  expect(result.status).toBe(0);
+});
+
+test.each([
+  "valid",
+  ...Object.keys(COMPONENTS.device.entries),
+  "worker-exit",
+])("device verification gates cache activation: %s", async (scenario) => {
+  const cacheRoot = await temporary();
+  const component = {
+    ...COMPONENTS.device,
+    version: "20.0.0",
+    verify: "dist/verify.mjs",
+  };
+  const installation = ensureComponent(component, {
+    cacheRoot,
+    fetchArtifact: async (_descriptor, directory) => {
+      await file(
+        join(directory, "package.json"),
+        JSON.stringify({ ...component, type: "module" })
+      );
+      for (const [name, entry] of Object.entries(component.entries)) {
+        let source = "export {};";
+        if (name === scenario)
+          source = 'import "@fixture/missing-runtime-dependency";';
+        else if (name === "worker")
+          source =
+            scenario === "worker-exit"
+              ? "process.exit(17);"
+              : 'if (process.argv[2] !== "--help") throw new Error("Expected worker --help"); process.exit(0);';
+        await file(join(directory, entry), source);
+      }
+      const worker = join(directory, "node_modules/@lobu/connector-worker");
+      await file(
+        join(worker, "package.json"),
+        JSON.stringify({
+          type: "module",
+          exports: {
+            "./daemon": "./dist/daemon.mjs",
+            "./executor/runtime": "./dist/executor.mjs",
+          },
+        })
+      );
+      await file(join(worker, "dist/daemon.mjs"), "export {};");
+      await file(join(worker, "dist/executor.mjs"), "export {};");
+      // Keep native verification healthy so only the selected entry can fail.
+      for (const name of ["isolated-vm", "isolated-vm-next"]) {
+        await file(
+          join(directory, "node_modules", name, "package.json"),
+          '{"main":"index.cjs"}'
+        );
+        await file(
+          join(directory, "node_modules", name, "index.cjs"),
+          "exports.Isolate = class { dispose() {} };"
+        );
+      }
+      await file(
+        join(directory, component.verify),
+        runtimeVerificationSource("device", component)
+      );
+    },
+    installDependencies: async () => undefined,
+  });
+  if (scenario === "valid") {
+    const installed = await installation;
+    await expect(
+      ensureComponent(component, { cacheRoot, offline: true })
+    ).resolves.toBe(installed);
+    return;
+  }
+  await expect(installation).rejects.toThrow("Runtime verification failed");
+  await expect(
+    ensureComponent(component, { cacheRoot, offline: true })
+  ).rejects.toThrow("not cached");
+});

--- a/scripts/__tests__/runtime-entrypoints.test.ts
+++ b/scripts/__tests__/runtime-entrypoints.test.ts
@@ -105,7 +105,7 @@ test.each([
           source =
             scenario === "worker-exit"
               ? "process.exit(17);"
-              : 'if (process.argv[2] !== "--help") throw new Error("Expected worker --help"); process.exit(0);';
+              : 'if (process.argv[2] !== "--help") throw new Error("Expected worker --help"); console.log("fixture worker usage"); process.exit(0);';
         await file(join(directory, entry), source);
       }
       const worker = join(directory, "node_modules/@lobu/connector-worker");
@@ -141,6 +141,15 @@ test.each([
   });
   if (scenario === "valid") {
     const installed = await installation;
+    for (const runtime of ["node", process.execPath]) {
+      const result = spawnSync(runtime, [join(installed, component.verify)], {
+        encoding: "utf8",
+        cwd: installed,
+      });
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe("");
+    }
     await expect(
       ensureComponent(component, { cacheRoot, offline: true })
     ).resolves.toBe(installed);

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -86,6 +86,7 @@ fi
 # contains every one of those in $RUN_DIR so the gate never clobbers the dev's
 # real contexts/login (and gives a fresh DB each run).
 export HOME="$RUN_DIR/home"
+export LOBU_RUNTIME_CACHE_DIR="$HOME/.cache/lobu/runtime"
 
 MOCK_PID=""
 cleanup() {

--- a/scripts/daemon-mcp-smoke.mjs
+++ b/scripts/daemon-mcp-smoke.mjs
@@ -8,12 +8,13 @@
 //
 // Local run against the working tree, before publishing:
 //   node scripts/pack-cli-smoke.mjs /tmp/lobu-candidate
-//   node scripts/daemon-mcp-smoke.mjs /tmp/lobu-candidate/node_modules/@lobu/cli/bin/lobu.js
+// To repeat just this smoke using that candidate's verified runtime cache:
+//   node scripts/daemon-mcp-smoke.mjs /tmp/lobu-candidate/node_modules/.bin/lobu /tmp/lobu-candidate/daemon-mcp-logs /tmp/lobu-candidate/runtime
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { cp, mkdtemp, realpath, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
@@ -21,23 +22,13 @@ import { dirname, join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 
-const cli = resolve(process.argv[2] ?? "");
-if (!process.argv[2] || !existsSync(cli)) {
+const cliPath = resolve(process.argv[2] ?? "");
+if (!process.argv[2] || !existsSync(cliPath)) {
   throw new Error(
-    "Usage: daemon-mcp-smoke.mjs <installed-lobu-bin> [failure-log-directory]"
+    "Usage: daemon-mcp-smoke.mjs <installed-lobu-bin> [failure-log-directory] [candidate-runtime-cache]"
   );
 }
-const requireCli = createRequire(cli);
-// Use the actual installed CLI's MCP client dependency, without importing any
-// gateway handlers or source-only test clients.
-const { Client } = await import(
-  pathToFileURL(requireCli.resolve("@modelcontextprotocol/sdk/client/index.js"))
-);
-const { StreamableHTTPClientTransport } = await import(
-  pathToFileURL(
-    requireCli.resolve("@modelcontextprotocol/sdk/client/streamableHttp.js")
-  )
-);
+const cli = await realpath(cliPath);
 // Canonical path: the shell reports its physical cwd, and macOS tmpdirs are
 // symlinks.
 const work = await realpath(await mkdtemp(join(tmpdir(), "lobu-daemon-mcp-")));
@@ -168,6 +159,33 @@ async function json(path, { method = "GET", body, headers = {} } = {}) {
 }
 
 async function connect(token) {
+  // Resolve from the tested artifact, including npm's .bin symlink. New
+  // launchers keep the SDK in the server component that this smoke booted;
+  // older published releases still keep it in the CLI dependency graph.
+  let requireMcp = createRequire(cli);
+  const cliDirectory = resolve(dirname(cli), "..");
+  const catalogPath = join(cliDirectory, "dist/runtime-components.json");
+  if (existsSync(catalogPath)) {
+    const { server } = JSON.parse(readFileSync(catalogPath, "utf8"));
+    const { ensureComponent } = await import(
+      pathToFileURL(join(cliDirectory, "dist/internal/runtime-components.js"))
+    );
+    const serverDirectory = await ensureComponent(server, {
+      cacheRoot: join(home, ".cache", "lobu", "runtime"),
+      offline: true,
+    });
+    requireMcp = createRequire(join(serverDirectory, "package.json"));
+  }
+  const { Client } = await import(
+    pathToFileURL(
+      requireMcp.resolve("@modelcontextprotocol/sdk/client/index.js")
+    )
+  );
+  const { StreamableHTTPClientTransport } = await import(
+    pathToFileURL(
+      requireMcp.resolve("@modelcontextprotocol/sdk/client/streamableHttp.js")
+    )
+  );
   const client = new Client({ name: "lobu-daemon-smoke", version: "1.0.0" });
   clients.push(client);
   await client.connect(
@@ -237,6 +255,19 @@ async function failedCommand(command, input, expectedError) {
 }
 
 async function main() {
+  if (process.argv[4]) {
+    // Pre-publication candidates are not on npm yet. Copy only an explicitly
+    // supplied, already-verified artifact cache into this smoke's private HOME.
+    // Published-artifact runs omit this argument and install from the registry.
+    await cp(
+      resolve(process.argv[4]),
+      join(home, ".cache", "lobu", "runtime"),
+      {
+        recursive: true,
+        verbatimSymlinks: true,
+      }
+    );
+  }
   const server = start("gateway", ["run", "--port", String(port)]);
   await check(
     "installed CLI boots an isolated gateway and Postgres",

--- a/scripts/pack-cli-smoke.mjs
+++ b/scripts/pack-cli-smoke.mjs
@@ -204,6 +204,16 @@ run(
   [join(root, "scripts/verify-cli-runtime.mjs"), destination],
   destination
 );
+run(
+  process.execPath,
+  [
+    join(root, "scripts/daemon-mcp-smoke.mjs"),
+    join(destination, "node_modules/.bin/lobu"),
+    join(destination, "daemon-mcp-logs"),
+    cacheRoot,
+  ],
+  destination
+);
 console.log(
   `Candidate CLI: ${join(destination, "node_modules/@lobu/cli/bin/lobu.js")}`
 );

--- a/scripts/published-artifact-smoke.sh
+++ b/scripts/published-artifact-smoke.sh
@@ -75,6 +75,7 @@ MOCK_REPLY="ARTIFACT_SMOKE_OK"
 WORK="${SMOKE_WORK:-/tmp/lobu-artifact-smoke}"
 rm -rf "$WORK"; mkdir -p "$WORK"
 export HOME="$WORK/home"; mkdir -p "$HOME"
+export LOBU_RUNTIME_CACHE_DIR="$HOME/.cache/lobu/runtime"
 
 PASSES=0; FAILS=0; SKIPS=0
 pass() { echo "  [OK]   $*"; PASSES=$((PASSES + 1)); }

--- a/scripts/runtime-components.mjs
+++ b/scripts/runtime-components.mjs
@@ -35,10 +35,10 @@ export const COMPONENTS = {
   device: {
     name: "@lobu/runtime-device",
     entries: {
-      daemon: "vendor/cli/dist/commands/daemon.js",
-      automation: "vendor/cli/dist/commands/automation.js",
-      connector: "vendor/cli/dist/commands/connector.js",
-      worker: "vendor/connector-worker/dist/bin.js",
+      daemon: "node_modules/@lobu/cli/dist/commands/daemon.js",
+      automation: "node_modules/@lobu/cli/dist/commands/automation.js",
+      connector: "node_modules/@lobu/cli/dist/commands/connector.js",
+      worker: "node_modules/@lobu/connector-worker/dist/bin.js",
     },
   },
   postgres: {
@@ -59,6 +59,57 @@ export function runtimeCatalog() {
       { ...value, version, verify: "dist/verify.mjs" },
     ])
   );
+}
+
+export function runtimeVerificationSource(key, component) {
+  const verify = [
+    'import { createRequire } from "node:module";',
+    'import { readFileSync } from "node:fs";',
+    "const require = createRequire(import.meta.url);",
+    'const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));',
+  ];
+  if (key === "device")
+    verify.push(
+      'import { spawnSync } from "node:child_process";',
+      'import { fileURLToPath } from "node:url";',
+      `const entries = ${JSON.stringify(component.entries)};`,
+      "// Import installed commands: name resolution alone misses broken transitive imports.",
+      "for (const [name, entry] of Object.entries(entries)) {",
+      '  const url = new URL("../" + entry, import.meta.url);',
+      "  try {",
+      '    if (name === "worker") {',
+      // The worker is an executable; importing it runs main and exits.
+      '      const child = spawnSync(process.execPath, [fileURLToPath(url), "--help"], { stdio: "inherit", timeout: 30000 });',
+      "      if (child.error) throw child.error;",
+      '      if (child.status !== 0) throw new Error("worker --help exited " + (child.status ?? child.signal));',
+      "    } else await import(url);",
+      "  } catch (error) {",
+      '    throw new Error("Cannot load device entry " + name + " (" + entry + "): " + error.message, { cause: error });',
+      "  }",
+      "}"
+    );
+  verify.push(
+    "for (const name of Object.keys(pkg.dependencies ?? {})) {",
+    '  if (name === "@lobu/connector-worker") import.meta.resolve("@lobu/connector-worker/daemon");',
+    "  else import.meta.resolve(name);",
+    "}"
+  );
+  if (key === "postgres")
+    verify.push(
+      'const pg = await import("./index.mjs"); pg.injectPgvector(pg.resolveEmbeddedNativeDir());'
+    );
+  if (key === "embeddings") verify.push('await import("./embeddings.js");');
+  if (key === "device")
+    verify.push(
+      'await import("@lobu/connector-worker/executor/runtime");',
+      'const nativeRequire = createRequire(import.meta.resolve("@lobu/connector-worker/daemon"));'
+    );
+  else verify.push("const nativeRequire = require;");
+  if (key === "server" || key === "device")
+    verify.push(
+      'const major = Number(process.versions.node.split(".")[0]); if (major !== 25) { const ivm = nativeRequire(major >= 26 ? "isolated-vm-next" : "isolated-vm"); const isolate = new ivm.Isolate({ memoryLimit: 8 }); isolate.dispose(); }'
+    );
+  return `${verify.join("\n")}\n`;
 }
 
 function copy(source, destination) {
@@ -346,32 +397,10 @@ export async function buildRuntimeComponents() {
         writeJson(path, pkg);
       }
     }
-    const verify = [
-      'import { createRequire } from "node:module";',
-      'import { readFileSync } from "node:fs";',
-      "const require = createRequire(import.meta.url);",
-      'const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));',
-      "for (const name of Object.keys(pkg.dependencies ?? {})) {",
-      '  if (name === "@lobu/connector-worker") import.meta.resolve("@lobu/connector-worker/daemon");',
-      "  else import.meta.resolve(name);",
-      "}",
-    ];
-    if (key === "postgres")
-      verify.push(
-        'const pg = await import("./index.mjs"); pg.injectPgvector(pg.resolveEmbeddedNativeDir());'
-      );
-    if (key === "embeddings") verify.push('await import("./embeddings.js");');
-    if (key === "device")
-      verify.push(
-        'await import("@lobu/connector-worker/executor/runtime");',
-        'const nativeRequire = createRequire(import.meta.resolve("@lobu/connector-worker/daemon"));'
-      );
-    else verify.push("const nativeRequire = require;");
-    if (key === "server" || key === "device")
-      verify.push(
-        'const major = Number(process.versions.node.split(".")[0]); if (major !== 25) { const ivm = nativeRequire(major >= 26 ? "isolated-vm-next" : "isolated-vm"); const isolate = new ivm.Isolate({ memoryLimit: 8 }); isolate.dispose(); }'
-      );
-    writeFileSync(join(directory, "dist/verify.mjs"), `${verify.join("\n")}\n`);
+    writeFileSync(
+      join(directory, "dist/verify.mjs"),
+      runtimeVerificationSource(key, component)
+    );
     writeJson(join(directory, "package.json"), manifest);
     writeJson(join(directory, "dist/component.json"), component);
   }

--- a/scripts/runtime-components.mjs
+++ b/scripts/runtime-components.mjs
@@ -79,7 +79,7 @@ export function runtimeVerificationSource(key, component) {
       "  try {",
       '    if (name === "worker") {',
       // The worker is an executable; importing it runs main and exits.
-      '      const child = spawnSync(process.execPath, [fileURLToPath(url), "--help"], { stdio: "inherit", timeout: 30000 });',
+      '      const child = spawnSync(process.execPath, [fileURLToPath(url), "--help"], { stdio: ["ignore", "ignore", "inherit"], timeout: 30000 });',
       "      if (child.error) throw child.error;",
       '      if (child.status !== 0) throw new Error("worker --help exited " + (child.status ?? child.signal));',
       "    } else await import(url);",


### PR DESCRIPTION
## Summary
Bun's isolated installer places the device command dependencies beside the installed packages, but the runtime catalog pointed at the staging copies under `vendor/`. The published canary therefore failed to start `lobu daemon` with `Cannot find package '@inquirer/prompts'` even though that dependency was installed.

- Point all four device entrypoints at their installed packages and load every advertised entry before activating the runtime cache. A missing import now rejects installation with the entry name and path.
- Resolve the daemon MCP smoke client from the server runtime that owns it, isolate runtime caches, and run the full daemon MCP smoke on the packed candidate before publication.

## Test plan
- [x] Intended files staged explicitly; `make pre-pr` passed (build, typechecks, file-level knip, naming and write-funnel gates). Full Linux graph runs in required GitHub CI.
- [x] Red: the previous verifier exited 0 while importing its advertised daemon exited 1 with an unresolved dependency.
- [x] Green: all four installed device entrypoints load; a regression fixture with a missing import fails verification and leaves no active cache.
- [x] Targeted tests: 22 passed, 0 failed (`scripts/__tests__/runtime-entrypoints.test.ts` and CLI runtime-component tests).

- [x] Full package build and packed-artifact checks passed with both Bun and npm runtime installs: native isolates, 23 built-in connectors, embedded Postgres/pgvector, web UI, local embedding service, external Postgres/remote embeddings, and daemon MCP scenarios.

Red output:
```text
oldVerifierExit: 0
advertisedDaemonImportExit: 1
Cannot find package '@inquirer/prompts' imported from .../device/vendor/cli/dist/commands/_lib/device-wizard.js
```

Green output:
```text
22 pass, 0 fail
Packed runtime: embedded PG/pgvector, migrations, web UI, local embedding service, and external DB/remote embeddings boot passed.
Daemon MCP smoke: 13 passed, 0 failed
```

## Notes
Follow-up to #3518, found by the first published-canary E2E run. The existing component boundaries and dependency ownership remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved runtime validation to ensure installed device components are available and functional before caching.
  - Prevented invalid or incomplete runtime installations from being reused offline.
  - Improved MCP daemon checks for installed and pre-release artifacts.

- **Testing**
  - Expanded smoke tests for published and candidate artifacts, including daemon and MCP connectivity.
  - Isolated runtime caches during CLI and artifact checks.
  - Added coverage for worker startup and device entrypoint verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->