### PR TITLE
fix(release): preserve runtime package provenance metadata

### DIFF
--- a/scripts/pack-cli-smoke.mjs
+++ b/scripts/pack-cli-smoke.mjs
@@ -28,6 +28,21 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const destination = resolve(process.argv[2] ?? "");
 if (!process.argv[2])
   throw new Error("Usage: pack-cli-smoke.mjs <empty-directory>");
+const repository = JSON.parse(
+  readFileSync(join(root, "packages/cli/package.json"), "utf8")
+).repository;
+assert.ok(repository?.url, "CLI source repository metadata is required");
+// npm provenance rejects generated artifacts without their source repository.
+for (const [key, component] of Object.entries(COMPONENTS)) {
+  const pkg = JSON.parse(
+    readFileSync(join(runtimeRoot, key, "package.json"), "utf8")
+  );
+  assert.equal(
+    pkg.repository?.url,
+    repository.url,
+    `${component.name} must declare its source repository for npm provenance`
+  );
+}
 mkdirSync(destination); // Refuse to overwrite an existing installation.
 const staging = join(destination, "packages");
 mkdirSync(staging);

--- a/scripts/runtime-components.mjs
+++ b/scripts/runtime-components.mjs
@@ -182,6 +182,7 @@ export async function buildRuntimeComponents() {
       version: component.version,
       type: "module",
       license: "BUSL-1.1",
+      repository: { type: cli.repository.type, url: cli.repository.url },
       files: ["dist", "vendor", "prebuilt", "npm-shrinkwrap.json"],
       engines: cli.engines,
       overrides: rootManifest.overrides,


### PR DESCRIPTION
## Summary

The canary workflow passed its packed CLI smoke but npm rejected the first runtime package because its generated manifest omitted `repository.url`. All four runtime artifacts now inherit the CLI's repository metadata. The pre-publication smoke rejects missing or mismatched metadata before installing any candidate packages.

## Test plan

- [x] Intended two files staged explicitly; `make pre-pr` and commit hooks passed. GitHub CI remains the canonical gate.
- [x] 141 focused release/runtime tests passed, with 1049 assertions.
- [x] Full package build passed; packed all four runtime artifacts and verified their actual tarball manifests preserve the source repository URL and Git type.
- [x] `make review-fix` completed; inspected its changes. Its eight missing/mismatched metadata probes rejected correctly.

Red from workflow 34727533235:
```text
npm error 422 Unprocessable Entity
Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/lobu-ai/lobu" from provenance
```

The previous four built runtime manifests each reported `repository=undefined`.

Green from the newly built and packed artifacts:
```text
@lobu/runtime-server: packed repository metadata PASS
@lobu/runtime-device: packed repository metadata PASS
@lobu/runtime-postgres: packed repository metadata PASS
@lobu/runtime-embeddings: packed repository metadata PASS
```

Live trusted publication and the full packed/published installation smokes will be rerun through the manual canary workflow after merge. This change preserves the existing dependency graphs and runtime behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Package metadata now consistently identifies the project’s source repository across CLI and component packages.
  - Publishing validation checks ensure repository information remains consistent for distributed packages.

- **Tests**
  - Added validation to the CLI smoke tests to detect mismatched repository metadata before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->