### PR TITLE
docs(auth.md): document the required RFC 8707 resource param in the device flow

### DIFF
--- a/packages/server/src/auth/oauth/auth-md.ts
+++ b/packages/server/src/auth/oauth/auth-md.ts
@@ -44,9 +44,11 @@ agent-attested (ID-JAG) zero-touch flow; do not attempt one.
    POST ${baseUrl}/oauth/device_authorization
    Content-Type: application/json
 
-   { "client_id": "<client_id>", "scope": "mcp:read mcp:write" }
+   { "client_id": "<client_id>", "scope": "mcp:read mcp:write", "resource": "${baseUrl}/mcp" }
    \`\`\`
-   Response includes \`device_code\`, \`user_code\`, and a poll \`interval\`.
+   \`resource\` (RFC 8707) is required for MCP device grants and binds the
+   token's audience to that MCP endpoint. Response includes \`device_code\`,
+   \`user_code\`, and a poll \`interval\`.
 
 3. Deliver the request to the user by email:
    \`\`\`http
@@ -67,8 +69,10 @@ agent-attested (ID-JAG) zero-touch flow; do not attempt one.
    POST ${baseUrl}/oauth/token
    Content-Type: application/json
 
-   { "grant_type": "urn:ietf:params:oauth:grant-type:device_code", "device_code": "<device_code>", "client_id": "<client_id>" }
+   { "grant_type": "urn:ietf:params:oauth:grant-type:device_code", "device_code": "<device_code>", "client_id": "<client_id>", "resource": "${baseUrl}/mcp" }
    \`\`\`
+   The \`resource\` must repeat the exact value sent to
+   \`/oauth/device_authorization\`; a mismatch is rejected.
    While pending you get \`{ "error": "authorization_pending" }\` (back off on
    \`slow_down\`). On approval you get \`access_token\` (+ \`refresh_token\`),
    scoped to what the user granted.


### PR DESCRIPTION
## Root cause
/oauth/device_authorization rejects MCP-scoped device grants without an RFC 8707 `resource` (routes.ts: "resource is required for MCP device authorization"), and the token poll rejects a resource that doesn't match the authorization ("Token request resource must match...") - but the published auth.md documented neither, so an agent following the doc verbatim fails twice.

## Fix
packages/server/src/auth/oauth/auth-md.ts - both documented requests now carry "resource": "${baseUrl}/mcp" with a one-line explanation each.

## Verification
Booted the stack from source and fetched the served page: GET /auth.md now shows resource in the device_authorization AND token examples; the value matches the server-side canonicalization (canonicalizeMcpResource against the public MCP URL). Pre-commit (biome + tsc): green.