### PR TITLE
fix(connections): derive a webhook slug when create omits one

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/webhook-connection-slug.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/webhook-connection-slug.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Inbound webhook connection create: the UI form has no slug input, but the
+ * server rejected slug-less creates with "Webhook connections require a
+ * non-numeric slug" — the connection could not be created at all. The server
+ * now derives a readable, non-numeric slug when the caller supplies none.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import type { ToolContext } from '../../../tools/registry';
+import { manageConnections } from '../../../tools/admin/manage_connections';
+import { __setChatInstanceManagerForTests } from '../../../lobu/gateway';
+import { orgContext } from '../../../lobu/stores/org-context';
+import { runtimeConnectionIdToSlug } from '../../../lobu/stores/connections-projection';
+import { getTestDb, cleanupTestDatabase } from '../../setup/test-db';
+import { initWorkspaceProvider } from '../../../workspace';
+import {
+  addUserToOrganization,
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const TEST_ENV = {} as Env;
+
+function ctxFor(organizationId: string, userId: string): ToolContext {
+  return {
+    organizationId,
+    userId,
+    memberRole: 'owner',
+    agentId: null,
+    isAuthenticated: true,
+    clientId: null,
+    scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    tokenType: 'oauth',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+    baseUrl: 'https://gateway.test/lobu',
+  } as ToolContext;
+}
+
+describe('webhook connection create without an explicit slug', () => {
+  let ctx: ToolContext;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    // Adapterless platforms never instantiate a chat adapter; a stub manager
+    // satisfies the connection-service seam without gateway startup. Its
+    // addConnection persists the row the way ChatInstanceManager.persistConnection
+    // does (no secret normalization needed for a synthetic token).
+    __setChatInstanceManagerForTests({
+      resolveConnectionConfig: async (_id: unknown, cfg: unknown) => cfg,
+      addConnection: async (
+        platform: string,
+        _agentId: unknown,
+        config: unknown,
+        _settings: unknown,
+        metadata: { teamName?: string } | undefined,
+        stableId: string,
+      ) => {
+        const orgId = orgContext.getStore()?.organizationId;
+        if (!orgId) throw new Error('stub addConnection outside org context');
+        const sql = getTestDb();
+        await sql`
+          INSERT INTO connections (
+            organization_id, connector_key, display_name, status, config,
+            credential_mode, slug, visibility, created_at, updated_at
+          ) VALUES (
+            ${orgId}, ${platform}, ${metadata?.teamName ?? null}, 'active',
+            ${sql.json((config ?? {}) as Record<string, unknown>)}, 'byo',
+            ${runtimeConnectionIdToSlug(stableId)}, 'org', now(), now()
+          )
+        `;
+      },
+      connectionMatches: () => false,
+      updateConnection: async () => {},
+    });
+  });
+
+  afterAll(() => {
+    __setChatInstanceManagerForTests(null);
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Webhook Slug Org' });
+    const user = await createTestUser({ name: 'Webhook Slug User' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    ctx = ctxFor(org.id, user.id);
+    await createTestConnectorDefinition({ key: 'webhook', name: 'Inbound Webhook' });
+    const sql = getTestDb();
+    await sql`
+      UPDATE connector_definitions
+      SET options_schema = ${sql.json({ 'x-lobu-adapterless-platform': 'webhook' })}
+      WHERE key = 'webhook'
+    `;
+  });
+
+  it('creates the connection with a derived non-numeric slug when none is supplied', async () => {
+    const res = await manageConnections(
+      {
+        action: 'create',
+        connector_key: 'webhook',
+        display_name: 'My Inbound Hook',
+        config: { token: 'wh_test_token_0123456789abcdef0123456789abcdef' },
+      },
+      TEST_ENV,
+      ctx,
+    );
+    expect('error' in res ? res.error : undefined).toBeUndefined();
+    if (!('connection' in res)) throw new Error('unexpected result shape');
+    const slug = (res.connection as { slug: string }).slug;
+    expect(slug).toMatch(/^agentconn-my-inbound-hook-[0-9a-f]{6}$/);
+    expect(slug).not.toMatch(/^\d+$/);
+  });
+
+  it('still rejects an explicitly numeric slug', async () => {
+    const res = await manageConnections(
+      { action: 'create', connector_key: 'webhook', slug: '12345', display_name: 'Numeric Hook' },
+      TEST_ENV,
+      ctx,
+    );
+    expect('error' in res && typeof res.error === 'string' ? res.error : '').toMatch(
+      /numeric/i,
+    );
+  });
+
+  it('honors an explicit non-numeric slug', async () => {
+    const res = await manageConnections(
+      {
+        action: 'create',
+        connector_key: 'webhook',
+        slug: 'orders-hook',
+        display_name: 'Orders Hook',
+        config: { token: 'wh_test_token_fedcba9876543210fedcba9876543210' },
+      },
+      TEST_ENV,
+      ctx,
+    );
+    expect('error' in res ? res.error : undefined).toBeUndefined();
+    if (!('connection' in res)) throw new Error('unexpected result shape');
+    expect((res.connection as { slug: string }).slug).toBe('agentconn-orders-hook');
+  });
+});

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -19,6 +19,7 @@ import {
 	type DbClient,
 } from "../../../../db/client";
 import { recordToolConfigChange } from "../../helpers/config-audit";
+import { slugify } from "../../../../auth/personal-org-provisioning";
 import {
 	connectorSecretKeysFromSchemas,
 	loadConnectorSecretKeys,
@@ -771,11 +772,19 @@ export async function handleCreate(
 				"x-lobu-adapterless-platform"
 			]);
 	if (connectionPlatform === args.connector_key) {
-		if (args.connector_key === "webhook" && !args.slug) {
-			return { error: "Webhook connections require a non-numeric slug." };
-		}
 		try {
-			const stableId = args.slug || randomUUID().replace(/-/g, "").slice(0, 16);
+			// The slug is OPTIONAL: the connection create form has no slug input,
+			// so requiring one made inbound-webhook connections impossible to
+			// create from the UI. Derive a readable slug from the display name
+			// with a random suffix against collisions. The embedded hyphen keeps
+			// the result non-numeric even for a numeric display name — numeric
+			// webhook URLs are reserved for provider connector IDs
+			// (upsertByoChatConnection enforces the same rule for explicit slugs).
+			const stableId =
+				args.slug ||
+				`${slugify(args.display_name ?? "") || "hook"}-${randomUUID()
+					.replace(/-/g, "")
+					.slice(0, 6)}`;
 			const created = await upsertByoChatConnection({
 				organizationId,
 				platform: args.connector_key,


### PR DESCRIPTION
## Root cause
`manage_connections` `action=create` hard-failed webhook (BYO chat platform) connections without an explicit slug: "Webhook connections require a non-numeric slug." The connection create form has no slug input, so inbound-webhook connections were impossible to create from the UI - the same path the API takes.

## Fix
In `crud.ts`, when the connector is a chat/adapterless platform and no slug is given, derive `${slugify(display_name)||"hook"}-<6 random hex>`. The embedded hyphen keeps the derived slug non-numeric even for a numeric display name, preserving the invariant that numeric webhook URLs are reserved for provider connector IDs (`upsertByoChatConnection` still rejects explicit numeric slugs independently).

## Verification (red -> green, real embedded PG)
New integration test `webhook-connection-slug.test.ts` (3 cases): create without slug succeeds with derived slug; explicit numeric slug still rejected; explicit non-numeric slug honored.
- RED on base: case 1 fails with the exact old error.
- GREEN with fix: 3/3 passed.
- Pre-commit (biome + full tsc) green.
