### PR TITLE
fix(cli): validate org set against current login

### DIFF
--- a/packages/cli/src/commands/__tests__/org.test.ts
+++ b/packages/cli/src/commands/__tests__/org.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import * as internal from "../../internal/index.js";
+import { orgSetCommand } from "../org.js";
+
+afterEach(() => mock.restore());
+
+describe("orgSetCommand", () => {
+  function context() {
+    spyOn(internal, "resolveContext").mockResolvedValue({
+      name: "cloud",
+      url: "https://app.lobu.ai/api/v1",
+      source: "config",
+    });
+  }
+
+  test("sets an org returned for the current login", async () => {
+    context();
+    spyOn(internal, "listOrganizations").mockResolvedValue([
+      { slug: "acme", name: "Acme" },
+    ]);
+    const set = spyOn(internal, "setActiveOrg").mockResolvedValue({} as never);
+    await orgSetCommand("acme", { context: "cloud" });
+    expect(set).toHaveBeenCalledWith("acme", "cloud");
+  });
+
+  test("rejects an arbitrary org slug that is not available", async () => {
+    context();
+    spyOn(internal, "listOrganizations").mockResolvedValue([
+      { slug: "acme", name: "Acme" },
+    ]);
+    const set = spyOn(internal, "setActiveOrg").mockResolvedValue({} as never);
+    await expect(orgSetCommand("made-up", { context: "cloud" })).rejects.toThrow(
+      /not available.*acme/i
+    );
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  test("requires login through listOrganizations", async () => {
+    context();
+    spyOn(internal, "listOrganizations").mockRejectedValue(
+      new Error('Not logged in to context "cloud"')
+    );
+    await expect(orgSetCommand("acme", { context: "cloud" })).rejects.toThrow(
+      /Not logged in/
+    );
+  });
+});

--- a/packages/cli/src/commands/org.ts
+++ b/packages/cli/src/commands/org.ts
@@ -50,6 +50,15 @@ export async function orgSetCommand(
   options?: { context?: string }
 ): Promise<void> {
   const target = await resolveContext(options?.context);
+  const orgs = await listOrganizations({ context: target.name });
+  if (!orgs.some((org) => org.slug === slug)) {
+    const available = orgs.map((org) => org.slug).join(", ");
+    throw new Error(
+      available
+        ? `Organization "${slug}" is not available for this login. Available: ${available}`
+        : `Organization "${slug}" is not available for this login.`
+    );
+  }
   await setActiveOrg(slug, target.name);
   console.log(
     chalk.green(`\n  Active org for context ${target.name} set to ${slug}\n`)


### PR DESCRIPTION
## Root cause
`lobu org set <slug>` only validated slug syntax, then persisted any string without checking login state or whether the account belongs to that organization.

## Fix
Fetch organizations for the selected authenticated context, persist only a returned slug, and show available slugs on mismatch. The existing organization-list call supplies the login gate.

## Verification
Tests cover valid org, unavailable org and logged-out use (3/3 pass). CLI typecheck passes.

No merge requested.