### PR TITLE
fix(mcp): name the remedy in admin-scope denial messages

### DIFF
--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -495,6 +495,21 @@ describe('routeAction per-action enforcement', () => {
         }
       )
     ).rejects.toThrow(/requires an MCP session with admin access/i);
+    // The denial must name the remedy, not just the tier (lobu#3449): the
+    // caller re-authorizes with the admin scope, no transport 403 required.
+    await expect(
+      routeAction(
+        'manage_connections',
+        'install_connector',
+        {
+          ...memberWriteCtx,
+          memberRole: 'admin',
+        },
+        {
+          install_connector: async () => ({ ok: true }),
+        }
+      )
+    ).rejects.toThrow(/grant the mcp:admin scope/i);
   });
 
   it('preserves system reaction calls', async () => {

--- a/packages/server/src/tools/admin/action-router.ts
+++ b/packages/server/src/tools/admin/action-router.ts
@@ -37,7 +37,7 @@ function enforceActionAccess(toolName: string, action: string, ctx: ToolContext)
     writeRole: `Action ${toolName}.${action} requires workspace membership with write access.`,
     readScope: `Action ${toolName}.${action} requires an MCP session with read access.`,
     writeScope: `Action ${toolName}.${action} requires an MCP session with write access.`,
-    adminScope: `Action ${toolName}.${action} requires an MCP session with admin access.`,
+    adminScope: `Action ${toolName}.${action} requires an MCP session with admin access. Reconnect this client and grant the mcp:admin scope to run it.`,
   });
 }
 

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -696,7 +696,7 @@ async function governEntitySchemaMutation(
       writeRole: 'Entity schema mutations require workspace owner or admin access.',
       readScope: 'Entity schema mutations require MCP admin access.',
       writeScope: 'Entity schema mutations require MCP admin access.',
-      adminScope: 'Entity schema mutations require MCP admin access.',
+      adminScope: 'Entity schema mutations require MCP admin access. Reconnect this client and grant the mcp:admin scope to continue.',
     });
   }
   const sql = getDb();

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -266,7 +266,7 @@ export function checkToolAccess(
     writeScope:
       'This MCP session is read-only. Reconnect with write-scoped OAuth, or ask an owner to add you.',
     adminScope:
-      'This MCP session does not include admin access. Reconnect with admin access after an owner grants the role.',
+      'This MCP session does not include admin access. Reconnect this client and grant the mcp:admin scope to continue.',
   });
   return requiredAccess;
 }


### PR DESCRIPTION
Partial fix for #3449 (message-only half; the 403 transport fix stays design-locked).

Partial for #3449 - the "cheap partial worth doing first" from the issue, not the transport fix.

## Summary
When a read/write OAuth token calls an SDK path needing `mcp:admin`, the denial reached the user as a statement of the missing tier ("requires an MCP session with admin access.") with no action. The issue's analysis stands: until the spec-conformant HTTP 403 + `WWW-Authenticate: insufficient_scope` step-up ships (design-lock required, batching guard needed), the error text is the only thing that reliably reaches the user - Claude Code detects a 403 but re-authenticates with the same pinned scopes, so the manual widen is needed regardless.

This appends the remedy to all three admin-scope denial sites, naming the action: **reconnect this client and grant the `mcp:admin` scope**.

- `tools/execute.ts` (`checkToolAccess`): "Reconnect with admin access after an owner grants the role" conflated member role with OAuth scope - now names the scope grant.
- `tools/admin/action-router.ts`: action denials name the remedy.
- `tools/admin/manage_entity_schema.ts`: same.

The `_meta['mcp/www_authenticate']` challenge path is untouched (still needed for OpenAI hosts). No transport, status-code, or contract changes; no design-lock needed for message text.

## Test plan
- [x] Red -> green: extended `tool-access.test.ts` to assert the admin denial names the remedy (`grant the mcp:admin scope`) - fails on unpatched `main` (`b4cde48`), passes here. 64/64 in that file.
- [x] Regression: `access-model-cross-check` (5), `sdk-tier-reporting` (3, integration), `operations-member-execute-authz` (10, integration), `started-side-effects` + `sdk-method-access` (21, bun) - all pass; existing assertions match the preserved message prefix.
- [ ] CI on the pushed branch.

## Notes
The full fix (HTTP 403 challenge with batching guard, plus settling whether a tool-level denial should produce a transport 403) remains design-locked per the issue and is deliberately not attempted here.
