### PR TITLE
fix(mcp): keep the session alive on unauthorized tool calls

### DIFF
--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -1528,7 +1528,12 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
     if (!session.authCtx.organizationId && !session.authCtx.isAuthenticated) {
       const toolCall = req.method === 'POST' ? await readToolCall(req) : null;
       if (req.method === 'GET' || toolCall) {
-        clearSession();
+        // A denied call is not a dead session: the 401 challenge is what makes
+        // the client upgrade its auth, and the retry arrives on THIS session.
+        // Clearing here punished exactly those clients — their first denied
+        // call killed the session, so every follow-up failed with "session
+        // expired" and forced a from-scratch re-initialize (same policy as the
+        // missing-header path above).
         return buildUnauthorizedResponse(
           req,
           req.method === 'GET'
@@ -1547,7 +1552,7 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
     ) {
       const toolCall = await readToolCall(req);
       if (toolCall && !isPublicReadable(toolCall.name, toolCall.args)) {
-        clearSession();
+        // See above: deny the call, keep the session.
         return buildUnauthorizedResponse(req, 'Authentication required for this tool.');
       }
     }


### PR DESCRIPTION
## Root cause
mcp-handler.ts called clearSession() before returning the 401 challenge in BOTH anonymous denial branches (root /mcp session tool call; anonymous public-org session calling a non-public tool). The denial destroyed the session, so the client's next call hit "MCP session expired" and had to re-initialize from scratch - punishing exactly the expired-token/logged-out clients the 401 challenge is meant to upgrade. The same function's missing-header path already documents the opposite policy ("Keep the live session intact... without an unnecessary re-initialize").

## Fix
Drop clearSession() from both denial branches; deny the call, keep the session.

## Verification
MCP integration suites on a real Postgres: auth.test.ts 59 passed/2 skipped, session-recovery + session-refresh-atomicity 12 passed. The only test that relied on clear-on-deny is already it.skip'd (post-#438). Caveat: the full inspector-based e2e (initialize -> denied call -> follow-up call on same session) was not re-run; the fix is one behavioral deletion verified against the full session/auth suites. Pre-commit (biome + tsc): green.