### PR TITLE
docs(connectors): checkpoints survive connector version bumps

### DIFF
--- a/docs/connector-authoring.md
+++ b/docs/connector-authoring.md
@@ -148,7 +148,13 @@ timeout, and one failure does not discard successful results from the others.
   it only when source identity genuinely changes.
 - **Checkpointing.** Return `checkpoint` (timestamp- or id-based) for incremental
   sync; use `ctx.emitEvents` / `ctx.updateCheckpoint` mid-sync for long runs so a
-  crash resumes from the last saved point.
+  crash resumes from the last saved point. The checkpoint is stored on the
+  configured feed and is **not** invalidated by bumping the connector's
+  `version` — updating connector source leaves feed state, checkpoints, and
+  collected data untouched. If you change the event or checkpoint shape, handle
+  old checkpoints in the connector itself: carry a schema/scope version inside
+  the checkpoint and reset when it mismatches, the way the shipped Google
+  connectors do (`google_calendar.ts`, `google_gmail.ts`).
 - **`eventKinds`.** Declare the event types the feed can emit. A feed's
   `eventKinds` are also the default Automation trigger catalog: each kind becomes
   a subscribable event type. The first successful non-dry sync establishes the


### PR DESCRIPTION
The hosted connector docs tell authors to bump the connector `version` to invalidate per-feed checkpoints when the event shape changes ("bump to invalidate per-feed checkpoints", "so the gateway forces a fresh checkpoint"). The platform does not do this: the checkpoint is stored on the feed row (`feeds.checkpoint`), and connector source updates leave feed state, checkpoints, and collected data untouched. An author relying on a version bump for a fresh baseline would silently resume incremental sync from the old checkpoint.

The in-repo `docs/connector-authoring.md` never made that claim but also never said what actually happens. This documents the real behavior and points authors at the pattern the shipped connectors use: carry a schema/scope version inside the checkpoint payload and reset on mismatch (`google_calendar.ts`, `google_gmail.ts`).

Verified against `db/migrations/00000000000000_baseline.sql` (checkpoint lives on the feed row, nothing ties it to `connector_versions.version`), `packages/server/src/tools/admin/manage_feeds.ts` (source updates leave checkpoints untouched), and the shipped Google connectors' own checkpoint-versioning pattern.

The lobu.ai/guides/author-a-connector/ page carries the incorrect claim and needs the matching site-side fix (separate repo).

**Maintainer note:** NOTE: this PR documents current behavior. If #3542 (fix(feeds): fail rejected connector batches...) is merged, version bumps WILL clear per-feed checkpoints and the 'no platform invalidation exists' claim in this doc must be updated to match. Land whichever order; the loser gets a follow-up edit.
