### PR TITLE
fix(images): prune browser test tooling from production

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -168,6 +168,11 @@ RUN if [ "$SKIP_WEB_BUILD" = "false" ] && [ -f packages/owletto/package.json ]; 
       mkdir -p /app/packages/owletto/dist; \
     fi
 
+# Keep browser automation available while building/testing, then remove its
+# installed packages by manifest identity before copying the production graph.
+COPY scripts/image-browser-tooling.mjs scripts/image-browser-tooling.mjs
+RUN node scripts/image-browser-tooling.mjs --prune /app
+
 # ===========================================
 # Runtime
 # ===========================================
@@ -215,6 +220,8 @@ COPY --from=builder /app/packages/server ./packages/server
 COPY --from=builder /app/packages/cli ./packages/cli
 RUN ln -s /app/packages/cli/bin/lobu.js /usr/local/bin/lobu
 COPY --from=builder /app/packages/owletto ./packages/owletto
+COPY --from=builder /app/scripts/image-browser-tooling.mjs ./scripts/image-browser-tooling.mjs
+RUN node scripts/image-browser-tooling.mjs --check /app
 
 # Database migrations (+ statement-at-a-time runner for transaction:false)
 COPY db/migrations ./db/migrations

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -92,6 +92,11 @@ RUN cd packages/core && bunx tsc \
     && cd ../embeddings && bunx tsc \
     && cd ../connector-worker && bun run build
 
+# Enforce the same production policy even if a future build dependency adds a
+# browser engine through an alias or nested package-manager store.
+COPY scripts/image-browser-tooling.mjs scripts/image-browser-tooling.mjs
+RUN node scripts/image-browser-tooling.mjs --prune /app
+
 # ===========================================
 # Runtime
 # ===========================================
@@ -126,6 +131,8 @@ COPY --from=builder --chown=worker:worker /app/packages/connector-sdk ./packages
 COPY --from=builder --chown=worker:worker /app/packages/connectors ./packages/connectors
 COPY --from=builder --chown=worker:worker /app/packages/embeddings ./packages/embeddings
 COPY --from=builder --chown=worker:worker /app/packages/connector-worker ./packages/connector-worker
+COPY --from=builder --chown=worker:worker /app/scripts/image-browser-tooling.mjs ./scripts/image-browser-tooling.mjs
+RUN node scripts/image-browser-tooling.mjs --check /app
 
 USER 1001
 

--- a/scripts/__tests__/image-browser-tooling.test.ts
+++ b/scripts/__tests__/image-browser-tooling.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  assertNoBrowserTooling,
+  pruneBrowserTooling,
+} from "../image-browser-tooling.mjs";
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true });
+});
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "lobu-image-browser-"));
+  roots.push(root);
+  return root;
+}
+function install(root: string, path: string, name: string) {
+  const directory = join(root, path);
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(
+    join(directory, "package.json"),
+    JSON.stringify({ name, version: "0.0.0" })
+  );
+  writeFileSync(join(directory, "cli.js"), "// synthetic executable\n");
+  return directory;
+}
+function link(root: string, path: string, target: string) {
+  const file = join(root, path);
+  mkdirSync(dirname(file), { recursive: true });
+  symlinkSync(relative(dirname(file), target), file);
+  return file;
+}
+
+describe("production image browser tooling", () => {
+  it.each([
+    "playwright",
+    "playwright-core",
+    "@playwright/test",
+    "@playwright/browser-chromium",
+    "patchright",
+    "patchright-core",
+    "puppeteer",
+    "puppeteer-core",
+    "@puppeteer/browsers",
+  ])("finds %s by manifest identity through an unrelated installation alias", (name) => {
+    const root = fixture();
+    const browser = install(root, "node_modules/synthetic-alias", name);
+    expect(() => assertNoBrowserTooling(root)).toThrow(name);
+    pruneBrowserTooling(root);
+    expect(existsSync(browser)).toBe(false);
+    expect(() => assertNoBrowserTooling(root)).not.toThrow();
+  });
+
+  it("removes flat packages and executable links while preserving runtime dependencies", () => {
+    const root = fixture();
+    const browser = install(
+      root,
+      "node_modules/playwright-vanilla",
+      "playwright"
+    );
+    const core = install(
+      root,
+      "node_modules/playwright-core",
+      "playwright-core"
+    );
+    const runtime = install(root, "node_modules/dotenv", "dotenv");
+    const bin = link(
+      root,
+      "node_modules/.bin/playwright",
+      join(browser, "cli.js")
+    );
+    const retainedBin = link(
+      root,
+      "node_modules/.bin/synthetic-runtime",
+      join(runtime, "cli.js")
+    );
+    expect(pruneBrowserTooling(root)).toBe(2);
+    expect(existsSync(browser)).toBe(false);
+    expect(existsSync(core)).toBe(false);
+    expect(() => lstatSync(bin)).toThrow();
+    expect(existsSync(retainedBin)).toBe(true);
+    expect(
+      JSON.parse(readFileSync(join(runtime, "package.json"), "utf8")).name
+    ).toBe("dotenv");
+    expect(pruneBrowserTooling(root)).toBe(0);
+  });
+
+  it("handles nested dependencies and isolated stores without deleting their owners", () => {
+    const root = fixture();
+    const owner = install(
+      root,
+      "packages/server/node_modules/synthetic-owner",
+      "synthetic-owner"
+    );
+    const nested = install(
+      root,
+      "packages/server/node_modules/synthetic-owner/node_modules/alias",
+      "puppeteer"
+    );
+    const stored = install(
+      root,
+      "node_modules/.bun/synthetic-store/node_modules/alias",
+      "playwright"
+    );
+    const alias = link(root, "node_modules/browser-alias", stored);
+    const nestedLink = link(
+      root,
+      "packages/server/node_modules/browser-alias",
+      stored
+    );
+    const bin = link(root, "node_modules/.bin/browser", join(stored, "cli.js"));
+    pruneBrowserTooling(root);
+    expect(existsSync(owner)).toBe(true);
+    for (const path of [nested, stored, alias, nestedLink, bin]) {
+      expect(() => lstatSync(path)).toThrow();
+    }
+  });
+
+  it("unlinks external browser aliases without modifying their targets", () => {
+    const root = fixture();
+    const outside = fixture();
+    const browser = install(outside, "browser", "playwright");
+    const alias = link(root, "node_modules/alias", browser);
+    const bin = link(
+      root,
+      "node_modules/.bin/browser",
+      join(browser, "cli.js")
+    );
+    pruneBrowserTooling(root);
+    expect(existsSync(browser)).toBe(true);
+    expect(() => lstatSync(alias)).toThrow();
+    expect(() => lstatSync(bin)).toThrow();
+  });
+
+  it("preserves development declarations, similarly named packages, and unrelated links", () => {
+    const root = fixture();
+    const runtime = install(
+      root,
+      "node_modules/playwright-utils",
+      "synthetic-runtime"
+    );
+    const owner = install(root, "packages/server", "synthetic-server");
+    writeFileSync(
+      join(owner, "package.json"),
+      JSON.stringify({
+        name: "synthetic-server",
+        devDependencies: { "playwright-vanilla": "npm:playwright@1.0.0" },
+      })
+    );
+    const before = readFileSync(join(owner, "package.json"), "utf8");
+    const retained = link(root, "node_modules/synthetic-server", owner);
+    const dangling = link(
+      root,
+      "node_modules/.bin/unrelated-missing",
+      join(root, "missing/cli.js")
+    );
+    pruneBrowserTooling(root);
+    expect(existsSync(runtime)).toBe(true);
+    expect(existsSync(retained)).toBe(true);
+    expect(lstatSync(dangling).isSymbolicLink()).toBe(true);
+    expect(readFileSync(join(owner, "package.json"), "utf8")).toBe(before);
+  });
+
+  it("fails inspection before removing packages if an installed manifest is malformed", () => {
+    const root = fixture();
+    const browser = install(root, "node_modules/alias", "playwright");
+    const malformed = install(
+      root,
+      "node_modules/synthetic-broken",
+      "synthetic-broken"
+    );
+    writeFileSync(join(malformed, "package.json"), "{");
+    expect(() => pruneBrowserTooling(root)).toThrow();
+    expect(existsSync(browser)).toBe(true);
+  });
+
+  it("exposes a failing read-only image check and an idempotent prune command", () => {
+    const root = fixture();
+    install(root, "node_modules/alias", "playwright");
+    const script = fileURLToPath(
+      new URL("../image-browser-tooling.mjs", import.meta.url)
+    );
+    const run = (mode: string) =>
+      spawnSync("node", [script, mode, root], { encoding: "utf8" });
+    const red = run("--check");
+    expect(red.status).toBe(1);
+    expect(red.stderr).toContain("Production image contains browser tooling");
+    expect(run("--prune").status).toBe(0);
+    expect(run("--check").status).toBe(0);
+    expect(run("--prune").stdout).toContain("Removed 0");
+  });
+});

--- a/scripts/image-browser-tooling.mjs
+++ b/scripts/image-browser-tooling.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// Browser automation remains available to development/E2E tests. Production
+// images use the paired extension and must not carry these test packages.
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  realpathSync,
+  rmSync,
+} from "node:fs";
+import { dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const browserPackages = new Set([
+  "playwright",
+  "playwright-core",
+  "@playwright/test",
+  "@playwright/browser-chromium",
+  "@playwright/browser-firefox",
+  "@playwright/browser-webkit",
+  "patchright",
+  "patchright-core",
+  "puppeteer",
+  "puppeteer-core",
+  "@puppeteer/browsers",
+]);
+
+function inside(path, directory) {
+  return path === directory || path.startsWith(`${directory}${sep}`);
+}
+
+function inspect(root) {
+  const packages = [];
+  const links = [];
+  function visit(directory) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isSymbolicLink()) {
+        let target;
+        try {
+          target = realpathSync(path);
+        } catch (error) {
+          if (error.code !== "ENOENT") throw error;
+          target = resolve(dirname(path), readlinkSync(path));
+        }
+        links.push({ path, target });
+      }
+      // Check package identity, not the installed directory name: aliases can
+      // hide Playwright behind any name. Physical Bun/pnpm stores and nested
+      // node_modules are visited too, without traversing directory symlinks.
+      if (
+        (entry.isDirectory() || entry.isSymbolicLink()) &&
+        /(?:^|\/)node_modules\/(?:@[^/]+\/)?[^/]+$/.test(path)
+      ) {
+        let manifest;
+        try {
+          manifest = JSON.parse(
+            readFileSync(join(path, "package.json"), "utf8")
+          );
+        } catch (error) {
+          if (error.code !== "ENOENT" && error.code !== "ENOTDIR") throw error;
+        }
+        if (browserPackages.has(manifest?.name)) {
+          packages.push({
+            path,
+            target: realpathSync(path),
+            name: manifest.name,
+          });
+        }
+      }
+      if (entry.isDirectory()) visit(path);
+    }
+  }
+  visit(realpathSync(resolve(root)));
+  return { packages, links };
+}
+
+export function assertNoBrowserTooling(root) {
+  const { packages } = inspect(root);
+  if (packages.length) {
+    throw new Error(
+      `Production image contains browser tooling:\n${packages
+        .map(({ name, path }) => `  ${name}: ${path}`)
+        .join("\n")}`
+    );
+  }
+}
+
+export function pruneBrowserTooling(root) {
+  const { packages, links } = inspect(root);
+  // Resolve links before deleting anything. This includes .bin executables,
+  // npm aliases, and package-local links into an isolated dependency store.
+  for (const link of links) {
+    if (packages.some((pkg) => inside(link.target, pkg.target))) {
+      rmSync(link.path, { force: true });
+    }
+  }
+  for (const pkg of packages.sort((a, b) => b.path.length - a.path.length)) {
+    // Only remove paths encountered inside the image. A symlink's external
+    // target is never traversed or deleted.
+    rmSync(pkg.path, { recursive: true, force: true });
+  }
+  assertNoBrowserTooling(root);
+  return packages.length;
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  const [mode, root, ...extra] = process.argv.slice(2);
+  if (!["--check", "--prune"].includes(mode) || !root || extra.length) {
+    throw new Error(
+      "Usage: image-browser-tooling.mjs <--check|--prune> <image-root>"
+    );
+  }
+  // Refuse a file or a symlink as the artifact root before any removal.
+  if (!lstatSync(resolve(root)).isDirectory())
+    throw new Error("Image root must be a directory");
+  if (mode === "--prune") {
+    console.log(
+      `Removed ${pruneBrowserTooling(root)} browser tooling package installations.`
+    );
+  } else {
+    assertNoBrowserTooling(root);
+    console.log("Production image contains no browser tooling packages.");
+  }
+}


### PR DESCRIPTION
## Summary

The app image copies the builder's development dependencies, so test-only Playwright still reaches production. Prune browser tooling after builds in the app and worker images, then check the copied dependency graph in each final stage. Match package manifest identities so npm aliases and nested Bun/pnpm stores are covered; remove their executable/dependency links while preserving unrelated packages, links, and development/E2E declarations.

## Test plan

- [x] Focused regressions: `PATH=/opt/homebrew/opt/node@22/bin:$PATH bun test scripts/__tests__/image-browser-tooling.test.ts` — 15 passed, 54 assertions. Includes nested/isolated aliases, executable links, external targets, malformed manifests, idempotence, and preservation of dotenv, development declarations, and unrelated dangling links.
- [x] `REVIEWER_CLI=codex CODEX_REVIEW_MODEL=gpt-6-astra make review-fix` — no defects; no edits.
- [x] `make pre-pr`, Node 22 syntax check, Biome, and whitespace checks.
- [x] Read-only check of the deployed worker artifact passed.
- [ ] Build and smoke-test the final images in CI; Docker is unavailable locally.

Red: the read-only checker on the deployed app image at `e5c20da609071b42beebe705e8c3b97d5a66f9ba` rejected the actual installed packages:

```text
Error: Production image contains browser tooling:
  playwright-core: /app/node_modules/playwright-core
  playwright: /app/node_modules/playwright-vanilla
command terminated with exit code 1
```

Green: synthetic copies of flat, nested, and isolated package layouts pass the same absence check after pruning:

```text
15 pass
0 fail
54 expect() calls
```

## Notes

This only removes browser tooling from the images. Production-required dependencies currently classified as development dependencies, including dotenv, remain installed. No production files, tenant state, or credentials were modified during verification.
