### PR TITLE
fix(chat): honor --dry-run on agent turns instead of dropping the flag

### DIFF
--- a/packages/server/src/__tests__/integration/agent-turn-producer.test.ts
+++ b/packages/server/src/__tests__/integration/agent-turn-producer.test.ts
@@ -336,6 +336,46 @@ describe('agent turn producer', () => {
     }
   });
 
+  it('CAPTURES side effects for a dry-run chat turn instead of performing them', async () => {
+    // `lobu chat --dry-run` (lobu issue: dry-run created a real entity): the
+    // session flag rides platformMetadata.dryRun, and the turn credential must
+    // carry it as a capture claim — otherwise the flag survives the whole
+    // enqueue path and is dropped exactly where it could have been enforced.
+    const org = await createTestOrganization();
+    const message = { ...messageFor(org.id), platformMetadata: { dryRun: true } } as MessagePayload;
+    await enqueueMessage(message, {
+      agentSettings: settingsStore,
+      catalog: catalogFor(tokenEchoingModule()),
+      gatewayUrl: GATEWAY_URL,
+    });
+    const [run] = await agentTurnRuns();
+    expect(verifyWorkerToken(run.action_input.credential as string)).toMatchObject({
+      runId: run.id,
+      organizationId: org.id,
+      executionMode: 'capture',
+    });
+    const postLinkButton = vi.fn(async () => ({ id: 'synthetic-post' }));
+    const app = createInteractionRoutes({ postLinkButton } as never);
+    const server = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' });
+    try {
+      if (!server.listening) await new Promise<void>((resolve) => server.once('listening', resolve));
+      const response = await fetch(`http://127.0.0.1:${(server.address() as AddressInfo).port}/internal/interactions/create`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${run.action_input.credential}`, 'content-type': 'application/json' },
+        body: JSON.stringify({ interactionType: 'link_button', url: 'https://example.invalid', label: 'Interaction attempt' }),
+      });
+      expect(response.status).toBe(200);
+      // The mirror of the live-turn assertion above: captured, NOT performed,
+      // and the attempt is recorded on the turn run for the dry-run preview.
+      expect(postLinkButton).not.toHaveBeenCalled();
+      const [captured] = await getTestDb()`SELECT dry_run_preview FROM runs WHERE id = ${run.id}`;
+      const sideEffects = (captured?.dry_run_preview as { side_effects?: Array<{ action: string }> } | null)?.side_effects ?? [];
+      expect(sideEffects.map((entry) => entry.action)).toContain('interactions.create');
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
   it.each(['compatible', 'codex'])('executes a %s tool round trip through worker HTTP and an isolate', async (protocol) => {
     const requests: Array<Record<string, any>> = [];
     const serverErrors: string[] = [];

--- a/packages/server/src/__tests__/unit/eval-capture-mode.test.ts
+++ b/packages/server/src/__tests__/unit/eval-capture-mode.test.ts
@@ -62,6 +62,38 @@ describe("buildWorkerTokenClaims — executionMode", () => {
 	});
 });
 
+describe("buildWorkerTokenClaims — chat dry-run", () => {
+	// `lobu chat --dry-run`: the CLI sets dryRun on its own session, the gateway
+	// stamps it onto the enqueue's platformMetadata, and it must mint the same
+	// capture claim an eval run gets — otherwise the flag is carried all the
+	// way to the queue and silently dropped, and the turn writes for real.
+	test("a dry-run chat session mints the capture claim", () => {
+		const claims = buildWorkerTokenClaims({
+			...base,
+			platformMetadata: { dryRun: true },
+		});
+		expect(claims.executionMode).toBe("capture");
+	});
+
+	test.each([
+		["false", false],
+		["string", "true"],
+		["null", null],
+	])("%s dryRun stays live", (_label, value) => {
+		const claims = buildWorkerTokenClaims({
+			...base,
+			platformMetadata: { dryRun: value },
+		});
+		expect(claims.executionMode).toBeUndefined();
+	});
+
+	test("an absent dryRun stays live", () => {
+		expect(
+			buildWorkerTokenClaims({ ...base, platformMetadata: {} }).executionMode,
+		).toBeUndefined();
+	});
+});
+
 describe("buildWorkerTokenClaims — automationRunId", () => {
 	// The claim addresses the row the internal-route guard writes its capture
 	// record onto. It rides the token so the guard never has to re-derive a run

--- a/packages/server/src/gateway/orchestration/worker-token-claims.ts
+++ b/packages/server/src/gateway/orchestration/worker-token-claims.ts
@@ -126,6 +126,15 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
 		// Only the literal 'capture' is honoured, and it originates server-side
 		// from the run row (automation-run-intent.ts) — never from a caller.
 		//
+		// A chat session's own `dryRun` flag maps onto the same claim. Its
+		// provenance differs — the caller set it on their OWN session at create
+		// time (`POST /api/v1/agents`), the gateway stored it and stamped it
+		// onto every enqueue — but the direction is the same restrictive one:
+		// capture can only suppress that session's own writes, so honouring it
+		// here cannot launder a privilege. Without this mapping the flag was
+		// carried all the way from the CLI to the queue payload and then
+		// silently dropped, so a `--dry-run` chat turn wrote for real.
+		//
 		// An absent claim means live. That direction is deliberate: making
 		// "absent" mean capture would, for the length of a rollout, silence
 		// every real Automation still running on a token minted before this
@@ -133,7 +142,8 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
 		// cannot obtain a session without `verifyAutomationRunIntent` deriving
 		// its mode from `runs.run_type` — and that chain is covered by tests.
 		executionMode:
-			args.platformMetadata?.executionMode === "capture"
+			args.platformMetadata?.executionMode === "capture" ||
+			args.platformMetadata?.dryRun === true
 				? "capture"
 				: undefined,
 		// Capture only: nothing reads it on a live run, and leaving live tokens


### PR DESCRIPTION
## Root cause
The dryRun flag was delivered end-to-end and then dropped at the last inch: CLI -> POST /api/v1/agents (session.dryRun) -> enqueue platformMetadata.dryRun (agent-threads.ts) -> mintTurnToken builds claims from platformMetadata via buildWorkerTokenClaims, which honored ONLY a literal executionMode='capture'. dryRun was read nowhere in the turn path, so a dry-run chat turn ran fully live and its manage calls wrote real rows.

## Fix
One mapping in buildWorkerTokenClaims: platformMetadata.dryRun === true mints the same executionMode='capture' claim an eval replay gets. The capture lane already implements exactly dry-run semantics: tools/execute.ts records any non-read tool call instead of running it; internal mutation routes return recorded success bodies via captureSideEffect; run_sdk forces its sandbox skip path for non-read methods; attempts are appended to the turn run's dry_run_preview.side_effects. Provenance note: unlike an eval's capture, the flag is caller-origin - but it can only suppress the caller's OWN session's writes, so the restrictive direction cannot launder a privilege. Absent claim still means live.

## Verification (red -> green, real embedded PG)
- New integration test in agent-turn-producer.test.ts: enqueue a chat message with platformMetadata.dryRun:true -> turn credential verifies with executionMode 'capture'; POST /internal/interactions/create with that credential returns 200 but postLinkButton is NOT called, and dry_run_preview.side_effects contains interactions.create.
- RED on base: same test fails (credential has no executionMode claim).
- 5 new unit tests in eval-capture-mode.test.ts: all pass.
- Regression: agent-turn-capture.test.ts 14/14; live-turn test still asserts NO capture claim on ordinary turns; full bun:test unit dir = main's baseline (1579 pass vs main's 1574, same 1 pre-existing fail + 1 pre-existing error, both environmental).
- Pre-commit (biome + full tsc) green.

Note: with capture semantics the dry-run agent still completes its turn and replies; mid-turn streaming messages are recorded rather than sent. If product wants dry-run to instead REFUSE writes loudly, that's a different UX and a decision for the maintainer.
