### PR TITLE
fix(server): rank exact-identifier matches first in entity search

### DIFF
--- a/packages/server/src/__tests__/integration/authz/search-entity-exact-identifier.test.ts
+++ b/packages/server/src/__tests__/integration/authz/search-entity-exact-identifier.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Integration test: an exact-identifier query must rank the identifier's
+ * owner first.
+ *
+ * QA repro (SEARCH_REPROS ISSUE 17.1, app.lobu.ai v1.6.0 @ b293f4d): query
+ * "instinct-agent-test2@mail.instinct.com" (the exact email of member
+ * "Instinct Test Two") returned member "Instinct Agent" at 0.5 above the
+ * email's actual owner at 0.38 - fuzzy name trigrams beat the exact email
+ * because entity search never consulted entity_identities at all.
+ *
+ * Fix: queryEntities gains an exact-identifier arm - a caller-org
+ * entity_identities row whose identifier equals the query (case-insensitive)
+ * matches at score 1.0 in the fuzzy, blended and non-fuzzy branches.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { ToolContext } from '../../../tools/registry';
+import { search } from '../../../tools/search';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const EMAIL = 'instinct-agent-test2@mail.instinct.com';
+
+function ctxFor(orgId: string, userId: string): ToolContext {
+  return {
+    organizationId: orgId,
+    userId,
+    memberRole: 'owner',
+    isAuthenticated: true,
+    tokenType: 'oauth',
+    scopedToOrg: false,
+    allowCrossOrg: true,
+    scopes: ['mcp:read'],
+  };
+}
+
+describe('search_memory > exact-identifier entity match', () => {
+  let orgId: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await initWorkspaceProvider();
+    await seedSystemEntityTypes();
+
+    const org = await createTestOrganization({ name: 'Identifier Match Org' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'id-owner@example.com' });
+    userId = user.id;
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    // The decoy: its NAME trigram-matches the email query.
+    await createTestEntity({ name: 'Instinct Agent', organization_id: orgId });
+
+    // The right answer: name shares little with the email; the email lives
+    // only in entity_identities, exactly as a connector-claimed member email.
+    const rightMember = await createTestEntity({
+      name: 'Instinct Test Two',
+      organization_id: orgId,
+    });
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO entity_identities (
+        organization_id, entity_id, namespace, identifier, source_connector
+      ) VALUES (
+        ${orgId}, ${rightMember.id}, 'email', ${EMAIL}, 'test:fixture'
+      )
+    `;
+  });
+
+  it('ranks the identifier owner first at full score', async () => {
+    const result = await search(
+      { query: EMAIL, include_content: false },
+      {} as Parameters<typeof search>[1],
+      ctxFor(orgId, userId)
+    );
+
+    expect(result.matches.length).toBeGreaterThan(0);
+    expect(result.matches[0].name).toBe('Instinct Test Two');
+    expect(result.matches[0].match_score).toBe(1.0);
+  });
+
+  it('matches identifiers case-insensitively', async () => {
+    const result = await search(
+      { query: EMAIL.toUpperCase(), include_content: false },
+      {} as Parameters<typeof search>[1],
+      ctxFor(orgId, userId)
+    );
+    expect(result.matches[0]?.name).toBe('Instinct Test Two');
+  });
+
+  it('non-fuzzy mode still matches exact identifiers', async () => {
+    const result = await search(
+      { query: EMAIL, fuzzy: false, include_content: false },
+      {} as Parameters<typeof search>[1],
+      ctxFor(orgId, userId)
+    );
+    expect(result.matches.map((m) => m.name)).toContain('Instinct Test Two');
+  });
+});

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -1794,6 +1794,23 @@ async function queryEntities(
   // Embedding param — only push when we have an embedding (avoids null::vector type error)
   const embeddingParamIdx = embedding?.length ? addParam(toVectorLiteral(embedding)) : null;
 
+  // Org param is bound up front (not at the org-filter block below) because the
+  // identifier arm of the query match condition also needs it. Placeholder
+  // indices all reference these variables, so the order shift is safe.
+  const orgParamIdx = addParam(scope.organizationId);
+
+  // Exact-identifier arm: a query that IS one of the entity's claimed
+  // identifiers (email, phone, ...) matches that entity at full score.
+  // Without this, an exact-email query only trigram-matched other members'
+  // NAMES ("instinct-agent-test2@mail.instinct.com" ranked "Instinct Agent"
+  // above the email's actual owner). Identity rows are tenant-private, so the
+  // EXISTS is scoped to the caller's org - cross-org public entities never
+  // match it, which is correct: their identifiers aren't the caller's to query.
+  const identifierExactSql =
+    queryParamIdx !== null
+      ? `EXISTS (SELECT 1 FROM entity_identities ei WHERE ei.entity_id = e.id AND ei.organization_id = $${orgParamIdx} AND lower(ei.identifier) = lower($${queryParamIdx}) AND ei.deleted_at IS NULL)`
+      : 'FALSE';
+
   // Query match condition: text match OR vector match
   if (query) {
     if (fuzzyEnabled) {
@@ -1820,12 +1837,14 @@ async function queryEntities(
         ? Math.max(0, Math.min(1, rawMinSimilarity))
         : 0.3;
       const minSimParamIdx = addParam(nameSimFloor);
-      const textCondition = `(LOWER(e.name) LIKE '%' || LOWER($${queryParamIdx}) || '%' OR LOWER(e.name) = LOWER($${queryParamIdx}) OR similarity(LOWER(e.name), LOWER($${queryParamIdx})) > $${minSimParamIdx}::numeric OR e.content_tsv @@ websearch_to_tsquery('english', $${queryParamIdx}))`;
+      const textCondition = `(LOWER(e.name) LIKE '%' || LOWER($${queryParamIdx}) || '%' OR LOWER(e.name) = LOWER($${queryParamIdx}) OR similarity(LOWER(e.name), LOWER($${queryParamIdx})) > $${minSimParamIdx}::numeric OR e.content_tsv @@ websearch_to_tsquery('english', $${queryParamIdx}) OR ${identifierExactSql})`;
       conditions.push(
         hasEmbedding ? `(${textCondition} OR e.embedding IS NOT NULL)` : textCondition
       );
     } else {
-      conditions.push(`LOWER(e.name) = LOWER($${queryParamIdx})`);
+      conditions.push(
+        `(LOWER(e.name) = LOWER($${queryParamIdx}) OR ${identifierExactSql})`
+      );
     }
   } else if (hasEmbedding) {
     conditions.push('e.embedding IS NOT NULL');
@@ -1839,7 +1858,6 @@ async function queryEntities(
   // operational counts (events, connections, automations) on caller-org rows
   // so cross-org public results don't leak other tenants' activity.
   const includePublic = args.include_public_catalogs ?? true;
-  const orgParamIdx = addParam(scope.organizationId);
   if (includePublic) {
     conditions.push(
       `(e.organization_id = $${orgParamIdx} OR EXISTS (SELECT 1 FROM organization o WHERE o.id = e.organization_id AND o.visibility = 'public'))`
@@ -1892,11 +1910,11 @@ async function queryEntities(
         : '0';
     const nameSimExpr =
       queryParamIdx !== null ? `similarity(LOWER(e.name), LOWER($${queryParamIdx}))` : '0';
-    scoreExpr = `(${vectorSimExpr}) * 0.6 + (${textRankExpr}) * 0.3 + (${nameSimExpr}) * 0.1`;
+    scoreExpr = `CASE WHEN ${identifierExactSql} THEN 1.0 ELSE (${vectorSimExpr}) * 0.6 + (${textRankExpr}) * 0.3 + (${nameSimExpr}) * 0.1 END`;
     matchReason = 'vector_blend';
   } else if (fuzzyEnabled && queryParamIdx !== null) {
     vectorSimExpr = 'NULL';
-    scoreExpr = `CASE WHEN LOWER(e.name) = LOWER($${queryParamIdx}) THEN 1.0 ELSE similarity(LOWER(e.name), LOWER($${queryParamIdx})) END`;
+    scoreExpr = `CASE WHEN LOWER(e.name) = LOWER($${queryParamIdx}) OR ${identifierExactSql} THEN 1.0 ELSE similarity(LOWER(e.name), LOWER($${queryParamIdx})) END`;
     matchReason = 'fuzzy_match';
   } else {
     vectorSimExpr = 'NULL';


### PR DESCRIPTION
# PR: fix(server): rank exact-identifier matches first in entity search

**Repo:** lobu-ai/lobu
**Branch:** fix/search-entity-exact-identifier
**Base:** main
**Patch:** 0004-entity-exact-identifier.patch (single commit dbb305c68, applies to main @ b4cde48)

---

## QA repro (SEARCH_REPROS ISSUE 17, sub-issue 1, hosted v1.6.0 @ b293f4d)

Query "instinct-agent-test2@mail.instinct.com" — the exact email of member "Instinct Test Two" — returned member "Instinct Agent" at 0.5, above the email's actual owner at 0.38.

## Root cause

`queryEntities` matched entities only on name (`LIKE` / trigram `similarity`) and `content_tsv`. It never consulted `entity_identities`, where connector-claimed emails/phones live. So an exact-email query scored pure name trigrams: the decoy member's name ("Instinct Agent") matched the email's local part better than the right member's name ("Instinct Test Two") did.

## Fix

An exact-identifier arm in `queryEntities`: an `entity_identities` row in the caller's org whose identifier equals the query (case-insensitive, not deleted) matches that entity at score 1.0 — in the fuzzy, blended (embedding), and non-fuzzy branches.

- Identifier rows are tenant-private, so the EXISTS is org-scoped and never fires for cross-org public-catalog entities (their identifiers aren't the caller's to query).
- Only an exact full-string identifier match scores 1.0; partial/fuzzy behavior is unchanged.

## Scope note — the rest of ISSUE 17 is NOT in this PR

Sub-issues 2-5 (token-order sensitivity, no relevance threshold for low-similarity content, own-org-first ordering reading as out-of-order, stop-word queries returning rows) are ranking-policy/tuning decisions, not clear bugs: each "fix" changes the recall contract for every caller. Recommended as a separate tuning pass with Emre's call on thresholds. Details in the task report.

## Verification (e2e in sandbox)

New integration test `search-entity-exact-identifier.test.ts` against real migrated Postgres (embedded PG 18), exercising the public `search` tool entry:

- exact email query → identifier owner ranked first at score 1.0 (decoy member present in fixtures)
- case-insensitive match
- `fuzzy: false` still matches exact identifiers

**RED→GREEN:** fix stashed → all 3 tests fail (identifier owner absent from matches); fix restored → 3/3 pass. Regression: existing `search-connection-visibility` + `search-content-org-scope` suites pass 12/12 with the param reorder this change makes (org param now bound before the query-match block).

## Caveats for the hub

- Applies cleanly to main @ b4cde48; independent of the internal-ops and embed-backfill branches (all touch search.ts/search-path.ts but different hunks; merge order shouldn't conflict, worth a quick rebase check after the first one lands).
- Not e2e-verified against hosted app.lobu.ai; the integration test reproduces the QA scenario through the same `search` tool entry point.
