### PR TITLE
fix(cli): make init dependency install explicit

### DIFF
--- a/packages/cli/src/__tests__/cli-ux.test.ts
+++ b/packages/cli/src/__tests__/cli-ux.test.ts
@@ -121,6 +121,14 @@ describe("lobu init --yes", () => {
     INIT_TIMEOUT
   );
 
+  test("--skip-install scaffolds without creating node_modules", async () => {
+    await initCommand(cwd, "no-install", { yes: true, skipInstall: true });
+    const proj = join(cwd, "no-install");
+    expect(existsSync(join(proj, "lobu.config.ts"))).toBe(true);
+    expect(existsSync(join(proj, "package.json"))).toBe(true);
+    expect(existsSync(join(proj, "node_modules"))).toBe(false);
+  });
+
   test(
     "scaffolded lobu.config.ts loads into desired state",
     async () => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -46,6 +46,8 @@ export interface InitOptions {
   noSentry?: boolean;
   hostedSlack?: boolean;
   listProviders?: boolean;
+  /** Scaffold files without installing project dependencies. */
+  skipInstall?: boolean;
   /**
    * Bootstrap a complete, re-appliable project from an existing Lobu Cloud org
    * (the inverse of `lobu apply`) instead of scaffolding a blank project. Never
@@ -369,12 +371,17 @@ export async function initCommand(
     // Same package.json/tsconfig the blank scaffold writes, so the bootstrapped
     // lobu.config.ts can resolve @lobu/cli/config + re-apply outside this monorepo.
     await scaffoldProjectPackaging(projectDir, projectName, cliVersion);
-    const depsSpinner = ora("Installing project dependencies...").start();
-    const depsWarning = installScaffoldedProjectDeps(projectDir);
-    if (depsWarning) {
-      depsSpinner.warn(depsWarning);
+    if (options.skipInstall) {
+      console.log(
+        chalk.yellow(
+          "\nSkipped dependency installation. Run `npm install` (or `bun install`) before `lobu apply`."
+        )
+      );
     } else {
-      depsSpinner.succeed("Project dependencies installed");
+      console.log(chalk.dim("\nInstalling project dependencies (this may take a few minutes)..."));
+      const depsWarning = installScaffoldedProjectDeps(projectDir, "inherit");
+      if (depsWarning) console.log(chalk.yellow(`\n⚠ ${depsWarning}`));
+      else console.log(chalk.green("✓ Project dependencies installed"));
     }
     if (!here) {
       console.log(chalk.cyan(`\n  Next: cd ${projectName}\n`));
@@ -752,13 +759,6 @@ export async function initCommand(
     await mkdir(join(projectDir, "connectors"), { recursive: true });
     await writeFile(join(projectDir, "connectors", ".gitkeep"), "");
 
-    // Install the freshly-declared devDependencies now so the runtime can
-    // resolve @lobu/connector-sdk from the project and editor types work
-    // out of the box. Warn-don't-fail (printed after the spinner settles).
-    spinner.text = "Installing project dependencies...";
-    const depsWarning = installScaffoldedProjectDeps(projectDir);
-    spinner.text = "Creating Lobu project...";
-
     await renderTemplate(
       "AGENTS.md.tmpl",
       variables,
@@ -770,10 +770,29 @@ export async function initCommand(
       join(projectDir, "TESTING.md")
     );
 
-    spinner.succeed("Project created successfully!");
+    // Keep the potentially long install visible. Hiding installer output behind
+    // the scaffold spinner makes a healthy first run look wedged on small hosts.
+    spinner.succeed("Project files created");
+    let depsWarning: string | null = null;
+    if (options.skipInstall) {
+      console.log(
+        chalk.yellow(
+          "\nSkipped dependency installation. Run `npm install` (or `bun install`) before `lobu apply`."
+        )
+      );
+    } else {
+      console.log(
+        chalk.dim(
+          "\nInstalling project dependencies (this may take a few minutes)..."
+        )
+      );
+      depsWarning = installScaffoldedProjectDeps(projectDir, "inherit");
+    }
 
     if (depsWarning) {
       console.log(chalk.yellow(`\n⚠ ${depsWarning}`));
+    } else if (!options.skipInstall) {
+      console.log(chalk.green("✓ Project dependencies installed"));
     }
 
     const gatewayUrl = `http://localhost:${gatewayPort}`;
@@ -1001,10 +1020,11 @@ async function generateLobuConfig(
  * the failure is returned as a warning string for the caller to print.
  */
 export function installScaffoldedProjectDeps(
-  projectDir: string
+  projectDir: string,
+  stdio: "inherit" | "pipe" = "pipe"
 ): string | null {
   try {
-    installProjectDeps(projectDir, { stdio: "pipe" });
+    installProjectDeps(projectDir, { stdio });
     return null;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -193,6 +193,10 @@ Memory:
       "Bootstrap a re-appliable project from an existing org (defaults to active session)"
     )
     .option("--url <url>", "Server URL override (with --from-org)")
+    .option(
+      "--skip-install",
+      "Scaffold files without installing dependencies (run npm install or bun install later)"
+    )
     .action(
       async (
         name: string | undefined,


### PR DESCRIPTION
## Root cause
`lobu init` synchronously installed the scaffold dependencies while hiding installer output behind the generic `Creating Lobu project...` spinner. On stable 19.2.0 the scaffold declared the CLI itself plus the connector SDK, expanding to 2.2 GB in the reproduced run and making healthy installs look wedged on small hosts.

## Fix
- Add `--skip-install` with clear follow-up guidance.
- Stream installer output instead of piping it away.
- Tell users the install may take a few minutes.
- Preserve the existing default install behavior for compatibility.

## Verification
- Stable 19.2.0 repro created 2.2 GB `node_modules`.
- New skip-install test passes (1/1).
- Dependency wiring suite passes (7/7).
- Built CLI e2e: `init -y --skip-install` completes in 1 second, creates expected project/package files, creates no `node_modules`, and help exposes the flag.

No merge requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--skip-install` option to the `init` command, allowing projects to be scaffolded without immediately installing dependencies.
  * Supports both blank projects and projects created from an existing organization setup.
  * Added clear status reporting for project creation and dependency installation.
  * When dependency installation is enabled, installer output is displayed directly in the command-line interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->