### PR TITLE
fix(events): compare page_visit titles badge-normalized so an unread count doesn’t supersede

### DIFF
--- a/packages/server/src/__tests__/integration/events/page-visit-title-badge.test.ts
+++ b/packages/server/src/__tests__/integration/events/page-visit-title-badge.test.ts
@@ -1,0 +1,121 @@
+/**
+ * A browser tab folds its unread count into the document title, so the same
+ * page arrives as "(3) WhatsApp" and later "WhatsApp". For a page_visit the
+ * URL is the identity and that badge is volatile: comparing titles raw made
+ * chrome.history supersede 93.6% of its own writes (#3328). The dedup path
+ * compares page_visit titles badge-normalized; a genuine title change still
+ * supersedes, and other semantic types compare titles exactly as before.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { insertEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  createTestConnection,
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestUser,
+  addUserToOrganization,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('page_visit title badge normalization', () => {
+  let orgId: string;
+  let connectionId: number;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    const org = await createTestOrganization({ name: 'Badge Org' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'badge-test@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    await createTestConnectorDefinition({
+      key: 'badge-connector',
+      name: 'Badge Connector',
+      organization_id: org.id,
+    });
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'badge-connector',
+    });
+    connectionId = connection.id;
+  });
+
+  function pageVisit(originId: string, title: string) {
+    return insertEvent(
+      {
+        entityIds: [],
+        organizationId: orgId,
+        originId,
+        title,
+        content: "page body",
+        sourceUrl: 'https://web.whatsapp.com/',
+        occurredAt: new Date('2026-09-10T12:00:00Z'),
+        semanticType: 'page_visit',
+        originType: 'page_visit',
+        connectorKey: 'badge-connector',
+        connectionId,
+      },
+      { onConflictUpdate: true }
+    );
+  }
+
+  it('does not supersede when only the unread badge moves in or out of the title', async () => {
+    const originId = `badge-${Date.now()}`;
+    const first = await pageVisit(originId, '(3) WhatsApp');
+    expect(first.change).toBe('inserted');
+
+    const badgeOut = await pageVisit(originId, 'WhatsApp');
+    expect(badgeOut.change).toBe('unchanged');
+    expect(badgeOut.id).toBe(first.id);
+
+    const badgeUp = await pageVisit(originId, '(7) WhatsApp');
+    expect(badgeUp.change).toBe('unchanged');
+    expect(badgeUp.id).toBe(first.id);
+  });
+
+  it('still supersedes a page_visit on a genuine title change', async () => {
+    const originId = `real-${Date.now()}`;
+    const first = await pageVisit(originId, '(3) WhatsApp');
+    const renamed = await pageVisit(originId, 'WhatsApp Business');
+    expect(renamed.change).toBe('superseded');
+    expect(renamed.id).not.toBe(first.id);
+  });
+
+  it('compares titles exactly for semantic types other than page_visit', async () => {
+    const originId = `other-${Date.now()}`;
+    const first = await insertEvent(
+      {
+        entityIds: [],
+        organizationId: orgId,
+        originId,
+        title: '(3) Standup notes',
+        content: 'notes',
+        occurredAt: new Date('2026-09-10T12:00:00Z'),
+        semanticType: 'content',
+        originType: 'content',
+        connectorKey: 'badge-connector',
+        connectionId,
+      },
+      { onConflictUpdate: true }
+    );
+    const second = await insertEvent(
+      {
+        entityIds: [],
+        organizationId: orgId,
+        originId,
+        title: 'Standup notes',
+        content: 'notes',
+        occurredAt: new Date('2026-09-10T12:00:00Z'),
+        semanticType: 'content',
+        originType: 'content',
+        connectorKey: 'badge-connector',
+        connectionId,
+      },
+      { onConflictUpdate: true }
+    );
+    expect(second.change).toBe('superseded');
+    expect(second.id).not.toBe(first.id);
+  });
+});

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -375,12 +375,31 @@ async function findCurrentEventByOrigin(
   return rows[0] as any;
 }
 
+/**
+ * Browser tabs fold their unread count into the document title, so a
+ * page_visit's title is volatile in exactly the way `metadata` already is:
+ * the badge moving in and out ("(3) WhatsApp" vs "WhatsApp") made one feed
+ * supersede 93.6% of everything it wrote over a measured 3-day prod window
+ * (#3328). Compare page_visit titles badge-normalized — the URL is the
+ * identity, and a genuine title change still mints a new version.
+ */
+const UNREAD_BADGE_PREFIX = /^\(\d+\)\s+/;
+function semanticEventTitle(
+  title: string | null | undefined,
+  semanticType: string | null | undefined
+): string | null {
+  const value = title ?? null;
+  if (value === null || semanticType !== 'page_visit') return value;
+  return value.replace(UNREAD_BADGE_PREFIX, '');
+}
+
 function isSemanticallyEqual(
   existing: NonNullable<Awaited<ReturnType<typeof findCurrentEventByOrigin>>>,
   params: InsertEventParams
 ): boolean {
   return (
-    (existing.title ?? null) === (params.title ?? null) &&
+    semanticEventTitle(existing.title, params.semanticType) ===
+      semanticEventTitle(params.title, params.semanticType) &&
     (existing.payload_text ?? null) === (params.content ?? null) &&
     existing.payload_type === (params.payloadType ?? 'text') &&
     stableJson(existing.payload_data ?? {}) === stableJson(params.payloadData ?? {}) &&


### PR DESCRIPTION
Fixes #3328.

Closes #3328.

## Summary
`title` is compared as real semantic content in `isSemanticallyEqual`, but for a `page_visit` the title is volatile: a browser tab's unread badge moves in and out of it ("(3) WhatsApp" vs "WhatsApp"). Measured on prod over 3 days (per the issue), `chrome.history` superseded 93.6% of its own 31,375 `page_visit` writes - 95.6% of all supersede volume - about sixteen rows per new fact, each one re-embedded.

Following the `semanticAttachmentState()` precedent from #3065, this compares `page_visit` titles **badge-normalized**: a leading `(n) ` prefix is stripped from both sides of the comparison. The URL remains the identity of a page visit; a genuine title change (site rename) still mints a new version, and semantic types other than `page_visit` compare titles exactly as before.

Server-side, in the dedup comparison, so it holds regardless of how often the feed rescans its window. The feed-side variant (emit only when visit time changed) remains available to the owletto repo as a separate optimization; it is not required to stop the churn.

## Test plan
- [x] Red -> green against `main` (`b4cde48`), real Postgres (embedded PG 18 + pgvector), `onConflictUpdate: true` dedup path:
  - RED (unpatched): inserting `(3) WhatsApp` then `WhatsApp` for the same origin returns `change: 'superseded'` - a new stored version for a badge move.
  - GREEN (this branch): same sequence returns `change: 'unchanged'` and reuses the row; `(7) WhatsApp` after that is also `unchanged`.
- [x] New coverage in `page-visit-title-badge.test.ts`: badge in/out does not supersede; genuine title change still supersedes; non-`page_visit` types still compare titles exactly (`(3) Standup notes` -> `Standup notes` supersedes).
- [x] Full `src/__tests__/integration/events/` suite: 56 files, 268 tests, all pass.
- [ ] `make pre-pr` / CI on the pushed branch (CI is the canonical gate).

## Notes
- Deliberately not touching: the full-window rescan cadence (feed-side, owletto), and the other two options from the issue. Normalizing at comparison time was chosen over treating `title` as fully volatile for `page_visit` so real renames still version.
- After deploy, one re-sync per live page may reconcile once; from then on badge moves are `unchanged` and the supersede rate for this feed should drop toward its real change rate.
