### PR TITLE
fix(cli): preserve runtime lock package identities across Bun versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1949,3 +1949,16 @@ jobs:
         run: |
           bun run --cwd packages/cli build
           node scripts/pack-cli-smoke.mjs "$RUNNER_TEMP/lazy-runtime-smoke"
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4.0
+
+      - name: Read release locks with consumer Bun
+        # Read the exact 1.3.5-generated release locks, without regenerating
+        # them under the consumer version and hiding migration defects.
+        run: |
+          for component in "$RUNNER_TEMP/lazy-runtime-smoke"/packages/@lobu-runtime-*; do
+            cp "$component/dist/dependencies.bun.lock" "$component/bun.lock"
+            (cd "$component" && bun install --frozen-lockfile --ignore-scripts --lockfile-only --linker=isolated)
+          done

--- a/scripts/__tests__/runtime-lock-portability.test.ts
+++ b/scripts/__tests__/runtime-lock-portability.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { lockRuntimeComponent } from "../runtime-components.mjs";
+
+const directories: string[] = [];
+afterEach(() => {
+  for (const directory of directories.splice(0))
+    rmSync(directory, { recursive: true, force: true });
+});
+
+test("frozen runtime locks retain local package identities across installers", () => {
+  const directory = mkdtempSync(join(tmpdir(), "lobu-lock-test-"));
+  directories.push(directory);
+  for (const name of ["dist", "vendor/example", "vendor/consumer"])
+    mkdirSync(join(directory, name), { recursive: true });
+  const writeJson = (path: string, value: unknown) =>
+    writeFileSync(join(directory, path), JSON.stringify(value));
+  writeJson("package.json", {
+    name: "runtime-fixture",
+    version: "1.0.0",
+    dependencies: {
+      example: "file:vendor/example",
+      "@fixture/consumer": "file:vendor/consumer",
+    },
+  });
+  // npm omits the name when it equals the directory basename. Bun 1.3's
+  // migration then invents /example, which newer Bun correctly rejects.
+  writeJson("vendor/example/package.json", {
+    name: "example",
+    version: "1.0.0",
+    main: "index.js",
+  });
+  writeFileSync(
+    join(directory, "vendor/example/index.js"),
+    "module.exports = 42;"
+  );
+  writeJson("vendor/consumer/package.json", {
+    name: "@fixture/consumer",
+    version: "1.0.0",
+    main: "index.js",
+    dependencies: { example: "file:../example" },
+  });
+  writeFileSync(
+    join(directory, "vendor/consumer/index.js"),
+    'module.exports = require("example");'
+  );
+
+  lockRuntimeComponent(directory);
+  const npmLock = JSON.parse(
+    readFileSync(join(directory, "npm-shrinkwrap.json"), "utf8")
+  );
+  expect(npmLock.packages["vendor/example"]).toMatchObject({
+    name: "example",
+    version: "1.0.0",
+  });
+  expect(npmLock.packages["vendor/consumer"].name).toBe("@fixture/consumer");
+  const bunLock = readFileSync(
+    join(directory, "dist/dependencies.bun.lock"),
+    "utf8"
+  );
+  expect(bunLock).toContain('"example@file:vendor/example"');
+  expect(bunLock).not.toContain('"/example@');
+  writeFileSync(join(directory, "bun.lock"), bunLock);
+
+  for (const [command, args] of [
+    [
+      "bun",
+      ["install", "--frozen-lockfile", "--ignore-scripts", "--linker=isolated"],
+    ],
+    ["npm", ["ci", "--ignore-scripts", "--no-audit", "--no-fund"]],
+  ] as const) {
+    const installed = spawnSync(command, [...args], {
+      cwd: directory,
+      encoding: "utf8",
+    });
+    expect(installed.status, installed.stderr).toBe(0);
+    const loaded = spawnSync(
+      "node",
+      [
+        "-e",
+        'if (require("example") !== 42 || require("@fixture/consumer") !== 42) process.exit(1)',
+      ],
+      {
+        cwd: directory,
+        encoding: "utf8",
+      }
+    );
+    expect(loaded.status, loaded.stderr).toBe(0);
+    rmSync(join(directory, "node_modules"), { recursive: true, force: true });
+  }
+}, 30_000);

--- a/scripts/runtime-components.mjs
+++ b/scripts/runtime-components.mjs
@@ -12,7 +12,7 @@ import {
 } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -407,6 +407,37 @@ export async function buildRuntimeComponents() {
   }
 }
 
+function completeLocalPackageNames(directory) {
+  const path = join(directory, "package-lock.json");
+  const lock = JSON.parse(readFileSync(path, "utf8"));
+  const root = realpathSync(directory);
+  for (const entry of Object.values(lock.packages ?? {})) {
+    if (!entry.link) continue;
+    const target = realpathSync(resolve(root, entry.resolved));
+    const within = relative(root, target);
+    if (within === ".." || within.startsWith(`..${sep}`) || isAbsolute(within))
+      throw new Error(
+        "Runtime lock contains a local package outside its artifact"
+      );
+    const metadata = lock.packages[entry.resolved];
+    const { name } = JSON.parse(
+      readFileSync(join(target, "package.json"), "utf8")
+    );
+    if (
+      !metadata ||
+      typeof name !== "string" ||
+      !name ||
+      (metadata.name && metadata.name !== name)
+    )
+      throw new Error("Runtime lock has inconsistent local package metadata");
+    // npm omits names matching the folder basename. Bun 1.3's npm-lock
+    // migration reconstructs those as /name, which Bun 1.4 rejects. Restore
+    // the optional canonical metadata without changing any resolved edge.
+    metadata.name ??= name;
+  }
+  writeJson(path, lock);
+}
+
 /** Release artifacts carry both managers' frozen dependency trees. */
 export function lockRuntimeComponent(directory) {
   // Resolve in an isolated project: package managers must never discover or
@@ -438,6 +469,7 @@ export function lockRuntimeComponent(directory) {
         throw new Error(
           `Failed to freeze runtime dependencies in ${directory}`
         );
+      if (command === "npm") completeLocalPackageNames(temporary);
     }
     copy(
       join(temporary, "package-lock.json"),


### PR DESCRIPTION
## Summary

Runtime packages generated with Bun 1.3.5 could not install under Bun 1.4.0: npm omits a local package name when it matches its folder, and Bun's npm-lock migration reconstructed `vendor/postgres` as `/postgres`. The frozen consumer install then failed with `Invalid package name`.

Restore canonical names from the shipped local package manifests before converting the npm lock. Package versions, integrity values, and dependency edges stay unchanged. Local targets must remain inside the artifact. CI also reads the exact 1.3.5-generated release locks with Bun 1.4.0, without regenerating them.

## Test plan

- [x] Intended three files staged explicitly; `make pre-pr` and commit hooks passed. GitHub CI owns the full required graph.
- [x] 44 focused tests passed (190 assertions); the new frozen-install regression passed separately with Bun 1.3.5 and Bun 1.4.0, including npm installation and actual nested package loading.
- [x] Red: original published server/device locks fail on Bun 1.4.0 with `Invalid package name` for `/postgres@file:vendor/postgres`. A network-free matching-name fixture reproduces `/example@file:vendor/example` with Bun 1.3.5.
- [x] Green: corrected fixture keeps `example@file:vendor/example`; both Bun versions and npm load direct and nested dependencies successfully.
- [x] Full packed candidate under Bun 1.3.5 and Node-only npm: native dependencies, embedded PG/pgvector, migrations, web UI, local/remote embedding service selection, external DB, shutdown, and 15 daemon/MCP scenarios passed.
- [x] Fresh Bun 1.4.0 installation of all four unchanged Bun 1.3.5-generated tarballs also passed native/runtime verification, embedded/external boot, cleanup, and all 15 daemon/MCP scenarios.
- [x] `make review-fix`: no actionable defects or changes; independently reproduced original failure and installed corrected 1.3.5 locks with 1.4.0.

## Notes

This changes release composition and its gates. Production Docker startup does not consume these runtime locks. The separate published-smoke readiness fix addresses registry propagation after thin CLI publication.
