### PR TITLE
fix(cli): detect broken native modules in doctor

### DIFF
--- a/packages/cli/src/commands/__tests__/doctor-native.test.ts
+++ b/packages/cli/src/commands/__tests__/doctor-native.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { checkInstalledNativeModule } from "../doctor";
+
+describe("doctor native dependency checks", () => {
+  test("fails when an installed native module cannot load", () => {
+    const check = checkInstalledNativeModule(
+      "sharp",
+      () => "/node_modules/sharp/package.json",
+      () => {
+        throw new Error("Cannot find module '../build/Release/sharp-linux-x64.node'");
+      }
+    );
+    expect(check).toEqual({
+      name: "native:sharp",
+      status: "fail",
+      detail:
+        "installed but not loadable: Cannot find module '../build/Release/sharp-linux-x64.node'",
+    });
+  });
+
+  test("passes when an installed native module loads", () => {
+    expect(
+      checkInstalledNativeModule(
+        "sharp",
+        () => "/node_modules/sharp/package.json",
+        () => ({})
+      )
+    ).toEqual({ name: "native:sharp", status: "ok", detail: "loadable" });
+  });
+
+  test("skips a module that is not part of the distribution", () => {
+    expect(
+      checkInstalledNativeModule("sharp", () => {
+        throw new Error("not installed");
+      })
+    ).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
+import { createRequire } from "node:module";
 import chalk from "chalk";
 import postgres from "postgres";
 import { checkMemoryHealth } from "./memory/_lib/memory-health.js";
@@ -33,6 +34,32 @@ function checkBinaryExists(name: string): Check {
     return { name, status: "ok", detail: first };
   } catch {
     return { name, status: "fail", detail: "not found" };
+  }
+}
+
+const moduleRequire = createRequire(import.meta.url);
+
+export function checkInstalledNativeModule(
+  name: string,
+  resolveModule: (id: string) => string = moduleRequire.resolve,
+  loadModule: (id: string) => unknown = moduleRequire
+): Check | null {
+  try {
+    resolveModule(`${name}/package.json`);
+  } catch {
+    // Newer/minimal distributions may not include this optional dependency.
+    return null;
+  }
+  try {
+    loadModule(name);
+    return { name: `native:${name}`, status: "ok", detail: "loadable" };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      name: `native:${name}`,
+      status: "fail",
+      detail: `installed but not loadable: ${detail}`,
+    };
   }
 }
 
@@ -216,6 +243,8 @@ export async function doctorCommand(
 
   checks.push(checkNodeVersion());
   checks.push(checkBinaryExists("git"));
+  const sharp = checkInstalledNativeModule("sharp");
+  if (sharp) checks.push(sharp);
 
   const databaseUrl = env.DATABASE_URL ?? process.env.DATABASE_URL;
   if (databaseUrl && isExternalDatabaseUrl(databaseUrl)) {


### PR DESCRIPTION
## Root cause
`lobu doctor` checked Node, git, database, ports and providers, but never loaded installed native modules. A stable 19.2.0 install with an unusable sharp binary could therefore report “All checks passed” before `lobu run` crashed.

## Fix
When sharp is present in the distribution, require it during doctor and fail with the underlying load error if its native binary is unusable. Skip the check when a newer/minimal distribution does not include sharp.

## Verification
Tests cover broken, loadable and absent native-module states (3/3 pass). CLI typecheck passes. This targets the stable 19.2.0 packaging line; current canary no longer includes sharp.

No merge requested.