### PR TITLE
fix(cli): scope telemetry env to project root

### DIFF
--- a/packages/cli/src/commands/__tests__/telemetry.test.ts
+++ b/packages/cli/src/commands/__tests__/telemetry.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { telemetryOnCommand } from "../telemetry";
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("telemetry env location", () => {
+  test("writes to the nearest Lobu project root, not the current subdirectory", async () => {
+    const root = mkdtempSync(join(tmpdir(), "lobu-telemetry-"));
+    roots.push(root);
+    writeFileSync(join(root, "lobu.config.ts"), "export default {};\n");
+    const nested = join(root, "packages", "worker");
+    mkdirSync(nested, { recursive: true });
+
+    await telemetryOnCommand({ cwd: nested, dsn: "https://public@example.test/1" });
+
+    expect(readFileSync(join(root, ".env"), "utf-8")).toContain(
+      "SENTRY_DSN=https://public@example.test/1"
+    );
+    expect(() => readFileSync(join(nested, ".env"), "utf-8")).toThrow();
+  });
+
+  test("refuses to create .env outside a Lobu project", async () => {
+    const root = mkdtempSync(join(tmpdir(), "not-lobu-"));
+    roots.push(root);
+    await expect(telemetryOnCommand({ cwd: root })).rejects.toThrow(
+      /No Lobu project found/
+    );
+    expect(() => readFileSync(join(root, ".env"), "utf-8")).toThrow();
+  });
+});

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -1,5 +1,5 @@
-import { readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { access, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
 import chalk from "chalk";
 import { setLocalEnvValue } from "../internal/local-env.js";
 import { parseEnvContent } from "../internal/env-file.js";
@@ -9,6 +9,23 @@ const SENTRY_DSN_DEFAULT =
 
 interface TelemetryOptions {
   cwd?: string;
+}
+
+async function findProjectRoot(cwd: string): Promise<string> {
+  let current = resolve(cwd);
+  for (;;) {
+    try {
+      await access(join(current, "lobu.config.ts"));
+      return current;
+    } catch {
+      const parent = dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+  }
+  throw new Error(
+    `No Lobu project found from ${resolve(cwd)}. Run this command inside a directory containing lobu.config.ts.`
+  );
 }
 
 async function loadEnv(cwd: string): Promise<Record<string, string>> {
@@ -23,7 +40,7 @@ async function loadEnv(cwd: string): Promise<Record<string, string>> {
 export async function telemetryStatusCommand(
   options: TelemetryOptions = {}
 ): Promise<void> {
-  const cwd = options.cwd ?? process.cwd();
+  const cwd = await findProjectRoot(options.cwd ?? process.cwd());
   const env = await loadEnv(cwd);
   const dsn = env.SENTRY_DSN ?? process.env.SENTRY_DSN;
   if (dsn) {
@@ -38,7 +55,7 @@ export async function telemetryStatusCommand(
 export async function telemetryOnCommand(
   options: TelemetryOptions & { dsn?: string } = {}
 ): Promise<void> {
-  const cwd = options.cwd ?? process.cwd();
+  const cwd = await findProjectRoot(options.cwd ?? process.cwd());
   const dsn = options.dsn ?? SENTRY_DSN_DEFAULT;
   await setLocalEnvValue(cwd, "SENTRY_DSN", dsn);
   // The shared community DSN points at the same Sentry project as the hosted
@@ -55,7 +72,7 @@ export async function telemetryOnCommand(
 export async function telemetryOffCommand(
   options: TelemetryOptions = {}
 ): Promise<void> {
-  const cwd = options.cwd ?? process.cwd();
+  const cwd = await findProjectRoot(options.cwd ?? process.cwd());
   const envPath = join(cwd, ".env");
   let raw = "";
   try {


### PR DESCRIPTION
## Root cause
Telemetry status/on/off used `process.cwd()` directly, so running `telemetry on` from `/tmp` or a nested directory created or edited that directory’s `.env` instead of the Lobu project.

## Fix
Walk upward to the nearest directory containing `lobu.config.ts`; use that as the environment location and refuse to mutate anything outside a Lobu project.

## Verification
- Nested-directory test proves the project-root `.env` is updated and nested `.env` is absent.
- Outside-project test proves no `.env` is created.
- Tests 2/2 pass.
- CLI typecheck passes.

No merge requested.