### PR TITLE
fix(cli): keep auth tokens out of whoami JSON

### DIFF
--- a/packages/cli/src/commands/__tests__/whoami.test.ts
+++ b/packages/cli/src/commands/__tests__/whoami.test.ts
@@ -51,6 +51,8 @@ describe("whoamiCommand --json", () => {
     expect(result.apiUrl).toBe("https://app.lobu.ai/api/v1");
     expect(result.local).toBe(false);
     expect(result.organizations).toEqual([]);
+    expect(result.hasAccessToken).toBe(false);
+    expect(result.hasWorkerToken).toBe(false);
   });
 
   test("emits session fields after refresh", async () => {
@@ -79,8 +81,10 @@ describe("whoamiCommand --json", () => {
     expect(result.email).toBe("user@example.com");
     expect(result.name).toBe("Test User");
     expect(result.userId).toBe("user-123");
-    expect(result.accessToken).toBe("session-token");
-    expect(result.workerToken).toBe("session-token");
+    expect(result.hasAccessToken).toBe(true);
+    expect(result.hasWorkerToken).toBe(true);
+    expect(result.accessToken).toBeUndefined();
+    expect(result.workerToken).toBeUndefined();
     expect(result.expiresAt).toBe(1_700_000_000_000);
     expect(result.orgSlug).toBe("acme");
     expect(result.organizations).toEqual([{ slug: "acme", name: "Acme Inc" }]);
@@ -107,8 +111,10 @@ describe("whoamiCommand --json", () => {
 
     const result = parseJsonOutput();
     expect(result.local).toBe(true);
-    expect(result.accessToken).toBe("session-token");
-    expect(result.workerToken).toBe("worker-pat");
+    expect(result.hasAccessToken).toBe(true);
+    expect(result.hasWorkerToken).toBe(true);
+    expect(result.accessToken).toBeUndefined();
+    expect(result.workerToken).toBeUndefined();
     expect(result.loggedIn).toBe(true);
   });
 
@@ -171,7 +177,8 @@ describe("whoamiCommand --json", () => {
 
     const result = parseJsonOutput();
     expect(result.loggedIn).toBe(true);
-    expect(result.workerToken).toBe("fallback-token");
+    expect(result.hasWorkerToken).toBe(true);
+    expect(result.workerToken).toBeUndefined();
   });
 
   test("tolerates listOrganizations failure", async () => {

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -25,13 +25,10 @@ interface WhoamiJson {
   email?: string;
   name?: string;
   userId?: string;
-  /** Live access token after refresh — the Better Auth session / OAuth token. */
-  accessToken?: string;
-  /**
-   * Token for the device worker API (`/api/workers/*`). On loopback installs
-   * this is the local-init worker PAT; otherwise it equals `accessToken`.
-   */
-  workerToken?: string;
+  /** True when a refreshed access token is available. Raw tokens are never printed. */
+  hasAccessToken: boolean;
+  /** True when a device-worker token is available. Raw tokens are never printed. */
+  hasWorkerToken: boolean;
   /** Epoch ms when `accessToken` expires, when known. */
   expiresAt?: number;
   /** Active org slug bound to this context, when set. */
@@ -145,8 +142,8 @@ async function emitJson(
     email: effective?.email,
     name: effective?.name,
     userId: effective?.userId,
-    accessToken: effective?.accessToken,
-    workerToken: workerToken ?? effective?.accessToken,
+    hasAccessToken: Boolean(effective?.accessToken),
+    hasWorkerToken: Boolean(workerToken ?? effective?.accessToken),
     expiresAt: effective?.expiresAt,
     orgSlug,
     personalOrgSlug,


### PR DESCRIPTION
## Root cause
`lobu whoami --json` serialized full access and worker tokens to stdout, exposing reusable credentials through terminals, logs and command capture.

## Fix
Replace raw token values with `hasAccessToken` and `hasWorkerToken` booleans while preserving identity, org and expiry metadata.

## Verification
Whoami suite passes (7/7) and explicitly asserts neither raw token field is emitted. CLI typecheck passes.

## Breaking-change caveat
Owletto Mac currently reads `workerToken` from this JSON and needs a coordinated Mac patch or secure replacement path before this can merge safely.

No merge requested.