### PR TITLE
test(server): lock embed_backfill retry-after-failure contract

### DIFF
--- a/packages/server/src/__tests__/integration/scheduled/trigger-embed-backfill-retry.test.ts
+++ b/packages/server/src/__tests__/integration/scheduled/trigger-embed-backfill-retry.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Repro for ISSUE 7 (2026-09-13 self-host QA): a failed embed_backfill run
+ * must NOT dead-end the backlog - the next trigger tick must re-enqueue the
+ * still-unembedded events in a fresh run.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import { triggerEmbedBackfill } from '../../../scheduled/trigger-embed-backfill';
+import { insertEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestConnection,
+  createTestConnectorDefinition,
+  createTestEntity,
+  createTestOrganization,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const MODEL = 'Xenova/bge-base-en-v1.5';
+
+describe('triggerEmbedBackfill retries after a failed run', () => {
+  let orgId: string;
+  let eventId: number;
+  let originalModel: string | undefined;
+
+  beforeAll(async () => {
+    originalModel = process.env.EMBEDDINGS_MODEL;
+    process.env.EMBEDDINGS_MODEL = MODEL;
+
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    const org = await createTestOrganization({ name: 'Backfill Retry Org' });
+    orgId = org.id;
+    const entity = await createTestEntity({ name: 'Retry Target', organization_id: org.id });
+    await createTestConnectorDefinition({
+      key: 'retry-connector',
+      name: 'Retry',
+      organization_id: org.id,
+    });
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'retry-connector',
+      entity_ids: [entity.id],
+    });
+
+    eventId = (
+      await insertEvent({
+        entityIds: [entity.id],
+        organizationId: orgId,
+        semanticType: 'content' as const,
+        originType: 'content' as const,
+        connectorKey: 'retry-connector',
+        connectionId: connection.id,
+        originId: 'failed-once',
+        title: 'failed once',
+        content: 'content whose first embedding attempt failed at cold boot',
+        occurredAt: new Date(),
+      })
+    ).id;
+
+    // The failed first attempt: terminal status, no longer active.
+    await getTestDb()`
+      INSERT INTO runs (organization_id, run_type, status, approval_status, action_input, created_at)
+      VALUES (${orgId}, 'embed_backfill', 'failed', 'auto', ${getTestDb().json({ event_ids: [eventId] })}, current_timestamp)
+    `;
+  });
+
+  afterAll(() => {
+    if (originalModel === undefined) delete process.env.EMBEDDINGS_MODEL;
+    else process.env.EMBEDDINGS_MODEL = originalModel;
+  });
+
+  it('re-enqueues unembedded events after their run failed', async () => {
+    const result = await triggerEmbedBackfill({} as Env);
+    expect(result.runsCreated).toBe(1);
+
+    const rows = (await getTestDb()`
+      SELECT action_input FROM runs
+      WHERE organization_id = ${orgId} AND run_type = 'embed_backfill' AND status = 'pending'
+    `) as Array<{ action_input: { event_ids: number[] } }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.action_input.event_ids).toContain(eventId);
+  });
+
+  it('does not stack a second run while one is active', async () => {
+    // A pending run now exists from the previous test: the dedup must hold so
+    // retries serialize instead of piling up.
+    const result = await triggerEmbedBackfill({} as Env);
+    expect(result.runsCreated).toBe(0);
+  });
+});


### PR DESCRIPTION
Title: test(server): lock embed_backfill retry-after-failure contract

Repo: lobu-ai/lobu - branch: fix/embed-backfill-retry, base: main (b4cde48)

## Context
QA (2026-09-13, @lobu/cli 19.2.0-canary ge3601ff, fresh self-host): cold boot with the embedding model not yet downloaded failed the first EmbedBackfill run ("POST /api/workers/complete-embeddings -> 400 fetch failed"); after a warm restart the events were reported un-embedded indefinitely. Expected: failed backfill re-queued until embeddings land.

## What this PR is
A regression test that locks the retry contract at the scheduler level:
1. An org with an unembedded event whose embed_backfill run is in terminal `failed` status gets a NEW pending run on the next `triggerEmbedBackfill` tick, containing that event.
2. While a run is active, no second run stacks (dedup holds).

Both pass on main today: the scheduler-side retry mechanism is intact, so this PR documents and locks it rather than changing behavior.

## What this PR is NOT (repro status, honestly)
I could not reproduce "never retries" at the scheduler level: the discovery scan re-finds unembedded events for orgs with only failed runs, and the claim/finalize path re-queues per-event write failures ("stays stale, will re-queue" in completeEmbeddings). The QA symptom points at the self-host runtime layer instead - candidates I could not exercise in the fix environment (no full `lobu run` stack / model download):
- `startEmbeddings()` (embedded-runtime.ts) forks the embeddings service but never respawns it after a crash (`child.on('exit')` only logs) - if the fork dies during the cold-boot model download, every later embed attempt fails until process restart.
- `startEmbeddedConnectorWorker` admits the same: a daemon that fails to start "is dead until process restart (no exponential-retry built into the daemon)".
- On-demand runtime components (#3518): if the embeddings component is absent when the worker needs the local pipeline, runs fail identically each tick (which QA would see as repeated failures, so this is the weakest suspect).

No code fix shipped for those: they are speculative without a real self-host repro, per repo rules. Happy to take a follow-up with a self-host rig.

## Verification
- `bun run test -- run src/__tests__/integration/scheduled/trigger-embed-backfill-retry.test.ts` in packages/server: 2/2 pass (embedded Postgres, real migrations).
- Existing neighbor suite trigger-embed-backfill.test.ts: 3/3 pass.
- Note: if this lands alongside a repair/ops backfill for dead vectors, see #3066 - the ops need noted there is separate (one-time prod backfill + ivfflat rebuild).
