### PR TITLE
fix(cli): route call list through context API

### DIFF
--- a/packages/cli/src/__tests__/call.test.ts
+++ b/packages/cli/src/__tests__/call.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { buildArgs, callCommand, parseArgEntry } from "../commands/call";
 import { ValidationError } from "../commands/memory/_lib/errors";
 import * as memoryAuth from "../commands/memory/_lib/memory-auth";
+import * as apiClient from "../internal/api-client";
 
 const originalFetch = globalThis.fetch;
 const originalStdoutWrite = process.stdout.write.bind(process.stdout);
@@ -123,6 +124,17 @@ describe("callCommand", () => {
       },
       key: "https://example.test/mcp/acme",
     });
+    spyOn(apiClient, "resolveApiClient").mockResolvedValue({
+      client: new apiClient.ApiClient(
+        "https://example.test",
+        "test-token",
+        ((input, init) => globalThis.fetch(input, init)) as typeof fetch
+      ),
+      contextName: "default",
+      apiBaseUrl: "https://example.test",
+      orgSlug: "acme",
+      token: "test-token",
+    });
     spyOn(memoryAuth, "getUsableToken").mockResolvedValue({
       token: "test-token",
       contextName: "default",
@@ -210,6 +222,35 @@ describe("callCommand", () => {
     const parsed = JSON.parse(captured.chunks.join(""));
     expect(parsed.tools).toHaveLength(1);
     expect(parsed.tools[0].name).toBe("search_memory");
+  });
+
+  test("--list uses the explicit/context API origin instead of the marketing host", async () => {
+    stubAuth();
+    const fetchMock = mock(async (url: string) => {
+      expect(url).toBe("https://cloud.example.test/api/acme/tools");
+      return new Response(JSON.stringify({ tools: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    spyOn(apiClient, "resolveApiClient").mockResolvedValue({
+      client: new apiClient.ApiClient(
+        "https://cloud.example.test",
+        "test-token",
+        fetchMock as unknown as typeof fetch
+      ),
+      contextName: "cloud",
+      apiBaseUrl: "https://cloud.example.test",
+      orgSlug: "acme",
+      token: "test-token",
+    });
+
+    await callCommand(undefined, {
+      list: true,
+      context: "cloud",
+      url: "https://cloud.example.test/api/v1",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   test("dispatches a tool call and prints the JSON result", async () => {

--- a/packages/cli/src/commands/call.ts
+++ b/packages/cli/src/commands/call.ts
@@ -15,9 +15,10 @@
 
 import { readFile } from "node:fs/promises";
 
+import { resolveApiClient } from "../internal/api-client.js";
 import { printJson } from "../internal/output.js";
 import { parseJsonObject, ValidationError } from "./memory/_lib/errors.js";
-import { restGet, restToolCall } from "./memory/_lib/mcp.js";
+import { restToolCall } from "./memory/_lib/mcp.js";
 import {
   getSessionForOrg,
   mcpUrlForOrg,
@@ -190,13 +191,14 @@ export async function callCommand(
 ): Promise<void> {
   const json = options.json === true;
   const raw = options.raw === true;
-  const mcpUrl = await resolveCallEndpoint(options);
-
   if (options.list || !tool) {
-    const result = await restGet<{ tools: ToolListEntry[] }>(
-      mcpUrl,
-      "tools",
-      options.context
+    const { client, orgSlug } = await resolveApiClient({
+      context: options.context,
+      org: options.org,
+      apiUrl: options.url,
+    });
+    const result = await client.get<{ tools: ToolListEntry[] }>(
+      `/api/${encodeURIComponent(orgSlug)}/tools`
     );
     const tools = Array.isArray(result?.tools) ? result.tools : [];
     printToolList(tools, {
@@ -207,6 +209,7 @@ export async function callCommand(
     return;
   }
 
+  const mcpUrl = await resolveCallEndpoint(options);
   const args = await buildArgs(options);
   const result = await restToolCall<unknown>(
     mcpUrl,


### PR DESCRIPTION
## Root cause
`lobu call --list` derived a REST URL by round-tripping through the memory/MCP URL. This discarded the selected context origin and could target the `lobu.ai` marketing host; explicit `--url` also entered irrelevant MCP session resolution.

## Fix
Resolve the selected context with the normal API client and GET `/api/{org}/tools` from that API origin. Tool execution continues to use the existing MCP-derived dispatcher.

## Verification
Call command suite passes (18/18), including an explicit test that a cloud context URL requests `https://cloud.example.test/api/acme/tools`. CLI typecheck passes.

No merge requested.