### PR TITLE
fix(agent-turn): bound the turn workspace so a runaway write refuses instead of killing the isolate

### DIFF
--- a/packages/connector-worker/src/__tests__/agent-turn-workspace.test.ts
+++ b/packages/connector-worker/src/__tests__/agent-turn-workspace.test.ts
@@ -165,6 +165,22 @@ describe("createWorkspace tools", () => {
     const second = toolMap(createWorkspace(["ls"]).tools);
     expect(await run(second.ls, {})).toBe("(empty directory)");
   });
+
+  test("write enforces the turn workspace byte budget, counting overwrites as deltas", async () => {
+    const t = toolMap(createWorkspace(["write"]).tools);
+    const chunk = "x".repeat(32 * 1024 * 1024);
+    await run(t.write, { file_path: "a.bin", content: chunk });
+    await run(t.write, { file_path: "b.bin", content: chunk });
+    // 64MB held: a third 32MB file would exceed the 64MB budget and is refused.
+    await expect(run(t.write, { file_path: "c.bin", content: chunk })).rejects.toThrow("limited to 64.0MB");
+    // A same-size overwrite is a delta of zero, not a fresh allocation.
+    await run(t.write, { file_path: "a.bin", content: chunk });
+    // Growing a file counts only the growth, and even that must fit.
+    await expect(run(t.write, { file_path: "a.bin", content: `${chunk}x` })).rejects.toThrow("limited to 64.0MB");
+    // Shrinking a file frees its bytes for later writes.
+    await run(t.write, { file_path: "a.bin", content: "freed" });
+    expect(await run(t.write, { file_path: "small.txt", content: "ok" })).toBe("Successfully wrote 2 bytes to small.txt");
+  }, 120000);
 });
 
 describe("edit and grep — pi's two remaining builtins, inside the isolate", () => {

--- a/packages/connector-worker/src/agent-turn/workspace.ts
+++ b/packages/connector-worker/src/agent-turn/workspace.ts
@@ -32,6 +32,13 @@ import type { AgentTurnBashPolicy, AgentTurnBuiltinTool, RuntimeExecRequest, Run
 export const WORKSPACE_ROOT = '/workspace';
 
 /**
+ * Total bytes the write and edit tools may place in one turn's workspace.
+ * Far above real workloads (the largest measured transcript is ~633KB) and
+ * far below the isolate memory ceiling that would otherwise kill the turn.
+ */
+export const WORKSPACE_WRITE_BUDGET_BYTES = 64 * 1024 * 1024;
+
+/**
  * Where the turn's own attachments are seeded. The name is part of the
  * agent-visible contract: the system prompt lists each upload by this path.
  */
@@ -288,9 +295,30 @@ export function createWorkspace(
   };
   // Pi owns mutation ordering, matching, cancellation, and result formatting.
   // Only filesystem access changes: every operation stays in this turn's tree.
+  // The budget below is the only bound on the write/edit tools: without it a
+  // write loop runs until the isolate's own memory ceiling kills the whole
+  // turn as MemoryLimitExceeded, instead of refusing with an error the model
+  // can read and act on. An overwrite counts as a delta, so rewriting one
+  // file in a loop does not accumulate. bash redirection goes through
+  // just-bash's own filesystem and is not intercepted at this layer, so the
+  // isolate memory limit stays the backstop there. Host-placed seed files
+  // also bypass this accounting; they are bounded by the host, not the model.
+  const writeSizes = new Map<string, number>();
+  let writtenBytes = 0;
   const writeFile = async (path: string, content: string): Promise<void> => {
     await ready;
-    await fs.writeFile(resolve(path), content);
+    const absolute = resolve(path);
+    const newSize = Buffer.byteLength(content);
+    const previousSize = writeSizes.get(absolute) ?? 0;
+    const projected = writtenBytes - previousSize + newSize;
+    if (projected > WORKSPACE_WRITE_BUDGET_BYTES) {
+      throw new Error(
+        `Refusing to write ${formatSize(newSize)} to ${path}: this turn's workspace is limited to ${formatSize(WORKSPACE_WRITE_BUDGET_BYTES)} total and already holds ${formatSize(writtenBytes)}. Write smaller content or split it across turns.`
+      );
+    }
+    await fs.writeFile(absolute, content);
+    writeSizes.set(absolute, newSize);
+    writtenBytes = projected;
   };
   // Host-placed files. Bytes go in as a Uint8Array rather than a string: a
   // decoded-to-UTF-8 round trip would corrupt every attachment that is not


### PR DESCRIPTION
Fixes #3459.

Closes #3459.

## Summary
The turn workspace's `write` tool had no size guard: `MAX_BYTES`/`MAX_LINES` only truncate *output* for `read`, `find` and `bash`, and just-bash's `InMemoryFs` has no quota. The only bound on a model write loop was the isolate's own 512MB memory ceiling (`packages/connector-worker/src/executor/isolate.ts`), and when it tripped the whole turn died as `MemoryLimitExceeded` - a generic OOM the model cannot read or act on.

This adds a 64MB total-bytes budget per turn workspace, enforced in the shared `writeFile` path (so `write` and `edit` are both covered):

- Overwrites count as a **delta**, not a fresh allocation - rewriting the same file in a loop does not accumulate, and shrinking a file frees its bytes for later writes.
- Exceeding the budget throws a normal tool error naming the limit and current usage ("this turn's workspace is limited to 64.0MB total and already holds 63.9MB..."), which the model can read and course-correct on, instead of losing the turn.
- 64MB is far above real workloads (largest measured transcript ~633KB, per the issue) and far below the isolate ceiling.
- `bash` redirection goes through just-bash's own filesystem and is not intercepted at this layer - the isolate memory limit stays the backstop there, and a new comment says so rather than implying full coverage. Host-placed seed files are bounded by the host and bypass this accounting.

No schema, API, or SDK changes. `WORKSPACE_WRITE_BUDGET_BYTES` is exported for tests.

## Test plan
- [x] Red -> green against `main` (`b4cde48`): a repro test writing two 32MB files then a third **passes the third write on unpatched main** (96MB written, no error - red) and **refuses it with the budget error on this branch** (green).
- [x] New coverage in `agent-turn-workspace.test.ts`: third 32MB file refuses at 64MB held; same-size overwrite is a zero delta and fits; growth counts only the growth; shrinking frees bytes; small writes still succeed with pi's exact success message.
- [x] Full `agent-turn-workspace.test.ts`: 15 pass, 0 fail. `agent-turn-tool-output.test.ts`: 2 pass, 0 fail.
- [ ] `make pre-pr` / CI on the pushed branch (local box had no pre-built workspace deps; package build in progress).

## Notes
Per the issue, the earlier pi-lane implementation predates #3402 and does not reapply; this is a rewrite against current `agent-turn/workspace.ts` (the file moved from `executor/` since the issue was filed). The budget lives in the shared `writeFile` closure rather than pi's factories, so it also covers `edit` without touching pi's contracts.