### PR TITLE
fix(server): never cache /api/organizations membership state

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1054,6 +1054,11 @@ app.get("/api/organizations", async (c) => {
 	}
 
 	const orgs = await provider.listOrganizations(search, userId);
+	// Membership is per-user authorization state: a cached `is_member: false`
+	// from the seconds after signup (before the member row commits) must never
+	// be replayed by a browser or intermediary cache — the client treats this
+	// payload as the membership gate for agent management.
+	c.header("Cache-Control", "no-store");
 	return c.json({ organizations: orgs });
 });
 


### PR DESCRIPTION
## Root cause
Signup creates the personal org with `is_member` computed live by the server (`multi-tenant.ts` `loadMembershipRole` runs fresh SQL per request), but `GET /api/organizations` carried no cache directive. Any intermediary or shared cache could serve a pre-signup response where the org still reads `is_member:false`, re-triggering the "not a member" gate after a successful signup. Server-side complement to the owletto fix (client TanStack cache held a stale `is_member:false` for up to 5 min via `staleTime: 300000`).

## Fix
Send `Cache-Control: no-store` on `GET /api/organizations`. Membership state is per-caller, mutated by invites/provisioning, and cheap to compute - it must never be cached.

## Verification
- curl against a real boot: `GET /api/organizations` now returns `cache-control: no-store` (header confirmed live).
- Pre-commit (biome + full tsc) green.
