### PR TITLE
fix(ci): wait for lazy runtime publication before smoke

### DIFF
--- a/.github/workflows/published-artifact-smoke.yml
+++ b/.github/workflows/published-artifact-smoke.yml
@@ -16,7 +16,7 @@ name: Published-artifact smoke
 
 on:
   # Called by publish-packages.yml and publish-canary.yml after npm accepts the
-  # new version. Keeping this in the same workflow makes the four-environment
+  # new version. Keeping this in the same workflow makes the consumer
   # artifact matrix a required part of the publication run instead of a
   # best-effort follow-up. It does not gate the canary dist-tag: `npm publish
   # --tag canary` moves that tag at publication because a separate
@@ -50,7 +50,7 @@ permissions:
 
 jobs:
   smoke:
-    # Each cell is an axis that hid a real, shipped bug. Keep all four.
+    # Each cell is an axis that hid a real, shipped bug. Keep every axis.
     strategy:
       fail-fast: false
       matrix:
@@ -70,6 +70,9 @@ jobs:
           # The oldest LTS we claim to support; catches a floor that clears
           # bookworm but not 22.04.
           - { name: jammy-nonroot, image: "ubuntu:22.04", as_root: false }
+          # Release artifacts built with Bun 1.3 must also install under the
+          # consumer's Bun 1.4; its frozen lockfile validation is stricter.
+          - { name: bookworm-bun-1-4-nonroot, image: "node:22-bookworm-slim", as_root: false, bun: "1.4.0" }
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     container: ${{ matrix.image }}
@@ -95,6 +98,16 @@ jobs:
 
       - uses: actions/checkout@v7
 
+      - name: Install the Bun consumer version
+        if: matrix.bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun }}
+
+      - name: Make Bun available to the unprivileged consumer
+        if: matrix.bun
+        run: install -m 755 "$(command -v bun)" /usr/local/bin/bun
+
       # Only the mock-provider harness is used from the checkout; everything
       # under test comes from npm.
       - name: Smoke the published artifact
@@ -112,6 +125,10 @@ jobs:
             # Everything the script touches lives under its own $WORK/$HOME.
             useradd -m -s /bin/bash smoke
             chown -R smoke:smoke .
+            if [ -n "${{ matrix.bun }}" ]; then
+              bun_version=$(su smoke -c 'bun --version')
+              test "$bun_version" = "${{ matrix.bun }}" || exit 1
+            fi
             su smoke -c "env LOBU_VERSION='$LOBU_VERSION' \
               SMOKE_WORK=/tmp/lobu-artifact-smoke-smoke \
               bash scripts/published-artifact-smoke.sh"
@@ -155,6 +172,6 @@ jobs:
             echo "SLACK_DEPLOY_WEBHOOK_URL not set; notification unavailable."
             exit 0
           fi
-          payload=$(jq -nc --arg text "CLI and daemon MCP smoke: ${RESULT}. Tested CLI: ${VERSION}. Four Linux environments. Results and failure logs: ${RUN_URL}" '{text: $text}')
+          payload=$(jq -nc --arg text "CLI and daemon MCP smoke: ${RESULT}. Tested CLI: ${VERSION}. Linux Node and Bun consumer environments. Results and failure logs: ${RUN_URL}" '{text: $text}')
           curl --fail-with-body -sS -X POST -H 'Content-type: application/json' \
             --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/scripts/__tests__/published-runtime-readiness.test.ts
+++ b/scripts/__tests__/published-runtime-readiness.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readRuntimeComponents,
+  waitForRuntimeComponents,
+} from "../lib/published-runtime-readiness.mjs";
+
+const components = [
+  { name: "@example/runtime-one", version: "1.2.3-canary.7" },
+  { name: "@example/runtime-two", version: "4.5.6" },
+];
+
+function registryProbe(reply: (url: string, call: number) => Response) {
+  let time = 0;
+  const calls: string[] = [];
+  const sleeps: number[] = [];
+  return {
+    calls,
+    sleeps,
+    advance: (ms: number) => {
+      time += ms;
+    },
+    options: {
+      waitMs: 25,
+      pollMs: 10,
+      now: () => time,
+      sleep: async (ms: number) => {
+        sleeps.push(ms);
+        time += ms;
+      },
+      log: () => undefined,
+      fetchImpl: async (url: string) => {
+        calls.push(url);
+        return reply(url, calls.length);
+      },
+    },
+  };
+}
+
+function available(component: (typeof components)[number]) {
+  return Response.json({
+    ...component,
+    dist: { tarball: "https://registry.npmjs.org/example/-/example.tgz" },
+  });
+}
+
+describe("published runtime readiness", () => {
+  it("waits for a delayed component without checking already visible components again", async () => {
+    const probe = registryProbe((url, call) =>
+      url.includes("runtime-two")
+        ? available(components[1])
+        : call < 3
+          ? new Response("not propagated", { status: 404 })
+          : available(components[0])
+    );
+    await waitForRuntimeComponents(components, probe.options);
+    expect(probe.sleeps).toEqual([10]);
+    expect(probe.calls).toEqual([
+      "https://registry.npmjs.org/%40example%2Fruntime-one/1.2.3-canary.7",
+      "https://registry.npmjs.org/%40example%2Fruntime-two/4.5.6",
+      "https://registry.npmjs.org/%40example%2Fruntime-one/1.2.3-canary.7",
+    ]);
+  });
+
+  it("shares one deadline across components and caps the final wait", async () => {
+    const probe = registryProbe(() => new Response(null, { status: 404 }));
+    await expect(
+      waitForRuntimeComponents(components, probe.options)
+    ).rejects.toThrow("publication wait budget");
+    expect(probe.sleeps).toEqual([10, 10, 5]);
+    expect(probe.calls).toHaveLength(6);
+  });
+
+  it("includes request time in the remaining budget", async () => {
+    const probe = registryProbe(() => {
+      probe.advance(17);
+      return new Response(null, { status: 404 });
+    });
+    await expect(
+      waitForRuntimeComponents([components[0]], probe.options)
+    ).rejects.toThrow("publication wait budget");
+    expect(probe.sleeps).toEqual([8]);
+    expect(probe.calls).toHaveLength(1);
+  });
+
+  it("PUBLISH_WAIT=0 checks every descriptor once without sleeping", async () => {
+    const probe = registryProbe(() => new Response(null, { status: 404 }));
+    await expect(
+      waitForRuntimeComponents(components, { ...probe.options, waitMs: 0 })
+    ).rejects.toThrow("publication wait budget");
+    expect(probe.calls).toHaveLength(2);
+    expect(probe.sleeps).toEqual([]);
+  });
+
+  for (const status of [401, 403, 429, 500]) {
+    it(`does not retry HTTP ${status}`, async () => {
+      const probe = registryProbe(() => new Response(null, { status }));
+      await expect(
+        waitForRuntimeComponents([components[0]], probe.options)
+      ).rejects.toThrow(`HTTP ${status}`);
+      expect(probe.calls).toHaveLength(1);
+      expect(probe.sleeps).toEqual([]);
+    });
+  }
+
+  it("does not retry network failures", async () => {
+    const probe = registryProbe(() => {
+      throw new Error("connection reset");
+    });
+    await expect(
+      waitForRuntimeComponents(components, probe.options)
+    ).rejects.toThrow("connection reset");
+    expect(probe.sleeps).toEqual([]);
+  });
+
+  for (const body of [
+    "not JSON",
+    JSON.stringify({ ...components[0], version: "9.9.9" }),
+    JSON.stringify({ ...components[0], name: "@example/different" }),
+    JSON.stringify(components[0]),
+  ]) {
+    it("rejects corrupt or mismatched registry metadata without retrying", async () => {
+      const probe = registryProbe(() => new Response(body));
+      await expect(
+        waitForRuntimeComponents([components[0]], probe.options)
+      ).rejects.toThrow();
+      expect(probe.calls).toHaveLength(1);
+      expect(probe.sleeps).toEqual([]);
+    });
+  }
+
+  it("reads exact names and versions from installed descriptors, while allowing older CLIs", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "runtime-readiness-"));
+    const manifest = join(directory, "runtime-components.json");
+    try {
+      expect(await readRuntimeComponents(manifest)).toEqual([]);
+      await writeFile(manifest, JSON.stringify({ arbitrary: components[1] }));
+      expect(await readRuntimeComponents(manifest)).toEqual([components[1]]);
+      for (const invalid of [
+        "null",
+        "[]",
+        "{}",
+        "not JSON",
+        JSON.stringify({
+          server: { name: "@example/runtime", version: "latest" },
+        }),
+      ]) {
+        await writeFile(manifest, invalid);
+        await expect(readRuntimeComponents(manifest)).rejects.toThrow();
+      }
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("gates component commands and retains the remaining CLI publication budget", async () => {
+    const smoke = await Bun.file(
+      new URL("../published-artifact-smoke.sh", import.meta.url)
+    ).text();
+    expect(
+      smoke.indexOf("scripts/lib/published-runtime-readiness.mjs")
+    ).toBeLessThan(smoke.indexOf('"$LOBU_BIN" connector runtime-self-check'));
+    expect(smoke).toContain('"$((PUBLISH_WAIT - waited))" "$PUBLISH_POLL"');
+    expect(smoke).toContain(
+      '"$INSTALL_DIR/node_modules/@lobu/cli/dist/runtime-components.json"'
+    );
+  });
+
+  it("runs a pinned Bun consumer as nonroot in addition to all four Node environments", async () => {
+    const workflow = Bun.YAML.parse(
+      await Bun.file(
+        new URL(
+          "../../.github/workflows/published-artifact-smoke.yml",
+          import.meta.url
+        )
+      ).text()
+    ) as any;
+    const cells = workflow.jobs.smoke.strategy.matrix.include;
+    expect(cells.filter((cell: any) => !cell.bun)).toHaveLength(4);
+    expect(cells.find((cell: any) => cell.bun === "1.4.0")).toMatchObject({
+      as_root: false,
+      image: "node:22-bookworm-slim",
+    });
+    const steps = workflow.jobs.smoke.steps;
+    expect(
+      steps.find((step: any) => step.uses === "oven-sh/setup-bun@v2")?.with[
+        "bun-version"
+      ]
+    ).toBe("${{ matrix.bun }}");
+    expect(steps.map((step: any) => step.run ?? "").join("\n")).toContain(
+      "/usr/local/bin/bun"
+    );
+  });
+});

--- a/scripts/__tests__/published-runtime-readiness.test.ts
+++ b/scripts/__tests__/published-runtime-readiness.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -166,6 +167,38 @@ describe("published runtime readiness", () => {
     expect(smoke).toContain(
       '"$INSTALL_DIR/node_modules/@lobu/cli/dist/runtime-components.json"'
     );
+  });
+
+  it("uses decimal seconds for validated wait settings, including leading zeros", async () => {
+    const smoke = await Bun.file(
+      new URL("../published-artifact-smoke.sh", import.meta.url)
+    ).text();
+    const configurationStart = smoke.indexOf(
+      'PUBLISH_WAIT="${PUBLISH_WAIT:-600}"'
+    );
+    const configurationEnd = smoke.indexOf("MOCK_REPLY=", configurationStart);
+    expect(configurationStart).toBeGreaterThanOrEqual(0);
+    expect(configurationEnd).toBeGreaterThan(configurationStart);
+    const configuration = smoke.slice(configurationStart, configurationEnd);
+    for (const [input, seconds] of [
+      ["08", 8],
+      ["0010", 10],
+      ["0008", 8],
+      ["0", 0],
+      ["000", 0],
+      ["600", 600],
+    ] as const) {
+      const result = spawnSync(
+        "bash",
+        [
+          "-euc",
+          `${configuration}\nprintf '%s:%s\\n' "$((PUBLISH_WAIT - 0))" "$PUBLISH_POLL"`,
+        ],
+        { encoding: "utf8", env: { ...process.env, PUBLISH_WAIT: input } }
+      );
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe(`${seconds}:10`);
+    }
   });
 
   it("runs a pinned Bun consumer as nonroot in addition to all four Node environments", async () => {

--- a/scripts/lib/published-runtime-readiness.mjs
+++ b/scripts/lib/published-runtime-readiness.mjs
@@ -1,0 +1,139 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+
+const exactVersion = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const packageName = /^(?:@[a-z0-9._-]+\/)?[a-z0-9._-]+$/;
+
+export async function readRuntimeComponents(manifestPath) {
+  let text;
+  try {
+    text = await readFile(manifestPath, "utf8");
+  } catch (error) {
+    // Older published CLIs install their runtime as ordinary dependencies.
+    if (error.code === "ENOENT") return [];
+    throw error;
+  }
+  const manifest = JSON.parse(text);
+  if (!manifest || Array.isArray(manifest) || typeof manifest !== "object") {
+    throw new Error("Invalid installed CLI runtime component manifest");
+  }
+  const components = Object.values(manifest);
+  if (
+    components.length === 0 ||
+    components.some(
+      (component) =>
+        !component ||
+        typeof component.name !== "string" ||
+        !packageName.test(component.name) ||
+        typeof component.version !== "string" ||
+        !exactVersion.test(component.version)
+    )
+  ) {
+    throw new Error(
+      "Runtime components must declare package names and exact versions"
+    );
+  }
+  return components.map(({ name, version }) => ({ name, version }));
+}
+
+export async function waitForRuntimeComponents(
+  components,
+  {
+    waitMs,
+    pollMs,
+    fetchImpl = fetch,
+    now = () => performance.now(),
+    sleep = delay,
+    log = console.log,
+  }
+) {
+  if (
+    !Number.isFinite(waitMs) ||
+    waitMs < 0 ||
+    !Number.isFinite(pollMs) ||
+    pollMs <= 0
+  ) {
+    throw new Error("Invalid runtime publication wait budget or poll interval");
+  }
+  const deadline = now() + waitMs;
+  let pending = components;
+  while (pending.length > 0) {
+    const missing = await Promise.all(
+      pending.map(async (component) => {
+        const { name, version } = component;
+        const label = `${name}@${version}`;
+        // PUBLISH_WAIT=0 still performs one bounded request per component.
+        const timeout =
+          waitMs === 0
+            ? 30_000
+            : Math.max(1, Math.min(30_000, deadline - now()));
+        const response = await fetchImpl(
+          `https://registry.npmjs.org/${encodeURIComponent(name)}/${encodeURIComponent(version)}`,
+          { signal: AbortSignal.timeout(Math.ceil(timeout)) }
+        );
+        if (response.status === 404) {
+          await response.body?.cancel();
+          return component;
+        }
+        if (!response.ok) {
+          await response.body?.cancel();
+          throw new Error(
+            `Runtime metadata ${label} returned HTTP ${response.status}; not waiting for propagation`
+          );
+        }
+        const metadata = await response.json();
+        if (
+          metadata?.name !== name ||
+          metadata.version !== version ||
+          typeof metadata.dist?.tarball !== "string" ||
+          !metadata.dist.tarball.startsWith("https://")
+        ) {
+          throw new Error(
+            `Invalid registry metadata for ${label}; not waiting for propagation`
+          );
+        }
+        return null;
+      })
+    );
+    pending = missing.filter(Boolean);
+    if (pending.length === 0) return;
+    const unavailable = pending
+      .map(({ name, version }) => `${name}@${version}`)
+      .join(", ");
+    const remaining = deadline - now();
+    if (remaining <= 0) {
+      throw new Error(
+        `Runtime versions still unavailable after the publication wait budget: ${unavailable}`
+      );
+    }
+    log(`Waiting for runtime registry propagation: ${unavailable}`);
+    await sleep(Math.min(pollMs, remaining));
+    if (now() >= deadline) {
+      throw new Error(
+        `Runtime versions still unavailable after the publication wait budget: ${unavailable}`
+      );
+    }
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  try {
+    const [manifestPath, waitSeconds, pollSeconds] = process.argv.slice(2);
+    const components = await readRuntimeComponents(manifestPath);
+    await waitForRuntimeComponents(components, {
+      waitMs: Number(waitSeconds) * 1000,
+      pollMs: Number(pollSeconds) * 1000,
+    });
+    console.log(
+      `Runtime registry metadata ready (${components.length} components)`
+    );
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/published-artifact-smoke.sh
+++ b/scripts/published-artifact-smoke.sh
@@ -69,6 +69,8 @@ case "$PUBLISH_WAIT" in
     exit 1
     ;;
 esac
+# Bash arithmetic treats leading zeros as octal; validated seconds are decimal.
+PUBLISH_WAIT=$((10#$PUBLISH_WAIT))
 PUBLISH_POLL=10
 MOCK_REPLY="ARTIFACT_SMOKE_OK"
 

--- a/scripts/published-artifact-smoke.sh
+++ b/scripts/published-artifact-smoke.sh
@@ -43,7 +43,7 @@
 #
 # Env:
 #   LOBU_VERSION   npm version/tag to install (default "latest")
-#   PUBLISH_WAIT   seconds to keep retrying an unresolvable version while the
+#   PUBLISH_WAIT   seconds to keep retrying unresolvable CLI/runtime versions while the
 #                  registry propagates (default 600; 0 = single attempt)
 #   SMOKE_AS_USER  unprivileged username to drop to (default: run as-is)
 #   GW_PORT        gateway port (default 8799)
@@ -115,8 +115,8 @@ note "install @lobu/cli@$LOBU_VERSION from npm"
 INSTALL_DIR="$WORK/install"; mkdir -p "$INSTALL_DIR"
 INSTALL_LOG="$WORK/npm-install.log"
 ( cd "$INSTALL_DIR" && npm init -y >/dev/null 2>&1 )
-# A release publishes all eight @lobu/* packages, then this gate installs one
-# of them and lets the resolver pull the other seven. Registry visibility is
+# A release publishes the CLI and its @lobu/* dependencies, then this gate
+# installs the CLI and lets the resolver pull its dependencies. Visibility is
 # not atomic across them, so for the first minutes after a publish the resolver
 # can report ETARGET for a sibling that is already published -- 18.0.0 failed
 # all four legs on "No matching version found for @lobu/embeddings@18.0.0"
@@ -144,8 +144,11 @@ while :; do
     break
   fi
   [ "$waited" -ge "$PUBLISH_WAIT" ] && { echo "gave up after ${waited}s waiting for the registry" >&2; break; }
-  sleep "$PUBLISH_POLL"
-  waited=$((waited + PUBLISH_POLL))
+  pause=$PUBLISH_POLL
+  remaining=$((PUBLISH_WAIT - waited))
+  [ "$pause" -gt "$remaining" ] && pause=$remaining
+  sleep "$pause"
+  waited=$((waited + pause))
 done
 tail -5 "$INSTALL_LOG"
 LOBU_BIN="$INSTALL_DIR/node_modules/.bin/lobu"
@@ -158,6 +161,21 @@ pass "installed, bin present"
 RESOLVED="$("$LOBU_BIN" --version 2>&1 | tr -d '[:space:]')"
 printf '%s\n' "$RESOLVED" > "$WORK/version.txt"
 if [ -n "$RESOLVED" ]; then pass "lobu --version -> $RESOLVED"; else fail "lobu --version produced nothing"; fi
+
+# Lazy runtime packages are outside npm's CLI dependency graph and can remain
+# invisible after the CLI resolves. Inspect every exact installed descriptor
+# before the first component-using command, sharing the existing wait budget.
+# This only reads registry metadata; the commands below still install and
+# verify the actual published components themselves.
+note "wait for published runtime versions"
+if node "$REPO_ROOT/scripts/lib/published-runtime-readiness.mjs" \
+  "$INSTALL_DIR/node_modules/@lobu/cli/dist/runtime-components.json" \
+  "$((PUBLISH_WAIT - waited))" "$PUBLISH_POLL"; then
+  pass "published runtime versions available"
+else
+  fail "published runtime versions unavailable"
+  echo "RESULT: published-artifact smoke FAILED (runtime publication)"; exit 1
+fi
 
 # Run from a directory that is deliberately outside the npm install tree. A
 # compiled connector must load the SDK from connector-worker's package graph,


### PR DESCRIPTION
## Summary

A newly published CLI can install successfully while its lazy runtime packages still return 404 from npm. The smoke now checks the exact package names and versions in the installed CLI runtime manifest before its first component command, shares the remaining `PUBLISH_WAIT` budget, and retries only metadata visibility 404s. Auth, transport, and malformed metadata failures stop immediately; actual component installation and verification remain in the CLI.

Validated wait seconds are normalized as decimal before Bash arithmetic, including leading-zero values such as `08`.

Adds a pinned Bun 1.4.0 nonroot consumer lane alongside the four existing Node/Linux environments, including an explicit version check after dropping privileges.

## Test plan

- [x] Four intended paths staged explicitly; `make pre-pr` passed.
- [x] 117 affected release tests passed on the final diff, including all 17 readiness tests covering delayed availability, shared deadline, request time, zero-wait, non-404 failures, installed descriptors, and consumer matrix coverage.
- [x] Actionlint, ShellCheck with sourced files, shell syntax, Biome, and diff checks passed.
- [x] Live readiness check used a fresh exact published CLI install and left the runtime cache absent; temporary install/home/cache removed.
- [x] Red → fix → green evidence below.

The [published Linux failure](https://github.com/lobu-ai/lobu/actions/runs/34732070963/job/103657980779) installed the CLI and device component before the server component remained unavailable:

```text
[OK] installed, bin present
[OK] connector runtime self-check from unrelated cwd
Error: Runtime @lobu/runtime-server@19.2.0-canary.1789263815.gd5a7129a35a98e44d849bc720c9ad7c3b82230ef is unavailable (404).
RESULT: published-artifact smoke FAILED (boot)
```

The missing Bun lane regression failed before the workflow change. With the fix:

```text
117 pass / 0 fail (17 readiness tests)
Runtime registry metadata ready (4 components)
runtime cache before: false; after: false
```

The decimal regression executes the actual Bash configuration block. It failed on the unchanged script with `PUBLISH_WAIT=08` (exit 1); normalization now passes `08`, `0010`, `0008`, `0`, `000`, and `600`.

## Notes

The full published Node/Bun container matrix runs on main and publication; the live local check above validates metadata readiness without preinstalling any runtime component.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release artifact checks to confirm installed runtime components become available and match expected versions before validation completes.
  * Improved wait-time handling for artifact installation and publication checks.

* **Tests**
  * Expanded coverage for runtime readiness, registry responses, version validation, and wait-time behavior.
  * Added consumer-environment validation for Bun 1.4 and existing Node environments, including non-root installation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->