### PR TITLE
feat(cli): show connector registration in scaffold

### DIFF
--- a/packages/cli/src/__tests__/cli-ux.test.ts
+++ b/packages/cli/src/__tests__/cli-ux.test.ts
@@ -117,6 +117,10 @@ describe("lobu init --yes", () => {
         readFileSync(join(proj, "tsconfig.json"), "utf-8")
       );
       expect(tsconfig.include).toContain("lobu.config.ts");
+      const config = readFileSync(join(proj, "lobu.config.ts"), "utf-8");
+      expect(config).toContain("connectorFromFile");
+      expect(config).toContain('"./connectors/example.connector.ts"');
+      expect(config).toContain("connectors: [exampleConnector]");
     },
     INIT_TIMEOUT
   );

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -964,8 +964,8 @@ async function generateLobuConfig(
   }
 
   const imports = options.enableHostedSlack
-    ? 'import { defineAgent, defineConfig, defineConnection, secret } from "@lobu/cli/config";'
-    : 'import { defineAgent, defineConfig, secret } from "@lobu/cli/config";';
+    ? 'import { connectorFromFile, defineAgent, defineConfig, defineConnection, secret } from "@lobu/cli/config";'
+    : 'import { connectorFromFile, defineAgent, defineConfig, secret } from "@lobu/cli/config";';
 
   const lines = [
     "// lobu.config.ts — Lobu project configuration",
@@ -982,8 +982,12 @@ async function generateLobuConfig(
     "});",
     ...(connectionDecls.length > 0 ? ["", ...connectionDecls] : []),
     "",
+    "// Add a connector implementation under connectors/, then uncomment:",
+    '// const exampleConnector = connectorFromFile("./connectors/example.connector.ts");',
+    "",
     "export default defineConfig({",
     ...configFields,
+    "  // connectors: [exampleConnector],",
     "});",
     "",
   ];


### PR DESCRIPTION
## Root cause
`lobu init` created `connectors/`, but generated `lobu.config.ts` did not import or demonstrate `connectorFromFile`, leaving new connector authors without a discoverable registration path.

## Fix
Add a commented, directly usable `connectorFromFile("./connectors/example.connector.ts")` example and `connectors` config entry to the generated config.

## Verification
Focused scaffold test passes (1/1) and asserts the generated config contains the import, example file path, and connectors registration.

No merge requested.