### PR TITLE
fix(operations): reuse authorized run file metadata

### DIFF
--- a/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
+++ b/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
@@ -1,11 +1,15 @@
 import GoogleCalendarConnector from "@lobu/connectors/google_calendar";
+import { fileInputSchema } from "@lobu/connector-sdk";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { MCP_PROTOCOL_VERSION, REDACTED_SENTINEL } from "@lobu/core";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { Env } from "../../index";
+import * as dbClient from "../../db/client";
 import { createAutomationRun } from "../../runs/queue-service";
 import { BROWSER_GROUP_TITLE_PREFIX } from "../../worker-api/browser-action-context";
 import { manageOperations } from "../../tools/admin/manage_operations";
-import { runSdkScript } from "../../tools/sdk_run";
 import type { ToolContext } from "../../tools/registry";
 import { createAuthProfile } from "../../utils/auth-profiles";
 import { initWorkspaceProvider } from "../../workspace";
@@ -18,6 +22,9 @@ import {
 	createTestUser,
 	seedOwnerContext,
 } from "../setup/test-fixtures";
+import * as gateway from "../../lobu/gateway";
+import { ArtifactStore } from "../../gateway/files/artifact-store";
+import { ingestInputFiles } from "../../gateway/files/input-files";
 
 const LOCAL = "demo.ops.backend.local";
 const MCP = "demo.ops.backend.mcp";
@@ -254,7 +261,7 @@ describe("operations.execute backend lifecycle", () => {
 									requestBody: {
 										content: {
 											"application/json": {
-												schema: { type: "object" },
+												schema: { type: "object", properties: { image: fileInputSchema({ maxBytes: 1024 }) } },
 											},
 										},
 									},
@@ -421,7 +428,78 @@ describe("operations.execute backend lifecycle", () => {
 		expect(Date.now() - started).toBeLessThan(10_000);
 	});
 
+	it("executes an inline action without rereading its run metadata", async () => {
+		const metadataReads: string[] = [];
+		const sql = getTestDb();
+		const trackedSql = new Proxy(sql, {
+			apply(target, thisArg, args) {
+				if (Array.isArray(args[0])) {
+					const query = args[0].join("?").replace(/\s+/g, " ").trim();
+					if (/^SELECT run_metadata FROM runs WHERE id =/i.test(query)) {
+						metadataReads.push(query);
+					}
+				}
+				return Reflect.apply(target, thisArg, args);
+			},
+		});
+		const getDb = vi.spyOn(dbClient, "getDb").mockReturnValue(trackedSql);
+		try {
+			const result = await manageOperations({
+				action: "execute", connection_id: localConnectionId,
+				operation_key: "echo", input: { value: "no-metadata-reread" },
+			}, {} as Env, ctx);
+			expect(result).toMatchObject({ status: "completed" });
+			expect(metadataReads).toEqual([]);
+		} finally {
+			getDb.mockRestore();
+		}
+	});
+
+	it.each(["auto", "approval", "substituted", "removed"])("preserves file authorization through %s inline execution", async (mode) => {
+		const directory = await mkdtemp(join(tmpdir(), "lobu-inline-files-test-"));
+		const store = new ArtifactStore(directory);
+		const services = vi.spyOn(gateway, "getLobuCoreServices").mockReturnValue({ getArtifactStore: () => store });
+		const sql = getTestDb();
+		const [{ config }] = await sql`SELECT config FROM connections WHERE id = ${httpConnectionId}`;
+		try {
+			const files = await ingestInputFiles([
+				{ name: "photo.png", mimeType: "image/png", data: Buffer.from("photo") },
+				{ name: "other.png", mimeType: "image/png", data: Buffer.from("other") },
+			], ctx, store, "https://gateway.test/lobu");
+			if (mode !== "auto") {
+				await sql`UPDATE connections SET config = ${sql.json({ ...config, action_modes: { create_item: "approval" } })} WHERE id = ${httpConnectionId}`;
+			}
+			const queued = await manageOperations({
+				action: "execute", connection_id: httpConnectionId, operation_key: "create_item",
+				input: { body: { image: files[0] } },
+			}, {} as Env, ctx) as { status: string; run_id: number };
+			if (mode !== "auto") {
+				expect(queued.status).toBe("pending_approval");
+				await manageOperations({
+					action: "approve", run_id: queued.run_id,
+					...(mode === "substituted" ? { input: { body: { image: files[1] } } } : {}),
+					...(mode === "removed" ? { input: { body: {} } } : {}),
+				}, {} as Env, ctx);
+			}
+			const [run] = await sql`SELECT status, action_output, error_message FROM runs WHERE id = ${queued.run_id}`;
+			if (mode === "removed" || mode === "substituted") {
+				expect(run).toMatchObject({ status: "failed", error_message: expect.stringContaining("changed after authorization") });
+			} else {
+				expect(run).toMatchObject({ status: "completed", action_output: { body: { body: { image: {
+					base64: Buffer.from("photo").toString("base64"), filename: "photo.png", content_type: "image/png",
+				} } } } });
+			}
+		} finally {
+			services.mockRestore();
+			await sql`UPDATE connections SET config = ${sql.json(config)} WHERE id = ${httpConnectionId}`;
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
 	it("carries one SDK invocation owner through real sandbox calls without sharing across invocations", async () => {
+		// Import after fixtures: loading this handler eagerly leaves undefined MCP
+		// registry entries when Vitest 4 runs this suite before the handoff/audit suites.
+		const { runSdkScript } = await import("../../tools/sdk_run");
 		const script = `export default async (ctx, client) => {
 			return await Promise.all(['first', 'second'].map(value => client.operations.execute({
 				connection_id: ${localConnectionId}, operation_key: 'echo',

--- a/packages/server/src/operations/file-inputs.ts
+++ b/packages/server/src/operations/file-inputs.ts
@@ -1,5 +1,4 @@
 import { type FileInputOptions, MAX_CONNECTOR_FILE_BYTES } from '@lobu/connector-sdk';
-import { getDb } from '../db/client';
 import type { ArtifactStore } from '../gateway/files/artifact-store';
 import { inputArtifactId, inputFileBinding, MAX_INPUT_FILES, storedInputFile } from '../gateway/files/input-files';
 import { getLobuCoreServices } from '../lobu/gateway';
@@ -59,9 +58,14 @@ async function rewriteFiles(
     const entries: [string, unknown][] = [];
     for (const [key, child] of Object.entries(value)) {
       const childSchemas = expanded.flatMap((item) => {
-        const candidate = Array.isArray(value)
-          ? Array.isArray(item.items) ? item.items[Number(key)] : item.items
-          : object(item.properties) && Object.hasOwn(item.properties, key) ? item.properties[key] : item.additionalProperties;
+        let candidate: unknown;
+        if (Array.isArray(value)) {
+          candidate = Array.isArray(item.items) ? item.items[Number(key)] : item.items;
+        } else if (object(item.properties) && Object.hasOwn(item.properties, key)) {
+          candidate = item.properties[key];
+        } else {
+          candidate = item.additionalProperties;
+        }
         return object(candidate) ? [candidate] : [];
       });
       entries.push([key, await visit(child, [...path, key], childSchemas)]);
@@ -69,6 +73,16 @@ async function rewriteFiles(
     return Array.isArray(value) ? entries.map(([, child]) => child) : Object.fromEntries(entries);
   }
   return await visit(input, [], [schema]) as Record<string, unknown>;
+}
+
+function readInlineFile(value: Schema, maxBytes: number) {
+  if (typeof value.base64 !== 'string' || typeof value.filename !== 'string' || typeof value.content_type !== 'string') return null;
+  const bytes = Buffer.from(value.base64, 'base64');
+  if (!bytes.length || bytes.length > maxBytes || bytes.toString('base64') !== value.base64) return null;
+  return {
+    bytes,
+    metadata: { artifactId: '', filename: value.filename, contentType: value.content_type, size: bytes.length, sha256: '' },
+  };
 }
 
 /** Authorize files before queuing; persist claims with the existing operation run. */
@@ -97,13 +111,9 @@ export async function prepareOperationFiles(
       maxBytes = Math.min(maxBytes, Number(declaration.maxBytes));
     }
     const binding = artifactId ? inputFileBinding(ctx) : undefined;
-    const inlineBytes = !artifactId && typeof value.base64 === 'string' ? Buffer.from(value.base64, 'base64') : undefined;
     const file = artifactId
       ? await storeOrThrow(store).read(artifactId, { binding, maxBytes })
-      : inlineBytes?.length && inlineBytes.length <= maxBytes && inlineBytes.toString('base64') === value.base64 &&
-          typeof value.filename === 'string' && typeof value.content_type === 'string'
-        ? { bytes: inlineBytes, metadata: { artifactId: '', filename: value.filename, contentType: value.content_type, size: inlineBytes.length, sha256: '' } }
-        : null;
+      : readInlineFile(value, maxBytes);
     if (!file) throw new ToolUserError('File is unavailable, outside this caller’s scope, or exceeds the connector limit. Upload it again in this workspace.', 422);
     for (const declaration of declarations) {
       const contentTypes = (declaration as unknown as FileInputOptions).contentTypes;
@@ -156,14 +166,4 @@ export async function resolveOperationFiles(
   });
   if (unresolvedClaims.size > 0) throw changed();
   return resolved;
-}
-
-export async function resolveRunFiles(runId: number, organizationId: string, input: Record<string, unknown>) {
-  // Approval can remove or inline a stored reference, so claims must be loaded
-  // before resolveOperationFiles decides that the input contains no references.
-  const [run] = await getDb()<{ run_metadata: Record<string, unknown> | null }>`
-    SELECT run_metadata FROM runs WHERE id = ${runId} AND organization_id = ${organizationId} AND run_type = 'action'
-  `;
-  if (!run) throw new ToolUserError('Operation run is unavailable.', 404);
-  return resolveOperationFiles(input, run.run_metadata);
 }

--- a/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/approvals.ts
@@ -1669,7 +1669,7 @@ export async function handleApprove(
 				AND organization_id = ${ctx.organizationId}
 				AND approval_status = 'pending'
 				AND run_type = 'action'
-			RETURNING id, connection_id, action_key, action_input, created_by_user_id, claimed_by
+			RETURNING id, connection_id, action_key, action_input, created_by_user_id, claimed_by, run_metadata
 		`;
 		if (rows.length === 0) return null;
 		// The confirmed card's event id is the run's approval identity for this
@@ -1695,6 +1695,7 @@ export async function handleApprove(
 		action_key: string;
 		action_input: Record<string, unknown> | null;
 		created_by_user_id: string | null;
+		run_metadata: Record<string, unknown> | null;
 	};
 
 	if (resolved.operation.backend === "local_action") {
@@ -1719,7 +1720,7 @@ export async function handleApprove(
 		(run.action_input ?? {}) as Record<string, unknown>,
 		run.created_by_user_id,
 		undefined,
-		{ deferTerminalWrite: true, claimedBy: inlineOwner },
+		{ deferTerminalWrite: true, claimedBy: inlineOwner, runMetadata: run.run_metadata },
 	);
 
 	if (result.status === "completed") {

--- a/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
+++ b/packages/server/src/tools/admin/manage_operations/handlers/execute.ts
@@ -27,7 +27,7 @@ import { resolveActionMode } from "../../../../operations/action-modes";
 import { getOperationForConnection } from "../../../../operations/connector-operations";
 import { LOST_LEASE_MESSAGE, runLeaseFence } from "../../../../runs/run-lease";
 import { executeHttpOperation } from "../../../../operations/execute-http-operation";
-import { prepareOperationFiles, resolveRunFiles } from "../../../../operations/file-inputs";
+import { prepareOperationFiles, resolveOperationFiles } from "../../../../operations/file-inputs";
 import { validateOperationInput } from "../../../../operations/input-validation";
 import { getMissingKnownOAuthScopes } from "../../../../operations/oauth-scope-readiness";
 import type { OperationDescriptor } from "../../../../operations/types";
@@ -356,6 +356,8 @@ async function executeMcpToolInline(
  * Options for {@link executeOperationInline}.
  */
 interface InlineExecutionOptions {
+	/** Server-stamped metadata from the created or claimed run, even when input has no file references. */
+	runMetadata: Record<string, unknown> | null | undefined;
 	/**
 	 * Skip the executor's terminal `runs` write. Used by approve's phase 2:
 	 * the terminal run state and its card event must commit together, so the
@@ -383,7 +385,7 @@ export async function executeOperationInline(
 ): Promise<InlineExecutionResult> {
 	const deferTerminalWrite = options.deferTerminalWrite ?? false;
 	try {
-		actionInput = await resolveRunFiles(runId, organizationId, actionInput);
+		actionInput = await resolveOperationFiles(actionInput, options.runMetadata);
 	} catch (error) {
 		return failRunInline(runId, organizationId, getErrorMessage(error), deferTerminalWrite, options.claimedBy);
 	}
@@ -999,7 +1001,7 @@ export async function handleExecute(
 		input,
 		visibilityUserId,
 		ctx.abortSignal,
-		{ claimedBy: claim.claimedBy },
+		{ claimedBy: claim.claimedBy, runMetadata },
 	);
 	await trackOperationReaction(runId);
 	if (result.status === "completed") {

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -1,4 +1,3 @@
-import { resolveOperationFiles } from "../operations/file-inputs";
 /**
  * POST /api/workers/poll
  *
@@ -40,6 +39,7 @@ import {
 } from '../gateway/services/transcript-snapshot';
 import { resolvePublicOrigin } from '../utils/public-origin';
 import { getDb, parsePgTextArray, pgTextArray } from '../db/client';
+import { resolveOperationFiles } from '../operations/file-inputs';
 import type { Outputs } from '../types/automations';
 import { deriveAutomationExtractionSchema } from '../utils/automation-extraction-schema';
 import { withDbRetry } from '../db/with-retry';


### PR DESCRIPTION
## Summary
Inline connector actions re-read run metadata even though creation or approval already has the trusted file claims. Carry those claims directly into execution and remove the redundant database helper. Keep rejection of changed or removed files after approval, simplify file parsing, and restore the worker module header.

## Test plan
- [x] Red: the new query-count regression failed with one extra SELECT run_metadata FROM runs.
- [x] Green: the same regression passed with no extra metadata lookup.
- [x] 92 integration tests co-run: backend execution, file handoff, approval transition atomicity, and MCP invocation audit. Includes automatic and approved file delivery plus changed/removed-file rejection.
- [x] 19 file-ingestion, file-authorization, download, and MCP contract unit tests.
- [x] make pre-pr: build, typecheck, knip, naming, and gateway/entity-write gates passed.
- [x] Fable review-fix completed and its edits were independently checked. Retained the test-only deferred SDK import: removing it reproduces four `tool.handler is not a function` failures when backend execution, file handoff, approval-transition, and invocation-audit suites run together under Vitest 4; keeping the deferred import restores the combined pass.
- [x] Exact-head Codex review — 0 bugs, 0 blockers, simplicity 95, bug-free confidence 89. Fable final review could not issue a verdict after reaching the configured accounts' quotas.
- [x] GitHub CI and make ui-review (not applicable: no frontend/submodule changes)
- [x] Merged squash `0955849dc391fef3eab591688c3cf536be29a3e4` deployed; production smoke 9/9 passed, followed by a fresh healthy readiness check.

## Notes
Follow-up to #3521. No public API, database, connector implementation, or approval-policy changes. Tests initialize the SDK helper after fixtures to share an initialized MCP registry with other Vitest suites. The organization-local connector declaration update was installed and its exact source was verified through the existing authorized MCP route. The remaining live provider draft test requires access to the private connection and remains separate from this repository change.
